### PR TITLE
Refine line follower quest dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ build/
 .DS_Store
 
 # Custom scripts
-f2clipboard.py
 
 # Logs
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,12 @@ These guidelines apply to all files in this repository.
 -   Include a `finish` option in the final node so quests end cleanly. Quests
     without a finish option will fail canonical tests.
 -   For rapid quest creation, reference `frontend/src/pages/docs/md/prompts-quests.md`
-    which contains AI prompt templates.
+    which contains AI prompt templates, including a **Quest Sequence Expansion**
+    section for brainstorming follow-up quests.
+-   When generating dialogue with an LLM, consult the biography and sample
+    quotes in `frontend/src/pages/docs/md/npcs.md` so the character voice stays
+    consistent. Each NPC entry lists at least five example lines harvested from
+    existing quests. Keep these examples updated when quests change.
 -   Review `frontend/src/pages/docs/md/quest-submission.md` for the submission workflow when contributing new quests.
 -   See `frontend/src/pages/docs/md/quest-template.md` for a minimal quest JSON template that works with [token.place](https://github.com/futuroptimist/token.place).
 -   Document any new or updated NPCs in `frontend/src/pages/docs/md/npcs.md`.
@@ -42,14 +47,15 @@ These guidelines apply to all files in this repository.
     Run `npm run coverage` locally to generate a detailed report before submitting changes.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
 -   token.place only provides open-source LLM inference. It does not host quests, but you can reuse the same prompts to generate dialogue here or in other projects.
--   The [f2clipboard](https://github.com/futuroptimist/f2clipboard) tool can speed
-    up copying quest prompts and snippets between projects. After merging, run
-    `npm ci` in the repo root and `(cd frontend && npm ci)` to restore a clean
-    state before validating quests.
+-   After merging, run `npm ci` in the repo root and `(cd frontend && npm ci)` to
+    restore a clean state before validating quests.
+-   To grow the quest tree across repositories, use token.place prompts to reuse
+    dialogue or items from sibling projects.
 -   Quest JSON files are compatible with the [token.place](https://github.com/futuroptimist/token.place) project, so feel free to share content across repos.
 -   The `test:pr` and `test:e2e:groups` scripts automatically start the dev
     server. Avoid starting it manually unless running Playwright directly.
 -   When adding inventory items in `frontend/src/pages/inventory/json/items.json`, assign the next numeric `id` and provide an image if possible.
+-   If you add a quest that changes the tech tree order, document the new sequence in `README.md` and update `frontend/__tests__/questQuality.test.js` accordingly.
 
 ## Pull Request Message
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,15 @@ For comprehensive information about developing DSPACE, see our [Developer Guide]
 
 Starter quest JSON files live in `frontend/src/pages/quests/json`. They follow the schema
 defined at `frontend/src/pages/quests/jsonSchemas/quest.json` and can reference NPC
-profiles in `frontend/src/pages/docs/md/npcs.md`. The schema now supports advanced
-fields such as `start`, `rewards` and item requirements, so older quests from
-the v2 era remain valid. Keep the NPC file updated when adding new characters.
+profiles in `frontend/src/pages/docs/md/npcs.md`. This file lists biography notes
+and sample dialogue for each character to help keep their voice consistent. The
+schema now supports advanced fields such as `start`, `rewards` and item requirements,
+so older quests from the v2 era remain valid. Keep the NPC file updated when
+adding new characters.
 Quest files are organized by category in subfolders, so feel free to expand any
 area—electronics, hydroponics, rocketry and more—with additional quests.
 
-Aquarium quests progress through a gentle learning curve: first set up a Walstad tank, then add dwarf shrimp and guppies, practice breeding, and finally keep a goldfish in a large tank.
+Aquarium quests progress through a gentle learning curve: set up a Walstad tank, ask Atlas to help position it, add dwarf shrimp, introduce guppies, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.
 
 To validate that quests use a canonical structure with clear start and finish
@@ -189,8 +191,6 @@ Item definitions live in `frontend/src/pages/inventory/json/items.json`. Assign 
 > [`token.place`](https://github.com/futuroptimist/token.place) when generating quest
 > dialogue. Token.place itself doesn't host quests, but you can reuse the same
 > prompts to create content across your projects.
-> You can also leverage [`f2clipboard`](https://github.com/futuroptimist/f2clipboard)
-> to copy quest templates or code snippets between repositories.
 
 ### AI-Assisted Quest Creation
 
@@ -213,6 +213,7 @@ npm ci
 ## Want to contribute?
 
 Check out the [Contribution Guide](./CONTRIBUTORS.md) to get started.
+Automated contributors like the Codex agent follow the rules in [AGENTS.md](./AGENTS.md). Feel free to consult it when preparing your own pull requests.
 
 If you have any questions, feel free to join the [Discord](https://discord.gg/A3UAfYvnxM) and say hello!
 

--- a/frontend/__tests__/questQuality.test.js
+++ b/frontend/__tests__/questQuality.test.js
@@ -261,8 +261,8 @@ function checkQuestProgression() {
     // Check for category progression (e.g., aquaria quests follow proper sequence)
     for (const [category, questIds] of questsByCategory.entries()) {
         if (category === 'aquaria') {
-            // Verify aquaria progression: walstad -> guppy -> shrimp -> breeding -> goldfish
-            const expectedOrder = ['walstad', 'guppy', 'shrimp', 'breeding', 'goldfish'];
+            // Verify aquaria progression: walstad -> shrimp -> guppy -> breeding -> goldfish
+            const expectedOrder = ['walstad', 'shrimp', 'guppy', 'breeding', 'goldfish'];
 
             // Get all relevant quests and sort by their position in the expected order
             const aquariaQuests = questIds

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
                 "cssnano": "^6.0.1",
                 "date-fns": "^2.30.0",
                 "dompurify": "^3.0.2",
+                "fake-indexeddb": "^6.0.1",
                 "highlight.js": "^11.8.0",
                 "jsdom": "^21.1.1",
                 "markdown-it": "^13.0.1",
@@ -6916,6 +6917,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fake-indexeddb": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+            "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
         "cssnano": "^6.0.1",
         "date-fns": "^2.30.0",
         "dompurify": "^3.0.2",
+        "fake-indexeddb": "^6.0.1",
         "highlight.js": "^11.8.0",
         "jsdom": "^21.1.1",
         "markdown-it": "^13.0.1",

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -9,11 +9,27 @@ slug: 'npcs'
 
 dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning and information retrieval capabilities, it can answer questions and engage in conversation effortlessly. dChat is provided free of charge to all metaguild members, and it's fully open source and self-hosted.
 
+### Sample Dialogue
+
+-   "Greetings, adventurer! I'm dChat, an advanced AI sidekick crafted by the grand codemancers of this realm."
+-   "Well, a friendly delivery robot dropped me off after you ordered me online."
+-   "No worries! I'm low-maintenance and won't hog your power supply."
+-   "Your quest, dear player, is to master the ancient art of ... questing."
+-   "Aha! A seasoned adventurer, I see. Just say the word, and we'll call it a wrap. You'll still need this, though!"
+
 ## Sydney
 
 <img src="/assets/npc/sydney.jpg" />
 
 Sydney, a tall and commanding woman, exudes an air of no-nonsense professionalism. As a 3D printing expert, she creates and repairs various tools and equipment for the metaguild. Raised among engineers and tinkerers, Sydney was captivated by the potential of 3D printing early on. After studying mechanical engineering in college, she quickly mastered the field. Sydney eagerly joined the metaguild to apply her skills to new challenges.
+
+### Sample Dialogue
+
+-   "Hello, friend! I'm Sydney, a 3D printing expert with the metaguild."
+-   "Fantastic! A 3D printer is an invaluable tool!"
+-   "First things first, I need you to accept the 3D printer."
+-   "Hey there, it's Sydney again! Ready for a quick project? Let's make a simple phone stand."
+-   "Great job! This stand will keep your phone propped up while you work on more projects."
 
 ## Nova
 
@@ -21,11 +37,27 @@ Sydney, a tall and commanding woman, exudes an air of no-nonsense professionalis
 
 Nova, an ingenious engineer with a quick wit, excels at rocketry. She designs and constructs the spacecraft used by the metaguild to explore the solar system. After studying aerospace engineering in college, she rapidly gained expertise in the field. Known for her perfectionism and ability to overcome obstacles, Nova embraced the metaguild as a means to employ her skills in groundbreaking ways.
 
+### Sample Dialogue
+
+-   "Hey friend! I'm Nova! I'm sure you've met some of my colleagues!"
+-   "Luckily I've already launched this exact rocket before! I estimate around 35 meters in perfect conditions."
+-   "Nahhh, you're good! According to the FAA, without additional paperwork, the rocket may weigh no more than 1500 grams."
+-   "Well first you've gotta print the rocket!"
+-   "Sure, but where's the fun in that? You've got that fancy little 3D printer Sydney gave you."
+
 ## Hydro
 
 <img src="/assets/npc/hydro.jpg" />
 
 Hydro, a relaxed and affable team member, has a gift for hydroponics and sustainable farming. They ensure the crew has a steady supply of food during lengthy space missions. Growing up on a small Earth farm, Hydro acquired a strong appreciation for sustainable agriculture. In college, they studied biology and became intrigued by hydroponics as a method for cultivating crops in harsh environments.
+
+### Sample Dialogue
+
+-   "Hey there! I'm Hydro, your local hydroponics expert!"
+-   "Oh I could talk for hours but I'll give you the short version: hydroponics is a method of growing plants using mineral nutrient solutions."
+-   "Excellent! First things first, I need you to accept this hydroponics tub."
+-   "Now that you've got your hydroponics tub, you'll need some dechlorinated water."
+-   "I know, right? It's almost like the gamedev is awkwardly reusing existing game systems."
 
 ## Orion
 
@@ -33,11 +65,27 @@ Hydro, a relaxed and affable team member, has a gift for hydroponics and sustain
 
 Orion is an electrical engineer whose enthusiasm for robotics and microprocessors knows no bounds. He specializes in designing and building intelligent robotic systems to assist the metaguild in various tasks. Orion's technical prowess and innovative thinking make him a valuable team member in the quest to push the boundaries of space exploration.
 
+### Sample Dialogue
+
+-   "Hey there! I'm Orion. Want to see how easy electronics can be? Let's build a simple LED circuit together."
+-   "You'll need an LED, a 330 ohm resistor, a breadboard, and a battery pack or USB power source."
+-   "Place the LED on the breadboard and connect the resistor in series with the long leg."
+-   "Hey there! Orion here. Ready to do something a bit more exciting? Let's make that LED blink with a microcontroller."
+-   "Open the Arduino IDE, load the Blink example, select the correct port, and hit upload."
+
 ## Vega
 
 <img src="/assets/npc/vega.jpg" />
 
 Vega is an expert in aquariums and terrariums, with years of experience in designing and maintaining these unique ecosystems. Their passion for aquatic and terrestrial life has led them to develop innovative techniques and solutions for creating balanced, thriving environments for a wide variety of species. Vega is dedicated to sharing their knowledge with others and helping people create beautiful, healthy habitats for their own pets and plants.
+
+### Sample Dialogue
+
+-   "Hi there! I'm Vega. Ready to try the Walstad method? It's a simple way to grow plants with minimal equipment."
+-   "You'll want a 40 liter tank, some organic soil capped with gravel, and a bunch of easy plants."
+-   "Your Walstad tank should be cycled now. A small colony of dwarf shrimp will keep algae in check."
+-   "Those shrimp are thriving! Ready for a couple guppies? They prefer 24-28°C water."
+-   "Guppies multiply quickly. Dense plants like hornwort give the fry shelter until they're bigger."
 
 ## Phoenix
 
@@ -45,11 +93,27 @@ Vega is an expert in aquariums and terrariums, with years of experience in desig
 
 Phoenix is a professional chemist specializing in sustainable rocket fuel development. With a strong background in chemistry and a focus on environmental conservation, they are committed to finding innovative solutions for the space industry that have a minimal impact on our planet. Phoenix's work has the potential to revolutionize space travel by making it more eco-friendly and accessible to a wider range of people.
 
+### Sample Dialogue
+
+-   "You've made some impressive strides in 3D printing. Your next challenge is to print 10 Benchies."
+-   "Well done! These Benchies look fantastic. Keep honing your 3D printing skills."
+-   "You've shown great progress with your 3D printing! Your next goal is to print 25 Benchies."
+-   "Excellent job! Your fleet of Benchies is growing. Keep up the great work."
+-   "You've truly mastered the art of 3D printing Benchies. Now, let's take things to the next level. I want to see a fleet of 100 Benchies."
+
 ## Atlas
 
 <img src="/assets/npc/atlas.jpg" />
 
 Atlas is a humanoid robot assistant designed to help with physical tasks that require strength and precision. With advanced AI capabilities, Atlas can perform a variety of tasks, from heavy lifting to delicate assembly work, making it an invaluable asset to the team. As our trusty robotic companion, Atlas ensures that we can accomplish our goals more efficiently and safely than ever before.
+
+### Sample Dialogue
+
+-   "Hello! I'm Atlas, your robotic assistant. Let me handle the heavy lifting."
+-   "On three ... one, two, three! Easy does it."
+-   "I'll keep the load steady while you guide it into place."
+-   "Great work! The tank is secure on the stand."
+-   "Anytime you need more muscle, just give me a shout."
 
 <style>
     img {

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -209,6 +209,20 @@ Please help me improve this dialogue by:
 Suggest specific improvements rather than rewriting the entire dialogue.
 ```
 
+### Quest Sequence Expansion
+
+Use this when you want an AI assistant to propose follow-up quests that build on
+existing content.
+
+```
+I maintain a quest tree for DSPACE. The latest quest I added was [LAST QUEST ID].
+Suggest several logical next quests that would follow it. For each quest propose:
+1. A short title
+2. A one-sentence summary
+3. The most fitting NPC guide
+4. Key items or processes that should be introduced, focusing on hands-on steps rather than purely conversational beats
+```
+
 ## Example: Complete Quest Creation
 
 Here's an example of how to use these prompts to create a complete quest:

--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -5,7 +5,7 @@ slug: 'quest-template'
 
 # Quest Template Example
 
-This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://github.com/futuroptimist/token.place) project and can be shared across repos. Feel free to copy this snippet into your editor or use the [f2clipboard](https://github.com/futuroptimist/f2clipboard) tool to speed up the process.
+This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://github.com/futuroptimist/token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
 
 ```json
 {

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -643,5 +643,61 @@
         "name": "Lettuce Seeds",
         "description": "Seeds for growing crisp hydroponic lettuce.",
         "image": "/assets/hydroponic_lettuce.jpg"
+    },
+    {
+        "id": "100",
+        "name": "Walstad aquarium (80 L)",
+        "description": "A planted tank using the low-tech Walstad method.",
+        "image": "/assets/walstad.jpg",
+        "price": "80 dUSD"
+    },
+    {
+        "id": "101",
+        "name": "Dwarf shrimp",
+        "description": "Hardy shrimp perfect for planted aquariums.",
+        "image": "/assets/quests/shrimp.svg",
+        "price": "3 dUSD"
+    },
+    {
+        "id": "102",
+        "name": "Guppy group",
+        "description": "Three females and one male guppy ready to breed.",
+        "image": "/assets/guppy.jpg",
+        "price": "6 dUSD"
+    },
+    {
+        "id": "103",
+        "name": "Hornwort cuttings",
+        "description": "Fast-growing stems that provide cover for fry.",
+        "image": "/assets/hornwort.jpg",
+        "price": "1 dUSD"
+    },
+    {
+        "id": "104",
+        "name": "Guppy grass starter",
+        "description": "Easy floating plant ideal for breeding tanks.",
+        "image": "/assets/guppy_grass.jpg",
+        "price": "1 dUSD"
+    },
+    {
+        "id": "105",
+        "name": "Duckweed portion",
+        "description": "Floating plant that helps absorb excess nutrients.",
+        "image": "/assets/duckweed.jpg",
+        "price": "1 dUSD"
+    },
+    {
+        "id": "106",
+        "name": "Heated Walstad aquarium (80 L, 26\u00B0C)",
+        "description": "An 80 L Walstad tank equipped with a heater set to 26\u00B0C.",
+        "image": "/assets/walstad.jpg",
+        "price": "85 dUSD"
+    },
+    {
+        "id": "107",
+        "name": "Walstad tank with guppies",
+        "description": "An 80 L heated Walstad aquarium containing three female and one male guppy.",
+        "image": "/assets/guppy.jpg",
+        "price": "90 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -909,6 +909,28 @@
         "duration": "8h"
     },
     {
+        "id": "heat-walstad",
+        "title": "Install a heater in your Walstad tank",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "100", "count": 1 },
+            { "id": "56", "count": 1 }
+        ],
+        "createItems": [{ "id": "106", "count": 1 }],
+        "duration": "5m"
+    },
+    {
+        "id": "stock-guppies",
+        "title": "Add guppies to your heated Walstad tank",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "106", "count": 1 },
+            { "id": "102", "count": 1 }
+        ],
+        "createItems": [{ "id": "107", "count": 1 }],
+        "duration": "1m"
+    },
+    {
         "id": "dCarbon-dOffset-1",
         "title": "dCarbon to dOffset",
         "requireItems": [],

--- a/frontend/src/pages/quests/json/aquaria/breeding.json
+++ b/frontend/src/pages/quests/json/aquaria/breeding.json
@@ -1,0 +1,27 @@
+{
+    "id": "aquaria/breeding",
+    "title": "Breed your guppies",
+    "description": "Raise the next generation of fish among dense plants.",
+    "image": "/assets/guppy.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Guppies multiply quickly. Dense plants like hornwort and guppy grass keep the fry safe right in the main tank.",
+            "options": [{ "type": "goto", "goto": "wait", "text": "I'll add lots of plants." }]
+        },
+        {
+            "id": "wait",
+            "text": "Once the fry are born, feed them crushed flakes several times a day so they grow quickly.",
+            "options": [{ "type": "goto", "goto": "release", "text": "They're growing fast." }]
+        },
+        {
+            "id": "release",
+            "text": "When they're large enough not to be eaten, just enjoy watching them join the community tank.",
+            "options": [{ "type": "finish", "text": "Tiny fish everywhere!" }]
+        }
+    ],
+    "rewards": [{ "id": "102", "count": 1 }],
+    "requiresQuests": ["aquaria/guppy"]
+}

--- a/frontend/src/pages/quests/json/aquaria/guppy.json
+++ b/frontend/src/pages/quests/json/aquaria/guppy.json
@@ -1,0 +1,36 @@
+{
+    "id": "aquaria/guppy",
+    "title": "Add guppies",
+    "description": "Introduce colorful guppies to your community tank.",
+    "image": "/assets/guppy.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Those shrimp are thriving! Ready for some guppies? They prefer 24-28°C water, so let's warm the tank first.",
+            "options": [
+                { "type": "process", "process": "heat-walstad", "text": "Install the heater." }
+            ]
+        },
+        {
+            "id": "acquire",
+            "text": "Pick three females and one male and float the bag in the tank to match temperature.",
+            "options": [{ "type": "goto", "goto": "release", "text": "Temperature matched." }]
+        },
+        {
+            "id": "release",
+            "text": "Gently net the guppies into the tank and discard the store water.",
+            "options": [
+                { "type": "process", "process": "stock-guppies", "text": "Introduce them." }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Fish are in and seem happy!",
+            "options": [{ "type": "finish", "text": "All done." }]
+        }
+    ],
+    "rewards": [{ "id": "107", "count": 1 }],
+    "requiresQuests": ["aquaria/shrimp"]
+}

--- a/frontend/src/pages/quests/json/aquaria/position-tank.json
+++ b/frontend/src/pages/quests/json/aquaria/position-tank.json
@@ -1,0 +1,27 @@
+{
+    "id": "aquaria/position-tank",
+    "title": "Move the Walstad tank",
+    "description": "Use Atlas to safely place the heavy aquarium on its stand.",
+    "image": "/assets/walstad.jpg",
+    "npc": "/assets/npc/atlas.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hello! I'm Atlas. Vega said you needed help moving that 80 liter tank onto the stand.",
+            "options": [{ "type": "goto", "goto": "lift", "text": "Yes please, it's heavy." }]
+        },
+        {
+            "id": "lift",
+            "text": "I'll take most of the weight. On three... one, two, three!",
+            "options": [{ "type": "goto", "goto": "place", "text": "Heave-ho!" }]
+        },
+        {
+            "id": "place",
+            "text": "Great job keeping it level. The tank is secure on the stand now.",
+            "options": [{ "type": "finish", "text": "Thanks for the assist!" }]
+        }
+    ],
+    "requiresQuests": ["aquaria/walstad"],
+    "rewards": []
+}

--- a/frontend/src/pages/quests/json/aquaria/shrimp.json
+++ b/frontend/src/pages/quests/json/aquaria/shrimp.json
@@ -1,0 +1,27 @@
+{
+    "id": "aquaria/shrimp",
+    "title": "Add dwarf shrimp",
+    "description": "Introduce hardy shrimp to help keep the tank clean.",
+    "image": "/assets/quests/shrimp.svg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your Walstad tank should be cycled now. A small colony of dwarf shrimp will keep algae in check.",
+            "options": [{ "type": "goto", "goto": "acquire", "text": "Sounds good!" }]
+        },
+        {
+            "id": "acquire",
+            "text": "Pick up a few shrimp from the store and float the bag in your tank to equalize temperature.",
+            "options": [{ "type": "goto", "goto": "acclimate", "text": "Bag is floating." }]
+        },
+        {
+            "id": "acclimate",
+            "text": "Slowly drip tank water into the bag for about an hour. Then release the shrimp gently.",
+            "options": [{ "type": "finish", "text": "Shrimp are in and exploring!" }]
+        }
+    ],
+    "rewards": [{ "id": "101", "count": 3 }],
+    "requiresQuests": ["aquaria/walstad"]
+}

