### PR TITLE
Add quest tree documentation and stub quests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ These guidelines apply to all files in this repository.
 -   Update `frontend/__tests__/itemQuality.test.js` when adding items so the quality ratio stays accurate.
 -   Update `frontend/__tests__/processQuality.test.js` when introducing new processes or unusual durations.
 -   If you add a quest that changes the tech tree order, document the new sequence in `README.md` and update `frontend/__tests__/questQuality.test.js` accordingly.
+-   Summarize new categories in `frontend/src/pages/docs/md/quest-trees.md` when they are introduced.
 
 ## Pull Request Message
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ so older quests from the v2 era remain valid. Keep the NPC file updated when
 adding new characters.
 Quest files are organized by category in subfolders, so feel free to expand any
 area—electronics, hydroponics, rocketry and more—with additional quests.
+See [Quest Trees](/docs/quest-trees) for an overview of the different categories and their progression.
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, ask Atlas to help position it, add dwarf shrimp, introduce guppies, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -89,6 +89,7 @@ _Note: This checklist will be removed before the final release._
 Finished all the quests already? As of v2.1 and its handful of quests, you could 100% the game in a little over a month. And most of the time you'd just be waiting for some multi-week progress bar to complete. It was like watching paint dry.
 
 Thanks to the new custom quest system, I managed to make all the new quests in-game without touching a single JSON file directly. Well, except when it came time to merge v3 into the main branch. Speaking of...
+Work has begun on several new quest trees, including Chemistry, Astronomy, and Programming. Early stubs are now in place, paving the way toward the promised quest expansion.
 
 ## Custom Quests
 

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -1,0 +1,31 @@
+---
+title: 'Quest Trees'
+slug: 'quest-trees'
+---
+
+# Quest Trees
+
+DSPACE quests are organized into themed trees that build skills over time. This page summarizes the current quest categories and highlights new trees in development.
+
+## Existing Quest Trees
+
+-   **Welcome** – introductory tutorial showing how to accept and complete quests
+-   **3D Printing** – receive a printer, then tackle small projects and larger print runs
+-   **Aquaria** – set up a Walstad tank, add shrimp, keep guppies, breed them, and graduate to goldfish
+-   **Hydroponics** – grow basil, expand to bucket systems, and experiment with lettuce
+-   **Electronics** – wire a basic circuit, program an Arduino, and build a dimmer
+-   **Robotics** – assemble a line follower and learn servo control after completing electronics basics
+-   **Rocketry** – print and launch a model rocket with parachute recovery
+-   **Energy** – harvest solar power and accumulate dWatts toward higher milestones
+-   **UBI** – an optional quest explaining the metaguild's basic income concept
+-   **Completionist** – track progress toward finishing all available quests
+
+## Planned Quest Trees
+
+The following quest lines are being drafted to help achieve the "10x More Quests" goal announced for v3:
+
+-   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles
+-   **Astronomy** – observational tasks that prepare players for future rocketry missions
+-   **Programming** – simple scripts for automating sensors and data collection
+
+Check back as these new quests are fleshed out and integrated into the main progression.

--- a/frontend/src/pages/quests/json/astronomy/observe-moon.json
+++ b/frontend/src/pages/quests/json/astronomy/observe-moon.json
@@ -1,0 +1,27 @@
+{
+    "id": "astronomy/observe-moon",
+    "title": "Observe the Moon",
+    "description": "Nova encourages you to sketch lunar features as an introduction to observational astronomy.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Nova here! Before we engineer spacecraft, it's helpful to study the skies. Tonight let's observe the Moon together.",
+            "options": [{ "type": "goto", "goto": "record", "text": "I'm ready" }]
+        },
+        {
+            "id": "record",
+            "text": "Use a small telescope or binoculars and sketch the major craters you see. This design practice sharpens your eye for future missions.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Sketch completed" }]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! With regular observation you'll overcome many challenges when plotting real rocket trajectories.",
+            "options": [{ "type": "finish", "text": "Onward!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}

--- a/frontend/src/pages/quests/json/chemistry/safe-reaction.json
+++ b/frontend/src/pages/quests/json/chemistry/safe-reaction.json
@@ -1,0 +1,27 @@
+{
+    "id": "chemistry/safe-reaction",
+    "title": "Demonstrate a Safe Chemical Reaction",
+    "description": "Phoenix walks you through a harmless experiment that introduces basic eco-friendly propellant concepts.",
+    "image": "/assets/quests/testprint.png",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Phoenix here, your resident chemist. I'd like to show you how a simple reaction demonstrates eco-friendly fuel chemistry. Interested?",
+            "options": [{ "type": "goto", "goto": "mix", "text": "Absolutely!" }]
+        },
+        {
+            "id": "mix",
+            "text": "Carefully mix baking soda with vinegar in this open bottle. The fizzing gas is harmless but shows how fuel chemistry releases energy.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "The reaction is bubbling!" }]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! We'll build on this sustainable experiment later to design clean rocket fuel.",
+            "options": [{ "type": "finish", "text": "Can't wait!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}

--- a/frontend/src/pages/quests/json/programming/hello-sensor.json
+++ b/frontend/src/pages/quests/json/programming/hello-sensor.json
@@ -1,0 +1,27 @@
+{
+    "id": "programming/hello-sensor",
+    "title": "Log Temperature Data",
+    "description": "dChat shows you how a short script can capture sensor information for later analysis.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Greetings! I'm dChat, your helpful AI assistant. Let's write a quick script that gathers temperature information from a sensor.",
+            "options": [{ "type": "goto", "goto": "script", "text": "Sounds good" }]
+        },
+        {
+            "id": "script",
+            "text": "Connect a basic temperature sensor and run this short Python example. The program will guide you through logging the data to a file.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "The data is logging" }]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! This simple automation will assist you with larger projects down the road.",
+            "options": [{ "type": "finish", "text": "Cool!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- document quest categories in new `quest-trees` page
- mention quest tree doc in README
- note progress toward more quests in 2025 changelog
- add chemistry, astronomy and programming quest stubs
- clarify AGENT docs about documenting new categories

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6860dbf77678832fa5589257d109f799