### PR TITLE
Add finish requirement checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ These guidelines apply to all files in this repository.
     `src/pages/quests/jsonSchemas` when adding quests.
 -   Ensure quest dialogue contains at least a start, middle, and completion node
     with at least one option per node.
+-   Include a `finish` option in the final node so quests end cleanly. Quests
+    without a finish option will fail canonical tests.
 -   Document any new or updated NPCs in `src/pages/docs/md/npcs.md`.
 
 ## Pull Request Message

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ profiles in `src/pages/docs/md/npcs.md`. The schema now supports advanced
 fields such as `start`, `rewards` and item requirements, so older quests from
 the v2 era remain valid. Keep the NPC file updated when adding new characters.
 
+To validate that quests use a canonical structure with clear start and finish
+steps, run the dedicated test:
+
+```bash
+npm test -- questCanonical
+```
+
+Additional quality checks are available:
+
+```bash
+npm test -- questQuality        # heuristics for dialogue quality (TODO: integrate OpenAI)
+npm test -- imageReferences     # verifies quest and NPC image files
+```
+
+
 > **Tip:** The quest format is compatible with projects like
 > [`token.place`](https://github.com/futuroptimist/token.place), so content can be
 > shared across repos.

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -87,6 +87,7 @@ webServer: {
 ```
 
 This configuration:
+
 1. Starts a server using `npm run dev` before tests begin
 2. Waits for the server to be available at `http://localhost:3002`
 3. Runs tests against this server
@@ -103,9 +104,9 @@ This configuration:
 We have automated checks to ensure no test files are orphaned from the test workflow:
 
 1. The `test-coverage.spec.ts` file verifies:
-   - All E2E tests are included in our test groups
-   - Important Jest test files are properly configured
-   - Your browser environment supports the capabilities needed for testing
+    - All E2E tests are included in our test groups
+    - Important Jest test files are properly configured
+    - Your browser environment supports the capabilities needed for testing
 
 This test runs as part of the `test:pr` and `test:e2e:groups` commands.
 
@@ -116,64 +117,71 @@ This test runs as part of the `test:pr` and `test:e2e:groups` commands.
 When creating new test files:
 
 1. For E2E tests:
-   - Place `.spec.ts` files in the `frontend/e2e/` directory
-   - Add them to a test group in `frontend/scripts/run-test-groups.mjs`
+
+    - Place `.spec.ts` files in the `frontend/e2e/` directory
+    - Add them to a test group in `frontend/scripts/run-test-groups.mjs`
 
 2. For Jest tests:
-   - Place `.test.js` files in the `frontend/__tests__/` directory
-   - Ensure they match the patterns in Jest's `testMatch` configuration
+    - Place `.test.js` files in the `frontend/__tests__/` directory
+    - Ensure they match the patterns in Jest's `testMatch` configuration
 
 ### Best Practices for Tests
 
 1. **Make Tests Skip Gracefully**: Use conditional skipping when features may not be available
-   ```typescript
-   if (!(await page.locator('#feature-element').count())) {
-     test.skip(true, 'Feature not available in this environment');
-   }
-   ```
+
+    ```typescript
+    if (!(await page.locator('#feature-element').count())) {
+        test.skip(true, 'Feature not available in this environment');
+    }
+    ```
 
 2. **Use Proper Waiting**: Always wait for network idle or specific elements to be visible
-   ```typescript
-   await page.waitForLoadState('networkidle');
-   await page.locator('.element').waitFor({ state: 'visible' });
-   ```
+
+    ```typescript
+    await page.waitForLoadState('networkidle');
+    await page.locator('.element').waitFor({ state: 'visible' });
+    ```
 
 3. **Handle Both Client and Server Rendering**: Account for hydration in tests
-   ```typescript
-   // Wait for hydration to complete
-   await page.locator('[data-hydrated="true"]').first().waitFor();
-   ```
+    ```typescript
+    // Wait for hydration to complete
+    await page.locator('[data-hydrated="true"]').first().waitFor();
+    ```
 
 ## Debugging Test Failures
 
 When tests fail, several options are available for debugging:
 
 1. **View Test Report**:
-   ```bash
-   npx playwright show-report test-results/html-report
-   ```
+
+    ```bash
+    npx playwright show-report test-results/html-report
+    ```
 
 2. **View Browser Traces**:
-   ```bash
-   npx playwright show-report test-results/html-report --tracing
-   ```
+
+    ```bash
+    npx playwright show-report test-results/html-report --tracing
+    ```
 
 3. **Run Tests in UI Mode**:
-   ```bash
-   npm run test:e2e:ui
-   ```
+
+    ```bash
+    npm run test:e2e:ui
+    ```
 
 4. **Run Tests in Debug Mode**:
-   ```bash
-   PWDEBUG=1 npx playwright test e2e/my-failing-test.spec.ts
-   ```
+    ```bash
+    PWDEBUG=1 npx playwright test e2e/my-failing-test.spec.ts
+    ```
 
 ## Continuous Integration
 
 In CI environments, tests run with special settings:
-- No server reuse (`reuseExistingServer: false`)
-- Headless browsers
-- Parallel execution based on available CPU cores
+
+-   No server reuse (`reuseExistingServer: false`)
+-   Headless browsers
+-   Parallel execution based on available CPU cores
 
 The `test:pr` command simulates this environment locally before you submit a PR.
 
@@ -200,17 +208,23 @@ describe('ItemForm Component', () => {
 We have specialized tests to ensure content quality:
 
 1. **Quest Quality Tests** (`questQuality.test.js`):
-   - Validates NPC dialogue style consistency
-   - Checks for ethical considerations in aquarium quests
-   - Verifies proper quest progression and dependencies
-   - Identifies dialogue that doesn't match NPC personalities
+
+    - Validates NPC dialogue style consistency
+    - Checks for ethical considerations in aquarium quests
+    - Verifies proper quest progression and dependencies
+    - Identifies dialogue that doesn't match NPC personalities
+    - Uses simple heuristics for now; integration with the OpenAI API is planned
 
 2. **Image Reference Tests** (`imageReferences.test.js`):
-   - Scans all quest JSON files for image references 
-   - Verifies that referenced images exist in the public directory
-   - Checks for proper image naming conventions
-   - Suggests similar images when references are broken
-   
+    - Scans all quest JSON files for image references
+    - Verifies that referenced images exist in the public directory
+    - Checks for proper image naming conventions
+    - Suggests similar images when references are broken
+3. **Quest Canonical Tests** (`questCanonical.test.js`):
+    - Ensures each quest includes a start node
+    - Requires at least one intermediate step and a finish option
+    - Helps keep quest dialogue consistent across repos
+
 These tests are designed to produce warnings rather than failures, allowing for ongoing development while still identifying quality issues to address.
 
 To run these tests specifically:
@@ -218,6 +232,7 @@ To run these tests specifically:
 ```bash
 npm test -- questQuality
 npm test -- imageReferences
+npm test -- questCanonical
 ```
 
 ### End-to-End Tests
@@ -684,9 +699,10 @@ npm test -- imageReferences
 ```
 
 If you encounter warnings about missing or incorrect images:
-- Check the image paths in your quest JSON files
-- Ensure all images are placed in the correct directory structure
-- Verify that images meet the size and dimension requirements
+
+-   Check the image paths in your quest JSON files
+-   Ensure all images are placed in the correct directory structure
+-   Verify that images meet the size and dimension requirements
 
 ### End-to-End Tests
 

--- a/frontend/__tests__/questCanonical.test.js
+++ b/frontend/__tests__/questCanonical.test.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+describe('Quest canonical structure', () => {
+    const questDir = path.join(__dirname, '../src/pages/quests/json');
+    const files = glob.sync(path.join(questDir, '**/*.json'));
+
+    files.forEach((file) => {
+        const quest = JSON.parse(fs.readFileSync(file));
+        const questName = path.relative(questDir, file);
+
+        test(`${questName} follows canonical structure`, () => {
+            const startId = quest.start || 'start';
+            const startNode =
+                quest.dialogue.find((n) => n.id === startId) ||
+                quest.dialogue.find((n) => n.id === 'start');
+            expect(startNode).toBeTruthy();
+            expect(startNode.options && startNode.options.length > 0).toBe(true);
+
+            // At least three dialogue nodes (start, middle, finish)
+            expect(quest.dialogue.length).toBeGreaterThanOrEqual(3);
+
+            // The final node must present a finish option
+            const lastNode = quest.dialogue[quest.dialogue.length - 1];
+            const hasFinish = Array.isArray(lastNode.options) &&
+                lastNode.options.some((o) => o.type === 'finish');
+            expect(hasFinish).toBe(true);
+        });
+    });
+});

--- a/src/pages/quests/json/aquaria/breeding.json
+++ b/src/pages/quests/json/aquaria/breeding.json
@@ -4,12 +4,18 @@
     "description": "Learn how to breed guppies and raise the fry.",
     "image": "/assets/quests/guppy-breeding.jpg",
     "npc": "/assets/npc/vega.jpg",
+    "start": "start",
     "requiresQuests": ["aquaria/guppy"],
     "dialogue": [
         {
             "id": "start",
             "text": "To breed guppies, select a healthy male and female and place them in a separate breeding tank with plenty of cover.",
-            "options": [{ "text": "Pair selected", "next": "cover" }]
+            "options": [{ "text": "Pair selected", "next": "condition" }]
+        },
+        {
+            "id": "condition",
+            "text": "Feed them quality live or frozen foods for a week to condition them for spawning.",
+            "options": [{ "text": "They're conditioned", "next": "cover" }]
         },
         {
             "id": "cover",
@@ -19,12 +25,17 @@
         {
             "id": "fry",
             "text": "After a few days you'll notice tiny fry swimming near the surface. Feed them powdered food or baby brine shrimp.",
-            "options": [{ "text": "They're growing", "next": "finish" }]
+            "options": [{ "text": "They're growing", "next": "raise" }]
+        },
+        {
+            "id": "raise",
+            "text": "Keep the adults separated so they don't eat the fry. Frequent small water changes help the babies grow quickly.",
+            "options": [{ "text": "They're thriving", "next": "finish" }]
         },
         {
             "id": "finish",
-            "text": "Keep the water pristine and separate adults if they harass the fry. Soon you'll have a healthy new generation.",
-            "options": [{ "text": "Can't wait!" }]
+            "text": "Soon your young guppies will be large enough to join the main tank or trade with friends.",
+            "options": [{ "type": "finish", "text": "Can't wait!" }]
         }
     ]
 }

--- a/src/pages/quests/json/aquaria/guppy.json
+++ b/src/pages/quests/json/aquaria/guppy.json
@@ -4,12 +4,18 @@
     "description": "Introduce guppies to your established tank.",
     "image": "/assets/quests/guppy.jpg",
     "npc": "/assets/npc/vega.jpg",
+    "start": "start",
     "requiresQuests": ["aquaria/walstad"],
     "dialogue": [
         {
             "id": "start",
             "text": "Your Walstad tank is thriving. It's time to add some colorful guppies to create a lively community.",
-            "options": [{ "text": "I'm ready", "next": "acclimate" }]
+            "options": [{ "text": "I'm ready", "next": "quarantine" }]
+        },
+        {
+            "id": "quarantine",
+            "text": "Quarantine new fish for at least a week in a bare tank to watch for illness before they join the community.",
+            "options": [{ "text": "They're healthy", "next": "acclimate" }]
         },
         {
             "id": "acclimate",
@@ -24,7 +30,17 @@
         {
             "id": "observe",
             "text": "Feed a small pinch of food and observe their behavior. Healthy guppies will explore every corner of the tank.",
-            "options": [{ "text": "Thanks for the tips!" }]
+            "options": [{ "text": "Looking good", "next": "enjoy" }]
+        },
+        {
+            "id": "enjoy",
+            "text": "Monitor water quality for the next few days and add plants for extra cover. Soon the guppies will brighten up the tank.",
+            "options": [{ "text": "Thanks for the tips!", "next": "finish" }]
+        },
+        {
+            "id": "finish",
+            "text": "You've successfully introduced community fish. Keep up with weekly water changes and enjoy the activity.",
+            "options": [{ "type": "finish", "text": "Will do!" }]
         }
     ]
 }

--- a/src/pages/quests/json/aquaria/walstad.json
+++ b/src/pages/quests/json/aquaria/walstad.json
@@ -4,6 +4,7 @@
     "description": "Set up a low-tech Walstad style aquarium with soil and plants.",
     "image": "/assets/quests/walstad.jpg",
     "npc": "/assets/npc/vega.jpg",
+    "start": "start",
     "requiresQuests": [],
     "dialogue": [
         {
@@ -19,12 +20,27 @@
         {
             "id": "plant",
             "text": "Add hardy stem plants like hornwort or water wisteria. They help balance nutrients while the tank settles.",
-            "options": [{ "text": "Plants added", "next": "cycle" }]
+            "options": [{ "text": "Plants added", "next": "cleanup" }]
+        },
+        {
+            "id": "cleanup",
+            "text": "Introduce a few ramshorn snails to nibble on algae while the plants settle. They'll keep the tank tidy with little effort.",
+            "options": [{ "text": "Snails added", "next": "cycle" }]
         },
         {
             "id": "cycle",
-            "text": "Great work! Fill the tank slowly and let it cycle for several weeks before you introduce any fish.",
-            "options": [{ "text": "I'll wait patiently." }]
+            "text": "Fill the tank slowly and run the filter. Test ammonia and nitrite until both read zero. This may take a few weeks.",
+            "options": [{ "text": "Water is stable", "next": "stock" }]
+        },
+        {
+            "id": "stock",
+            "text": "Your Walstad tank is ready! Start with a small school of peaceful fish to maintain balance.",
+            "options": [{ "text": "Will do!", "next": "finish" }]
+        },
+        {
+            "id": "finish",
+            "text": "Enjoy your low-maintenance ecosystem. Weekly top-offs should be all you need.",
+            "options": [{ "type": "finish", "text": "Thanks, Vega!" }]
         }
     ]
 }


### PR DESCRIPTION
## Summary
- document finish requirement in AGENTS
- mention additional quest quality tests in README
- update TESTING guide with OpenAI integration note
- enforce finish option on final quest node

## Testing
- `npm run check` *(fails: ESLint couldn't find a config)*
- `npm run test:pr` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684a4bf23778832f93e50b486b4701d5