### PR TITLE
Fix docs for automated E2E tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ These guidelines apply to all files in this repository.
 -   Continuous integration runs `npm run check` and `npm test -- --coverage` via
     GitHub Actions.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
+-   The quest format is compatible with other repos like `token.place`. Look for
+    opportunities to share content across projects.
+-   The `test:pr` and `test:e2e:groups` scripts automatically start the dev
+    server. Avoid starting it manually unless running Playwright directly.
 
 ## Pull Request Message
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -155,7 +155,7 @@ npm run coverage
 E2E tests verify the application behaves correctly from a user's perspective:
 
 ```bash
-# Start the development server first (required for E2E tests)
+# Start the development server manually only when invoking Playwright directly
 npm run dev
 
 # In a new terminal, run all E2E tests (takes longer)
@@ -165,14 +165,16 @@ npm run test:e2e
 npm run test:e2e:groups
 ```
 
-> **Important:** End-to-end (E2E) tests require the development server to be running at http://localhost:3002. Always start the server with `npm run dev` before running any E2E tests.
+> **Important:** When using `npm run test:pr` or `npm run test:e2e:groups`, the
+> development server is started automatically. Start the server yourself only if
+> you run Playwright commands directly.
 
 ### Test Categories
 
 Specialized test commands for different areas:
 
 ```bash
-# Start the development server first
+# If running Playwright directly, start the dev server first
 npm run dev
 
 # In a new terminal, run specific test categories:
@@ -197,7 +199,7 @@ npm run test:e2e:integration
 For faster development cycles:
 
 ```bash
-# Start the development server first
+# Optional: start the dev server if you plan to run Playwright directly
 npm run dev
 
 # In a new terminal, run quick tests
@@ -619,14 +621,13 @@ if (hasLocalStorage) {
 
 ### Server Dependencies
 
-The E2E test suite requires a running development server:
-
-- Tests expect the server to be running on port 3002
-- Always start the server with `npm run dev` before running E2E tests
-- Connection errors (`ERR_CONNECTION_REFUSED`) indicate a missing server
+The E2E test suite requires a development server running on port 3002.
+When using the provided test scripts this is handled automatically.
+Start the server manually only if you execute Playwright directly.
+Connection errors (`ERR_CONNECTION_REFUSED`) indicate a missing server.
 
 ```bash
-# Best practice: Run server in one terminal
+# Optional: run server in one terminal when invoking Playwright directly
 npm run dev
 
 # Then run tests in another terminal


### PR DESCRIPTION
## Summary
- clarify that `test:e2e:groups` and `test:pr` start the dev server automatically
- note quest format compatibility with other repos in AGENTS instructions

## Testing
- `npm run check`
- `npm run test:pr` *(fails: Test Coverage, Structure Tests, Item Tests, Process Tests, Quest Tests, Integration Tests, Shop Functionality, User Profile, Game Systems)*

------
https://chatgpt.com/codex/tasks/task_e_684b9061eb94832f81729a9be19c6bde