### PR TITLE
Fix coverage badge branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    branches: [ v3 ]
   pull_request:
 
 jobs:

--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to RPi
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [v3]
 
 jobs:
   deploy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ These guidelines apply to all files in this repository.
     optimized formats before adding them to the repo.
 -   Continuous integration runs `npm run test:pr` on pushes and pull requests.
     Coverage uploads to Codecov when the `CODECOV_TOKEN` secret is set. You'll
-    see the results in the **Checks** tab of your PR.
+    see the results in the **Checks** tab of your PR. Ensure the README's Codecov badge tracks the `v3` branch so it reflects CI results.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
 -   token.place only provides open-source LLM inference. It does not host quests, but you can reuse the same prompts to generate dialogue here or in other projects.
 -   The [f2clipboard](https://github.com/futuroptimist/f2clipboard) tool can speed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSPACE - Democratized Space
 
 [![CI](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml/badge.svg)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/democratizedspace/dspace/branch/main/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
+[![codecov](https://codecov.io/gh/democratizedspace/dspace/branch/v3/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
 
 You can find the game at [democratized.space](https://democratized.space).
 
@@ -100,7 +100,7 @@ npm run test:e2e:coverage
 
 ### Continuous Integration
 
-GitHub Actions automatically run `npm run test:pr` on every pull request and push to `main`.
+GitHub Actions automatically run `npm run test:pr` on every pull request and push to `v3`.
 If the `CODECOV_TOKEN` secret is configured, coverage reports upload to Codecov and update the badge at the top of this README.
 You'll find the CI results under the **Checks** tab of your pull request.
 
@@ -126,7 +126,7 @@ The app will be available on port 3002. Point your Cloudflare Tunnel at `http://
 
 The workflow `.github/workflows/rpi-deploy.yml` builds an ARM64 Docker image and optionally deploys it to a Raspberry Pi over SSH.
 Add registry credentials in `GHCR_TOKEN` (or another registry) and set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` secrets.
-Trigger the workflow manually or on pushes to `main` to update the Pi and restart the `app` service.
+Trigger the workflow manually or on pushes to `v3` to update the Pi and restart the `app` service.
 
 ## Project Architecture
 


### PR DESCRIPTION
## Summary
- use the `v3` branch for CI workflow triggers
- update README's Codecov badge and docs to track `v3`
- note the default branch in AGENTS instructions

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6853d1526a90832f94f7020106c8e4e2