### PR TITLE
Add entry-level electronics quest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ These guidelines apply to all files in this repository.
 -   Continuous integration runs `npm run check` and `npm test -- --coverage` via
     GitHub Actions.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
+-   Mention new quest categories in the README's Built-in Quests section when you add them.
 
 ## Pull Request Message
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ fields such as `start`, `rewards` and item requirements, so older quests from
 the v2 era remain valid. Keep the NPC file updated when adding new characters.
 
 Aquarium quests progress through a gentle learning curve: first set up a Walstad tank, then add dwarf shrimp and guppies, practice breeding, and finally keep a goldfish in a large tank.
+Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.
 
 To validate that quests use a canonical structure with clear start and finish
 steps, run the dedicated test:

--- a/frontend/public/assets/quests/basic_circuit.svg
+++ b/frontend/public/assets/quests/basic_circuit.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="100%" height="100%" fill="#DDDDDD" />
+  <circle cx="200" cy="200" r="40" fill="#ff0000" />
+  <line x1="100" y1="200" x2="160" y2="200" stroke="#000" stroke-width="8" />
+  <line x1="240" y1="200" x2="300" y2="200" stroke="#000" stroke-width="8" />
+  <rect x="300" y="185" width="50" height="30" fill="#000" />
+</svg>

--- a/frontend/src/pages/quests/json/electronics/basic-circuit.json
+++ b/frontend/src/pages/quests/json/electronics/basic-circuit.json
@@ -1,0 +1,54 @@
+{
+    "id": "electronics/basic-circuit",
+    "title": "Build a basic LED circuit",
+    "description": "Learn electronics fundamentals by lighting up a simple LED.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there! I'm Orion. Want to see how easy electronics can be? Let's build a simple LED circuit together.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "materials",
+                    "text": "Sure, what do I need?"
+                }
+            ]
+        },
+        {
+            "id": "materials",
+            "text": "You'll need an LED, a 330 ohm resistor, a breadboard, and a battery pack or USB power source. Ready to put it together?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "text": "Yep, let's assemble it."
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "Place the LED on the breadboard and connect the resistor in series with the long leg. Hook everything up to power and the LED should glow.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "It works!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! You've built your first circuit and lit up an LED.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- introduce a basic electronics quest teaching how to light an LED
- document the new quest category in the README
- note in AGENTS.md to mention new categories in the README
- include a simple SVG for the quest image

## Testing
- `npm run check`
- `npm run test:pr` *(fails: several e2e groups did not pass)*

------
https://chatgpt.com/codex/tasks/task_e_684b90a17e30832fa908d9471ad79c6f