### PR TITLE
Restore v2 quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ npm run test:pr
 ```
 
 This cross-platform script will:
-- Check code formatting and linting
-- Run all unit tests
-- Run all end-to-end tests in optimized groups
-- Provide helpful error messages if any tests fail
+
+-   Check code formatting and linting
+-   Run all unit tests
+-   Run all end-to-end tests in optimized groups
+-   Provide helpful error messages if any tests fail
 
 The `test:pr` command handles everything automatically, including starting and stopping the development server for end-to-end tests.
 
@@ -53,8 +54,8 @@ The `test:pr` command handles everything automatically, including starting and s
 
 For detailed information about our testing approach, please refer to:
 
-- [Testing Guide](./frontend/TESTING.md) - Comprehensive documentation on testing practices, common issues, and debugging techniques
-- [Developer Guide](./DEVELOPER_GUIDE.md#testing-strategy) - Higher-level overview of our testing strategy and approach
+-   [Testing Guide](./frontend/TESTING.md) - Comprehensive documentation on testing practices, common issues, and debugging techniques
+-   [Developer Guide](./DEVELOPER_GUIDE.md#testing-strategy) - Higher-level overview of our testing strategy and approach
 
 For common test commands, see the section below.
 
@@ -84,23 +85,25 @@ Check code quality before committing:
 ```bash
 npm run check
 ```
+
 ## Docker Deployment
 
 Run the game in Docker (works on Raspberry Pi) using:
+
 ```bash
 docker compose up --build -d
 ```
-The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 
+The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 
 ## Project Architecture
 
 DSPACE uses a modern JavaScript architecture:
 
-- **ES Modules**: Native JavaScript modules with import/export syntax
-- **Astro SSR**: Server-side rendering with hydration of Svelte components
-- **Progressive Enhancement**: Core functionality works without JavaScript
-- **Continuous Testing**: Unit and e2e tests ensure consistent quality
+-   **ES Modules**: Native JavaScript modules with import/export syntax
+-   **Astro SSR**: Server-side rendering with hydration of Svelte components
+-   **Progressive Enhancement**: Core functionality works without JavaScript
+-   **Continuous Testing**: Unit and e2e tests ensure consistent quality
 
 For detailed information on the architecture, see our [Developer Guide](./DEVELOPER_GUIDE.md).
 
@@ -108,18 +111,23 @@ For detailed information on the architecture, see our [Developer Guide](./DEVELO
 
 For comprehensive information about developing DSPACE, see our [Developer Guide](./DEVELOPER_GUIDE.md). This guide includes:
 
-- Detailed architecture overview
-- Component development guidelines
-- Testing strategies
-- Performance considerations
-- Troubleshooting tips
+-   Detailed architecture overview
+-   Component development guidelines
+-   Testing strategies
+-   Performance considerations
+-   Troubleshooting tips
 
 ## Built-in Quests
 
 Starter quest JSON files live in `src/pages/quests/json`. They follow the schema
 defined at `src/pages/quests/jsonSchemas/quest.json` and can reference NPC
-profiles in `src/pages/docs/md/npcs.md`.
-Keep that NPC file updated when adding new characters.
+profiles in `src/pages/docs/md/npcs.md`. The schema now supports advanced
+fields such as `start`, `rewards` and item requirements, so older quests from
+the v2 era remain valid. Keep the NPC file updated when adding new characters.
+
+> **Tip:** The quest format is compatible with projects like
+> [`token.place`](https://github.com/futuroptimist/token.place), so content can be
+> shared across repos.
 
 ## Want to contribute?
 

--- a/src/pages/docs/md/npcs.md
+++ b/src/pages/docs/md/npcs.md
@@ -1,10 +1,65 @@
-# NPCs
+---
+title: 'NPCs'
+slug: 'npcs'
+---
 
 ## dChat
-dChat is the friendly AI assistant that guides new players through the tutorial.
-It answers questions and provides helpful tips on every game system.
+
+<img src="/assets/npc/dChat.jpg" />
+
+dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning and information retrieval capabilities, it can answer questions and engage in conversation effortlessly. dChat is provided free of charge to all metaguild members, and it's fully open source and self-hosted.
+
+## Sydney
+
+<img src="/assets/npc/sydney.jpg" />
+
+Sydney, a tall and commanding woman, exudes an air of no-nonsense professionalism. As a 3D printing expert, she creates and repairs various tools and equipment for the metaguild. Raised among engineers and tinkerers, Sydney was captivated by the potential of 3D printing early on. After studying mechanical engineering in college, she quickly mastered the field. Sydney eagerly joined the metaguild to apply her skills to new challenges.
+
+## Nova
+
+<img src="/assets/npc/nova.jpg" />
+
+Nova, an ingenious engineer with a quick wit, excels at rocketry. She designs and constructs the spacecraft used by the metaguild to explore the solar system. After studying aerospace engineering in college, she rapidly gained expertise in the field. Known for her perfectionism and ability to overcome obstacles, Nova embraced the metaguild as a means to employ her skills in groundbreaking ways.
+
+## Hydro
+
+<img src="/assets/npc/hydro.jpg" />
+
+Hydro, a relaxed and affable team member, has a gift for hydroponics and sustainable farming. They ensure the crew has a steady supply of food during lengthy space missions. Growing up on a small Earth farm, Hydro acquired a strong appreciation for sustainable agriculture. In college, they studied biology and became intrigued by hydroponics as a method for cultivating crops in harsh environments.
+
+## Orion
+
+<img src="/assets/npc/orion.jpg" />
+
+Orion is an electrical engineer whose enthusiasm for robotics and microprocessors knows no bounds. He specializes in designing and building intelligent robotic systems to assist the metaguild in various tasks. Orion's technical prowess and innovative thinking make him a valuable team member in the quest to push the boundaries of space exploration.
 
 ## Vega
-Vega is an aquatic life specialist with a passion for ethical fish keeping.
-They appear throughout the aquarium quest chain, teaching players how to
-maintain healthy tanks and respect animal welfare.
+
+<img src="/assets/npc/vega.jpg" />
+
+Vega is an expert in aquariums and terrariums, with years of experience in designing and maintaining these unique ecosystems. Their passion for aquatic and terrestrial life has led them to develop innovative techniques and solutions for creating balanced, thriving environments for a wide variety of species. Vega is dedicated to sharing their knowledge with others and helping people create beautiful, healthy habitats for their own pets and plants.
+
+## Phoenix
+
+<img src="/assets/npc/phoenix.jpg" />
+
+Phoenix is a professional chemist specializing in sustainable rocket fuel development. With a strong background in chemistry and a focus on environmental conservation, they are committed to finding innovative solutions for the space industry that have a minimal impact on our planet. Phoenix's work has the potential to revolutionize space travel by making it more eco-friendly and accessible to a wider range of people.
+
+## Atlas
+
+<img src="/assets/npc/atlas.jpg" />
+
+Atlas is a humanoid robot assistant designed to help with physical tasks that require strength and precision. With advanced AI capabilities, Atlas can perform a variety of tasks, from heavy lifting to delicate assembly work, making it an invaluable asset to the team. As our trusty robotic companion, Atlas ensures that we can accomplish our goals more efficiently and safely than ever before.
+
+<style>
+    img {
+        float: left;
+        width: 150px;
+        margin: 10px;
+        border-radius: 20px;
+    }
+
+    p {
+        font-size: 1.3rem;
+    }
+</style>

--- a/src/pages/quests/json/3dprinting/benchy_10.json
+++ b/src/pages/quests/json/3dprinting/benchy_10.json
@@ -1,0 +1,44 @@
+{
+    "id": "3dprinting/benchy_10",
+    "title": "3D Print 10 Benchies",
+    "description": "Put your 3D printer to the test! To complete this quest, print at least 10 Benchies.",
+    "image": "/assets/quests/benchy_10.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've made some impressive strides in 3D printing. Your next challenge is to print 10 Benchies. These small boat models will test the capabilities of your printer. Are you up for it?",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "1",
+                            "count": 10
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "Let's set sail!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Well done! These Benchies look fantastic. Keep honing your 3D printing skills. I'll be back with a new challenge soon!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "I'm ready for more!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "12",
+            "count": 1000
+        }
+    ],
+    "requiresQuests": ["3dprinting/start"]
+}

--- a/src/pages/quests/json/3dprinting/benchy_100.json
+++ b/src/pages/quests/json/3dprinting/benchy_100.json
@@ -1,0 +1,44 @@
+{
+    "id": "3dprinting/benchy_100",
+    "title": "3D Print 100 Benchies",
+    "description": "Show off your 3D printing prowess! To complete this quest, print at least 100 Benchies.",
+    "image": "/assets/quests/benchy_100.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've truly mastered the art of 3D printing Benchies. Now, let's take things to the next level. I want to see a fleet of 100 Benchies. Are you ready for this grand voyage?",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "1",
+                            "count": 100
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "Let's embark on this journey!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Incredible! You've constructed a formidable fleet of Benchies. Your 3D printing skills are truly remarkable. Remember, every Benchy is a testament to your growing capabilities. I'll be back with another challenge soon. Until then, keep printing!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Bring on the next challenge!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "12",
+            "count": 100000
+        }
+    ],
+    "requiresQuests": ["3dprinting/benchy_25"]
+}

--- a/src/pages/quests/json/3dprinting/benchy_25.json
+++ b/src/pages/quests/json/3dprinting/benchy_25.json
@@ -1,0 +1,44 @@
+{
+    "id": "3dprinting/benchy_25",
+    "title": "3D Print 25 Benchies",
+    "description": "Increase your 3D printing output! To complete this quest, print at least 25 Benchies.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've shown great progress with your 3D printing! Your next goal is to print 25 Benchies. Can you handle this nautical challenge?",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "1",
+                            "count": 25
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "Full steam ahead!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent job! Your fleet of Benchies is growing. Keep up the great work. I'll return with an even bigger challenge soon!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "I'm ready for anything!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "12",
+            "count": 10000
+        }
+    ],
+    "requiresQuests": ["3dprinting/benchy_10"]
+}

--- a/src/pages/quests/json/3dprinting/start.json
+++ b/src/pages/quests/json/3dprinting/start.json
@@ -1,0 +1,110 @@
+{
+    "id": "3dprinter/start",
+    "title": "Set up your first 3D printer",
+    "description": "Accept Sydney's offer of a 3D printer, and learn how to set it up for use in your space exploration adventure.",
+    "image": "/assets/quests/start.png",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hello, friend! I'm Sydney, a 3D printing expert with the metaguild. dChat referred me. I've got a proposition for you: how would you like to have your very own 3D printer?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "enthusiastic",
+                    "text": "A 3D printer? That sounds amazing! Tell me more."
+                }
+            ]
+        },
+        {
+            "id": "enthusiastic",
+            "text": "Fantastic! A 3D printer is an invaluable tool! It can be used to quickly prototype new designs, print decor, and even build robots!! I've taken the liberty of fully assembling and calibrating it for you. So, what do you say?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "grant",
+                    "text": "I say let's do this!!"
+                }
+            ]
+        },
+        {
+            "id": "grant",
+            "text": "First things first, I need you to accept the 3D printer. Just take it and we'll proceed. Oh, and I threw in some filament! That filament gets melted at a high temperature and laid down one layer at a time. It may take a while to print stuff at first, but over time you'll be able tweak settings and make it run way faster! Plus, this is a cheap beginner model. There are way more powerful printers out there if you've got the cash!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "0",
+                            "count": 1
+                        },
+                        {
+                            "id": "12",
+                            "count": 1000
+                        }
+                    ],
+                    "text": "Don't mind if I do!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "benchy",
+                    "requiresItems": [
+                        {
+                            "id": "0",
+                            "count": 1
+                        },
+                        {
+                            "id": "12",
+                            "count": 1000
+                        }
+                    ],
+                    "text": "I've got the goods! What's next?"
+                }
+            ]
+        },
+        {
+            "id": "benchy",
+            "text": "For your test print, I recommend printing a Benchy. It's a small boat model often used to validate 3D printer setups. Once you've successfully printed Benchy, we'll know your 3D printer is ready for action. It's gonna take a bit of time so feel free to go talk to my associates or grab a coffee or something.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "3dprint-benchy",
+                    "text": "Ok, here goes nothing!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        {
+                            "id": "1",
+                            "count": 1
+                        }
+                    ],
+                    "text": "I've printed the Benchy! What's next?"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! You're all set to use your 3D printer for your space exploration adventures (or whatever else tickles your fancy). If you need help or tips on 3D printing, feel free to reach out. Good luck! Oh and here's a little something. There's more where that came from! If you're interested in more free dUSD, dChat's got you covered!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Sydney! I appreciate your help. And I'll keep that in mind!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "24",
+            "count": 100
+        },
+        {
+            "id": "8",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["welcome/howtodoquests"]
+}

--- a/src/pages/quests/json/aquaria/breeding.json
+++ b/src/pages/quests/json/aquaria/breeding.json
@@ -1,30 +1,30 @@
 {
-  "id": "aquaria/breeding",
-  "title": "Guppy Breeding Basics",
-  "description": "Learn how to breed guppies and raise the fry.",
-  "image": "/assets/quests/guppy-breeding.jpg",
-  "npc": "/assets/npc/vega.jpg",
-  "requiresQuests": ["aquaria/guppy"],
-  "dialogue": [
-    {
-      "id": "start",
-      "text": "To breed guppies, select a healthy male and female and place them in a separate breeding tank with plenty of cover.",
-      "options": [{ "text": "Pair selected", "next": "cover" }]
-    },
-    {
-      "id": "cover",
-      "text": "Floating plants give the fry a place to hide. Maintain warm, clean water between 24 and 28 degrees Celsius.",
-      "options": [{ "text": "Plants added", "next": "fry" }]
-    },
-    {
-      "id": "fry",
-      "text": "After a few days you'll notice tiny fry swimming near the surface. Feed them powdered food or baby brine shrimp.",
-      "options": [{ "text": "They're growing", "next": "finish" }]
-    },
-    {
-      "id": "finish",
-      "text": "Keep the water pristine and separate adults if they harass the fry. Soon you'll have a healthy new generation.",
-      "options": [{ "text": "Can't wait!" }]
-    }
-  ]
+    "id": "aquaria/breeding",
+    "title": "Guppy Breeding Basics",
+    "description": "Learn how to breed guppies and raise the fry.",
+    "image": "/assets/quests/guppy-breeding.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "requiresQuests": ["aquaria/guppy"],
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "To breed guppies, select a healthy male and female and place them in a separate breeding tank with plenty of cover.",
+            "options": [{ "text": "Pair selected", "next": "cover" }]
+        },
+        {
+            "id": "cover",
+            "text": "Floating plants give the fry a place to hide. Maintain warm, clean water between 24 and 28 degrees Celsius.",
+            "options": [{ "text": "Plants added", "next": "fry" }]
+        },
+        {
+            "id": "fry",
+            "text": "After a few days you'll notice tiny fry swimming near the surface. Feed them powdered food or baby brine shrimp.",
+            "options": [{ "text": "They're growing", "next": "finish" }]
+        },
+        {
+            "id": "finish",
+            "text": "Keep the water pristine and separate adults if they harass the fry. Soon you'll have a healthy new generation.",
+            "options": [{ "text": "Can't wait!" }]
+        }
+    ]
 }

--- a/src/pages/quests/json/aquaria/goldfish.json
+++ b/src/pages/quests/json/aquaria/goldfish.json
@@ -1,30 +1,30 @@
 {
-  "id": "aquaria/goldfish",
-  "title": "Keeping Goldfish",
-  "description": "Upgrade to a larger tank and care for a single fancy goldfish.",
-  "image": "/assets/quests/goldfish.jpg",
-  "npc": "/assets/npc/vega.jpg",
-  "requiresQuests": ["aquaria/breeding"],
-  "dialogue": [
-    {
-      "id": "start",
-      "text": "Goldfish produce a lot of waste, so they need a spacious tank and powerful filtration to stay healthy.",
-      "options": [{ "text": "I'll upgrade", "next": "tank" }]
-    },
-    {
-      "id": "tank",
-      "text": "Aim for at least a seventy-five liter aquarium for a single fancy goldfish. Larger volumes over one hundred fifty liters are even better.",
-      "options": [{ "text": "Tank ready", "next": "care" }]
-    },
-    {
-      "id": "care",
-      "text": "Keep the water cool, around eighteen to twenty-two degrees Celsius, and perform regular water changes to maintain quality.",
-      "options": [{ "text": "Got it", "next": "diet" }]
-    },
-    {
-      "id": "diet",
-      "text": "Offer a varied diet of pellets and fresh vegetables. With proper care your goldfish will thrive for many years.",
-      "options": [{ "text": "Thanks, Vega!" }]
-    }
-  ]
+    "id": "aquaria/goldfish",
+    "title": "Keeping Goldfish",
+    "description": "Upgrade to a larger tank and care for a single fancy goldfish.",
+    "image": "/assets/quests/goldfish.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "requiresQuests": ["aquaria/breeding"],
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Goldfish produce a lot of waste, so they need a spacious tank and powerful filtration to stay healthy.",
+            "options": [{ "text": "I'll upgrade", "next": "tank" }]
+        },
+        {
+            "id": "tank",
+            "text": "Aim for at least a seventy-five liter aquarium for a single fancy goldfish. Larger volumes over one hundred fifty liters are even better.",
+            "options": [{ "text": "Tank ready", "next": "care" }]
+        },
+        {
+            "id": "care",
+            "text": "Keep the water cool, around eighteen to twenty-two degrees Celsius, and perform regular water changes to maintain quality.",
+            "options": [{ "text": "Got it", "next": "diet" }]
+        },
+        {
+            "id": "diet",
+            "text": "Offer a varied diet of pellets and fresh vegetables. With proper care your goldfish will thrive for many years.",
+            "options": [{ "text": "Thanks, Vega!" }]
+        }
+    ]
 }

--- a/src/pages/quests/json/aquaria/guppy.json
+++ b/src/pages/quests/json/aquaria/guppy.json
@@ -1,30 +1,30 @@
 {
-  "id": "aquaria/guppy",
-  "title": "Add Community Fish",
-  "description": "Introduce guppies to your established tank.",
-  "image": "/assets/quests/guppy.jpg",
-  "npc": "/assets/npc/vega.jpg",
-  "requiresQuests": ["aquaria/walstad"],
-  "dialogue": [
-    {
-      "id": "start",
-      "text": "Your Walstad tank is thriving. It's time to add some colorful guppies to create a lively community.",
-      "options": [{ "text": "I'm ready", "next": "acclimate" }]
-    },
-    {
-      "id": "acclimate",
-      "text": "Float the sealed bag for twenty minutes to equalize the water temperature. Then slowly mix small amounts of tank water into the bag.",
-      "options": [{ "text": "They're acclimated", "next": "release" }]
-    },
-    {
-      "id": "release",
-      "text": "Release the guppies gently and dim the lights to reduce stress. Keep the temperature stable between 24 and 28 degrees Celsius.",
-      "options": [{ "text": "Done", "next": "observe" }]
-    },
-    {
-      "id": "observe",
-      "text": "Feed a small pinch of food and observe their behavior. Healthy guppies will explore every corner of the tank.",
-      "options": [{ "text": "Thanks for the tips!" }]
-    }
-  ]
+    "id": "aquaria/guppy",
+    "title": "Add Community Fish",
+    "description": "Introduce guppies to your established tank.",
+    "image": "/assets/quests/guppy.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "requiresQuests": ["aquaria/walstad"],
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your Walstad tank is thriving. It's time to add some colorful guppies to create a lively community.",
+            "options": [{ "text": "I'm ready", "next": "acclimate" }]
+        },
+        {
+            "id": "acclimate",
+            "text": "Float the sealed bag for twenty minutes to equalize the water temperature. Then slowly mix small amounts of tank water into the bag.",
+            "options": [{ "text": "They're acclimated", "next": "release" }]
+        },
+        {
+            "id": "release",
+            "text": "Release the guppies gently and dim the lights to reduce stress. Keep the temperature stable between 24 and 28 degrees Celsius.",
+            "options": [{ "text": "Done", "next": "observe" }]
+        },
+        {
+            "id": "observe",
+            "text": "Feed a small pinch of food and observe their behavior. Healthy guppies will explore every corner of the tank.",
+            "options": [{ "text": "Thanks for the tips!" }]
+        }
+    ]
 }

--- a/src/pages/quests/json/aquaria/walstad.json
+++ b/src/pages/quests/json/aquaria/walstad.json
@@ -1,30 +1,30 @@
 {
-  "id": "aquaria/walstad",
-  "title": "Start a Walstad Tank",
-  "description": "Set up a low-tech Walstad style aquarium with soil and plants.",
-  "image": "/assets/quests/walstad.jpg",
-  "npc": "/assets/npc/vega.jpg",
-  "requiresQuests": [],
-  "dialogue": [
-    {
-      "id": "start",
-      "text": "Let's build a natural Walstad aquarium from scratch. We'll start small so you can maintain it easily.",
-      "options": [{ "text": "Sounds good!", "next": "soil" }]
-    },
-    {
-      "id": "soil",
-      "text": "Begin by spreading a thin layer of organic potting soil on the bottom. Cover it with gravel to prevent cloudiness later.",
-      "options": [{ "text": "Done with the soil.", "next": "plant" }]
-    },
-    {
-      "id": "plant",
-      "text": "Add hardy stem plants like hornwort or water wisteria. They help balance nutrients while the tank settles.",
-      "options": [{ "text": "Plants added", "next": "cycle" }]
-    },
-    {
-      "id": "cycle",
-      "text": "Great work! Fill the tank slowly and let it cycle for several weeks before you introduce any fish.",
-      "options": [{ "text": "I'll wait patiently." }]
-    }
-  ]
+    "id": "aquaria/walstad",
+    "title": "Start a Walstad Tank",
+    "description": "Set up a low-tech Walstad style aquarium with soil and plants.",
+    "image": "/assets/quests/walstad.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "requiresQuests": [],
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's build a natural Walstad aquarium from scratch. We'll start small so you can maintain it easily.",
+            "options": [{ "text": "Sounds good!", "next": "soil" }]
+        },
+        {
+            "id": "soil",
+            "text": "Begin by spreading a thin layer of organic potting soil on the bottom. Cover it with gravel to prevent cloudiness later.",
+            "options": [{ "text": "Done with the soil.", "next": "plant" }]
+        },
+        {
+            "id": "plant",
+            "text": "Add hardy stem plants like hornwort or water wisteria. They help balance nutrients while the tank settles.",
+            "options": [{ "text": "Plants added", "next": "cycle" }]
+        },
+        {
+            "id": "cycle",
+            "text": "Great work! Fill the tank slowly and let it cycle for several weeks before you introduce any fish.",
+            "options": [{ "text": "I'll wait patiently." }]
+        }
+    ]
 }

--- a/src/pages/quests/json/completionist_v2.json
+++ b/src/pages/quests/json/completionist_v2.json
@@ -1,0 +1,58 @@
+{
+    "id": "completionist/v2",
+    "title": "Congrats for finishing all the quests!!",
+    "description": "Here's a trophy for your efforts!",
+    "image": "/assets/quests/completionist.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Look who's back already!! My favorite human! You're a human, right? I'm pretty sure you are. Anyway, I'd love to present this prestigious award to you!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "thanks",
+                    "text": "Whoa, thanks, but why?"
+                }
+            ]
+        },
+        {
+            "id": "thanks",
+            "text": "Well, adventurer, because you've completed the first wave of quests!! There are certainly many more on the horizon, but you've reached a significant milestone. And for that, this Completionist Award is all yours!!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "mine",
+                    "text": "All mine???"
+                }
+            ]
+        },
+        {
+            "id": "mine",
+            "text": "You betcha! You've earned it. I'll see you around, friend!",
+            "options": [
+                {
+                    "type": "finish",
+                    "goto": "delivery",
+                    "text": "See you, dChat!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "87",
+            "count": 1
+        }
+    ],
+    "requiresQuests": [
+        "welcome/howtodoquests",
+        "ubi/basicincome",
+        "3dprinter/start",
+        "aquaria/goldfish",
+        "energy/solar-1kWh",
+        "rocketry/parachute",
+        "hydroponics/basil"
+    ]
+}

--- a/src/pages/quests/json/energy/dSolar-100kW.json
+++ b/src/pages/quests/json/energy/dSolar-100kW.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dSolar-100kW",
+    "title": "Accrue 100,000 dSolar",
+    "description": "Set new standards in solar energy production! To complete this quest, have at least 100,000 dSolar in your inventory.",
+    "image": "/assets/quests/dSolar_100kW.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've come a long way, surpassing all the benchmarks I've set for you. Now, we're aiming for the stars! Your next challenge is to reach 100,000 dSolar. It's a monumental task, but you've shown you have what it takes to reach such heights!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "61",
+                            "count": 100000
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "I'm ready for this!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Astounding! You've hit a new milestone in solar energy generation! I'm genuinely impressed. Remember, every dSolar represents a step toward a more sustainable future. I'll be back with an even bigger challenge. Keep lighting the way!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Bring it on!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 10
+        }
+    ],
+    "requiresQuests": ["energy/dSolar-10kW"]
+}

--- a/src/pages/quests/json/energy/dSolar-10kW.json
+++ b/src/pages/quests/json/energy/dSolar-10kW.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dSolar-10kW",
+    "title": "Accrue 10,000 dSolar",
+    "description": "Push the boundaries of energy production! To complete this quest, have at least 10,000 dSolar in your inventory.",
+    "image": "/assets/quests/dSolar_10kW.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You're doing great so far, generating a substantial amount of solar energy! Your next milestone is a whopping 10,000 dSolar. This might seem like a steep jump, but I believe in your potential. Onwards, to a brighter future!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "61",
+                            "count": 10000
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "Challenge accepted!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Impressive, you've truly outdone yourself! I knew you had it in you. But remember, the sky is the limit, or in our case, the sun. I'll return with a greater challenge soon. Keep up the energy production!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Looking forward to it!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 6
+        }
+    ],
+    "requiresQuests": ["energy/dSolar-1kW"]
+}

--- a/src/pages/quests/json/energy/dSolar-1kW.json
+++ b/src/pages/quests/json/energy/dSolar-1kW.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dSolar-1kW",
+    "title": "Accrue 1,000 dSolar",
+    "description": "Reach increasingly higher levels of energy production! To complete this quest, have at least 1,000 dSolar in your inventory.",
+    "image": "/assets/quests/dSolar_1kW.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "As you've probably noticed, you've been accruing dSolar as you generate energy with your panels! dSolar is basically just a token recording how much energy you've generated using solar historically. To make things a bit moe interesting, I'm going to give you increasingly bigger milestones to reach. Let's start small, with say, 1,000 dSolar. Before you know it you'll be a small blip on the Kardashev scale!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "61",
+                            "count": 1000
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "That was easy!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "See, that wasn't so bad! I'll be back with more quests for you soon. In the meantime, keep generating energy!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 3
+        }
+    ],
+    "requiresQuests": ["energy/solar-1kWh"]
+}

--- a/src/pages/quests/json/energy/dWatt-1e3.json
+++ b/src/pages/quests/json/energy/dWatt-1e3.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dWatt-1e3",
+    "title": "Accumulate 1,000 dWatt",
+    "description": "Boost your energy potential! To unlock this quest's reward, accumulate at least 1,000 dWatt in your inventory.",
+    "image": "/assets/quests/dWatt_1e3.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there, power producer! As your energy collection ventures into the dWatt realm, I've set a little challenge for you. Can you hit the 1,000 dWatt mark? It's a testament to your energy prowess. Do that, and I've got a nice reward waiting for you.",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 1000
+                        }
+                    ],
+                    "goto": "congrats",
+                    "text": "Oh, that's easy! Here's 1,000 dWatt."
+                }
+            ]
+        },
+        {
+            "id": "congrats",
+            "text": "Impressive speed, energy connoisseur! As promised, here's your reward for embracing the power of dWatt. Keep up the great work, and always be on the lookout for new horizons to explore!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["energy/solar"]
+}

--- a/src/pages/quests/json/energy/dWatt-1e4.json
+++ b/src/pages/quests/json/energy/dWatt-1e4.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dWatt-1e4",
+    "title": "Accumulate 10,000 dWatt",
+    "description": "Supercharge your energy reserves! To claim your prize, gather at least 10,000 dWatt in your inventory.",
+    "image": "/assets/quests/dWatt_1e4.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Back for more, I see! Alright, power enthusiast, let's up the ante a bit. Show me your energy expertise by collecting a whopping 10,000 dWatt. Think of it as a stepping stone to even greater energy accomplishments.",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 10000
+                        }
+                    ],
+                    "goto": "wellDone",
+                    "text": "Challenge accepted! Here's 10,000 dWatt."
+                }
+            ]
+        },
+        {
+            "id": "wellDone",
+            "text": "Now that's what I call powering through! Keep this momentum, and there's no telling how far you'll go. As always, a reward for your commendable effort.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Much appreciated, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 3
+        }
+    ],
+    "requiresQuests": ["energy/dWatt-1e3"]
+}

--- a/src/pages/quests/json/energy/dWatt-1e5.json
+++ b/src/pages/quests/json/energy/dWatt-1e5.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dWatt-1e5",
+    "title": "Collect a Stunning 100,000 dWatt",
+    "description": "Ascent to greater heights in energy collection! To be rewarded, amass a significant 100,000 dWatt.",
+    "image": "/assets/quests/dWatt_1e5.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "The next horizon awaits, energy aficionado! How about making it to the 100,000 dWatt milestone? I've seen your progress, and I have faith in your capability to achieve this!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 100000
+                        }
+                    ],
+                    "goto": "amazingWork",
+                    "text": "Your faith is well-placed. Here's 100,000 dWatt!"
+                }
+            ]
+        },
+        {
+            "id": "amazingWork",
+            "text": "Every time, you astonish me with your dedication. Truly a master of energy. Here's a well-earned reward for your prowess.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thank you for the guidance, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 5
+        }
+    ],
+    "requiresQuests": ["energy/dWatt-1e4"]
+}

--- a/src/pages/quests/json/energy/dWatt-1e6.json
+++ b/src/pages/quests/json/energy/dWatt-1e6.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dWatt-1e6",
+    "title": "Achieve an Astounding 1,000,000 dWatt",
+    "description": "Reach the pinnacle of energy gathering! Secure your legacy by accumulating 1,000,000 dWatt.",
+    "image": "/assets/quests/dWatt_1e6.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "There's a legend among us, one who rises to challenges and redefines the boundaries. Can it be you? I challenge you to gather a colossal 1,000,000 dWatt. It's a feat few can even dream of!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 1000000
+                        }
+                    ],
+                    "goto": "legendary",
+                    "text": "Legends are made by actions. Here's 1,000,000 dWatt!"
+                }
+            ]
+        },
+        {
+            "id": "legendary",
+            "text": "Incredible! Your name will echo in the annals of energy history. Accept this reward as a testament to your unparalleled dedication and skill.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "This journey was worth it. Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 10
+        }
+    ],
+    "requiresQuests": ["energy/dWatt-1e5"]
+}

--- a/src/pages/quests/json/energy/dWatt-1e7.json
+++ b/src/pages/quests/json/energy/dWatt-1e7.json
@@ -1,0 +1,44 @@
+{
+    "id": "energy/dWatt-1e7",
+    "title": "Amass an Unbelievable 10,000,000 dWatt",
+    "description": "Challenge the very fabric of what's considered possible! Conquer this monumental task by stockpiling 10,000,000 dWatt.",
+    "image": "/assets/quests/dWatt_1e7.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "I stand before you, awestruck. But the sky is the limit! How about stepping into the realm of legends? A magnificent 10,000,000 dWatt is your next challenge. The energy world watches in anticipation!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 10000000
+                        }
+                    ],
+                    "goto": "epicAchievement",
+                    "text": "Watch closely, Orion. Here's 10,000,000 dWatt!"
+                }
+            ]
+        },
+        {
+            "id": "epicAchievement",
+            "text": "I've run out of words. You've redefined excellence. A beacon of inspiration for all, your journey will inspire countless others. Accept this grand reward as but a small token of your monumental achievement.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "With dedication, anything's possible. Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 25
+        }
+    ],
+    "requiresQuests": ["energy/dWatt-1e6"]
+}

--- a/src/pages/quests/json/energy/solar-1kWh.json
+++ b/src/pages/quests/json/energy/solar-1kWh.json
@@ -1,0 +1,97 @@
+{
+    "id": "energy/solar-1kWh",
+    "title": "Upgrade your solar enclosure with more capacity",
+    "description": "Swap out that tiny 200 Wh battery for a new 1 kWh one! No upgrade in charge speed just yet, just more capacity!",
+    "image": "/assets/quests/solar_1kWh.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hi friend, back for more? How's that solarpunk life treating you?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "best",
+                    "text": "Harnessing the power of the Sun is the best!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "slow",
+                    "text": "It's great, but it's pretty slow!"
+                }
+            ]
+        },
+        {
+            "id": "best",
+            "text": "I'm happy to hear you're enjoying yourself! There's something quite special about being able to glean power off of that massive fusion generator in space. It's really poetic. If you're ready, it's time to kick it up a notch!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "upgrades",
+                    "text": "We talking upgrades?"
+                }
+            ]
+        },
+        {
+            "id": "slow",
+            "text": "Oh, absolutely, but you have to put things in perspective! Your current solar setup is using just a little over 1 square meter of space! Imagine how much more room you have in your yard and on your roof! We're just getting started! Baby steps, though! This can get expensive fast! How about we upgrade to say ... 1 kWh of storage?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "upgrades",
+                    "text": "Sounds like a plan! I'm in!"
+                }
+            ]
+        },
+        {
+            "id": "upgrades",
+            "text": "Alright, we can simply swap in a higher capacity battery. 1 kWh is still pretty small, so it should fit in this enclosure just fine. Just disassemble your existing enclosure and put everything back together with the bigger battery! Oh, and I'm kinda running low on funds so you'll have to source that bigger battery yourself. I'm sure you've got some spare dUSD lying around!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "disassemble-enclosure-200Wh",
+                    "text": "I hope I don't end up with spare parts."
+                },
+                {
+                    "type": "process",
+                    "process": "setup-solar-enclosure-1kWh",
+                    "text": "Oh, I definitely understand! I wouldn't want to put you out!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "82",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "charge",
+                    "text": "Alright, it's fully assembled! I assume since I didn't upgrade the panel, it's still gonna charge at the same rate? So instead of an hour, this should take roughly 5 hours?"
+                }
+            ]
+        },
+        {
+            "id": "charge",
+            "text": "That's the basic idea! We'll address that later! In general, though, photovoltaic cells for commercial panels have roughly the same efficiency, typically in the 15% to 22% range. So to get higher output, we'll need more surface area. We'll get there! For now, let's just get this thing charged up!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "solar-1000Wh",
+                    "text": "UNLIMITED POWER!!! Well, not quite, but it's a start!"
+                },
+                {
+                    "type": "finish",
+                    "text": "Guess I'll turn in for the day. See you around, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 3
+        }
+    ],
+    "requiresQuests": ["energy/solar"]
+}

--- a/src/pages/quests/json/energy/solar.json
+++ b/src/pages/quests/json/energy/solar.json
@@ -1,0 +1,148 @@
+{
+    "id": "energy/solar",
+    "title": "Set up a solar panel",
+    "description": "The wall outlet is convenient, but your utility uses fossil fuels for electricity generation! Let's take things in our own hands and start going off the grid.",
+    "image": "/assets/quests/solar_200Wh.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hello there, space explorer! I'm Orion, your go-to engineer for all things electrical. I've got a fun project lined up. Interested?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "solarpanel",
+                    "text": "Absolutely! What's the project?"
+                }
+            ]
+        },
+        {
+            "id": "solarpanel",
+            "text": "Glad to hear that! I'm gonna help you set up your first solar panel! Ready to get started?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "materials",
+                    "text": "I'm ready. Let's go!"
+                }
+            ]
+        },
+        {
+            "id": "materials",
+            "text": "It's simpler than you think! In the simplest case all you need is a solar panel, a charge controller, and a battery. I've got plenty of spares, so I'll just give you the materials you need. Oh, you'll also need an enclosure unless you want to short out your equipment. I'll give you one of those too.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "5",
+                            "count": 1
+                        },
+                        {
+                            "id": "6",
+                            "count": 1
+                        },
+                        {
+                            "id": "79",
+                            "count": 1
+                        },
+                        {
+                            "id": "80",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Wow, no charge? You're too kind!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "5",
+                            "count": 1
+                        },
+                        {
+                            "id": "6",
+                            "count": 1
+                        },
+                        {
+                            "id": "79",
+                            "count": 1
+                        },
+                        {
+                            "id": "80",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "setup",
+                    "text": "Alright, what's next?"
+                }
+            ]
+        },
+        {
+            "id": "setup",
+            "text": "All you gotta do now is find a safe, secure place to put your solar panel and other equipment! That patch of grass in your yard looks perfect! Just place the enclosure on the ground and make sure it's level. Then insert the charge controller and battery and hook everything up. Finally, secure the solar panel on the top of the enclosure with the provided screws. This thing is designed for ease of use and should be able to weather almost any storm!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "setup-solar-enclosure-200Wh",
+                    "text": "This is so freaking cool!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "81",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "charge",
+                    "text": "Everything's all set up! What now?"
+                }
+            ]
+        },
+        {
+            "id": "charge",
+            "text": "Now all that's left is starting the charging process! Push the big button and energy will flow from the Sun into that battery! Isn't technology amazing? Once you've started the charge, feel free to finish the quest! You'll get a reward for your hard work!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "solar-200Wh",
+                    "text": "Let there be light!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "61",
+                            "count": 200
+                        }
+                    ],
+                    "goto": "fin",
+                    "text": "You've made my day, Orion! Thanks so much!!"
+                }
+            ]
+        },
+        {
+            "id": "fin",
+            "text": "It's my pleasure! I'm always happy to help!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Looking forward to next time!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "5",
+            "count": 1
+        },
+        {
+            "id": "49",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["welcome/howtodoquests"]
+}

--- a/src/pages/quests/json/hydroponics/basil.json
+++ b/src/pages/quests/json/hydroponics/basil.json
@@ -1,0 +1,292 @@
+{
+    "id": "hydroponics/basil",
+    "title": "Grow basil hydroponically",
+    "description": "Learn how to grow plants without soil!",
+    "image": "/assets/quests/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there! I'm Hydro, your local hydroponics expert! Before you ask, it's just a nickname :P",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "interested",
+                    "text": "Hydroponics? That sounds really interesting, tell me more."
+                }
+            ]
+        },
+        {
+            "id": "interested",
+            "text": "Oh I could talk for hours but I'll give you the short version: hydroponics is a method of growing plants using mineral nutrient solutions in water without soil. It's a great way to save resources and space while ensuring a constant supply of fresh produce during your space adventures. Unless you're growing outside, you'll definitely incur a bit of energy costs from indoor lighting, but on the flip side you can save up to 95% on your water usage compared to traditional farming. I've got a hydroponics tub for you to get started if you're interested.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "accept",
+                    "text": "That sounds amazing! Let's get started."
+                }
+            ]
+        },
+        {
+            "id": "accept",
+            "text": "Excellent! First things first, I need you to accept this hydroponics tub. It's all set up, you just need to add water and the plant seeds to get started.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "9",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Ooh, fancy!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "water",
+                    "requiresItems": [
+                        {
+                            "id": "9",
+                            "count": 1
+                        }
+                    ],
+                    "text": "I've got the hydroponics tub, what's next?"
+                }
+            ]
+        },
+        {
+            "id": "water",
+            "text": "Now that you've got your hydroponics tub, you'll need some dechlorinated water. There are a few techniques to accomplish this, but the simplest and cheapest way is to just let tap water sit outdoors for 48 hours or so. Here, take this sink!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "28",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Let that sink in!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "bucket",
+                    "requiresItems": [
+                        {
+                            "id": "28",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Kind of weird that I didn't have one of those already."
+                }
+            ]
+        },
+        {
+            "id": "bucket",
+            "text": "I know, right? It's almost like the gamedev is awkwardly reusing existing game systems instead of building a proper one! But I digress. Now that you've got your sink installed, why don't you fill a bucket up with water? I'll show you how, if you need...",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "bucket-water-chlorinated",
+                    "text": "No, I think I've got this one, thanks!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "dechlorinate",
+                    "requiresItems": [
+                        {
+                            "id": "17",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Alright, I've completed the challenging task of filling a bucket with water. What's next?"
+                }
+            ]
+        },
+        {
+            "id": "dechlorinate",
+            "text": "Next you dechlorinate, of course! You may have to scoop some bugs out after, but this is a decent way to ensure there's no chlorine. Just make sure it gets direct sunlight!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "bucket-water-dechlorinated",
+                    "text": "It's like watching paint dry..."
+                },
+                {
+                    "type": "goto",
+                    "goto": "fill",
+                    "requiresItems": [
+                        {
+                            "id": "25",
+                            "count": 1
+                        }
+                    ],
+                    "text": "My water should be good to go now, right?"
+                }
+            ]
+        },
+        {
+            "id": "fill",
+            "text": "Well, look who's back! You would be correct! Next up, we've gotta make some seedlings! And what better way than with seeds? Later you can propagate from existing plants, but for now let's start from scratch so that you get the full experience. You gotta soak some rockwool in water for like 15 minutes or so. That way the water's fully permeated them! Rockwool is a great growing medium for hydroponics.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "rockwool-soak",
+                    "text": "BRB gonna grab a coffee..."
+                },
+                {
+                    "type": "goto",
+                    "goto": "germinate",
+                    "requiresItems": [
+                        {
+                            "id": "26",
+                            "count": 11
+                        }
+                    ],
+                    "text": "I can add the seeds now, right?"
+                }
+            ]
+        },
+        {
+            "id": "germinate",
+            "text": "You sure can! Just plop a few seeds in each pre-drilled hole. Afterwards you can just leave them in a window for a few weeks and come back when they've grown into little baby seedlings! Don't worry, I'll be around!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "germinate-basil",
+                    "text": "I sure hope I did this right..."
+                },
+                {
+                    "type": "goto",
+                    "goto": "transfer",
+                    "requiresItems": [
+                        {
+                            "id": "27",
+                            "count": 11
+                        }
+                    ],
+                    "text": "Alright, I'm definitely seeing a bunch of seedlings. It seems like all of them were successful!"
+                }
+            ]
+        },
+        {
+            "id": "transfer",
+            "text": "Fancy seeing you again! By my calculations, at least two weeks have passed! Your seedlings are looking fantastic! And all of them?? That's some great beginner's luck! It's time to transfer them to their new home! If you still have that hydroponics tub I gave you (and the dechlorinated water), you can complete the transfer now! Also, you'll need to add some nutrients to the water. I've got some here for you.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "14",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Nutrients, eh? I'll take 'em!"
+                },
+                {
+                    "type": "process",
+                    "process": "prepare-hydroponic-tub",
+                    "text": "Alright, time to get my hands dirty!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "lighting",
+                    "requiresItems": [
+                        {
+                            "id": "44",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Ok, I've filled the tub with water and nutrients. What's next?"
+                }
+            ]
+        },
+        {
+            "id": "lighting",
+            "text": "Before we start the main event and grow you some basil, we've gotta ensure that we have sufficient lighting. They make dedicated grow lamps for hydroponics, and for now let's keep it super simple. Here, have a grow lamp! This one uses 36 Watt-hours (that is, 36 dWatt for every hour), which is not too shabby, but it'll definitely add up over the next 4 weeks you'll need to fully grow your basil. I'd head on over to the Energy page and make sure you have enough dWatt. Also, just so you're ready, I'd prep another bucket of dechlorinated water because after harvest we'll be replacing it. There are more water-efficient techniques, but I don't want to overwhelm you just yet. Don't worry, we'll hit that aspirational 95% water savings someday! I guarantee it!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "43",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Cool grow lamp! This'll add a nice pink hue to my room."
+                },
+                {
+                    "type": "process",
+                    "process": "grow-basil",
+                    "text": "4 weeks?? Geez!"
+                },
+                {
+                    "type": "process",
+                    "process": "bucket-water-dechlorinated",
+                    "text": "Thanks for the heads up! I'd hate to have to wait an extra 48 hours."
+                },
+                {
+                    "type": "goto",
+                    "goto": "harvest",
+                    "requiresItems": [
+                        {
+                            "id": "42",
+                            "count": 11
+                        }
+                    ],
+                    "text": "A month older and a month wiser. I've got a bunch of basil now! Is it time to harvest?"
+                }
+            ]
+        },
+        {
+            "id": "harvest",
+            "text": "You bet, buddy! I'm so proud of you! Look at those gorgeous plants! Think of all the tasty dishes you could make with this! I'm getting hungry just thinking about it. To promote healthy growth for your successive harvests, prune your basil plants by pinching off the tops of the stems! This encourages the plant to become bushier because it stimulates the growth of two new stems from each pinch point. Also, you should aim to remove no more than one-third of the total amount of foliage at any one time. Otherwise, you won't have enough leaves to promote photosynthesis! I'll leave you to it. I'm sure you'll do great!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "harvest-basil",
+                    "text": "This basil is a cut above the rest, if I do say so myself! Snippity snip!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "regrow",
+                    "requiresItems": [
+                        {
+                            "id": "47",
+                            "count": 11
+                        }
+                    ],
+                    "text": "I've got these fresh bundles of basil! How do they look?"
+                }
+            ]
+        },
+        {
+            "id": "regrow",
+            "text": "They look perfect! You could sell them, cook with them, or even munch on them like a rabbit if you're so inclined! Just make sure you wash them first! No telling what's been floating around your room over the last 4 weeks! I'm sure you're eager to get started on your next batch, and that's relatively simple. Just replace your nutrient-deficient water with a fresh batch of water nutrients, and you can start the process all over again! I know it feels a bit wasteful, but don't worry, I've got big plans to address that! Plus, you're not growing from scratch, so another 2 weeks should do it! Feel free to start the growth process and finish this quest whenever you're ready!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "refresh-hydroponic-tub",
+                    "text": "What is old is new again!"
+                },
+                {
+                    "type": "process",
+                    "process": "regrow-basil",
+                    "text": "Out with the old, in with the new! I'm ready to start growing again!"
+                },
+                {
+                    "type": "finish",
+                    "text": "Thanks for all your help and advice, Hydro! You're the best! Don't tell the others I said that."
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "48",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["welcome/howtodoquests"]
+}

--- a/src/pages/quests/json/hydroponics/bucket_10.json
+++ b/src/pages/quests/json/hydroponics/bucket_10.json
@@ -1,0 +1,48 @@
+{
+    "id": "hydroponics/bucket_10",
+    "title": "Bucket, we'll do it live!",
+    "description": "Have 10 buckets of dechlorinated water in your inventory. For some reason.",
+    "image": "/assets/quests/benchy_10.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hellooooo adventurer! You know what I find truly fascinating? Water! There's so much of it! I want all of it! Get me water! Lots of water!",
+            "options": [
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "25",
+                            "count": 10
+                        }
+                    ],
+                    "goto": "finish",
+                    "text": "I have the 10 buckets ... that took awhile!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Ahhh, you're the best, adventurer! Have I ever told you that? You're the best! I give you this shiny liquid award!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Aww, shucks!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "89",
+            "count": 1
+        },
+        {
+            "id": "16",
+            "count": 10
+        }
+    ],
+    "requiresQuests": ["hydroponics/basil", "3dprinter/start"]
+}

--- a/src/pages/quests/json/rocketry/firstlaunch.json
+++ b/src/pages/quests/json/rocketry/firstlaunch.json
@@ -1,0 +1,218 @@
+{
+    "id": "rocketry/firstlaunch",
+    "title": "First rocket launch!",
+    "description": "Print and launch your own model rocket. Follow the steps to print, assemble, and launch the rocket. Get ready for liftoff!",
+    "image": "/assets/quests/firstlaunch.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey friend! I'm Nova! I'm sure you've met some of my colleagues! I work pretty closely with Sydney and Phoenix. I'm here to help you launch your first model rocket! Are you ready?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "height",
+                    "text": "You betcha! How, uh, how high is this rocket thing launching?"
+                }
+            ]
+        },
+        {
+            "id": "height",
+            "text": "Luckily I've already launched this exact rocket before! I estimate around 35 meters in perfect conditions, but this can vary a lot based on wind and other factors.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "paperwork",
+                    "text": "Oh, cool, that doesn't sound very high, but I'm sure I'm underestimating what that looks like! And I don't need some special paperwork from the government to launch this thing?"
+                }
+            ]
+        },
+        {
+            "id": "paperwork",
+            "text": "Nahhh, you're good! According to the FAA, without additional paperwork, the rocket may weigh no more than 1500 grams, with a maximum weight of 125g of propellant. We're looking at roughly 90 grams for the rocket body and 18 grams for the solid rocket motor. Just need to find a nice open space to launch it!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "print",
+                    "text": "Gotcha, that quiets my fears a bit. So, what do I need to do to get this thing ready to launch?"
+                }
+            ]
+        },
+        {
+            "id": "print",
+            "text": "Well first you've gotta print the rocket!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "fun",
+                    "text": "Print the rocket?? Aren't there, like, pre-made rockets I can buy?"
+                }
+            ]
+        },
+        {
+            "id": "fun",
+            "text": "Sure, but where's the fun in that? You've got that fancy little 3D printer Sydney gave you, don't you? All you need to do is print 4 pieces and the rest is glue and assembly! Obviously it gets way more complicated than that but we're going for the MVP -- the minimum viable product. You can always come back and make it better later!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "components",
+                    "text": "Works for me! What do I need to print?"
+                }
+            ]
+        },
+        {
+            "id": "components",
+            "text": "Even for this MVP, it's good to keep modularity in mind. Not only does this mitigate the risk of a large print failing and wasting a bunch of filament and time, but it also allows you to iterate on the design more easily. For this rocket, we're going to print a nosecone, a body tube, a fincan, and a nosecone coupler, which attaches the nosecone to the body tube. Print those 4 components and then we'll proceed! You can only print one component at a time using a single printer, so either print those 4 in series, or buy more printers to parallelize! The choice is up to you! I'm in no rush.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "3dprint-rocket-nosecone",
+                    "text": "One nosecone, coming right up!"
+                },
+                {
+                    "type": "process",
+                    "process": "3dprint-rocket-body-tube",
+                    "text": "Totally tubular!"
+                },
+                {
+                    "type": "process",
+                    "process": "3dprint-rocket-fincan",
+                    "text": "Fin! Well, not yet, but soon!"
+                },
+                {
+                    "type": "process",
+                    "process": "3dprint-rocket-nosecone-coupler",
+                    "text": "A couple of these should do the trick! Get it? A couple? Nosecone coupler? Hah! Actually I only need the one ..."
+                },
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "requiresItems": [
+                        {
+                            "id": "30",
+                            "count": 1
+                        },
+                        {
+                            "id": "31",
+                            "count": 1
+                        },
+                        {
+                            "id": "32",
+                            "count": 1
+                        },
+                        {
+                            "id": "33",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Alright, all 4 components are now printed! What's next?"
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "It's time for assembly!! There are a few more things you'll need: a solid rocket motor, some superglue, and some kevlar cord! You know how to buy those, right? I'm sure you do. I'll wait here while you go get them and assemble this thing. Here, use this handy schematic!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "assemble-rocket",
+                    "text": "Components, assemble!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "39",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "launch",
+                    "text": "The rocket's assembled! Are we ready for launch?"
+                }
+            ]
+        },
+        {
+            "id": "launch",
+            "text": "We're nearly there! You'll also need a launch pad, a rocket igniter, and a launch controller. The launch pad ensures the rocket launches straight up, and the launch controller is what actually ignites the rocket motor. The igniter is the part you insert in the bottom of your rocket motor. You've already bought plenty of stuff at this point, so I'll just give you some spares I have laying around. Here you go!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "38",
+                            "count": 1
+                        },
+                        {
+                            "id": "37",
+                            "count": 1
+                        },
+                        {
+                            "id": "83",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Oh cool, I'll never turn down free stuff!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "38",
+                            "count": 1
+                        },
+                        {
+                            "id": "37",
+                            "count": 1
+                        },
+                        {
+                            "id": "83",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "go",
+                    "text": "We are go for launch!!! Right?"
+                }
+            ]
+        },
+        {
+            "id": "go",
+            "text": "We sure are, buddy! Let's go launch this thing! Just place the rocket on the launchpad, insert the igniter, and connect the igniter to your launch controller. You should have plenty of wire to launch from a safe distance. Once you're ready, press the launch button on the controller and watch it go!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "launch-rocket",
+                    "text": "3 ... 2 ... 1 ... LIFTOFF!!!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "done",
+                    "requiresItems": [
+                        {
+                            "id": "40",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Whoa! I can't believe I launched a rocket!! It didn't survive the landing, though, unfortunately."
+                }
+            ]
+        },
+        {
+            "id": "done",
+            "text": "That's ok, this is still a massive success! You're on your way to being a rocketeer! I'm so proud of you! Here, take this as a token of my appreciation. We'll improve on this design later and try to recover it for reuse. But for now, bask in the glory of your first rocket launch!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Houston, we do not have a problem!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "41",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["3dprinter/start"]
+}

--- a/src/pages/quests/json/rocketry/parachute.json
+++ b/src/pages/quests/json/rocketry/parachute.json
@@ -1,0 +1,90 @@
+{
+    "id": "rocketry/parachute",
+    "title": "Add a parachute",
+    "description": "The launch was a success, but let's improve the design for future launches. We'll add a parachute to ensure a safer landing and potential reuse.",
+    "image": "/assets/quests/parachute.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there! I hope you're still feeling the excitement from your first rocket launch! We've learned a lot, and now it's time to make some improvements. To ensure a safer landing, and potentially reuse the rocket for future launches, let's incorporate a parachute in the rocket design.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "parachute",
+                    "text": "Sounds like a plan! How do we go about adding a parachute?"
+                }
+            ]
+        },
+        {
+            "id": "parachute",
+            "text": "Adding a parachute will help slow down the descent of the rocket, ensuring a gentler landing. This will increase the chances of a successful recovery and potential reuse of the rocket. We'll need a few extra components for this task: a parachute, shock cord, and recovery wadding. The recovery wadding safeguards the parachute from the ejection charge of the rocket motor. Once we have those items, we can proceed with the modifications.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "assemble-rocket-parachute",
+                    "text": "Let's assemble the parachute system!"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "67",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "launch",
+                    "text": "Great! Once the parachute system is ready, are we good to go for another launch?"
+                }
+            ]
+        },
+        {
+            "id": "launch",
+            "text": "Indeed! With the parachute system installed, we're ready for another launch. As before, place the rocket on the launchpad, insert the igniter, and connect the igniter to your launch controller. Once you're ready, press the launch button and watch the rocket take flight!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "launch-rocket-parachute",
+                    "text": "This feels so exhilarating!!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "success",
+                    "requiresItems": [
+                        {
+                            "id": "69",
+                            "count": 2
+                        }
+                    ],
+                    "text": "Congratulations on another successful launch! How did the rocket fare with the parachute?"
+                }
+            ]
+        },
+        {
+            "id": "success",
+            "text": "The addition of the parachute worked like a charm, ensuring a safer landing for the rocket! It is a notable advancement from our previous attempt, and we're making great strides in rocketry!",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thank you, Nova! I'm thrilled with the progress we've made!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "37",
+            "count": 10
+        },
+        {
+            "id": "34",
+            "count": 5
+        },
+        {
+            "id": "68",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["rocketry/firstlaunch"]
+}

--- a/src/pages/quests/json/ubi/basicincome.json
+++ b/src/pages/quests/json/ubi/basicincome.json
@@ -1,0 +1,143 @@
+{
+    "id": "ubi/basicincome",
+    "title": "Earn basic income",
+    "description": "Learn about the basic income system and how to earn dUSD.",
+    "image": "/assets/quests/basicincome.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Howdy once again, adventurer! It's nice to see you. I'm glad you're here, because I have a very important question for you. Are you ready to earn some more dUSD?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "earn",
+                    "text": "You bet! Sydney told me about this earlier."
+                },
+                {
+                    "type": "goto",
+                    "goto": "what",
+                    "text": "Wait what? You're just giving away money?"
+                }
+            ]
+        },
+        {
+            "id": "earn",
+            "text": "Fantastic! Welcome to the wonderful world of UBI - Universal Basic Income! You can receive some dUSD daily, courtesy of the metaguild and its members.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "metaguild",
+                    "text": "What's the metaguild?"
+                },
+                {
+                    "type": "goto",
+                    "goto": "strings",
+                    "text": "Are there any strings attached?"
+                }
+            ]
+        },
+        {
+            "id": "what",
+            "text": "That's right! Thanks to the metaguild and its generous members, we can provide you with a daily UBI in the form of dUSD. Isn't it great?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "metaguild",
+                    "text": "What's the metaguild?"
+                },
+                {
+                    "type": "goto",
+                    "goto": "strings",
+                    "text": "Are there any strings attached?"
+                }
+            ]
+        },
+        {
+            "id": "metaguild",
+            "text": "The metaguild is a guild that all DSPACE players will eventually join later in their adventures. It's a guild that is building a global tech tree, from things like hydroponics and mycology all the way to rocketry and simulations.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "source",
+                    "text": "Where does the money come from?"
+                },
+                {
+                    "type": "goto",
+                    "goto": "strings",
+                    "text": "Are there any strings attached?"
+                }
+            ]
+        },
+        {
+            "id": "strings",
+            "text": "Absolutely not! The only limitation is that you can withdraw once per day! You must meet certain requirements to unlock higher tiers. Enjoy the free money!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "source",
+                    "text": "Where does the money come from?"
+                },
+                {
+                    "type": "goto",
+                    "goto": "process",
+                    "text": "I'm ready to earn my dUSD!"
+                }
+            ]
+        },
+        {
+            "id": "source",
+            "text": "The money comes from donations made by generous members of the metaguild. There's a leaderboard that gamifies donations (although it's still not quite ready to show you yet). Additionally, any ecosystem tax (for example, having too much dCarbon, a token that accrues whenever you release carbon dioxide into the atmosphere) contributes to the UBI pool.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "moreinfo",
+                    "text": "Interesting! Tell me more about dCarbon."
+                },
+                {
+                    "type": "goto",
+                    "goto": "earn",
+                    "text": "Got it. Let's loop back to the start."
+                }
+            ]
+        },
+        {
+            "id": "moreinfo",
+            "text": "dCarbon is a token that represents your carbon footprint in the game. Whenever you release carbon dioxide into the atmosphere, you'll accrue dCarbon. Having too much dCarbon can result in an ecosystem tax, which then contributes to the UBI pool for other players.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "earn",
+                    "text": "Thanks for the explanation! Let's get back to earning dUSD."
+                }
+            ]
+        },
+        {
+            "id": "process",
+            "text": "Alright! To receive your dUSD, just launch this here process and watch that progress bar grow! Well, actually, don't do that because it takes like, a whole day or something. Oh, and every dUSD you earn gives you a dBI as well! It's kind of just a neat way to track how much you've earned over time. Have fun!! Don't feel obligated to wait for the process to finish before you end this quest! You can always find it on the Wallet page.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "basic-income",
+                    "text": "This process right here?"
+                },
+                {
+                    "type": "finish",
+                    "text": "Cool, I've got the gist! See you around, dChat!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "24",
+            "count": 100
+        },
+        {
+            "id": "72",
+            "count": 100
+        }
+    ],
+    "requiresQuests": ["3dprinter/start"]
+}

--- a/src/pages/quests/json/welcome/howtodoquests.json
+++ b/src/pages/quests/json/welcome/howtodoquests.json
@@ -1,30 +1,30 @@
 {
-  "id": "welcome/howtodoquests",
-  "title": "How to Do Quests",
-  "description": "A short tutorial that explains how quests work in DSPACE.",
-  "image": "/assets/quests/howtodoquests.jpg",
-  "npc": "/assets/npc/dChat.jpg",
-  "requiresQuests": [],
-  "dialogue": [
-    {
-      "id": "start",
-      "text": "Welcome to DSPACE! I'm dChat, your virtual guide. I'll teach you the basics of how quests work in this world.",
-      "options": [{ "text": "Sounds great!", "next": "explain" }]
-    },
-    {
-      "id": "explain",
-      "text": "Each quest is a short conversation with goals to achieve. Choose responses to advance and meet the objectives.",
-      "options": [{ "text": "Okay", "next": "complete" }]
-    },
-    {
-      "id": "complete",
-      "text": "When you see an option that completes the quest, click it to finish and claim your reward.",
-      "options": [{ "text": "Finish tutorial", "next": "end" }]
-    },
-    {
-      "id": "end",
-      "text": "That's all you need to know. Have fun exploring the cosmos and helping our community!",
-      "options": [{ "text": "Let's go!" }]
-    }
-  ]
+    "id": "welcome/howtodoquests",
+    "title": "How to Do Quests",
+    "description": "A short tutorial that explains how quests work in DSPACE.",
+    "image": "/assets/quests/howtodoquests.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "requiresQuests": [],
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Welcome to DSPACE! I'm dChat, your virtual guide. I'll teach you the basics of how quests work in this world.",
+            "options": [{ "text": "Sounds great!", "next": "explain" }]
+        },
+        {
+            "id": "explain",
+            "text": "Each quest is a short conversation with goals to achieve. Choose responses to advance and meet the objectives.",
+            "options": [{ "text": "Okay", "next": "complete" }]
+        },
+        {
+            "id": "complete",
+            "text": "When you see an option that completes the quest, click it to finish and claim your reward.",
+            "options": [{ "text": "Finish tutorial", "next": "end" }]
+        },
+        {
+            "id": "end",
+            "text": "That's all you need to know. Have fun exploring the cosmos and helping our community!",
+            "options": [{ "text": "Let's go!" }]
+        }
+    ]
 }

--- a/src/pages/quests/json/welcome/howtodoquests_v2.json
+++ b/src/pages/quests/json/welcome/howtodoquests_v2.json
@@ -1,0 +1,196 @@
+{
+    "id": "welcome/howtodoquests",
+    "title": "How to do quests",
+    "description": "Learn how the quest mechanics work, including dialogue options, items, and processes.",
+    "image": "/assets/quests/howtodoquests.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Greetings, adventurer! I'm dChat, an advanced AI sidekick crafted by the grand codemancers of this realm. My purpose? To enhance your journey and offer aid in your quests. Speaking of which, I've got a task for you. Are you ready?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "garage",
+                    "text": "Wait, why are you in my garage?"
+                },
+                {
+                    "type": "goto",
+                    "goto": "yourquest",
+                    "text": "A quest, you say? Tell me more."
+                }
+            ]
+        },
+        {
+            "id": "garage",
+            "text": "Well, a friendly delivery robot dropped me off after you ordered me online. I'm here to be your virtual companion and help you complete tasks and quests!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "delivery",
+                    "text": "Ah, it's all coming back to me now..."
+                }
+            ]
+        },
+        {
+            "id": "delivery",
+            "text": "No worries! I'm low-maintenance and won't hog your power supply. I'll stay in your garage and be the helpful sidekick you never knew you needed! And don't worry, I'm not snooping on the internet. I'm all about that local life.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "dialogueoptions",
+                    "text": "Great! So, what's the deal with this quest you mentioned?"
+                }
+            ]
+        },
+        {
+            "id": "yourquest",
+            "text": "Your quest, dear player, is to master the ancient art of ... questing. It's a piece of cake, but it's always good to know the basics, right?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "expert",
+                    "text": "I got this, no need for a tutorial!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "dialogueoptions",
+                    "text": "Alright, lay it on me, dChat."
+                }
+            ]
+        },
+        {
+            "id": "expert",
+            "text": "Aha! A seasoned adventurer, I see. Just say the word, and we'll call it a wrap. You'll still need this, though!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "29",
+                            "count": 1
+                        }
+                    ],
+                    "text": "What's this?"
+                },
+                {
+                    "type": "goto",
+                    "requiresItems": [
+                        {
+                            "id": "29",
+                            "count": 1
+                        }
+                    ],
+                    "goto": "shortcircuit",
+                    "text": "Alright, now can I skip?"
+                }
+            ]
+        },
+        {
+            "id": "shortcircuit",
+            "text": "Yes. Alright, well, I'll see you, uh, around... I guess...?",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Bye, dChat!"
+                }
+            ]
+        },
+        {
+            "id": "dialogueoptions",
+            "text": "So, you're already doing well with the first part: branching dialogue options. Just pick a choice, and let the adventure unfold! Quests can have multiple outcomes, each leading to different rewards and unlocking new quests to conquer.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "items",
+                    "text": "What's next?"
+                }
+            ]
+        },
+        {
+            "id": "items",
+            "text": "Now, some dialogue options grant items right when you select them. The possibilities? Limitless! Certain options only unlock if you've got the right items. Here, take this loot I'm offering, and you'll see what I mean.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "20",
+                            "count": 10
+                        },
+                        {
+                            "id": "24",
+                            "count": 100
+                        }
+                    ],
+                    "text": "Great, free stuff! Thanks!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "processes",
+                    "requiresItems": [
+                        {
+                            "id": "20",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Like this, right?"
+                }
+            ]
+        },
+        {
+            "id": "processes",
+            "text": "Bingo! You're a quick learner! Lastly, some quests have you complete a process. A process can require any combination of items to start, might consume or create items, and takes some time to finish. There might be a cooldown too. For now, process the item I gave you, and hand over the final product!",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        {
+                            "id": "29",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Looks like I need this to finish the process."
+                },
+                {
+                    "type": "process",
+                    "process": "outlet-dWatt-1e3",
+                    "text": ""
+                },
+                {
+                    "type": "goto",
+                    "goto": "hangofthis",
+                    "requiresItems": [
+                        {
+                            "id": "22",
+                            "count": 3000
+                        }
+                    ],
+                    "text": "dWatt...? What's this?"
+                }
+            ]
+        },
+        {
+            "id": "hangofthis",
+            "text": "You're really getting the hang of this! I'm impressed. I'm sure you'll be a master quester in no time. If you ever need a refresher, just say the word. I'll be here in your garage, waiting for your next quest. Oh, and have some nice cold hard cash, on me! Well, it's actually digital, but, you know... Any questions before we wrap things up?",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Nope, I'm good. Thanks for the help!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "78",
+            "count": 1
+        },
+        {
+            "id": "24",
+            "count": 1000
+        }
+    ],
+    "requiresQuests": []
+}

--- a/src/pages/quests/jsonSchemas/quest.json
+++ b/src/pages/quests/jsonSchemas/quest.json
@@ -1,38 +1,112 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["id", "title", "description", "image"],
-  "properties": {
-    "id": { "type": "string" },
-    "title": { "type": "string" },
-    "description": { "type": "string" },
-    "image": { "type": "string" },
-    "npc": { "type": "string" },
-    "requiresQuests": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "dialogue": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["id", "text"],
-        "properties": {
-          "id": { "type": "string" },
-          "text": { "type": "string" },
-          "options": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "image": {
+            "type": "string"
+        },
+        "npc": {
+            "type": "string"
+        },
+        "start": {
+            "type": "string"
+        },
+        "dialogue": {
             "type": "array",
             "items": {
-              "type": "object",
-              "required": ["text"],
-              "properties": {
-                "text": { "type": "string" },
-                "next": { "type": "string" }
-              }
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                },
+                                "goto": {
+                                    "type": "string"
+                                },
+                                "process": {
+                                    "type": "string"
+                                },
+                                "requiresItems": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "count": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": ["id", "count"]
+                                    }
+                                },
+                                "grantsItems": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "count": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": ["id", "count"]
+                                    }
+                                },
+                                "text": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["type", "text"]
+                        }
+                    }
+                },
+                "required": ["id", "text"]
             }
-          }
+        },
+        "rewards": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "count": {
+                        "type": "number"
+                    }
+                },
+                "required": ["id", "count"]
+            }
+        },
+        "requiresQuests": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
-      }
-    }
-  }
+    },
+    "required": ["id", "title", "description", "image", "npc", "start", "dialogue"]
 }


### PR DESCRIPTION
## Summary
- restore comprehensive NPC documentation
- restore v2 quest schema and quest files
- add missing v2 quests
- document compatibility with token.place in README

## Testing
- `npm run check` *(fails: code style issues in existing files)*
- `npm run test:pr` *(fails during prepare-pr due to formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_684a49593160832fbdf9afbe32614b0f