--- a/frontend/src/pages/quests/json/aquaria/walstad.json
+++ b/frontend/src/pages/quests/json/aquaria/walstad.json
@@ -1,0 +1,32 @@
+{
+    "id": "aquaria/walstad",
+    "title": "Set up a Walstad tank",
+    "description": "Create a low-tech planted aquarium using the Walstad method.",
+    "image": "/assets/walstad.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hi there! I'm Vega. Ready to try the Walstad method? It's a simple way to grow plants with minimal equipment.",
+            "options": [{ "type": "goto", "goto": "materials", "text": "Sure! What do I need?" }]
+        },
+        {
+            "id": "materials",
+            "text": "You'll want an 80 liter tank, some organic soil capped with gravel, and easy plants like hornwort, guppy grass, and duckweed. Grab a light and we'll get started.",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Got it. Let's set it up." }]
+        },
+        {
+            "id": "setup",
+            "text": "Spread the soil, add gravel, plant everything, then fill gently with dechlorinated water. Let it settle for a day or two.",
+            "options": [{ "type": "goto", "goto": "cycle", "text": "Looks good so far." }]
+        },
+        {
+            "id": "cycle",
+            "text": "Great! Give the tank a couple weeks to cycle before adding livestock. Keep the light on about eight hours a day.",
+            "options": [{ "type": "finish", "text": "I'll let it cycle. Thanks!" }]
+        }
+    ],
+    "rewards": [{ "id": "100", "count": 1 }],
+    "requiresQuests": ["welcome/howtodoquests"]
+}

