### PR TITLE
Fix duration parsing

### DIFF
--- a/frontend/__tests__/durationUtils.test.js
+++ b/frontend/__tests__/durationUtils.test.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+const { durationInSeconds } = require('../src/utils.js');
+
+describe('durationInSeconds', () => {
+    test('parses integer duration', () => {
+        expect(durationInSeconds('1h 30m')).toBe(5400);
+    });
+
+    test('parses fractional duration', () => {
+        expect(durationInSeconds('0.5h')).toBe(1800);
+    });
+});

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -40,6 +40,8 @@ Duration must follow the pattern `(\d+h\s*)?(\d+m\s*)?(\d+s\s*)?`, for example:
 -   "1h 30m" (1 hour, 30 minutes)
 -   "5m 30s" (5 minutes, 30 seconds)
 
+Fractional values are allowed, so `0.5h` will be interpreted as thirty minutes.
+
 ### Implementation State
 
 The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types.

--- a/frontend/src/pages/quests/svelte/ManageQuests.svelte
+++ b/frontend/src/pages/quests/svelte/ManageQuests.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import Quest from './Quest.svelte';
     import { questFinished } from '../../../utils/gameState.js';
+    import { db } from '../../../utils/customcontent.js';
 
     export let quests = [];
     let mounted = false;
@@ -35,16 +36,8 @@
     async function handleDelete(questId) {
         if (confirm('Are you sure you want to delete this quest?')) {
             try {
-                const response = await fetch(`/api/quests/${questId}`, {
-                    method: 'DELETE',
-                });
-
-                if (response.ok) {
-                    // Remove quest from local state
-                    quests = quests.filter((q) => q.id !== questId);
-                } else {
-                    alert('Failed to delete quest');
-                }
+                await db.quests.delete(questId);
+                quests = quests.filter((q) => q.id !== questId);
             } catch (error) {
                 console.error('Error deleting quest:', error);
                 alert('Failed to delete quest');

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -122,13 +122,14 @@ export const datetimeAfterDuration = (durationSeconds) => {
 
 export const durationInSeconds = (durationString) => {
     try {
-        const durationComponents = durationString.split(' ');
+        const durationComponents = durationString.split(' ').filter(Boolean);
 
         // for each item in durationComponents, get the number and the unit
         // then convert the number to seconds
         let durationSeconds = 0;
         for (const component of durationComponents) {
-            const number = parseInt(component);
+            const number = parseFloat(component);
+            if (isNaN(number)) continue;
             const unit = component.replace(number, '');
             let seconds = 0;
             switch (unit) {


### PR DESCRIPTION
## Summary
- parse fractional durations correctly
- use local DB for ManageQuests deletion
- document fractional duration format
- add unit test for duration parsing

## Testing
- `npm run check`
- `npm run test:pr` *(fails: Test Suite Summary: 0 groups passed, 9 groups failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bc97bc3e4832fb9cc1600f6327923