### PR TITLE
Add item and process quality tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ These guidelines apply to all files in this repository.
 -   The `test:pr` and `test:e2e:groups` scripts automatically start the dev
     server. Avoid starting it manually unless running Playwright directly.
 -   When adding inventory items in `frontend/src/pages/inventory/json/items.json`, assign the next numeric `id` and provide an image if possible.
+-   Update `frontend/__tests__/itemQuality.test.js` when adding items so the quality ratio stays accurate.
+-   Update `frontend/__tests__/processQuality.test.js` when introducing new processes or unusual durations.
 -   If you add a quest that changes the tech tree order, document the new sequence in `README.md` and update `frontend/__tests__/questQuality.test.js` accordingly.
 
 ## Pull Request Message

--- a/README.md
+++ b/README.md
@@ -180,12 +180,21 @@ Additional quality checks are available:
 
 ```bash
 npm test -- questQuality        # heuristics for dialogue quality (TODO: integrate OpenAI)
+npm test -- itemQuality         # validates items.json for realism and completeness
+npm test -- processQuality      # validates processes.json for realistic durations
 npm test -- imageReferences     # verifies quest and NPC image files
 ```
 
 ## Built-in Items
 
 Item definitions live in `frontend/src/pages/inventory/json/items.json`. Assign new sequential `id` numbers and include an image path when adding items. See `frontend/src/pages/docs/md/item-guidelines.md` for detailed guidance.
+
+## Built-in Processes
+
+Process definitions are stored in `frontend/src/pages/processes/processes.json`.
+Durations should mirror real-world expectations when possible. See
+`frontend/src/pages/docs/md/process-guidelines.md` for more tips on designing
+and balancing new processes.
 
 > **Tip:** We use the open-source LLM inference from
 > [`token.place`](https://github.com/futuroptimist/token.place) when generating quest

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -224,6 +224,12 @@ We have specialized tests to ensure content quality:
     - Ensures each quest includes a start node
     - Requires at least one intermediate step and a finish option
     - Helps keep quest dialogue consistent across repos
+4. **Item Quality Tests** (`itemQuality.test.js`):
+    - Verifies item names, descriptions, and images
+    - Checks price formatting and flags unrealistic values
+5. **Process Quality Tests** (`processQuality.test.js`):
+    - Validates duration strings and item references
+    - Warns when processes lack items or have extreme durations
 
 These tests are designed to produce warnings rather than failures, allowing for ongoing development while still identifying quality issues to address.
 
@@ -231,6 +237,8 @@ To run these tests specifically:
 
 ```bash
 npm test -- questQuality
+npm test -- itemQuality
+npm test -- processQuality
 npm test -- imageReferences
 npm test -- questCanonical
 ```

--- a/frontend/__tests__/itemQuality.test.js
+++ b/frontend/__tests__/itemQuality.test.js
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+
+const itemsFile = path.join(__dirname, '../src/pages/inventory/json/items.json');
+const publicDir = path.join(__dirname, '../public');
+
+const items = JSON.parse(fs.readFileSync(itemsFile));
+
+function checkItem(item) {
+    const issues = [];
+    if (!item.name || item.name.trim().length < 3) {
+        issues.push('missing or short name');
+    }
+    if (!item.description || item.description.trim().length < 10) {
+        issues.push('missing or short description');
+    }
+    if (item.price) {
+        const match = item.price.toString().match(/([0-9]+(\.[0-9]+)?)\s*dUSD/);
+        if (!match) {
+            issues.push('invalid price format');
+        } else {
+            const priceVal = parseFloat(match[1]);
+            if (isNaN(priceVal) || priceVal <= 0 || priceVal > 100000) {
+                issues.push(`price out of range (${item.price})`);
+            }
+        }
+    }
+    if (item.image) {
+        const imagePath = path.join(publicDir, item.image.replace(/^\//, ''));
+        if (!fs.existsSync(imagePath)) {
+            issues.push(`missing image file ${item.image}`);
+        }
+    } else {
+        issues.push('missing image');
+    }
+    return issues;
+}
+
+describe('Item Quality Validation', () => {
+    test('items meet quality guidelines', () => {
+        const issues = [];
+        let validCount = 0;
+        items.forEach((item) => {
+            const itemIssues = checkItem(item);
+            if (itemIssues.length === 0) {
+                validCount++;
+            } else {
+                issues.push(`Item ${item.id}: ${itemIssues.join('; ')}`);
+            }
+        });
+
+        const ratio = validCount / items.length;
+        console.log(`${Math.round(ratio * 100)}% items meeting quality goal`);
+
+        if (issues.length > 0) {
+            console.warn('Item Quality Issues:');
+            issues.forEach((i) => console.warn(`- ${i}`));
+        }
+
+        expect(true).toBe(true);
+    });
+});

--- a/frontend/__tests__/processQuality.test.js
+++ b/frontend/__tests__/processQuality.test.js
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+const { durationInSeconds } = require('../src/utils.js');
+
+const processesFile = path.join(__dirname, '../src/pages/processes/processes.json');
+const itemsFile = path.join(__dirname, '../src/pages/inventory/json/items.json');
+
+const processes = JSON.parse(fs.readFileSync(processesFile));
+const items = JSON.parse(fs.readFileSync(itemsFile));
+const itemIds = new Set(items.map((i) => i.id));
+
+function checkProcess(proc) {
+    const issues = [];
+    if (!proc.title || proc.title.trim().length < 3) {
+        issues.push('missing or short title');
+    }
+
+    const seconds = durationInSeconds(proc.duration);
+    if (!seconds || seconds <= 0) {
+        issues.push(`invalid duration ${proc.duration}`);
+    }
+    if (seconds > 31536000) {
+        issues.push('duration longer than one year');
+    }
+
+    const hasItems =
+        (proc.requireItems && proc.requireItems.length > 0) ||
+        (proc.consumeItems && proc.consumeItems.length > 0) ||
+        (proc.createItems && proc.createItems.length > 0);
+
+    if (!hasItems) {
+        issues.push('no item relationships');
+    }
+
+    ['requireItems', 'consumeItems', 'createItems'].forEach((key) => {
+        (proc[key] || []).forEach((entry) => {
+            if (!itemIds.has(entry.id)) {
+                issues.push(`unknown item ${entry.id} in ${key}`);
+            }
+        });
+    });
+
+    return issues;
+}
+
+describe('Process Quality Validation', () => {
+    test('processes meet quality guidelines', () => {
+        const issues = [];
+        let validCount = 0;
+        processes.forEach((proc) => {
+            const procIssues = checkProcess(proc);
+            if (procIssues.length === 0) {
+                validCount++;
+            } else {
+                issues.push(`Process ${proc.id}: ${procIssues.join('; ')}`);
+            }
+        });
+
+        const ratio = validCount / processes.length;
+        console.log(`${Math.round(ratio * 100)}% processes meeting quality goal`);
+
+        if (issues.length > 0) {
+            console.warn('Process Quality Issues:');
+            issues.forEach((i) => console.warn(`- ${i}`));
+        }
+
+        expect(true).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- create `itemQuality.test.js` and `processQuality.test.js` to evaluate built-in data
- document new tests in README and TESTING guides
- update agent instructions with maintenance notes

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68565a9db4a8832f927a766cf548c278