### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,7 +21,14 @@ jobs:
       - run: npm ci
       - run: cd frontend && npm ci
       - run: npm run test:pr
+      - run: cd frontend && npm run coverage
+        if: env.CODECOV_TOKEN != ''
       - uses: actions/upload-artifact@v4
+        if: env.CODECOV_TOKEN != ''
         with:
           name: coverage
           path: frontend/coverage
+      - uses: codecov/codecov-action@v5
+        if: env.CODECOV_TOKEN != ''
+        with:
+          token: ${{ env.CODECOV_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ These guidelines apply to all files in this repository.
     when introducing new aquaria quests or changing their order.
 -   Avoid committing large binary assets (e.g., PSD files). Convert graphics to
     optimized formats before adding them to the repo.
--   Continuous integration runs `npm run check` and `npm test -- --coverage` via
-    GitHub Actions.
+-   Continuous integration runs `npm run test:pr` on pushes and pull requests.
+    Coverage uploads to Codecov when the `CODECOV_TOKEN` secret is set. You'll
+    see the results in the **Checks** tab of your PR.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
 -   token.place only provides open-source LLM inference. It does not host quests, but you can reuse the same prompts to generate dialogue here or in other projects.
 -   The [f2clipboard](https://github.com/futuroptimist/f2clipboard) tool can speed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSPACE - Democratized Space
 
-![CI](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/coverage-unknown-lightgrey)
+[![CI](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml/badge.svg)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/democratizedspace/dspace/branch/main/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
 
 You can find the game at [democratized.space](https://democratized.space).
 
@@ -93,6 +93,12 @@ npm run test:e2e:groups
 ```
 
 > **Important:** End-to-end (E2E) tests use Playwright, which automatically starts and stops the development server when needed. You should not manually start a server when running these tests, as this could lead to port conflicts or unexpected behavior.
+
+### Continuous Integration
+
+GitHub Actions automatically run `npm run test:pr` on every pull request and push to `main`.
+If the `CODECOV_TOKEN` secret is configured, coverage reports upload to Codecov and update the badge at the top of this README.
+You'll find the CI results under the **Checks** tab of your pull request.
 
 ## Code Quality
 


### PR DESCRIPTION
## Summary
- upload coverage reports to Codecov when CODECOV_TOKEN is present
- skip Codecov step for forked PRs
- document CI behavior in README and AGENTS

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68531925e020832f9a2d5de464b342ed