### PR TITLE
Fix docs for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Clone and set up the project:
 git clone https://github.com/democratizedspace/dspace.git
 cd dspace
 npm install
+# Install frontend dependencies
+cd frontend && npm install
+cd ..
 ```
 
 Start the development server:


### PR DESCRIPTION
## Summary
- clarify that frontend dependencies require `npm install`

## Testing
- `npm run check`
- `npm run test:pr` *(fails: Cannot find modules / TextDecoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684931a61948832f96de89ee32d05c24