### PR TITLE
Improve quest dialogue completeness

### DIFF
--- a/frontend/src/pages/quests/json/3dprinting/benchy_10.json
+++ b/frontend/src/pages/quests/json/3dprinting/benchy_10.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "progress",
-            "text": "Keep going until you reach the goal!",
+            "text": "Keep printing Benchies one by one until your workspace looks like a miniature marina. You'll know you've hit the mark when you can't fit another boat on the shelf!",
             "options": [
                 {
                     "type": "goto",
@@ -35,14 +35,14 @@
             ]
         },
         {
+            "id": "congrats",
+            "text": "That's a full fleet of ten Benchies! Your printer handled the run like a champ and each hull looks smooth and shiny.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "What's next?" }]
+        },
+        {
             "id": "finish",
             "text": "Well done! These Benchies look fantastic. Keep honing your 3D printing skills. I'll be back with a new challenge soon!",
-            "options": [
-                {
-                    "type": "finish",
-                    "text": "I'm ready for more!"
-                }
-            ]
+            "options": [{ "type": "finish", "text": "I'm ready for more!" }]
         }
     ],
     "rewards": [
@@ -51,5 +51,5 @@
             "count": 1000
         }
     ],
-    "requiresQuests": ["3dprinting/start"]
+    "requiresQuests": ["3dprinter/start"]
 }

--- a/frontend/src/pages/quests/json/3dprinting/benchy_100.json
+++ b/frontend/src/pages/quests/json/3dprinting/benchy_100.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "progress",
-            "text": "Keep going until you reach the goal!",
+            "text": "This is a marathon print session. Keep your machines running until a hundred Benchies line your shelves like a tiny armada.",
             "options": [
                 {
                     "type": "goto",
@@ -35,14 +35,14 @@
             ]
         },
         {
+            "id": "congrats",
+            "text": "One hundred Benchies! The print farm is in full swing and you've proven your dedication.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "That was intense!" }]
+        },
+        {
             "id": "finish",
             "text": "Incredible! You've constructed a formidable fleet of Benchies. Your 3D printing skills are truly remarkable. Remember, every Benchy is a testament to your growing capabilities. I'll be back with another challenge soon. Until then, keep printing!",
-            "options": [
-                {
-                    "type": "finish",
-                    "text": "Bring on the next challenge!"
-                }
-            ]
+            "options": [{ "type": "finish", "text": "Bring on the next challenge!" }]
         }
     ],
     "rewards": [

--- a/frontend/src/pages/quests/json/3dprinting/benchy_25.json
+++ b/frontend/src/pages/quests/json/3dprinting/benchy_25.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "progress",
-            "text": "Keep going until you reach the goal!",
+            "text": "Your printer will be humming for a while. Keep the builds running until you've amassed twenty-five sturdy little Benchies.",
             "options": [
                 {
                     "type": "goto",
@@ -35,14 +35,14 @@
             ]
         },
         {
+            "id": "congrats",
+            "text": "Twenty-five prints later and you've got a respectable armada. Each one is a testament to your patience and persistence.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "All done!" }]
+        },
+        {
             "id": "finish",
             "text": "Excellent job! Your fleet of Benchies is growing. Keep up the great work. I'll return with an even bigger challenge soon!",
-            "options": [
-                {
-                    "type": "finish",
-                    "text": "I'm ready for anything!"
-                }
-            ]
+            "options": [{ "type": "finish", "text": "I'm ready for anything!" }]
         }
     ],
     "rewards": [

--- a/frontend/src/pages/quests/json/energy/solar.json
+++ b/frontend/src/pages/quests/json/energy/solar.json
@@ -125,7 +125,7 @@
         },
         {
             "id": "fin",
-            "text": "It's my pleasure! I'm always happy to help!",
+            "text": "It's my pleasure! I'm always happy to help fellow explorers harness clean energy. Keep an eye on your charge levels and soon you'll be running entirely on sunlight!",
             "options": [
                 {
                     "type": "finish",

--- a/frontend/src/pages/quests/json/hydroponics/bucket_10.json
+++ b/frontend/src/pages/quests/json/hydroponics/bucket_10.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "progress",
-            "text": "Keep going until you reach the goal!",
+            "text": "Hauling water isn't glamorous, but it's great practice for future hydroponic adventures. Keep those buckets coming until you've collected ten of them.",
             "options": [
                 {
                     "type": "goto",
@@ -33,6 +33,11 @@
                     ]
                 }
             ]
+        },
+        {
+            "id": "congrats",
+            "text": "You managed to wrangle all ten buckets of dechlorinated water. That's a lot of arm work!",
+            "options": [{ "type": "goto", "goto": "finish", "text": "My arms are tired!" }]
         },
         {
             "id": "finish",

--- a/frontend/src/pages/quests/json/rocketry/firstlaunch.json
+++ b/frontend/src/pages/quests/json/rocketry/firstlaunch.json
@@ -41,7 +41,7 @@
         },
         {
             "id": "print",
-            "text": "Well first you've gotta print the rocket!",
+            "text": "First things first, you'll need to 3D print the rocket itself. It's a quick job with lightweight PLA filament and should only take about an hour.",
             "options": [
                 {
                     "type": "goto",


### PR DESCRIPTION
## Summary
- fill in short quest dialogue stubs
- add missing `congrats` nodes
- update quest dependencies

## Testing
- `npm run format`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68638979c560832fae4cefe45bc286ec