### PR TITLE
Improve quest creation docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ These guidelines apply to all files in this repository.
     with at least one option per node.
 -   Include a `finish` option in the final node so quests end cleanly. Quests
     without a finish option will fail canonical tests.
+-   For rapid quest creation, reference `frontend/src/pages/docs/md/prompts-quests.md`
+    which contains AI prompt templates.
 -   Document any new or updated NPCs in `frontend/src/pages/docs/md/npcs.md`.
 -   Update quest progression tests in `frontend/__tests__/questQuality.test.js`
     when introducing new aquaria quests or changing their order.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ npm test -- imageReferences     # verifies quest and NPC image files
 > [`token.place`](https://github.com/futuroptimist/token.place), so content can be
 > shared across repos.
 
+### AI-Assisted Quest Creation
+
+For faster quest development, consult our [Quest Prompts](/docs/prompts-quests)
+guide. It includes ready-made prompt templates for tools like GPT-4 or Claude to
+help you generate dialogue and structure quickly. Combine these with the
+[Quest Development Guidelines](/docs/quest-guidelines) to streamline content
+creation.
+
 ## Want to contribute?
 
 Check out the [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v2.1/CONTRIBUTORS.md) to get started.


### PR DESCRIPTION
## Summary
- document quest prompt templates in AGENTS guidelines
- add AI-assisted quest creation tips to README

## Testing
- `npm run check`
- `npm run test:pr` *(fails: end-to-end tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bcc549fc8832fa3783d1a619a6721