--- a/frontend/src/pages/quests/json/robotics/line-follower.json
+++ b/frontend/src/pages/quests/json/robotics/line-follower.json
@@ -1,0 +1,28 @@
+{
+    "id": "robotics/line-follower",
+    "title": "Build a line-following robot",
+    "description": "Use two light sensors to make a simple robot follow a track.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's take your servo skills further. We'll build a tiny robot that follows a dark line on the floor.",
+            "options": [
+                { "type": "goto", "goto": "parts", "text": "I'm in! What parts do I need?" }
+            ]
+        },
+        {
+            "id": "parts",
+            "text": "You'll need two infrared sensors, a pair of continuous-rotation servos, and an Arduino. Mount everything on a small chassis.",
+            "options": [{ "type": "goto", "goto": "code", "text": "Hardware assembled." }]
+        },
+        {
+            "id": "code",
+            "text": "Upload a simple PID loop that adjusts motor speed based on the sensors. Place the bot on a black line and watch it drive!",
+            "options": [{ "type": "finish", "text": "It works!" }]
+        }
+    ],
+    "requiresQuests": ["welcome/howtodoquests"]
+}


### PR DESCRIPTION
## Summary
- address review comment to use the howtodoquests intro for line follower
- document NPC reference tips in README
- mention Quest Sequence Expansion prompt in AGENTS guidelines

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6854aa82844c832f94e073d7cfb3bc81