### PR TITLE
Add resetGameState utility and tests

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -475,6 +475,8 @@ For component state:
 - Use local state with Svelte's reactive variables where possible
 - Use stores for shared state across components
 - Leverage the game state system for persistent game data
+- During development you can quickly wipe progress by calling
+  `resetGameState()` from `frontend/src/utils/gameState/common.js`.
 
 ### Creating New Components
 

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -1,0 +1,42 @@
+const {
+    loadGameState,
+    saveGameState,
+    exportGameStateString,
+    importGameStateString,
+    resetGameState,
+} = require('../../src/utils/gameState/common.js');
+
+describe('gameState - common utilities', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetGameState();
+    });
+
+    test('resetGameState should initialize empty state', () => {
+        const state = loadGameState();
+        state.inventory['1'] = 5;
+        saveGameState(state);
+
+        resetGameState();
+        const fresh = loadGameState();
+        expect(fresh).toEqual({ quests: {}, inventory: {}, processes: {} });
+    });
+
+    test('exportGameStateString should reflect latest saved state', () => {
+        const state = loadGameState();
+        state.inventory['1'] = 5;
+        saveGameState(state);
+
+        const exported = exportGameStateString();
+        const decoded = JSON.parse(Buffer.from(exported, 'base64').toString('utf8'));
+        expect(decoded.inventory['1']).toBe(5);
+    });
+
+    test('importGameStateString should replace current state', () => {
+        const newState = { quests: { foo: true }, inventory: { 2: 3 }, processes: {} };
+        const encoded = Buffer.from(JSON.stringify(newState)).toString('base64');
+        importGameStateString(encoded);
+        const loaded = loadGameState();
+        expect(loaded).toEqual(newState);
+    });
+});

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -18,7 +18,8 @@ export const loadGameState = () => {
     return initializeGameState();
 };
 
-export const saveGameState = (gameState) => {
+export const saveGameState = (newState) => {
+    gameState = newState;
     localStorage.setItem(gameStateKey, JSON.stringify(gameState));
     state.set(gameState); // Update the state store directly
 };
@@ -41,4 +42,9 @@ export const importGameStateString = (gameStateString) => {
 
     // Save the updated game state to local storage and update the state store
     saveGameState(gameState);
+};
+
+export const resetGameState = () => {
+    const freshState = initializeGameState();
+    saveGameState(freshState);
 };


### PR DESCRIPTION
## Summary
- add `resetGameState` helper and update `saveGameState`
- document reset helper in Developer Guide
- test common game state utilities

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68533ba3c714832fa11ac59d8f0ed711