### PR TITLE
Add woodworking quest line

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -115,6 +115,20 @@ Atlas is a humanoid robot assistant designed to help with physical tasks that re
 -   "Great work! The tank is secure on the stand."
 -   "Anytime you need more muscle, just give me a shout."
 
+## Cedar
+
+<img src="/assets/npc/cedar.jpg" />
+
+Cedar is a seasoned woodworker who loves guiding newcomers. Years of building furniture have made them patient and detail-oriented. Cedar will help you master safe tool use and gradually tackle bigger projects.
+
+### Sample Dialogue
+
+-   "Hey there! I'm Cedar. Let's make sure you've got a solid bench before we start cutting."
+-   "Measure twice, cut once! That's a rule you'll hear often in my shop."
+-   "Keep your fingers clear of the blade and let the saw do the work."
+-   "Nice job on that birdhouse! Sand the edges so our feathered friends stay safe."
+-   "Ready for a bigger project? A sturdy step stool will test your skills."
+
 <style>
     img {
         float: left;

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -19,6 +19,7 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 -   **Energy** – harvest solar power and accumulate dWatts toward higher milestones
 -   **UBI** – an optional quest explaining the metaguild's basic income concept
 -   **Completionist** – track progress toward finishing all available quests
+-   **Woodworking** – build a sturdy workbench, then craft birdhouses, stools and shelves
 
 ## Planned Quest Trees
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -699,5 +699,61 @@
         "description": "An 80 L heated Walstad aquarium containing three female and one male guppy.",
         "image": "/assets/guppy.jpg",
         "price": "90 dUSD"
+    },
+    {
+        "id": "108",
+        "name": "Workbench",
+        "description": "A sturdy table that provides a safe space for sawing and assembly.",
+        "image": "/assets/workbench.jpg",
+        "price": "120 dUSD"
+    },
+    {
+        "id": "109",
+        "name": "Handsaw",
+        "description": "Basic saw for cutting lumber to size.",
+        "image": "/assets/handsaw.jpg",
+        "price": "15 dUSD"
+    },
+    {
+        "id": "110",
+        "name": "Wood glue",
+        "description": "Adhesive designed for bonding wooden pieces.",
+        "image": "/assets/wood_glue.jpg",
+        "price": "5 dUSD"
+    },
+    {
+        "id": "111",
+        "name": "Sandpaper pack",
+        "description": "Assorted grits for smoothing rough lumber and finished projects.",
+        "image": "/assets/sandpaper.jpg",
+        "price": "3 dUSD"
+    },
+    {
+        "id": "112",
+        "name": "Pine board",
+        "description": "A lightweight plank ideal for beginner projects.",
+        "image": "/assets/pine_board.jpg",
+        "price": "8 dUSD"
+    },
+    {
+        "id": "113",
+        "name": "Birdhouse",
+        "description": "A small wooden shelter perfect for backyard birds.",
+        "image": "/assets/birdhouse.jpg",
+        "price": "18 dUSD"
+    },
+    {
+        "id": "114",
+        "name": "Step stool",
+        "description": "A compact stool that helps reach higher shelves safely.",
+        "image": "/assets/step_stool.jpg",
+        "price": "25 dUSD"
+    },
+    {
+        "id": "115",
+        "name": "Bookshelf",
+        "description": "A simple wooden shelf ready to hold your growing library.",
+        "image": "/assets/bookshelf.jpg",
+        "price": "45 dUSD"
     }
 ]

--- a/frontend/src/pages/quests/json/woodworking/birdhouse.json
+++ b/frontend/src/pages/quests/json/woodworking/birdhouse.json
@@ -1,0 +1,59 @@
+{
+    "id": "woodworking/birdhouse",
+    "title": "Build a birdhouse",
+    "description": "Use simple tools to craft a home for local birds.",
+    "image": "/assets/birdhouse.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Now that your bench is ready, let's try a small project. A birdhouse is perfect for practicing basic cuts and assembly.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "Sounds fun!" }]
+        },
+        {
+            "id": "gather",
+            "text": "You'll need a pine board, wood glue, and your handsaw. I'll hand over what you don't already have so we can get started right away.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "112", "count": 1 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "Gather materials"
+                },
+                {
+                    "type": "goto",
+                    "goto": "build",
+                    "requiresItems": [
+                        { "id": "112", "count": 1 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "Materials ready"
+                }
+            ]
+        },
+        {
+            "id": "build",
+            "text": "Cut the board into panels, glue the walls together, then attach the roof. After the glue dries, smooth all edges with sandpaper so birds won't get hurt.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "The birdhouse is complete" }]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent craftsmanship! Mount your birdhouse outdoors and watch for new feathered tenants.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "113", "count": 1 }],
+                    "text": "Take the birdhouse"
+                },
+                { "type": "finish", "text": "Thanks for the lesson!" }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/workbench"]
+}

--- a/frontend/src/pages/quests/json/woodworking/bookshelf.json
+++ b/frontend/src/pages/quests/json/woodworking/bookshelf.json
@@ -1,0 +1,59 @@
+{
+    "id": "woodworking/bookshelf",
+    "title": "Build a small bookshelf",
+    "description": "Apply your skills to assemble a functional bookshelf.",
+    "image": "/assets/bookshelf.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "For a final challenge we'll make a bookshelf. It's larger than the stool but uses the same techniques you've learned.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "Let's do it" }]
+        },
+        {
+            "id": "gather",
+            "text": "You'll need several pine boards plus glue and your trusty handsaw. Measure everything carefully so the shelves fit snugly.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "Buy lumber"
+                },
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "requiresItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "All materials ready"
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "Cut the side panels and shelves, glue and clamp everything square, then let it dry. Finish by sanding the surfaces smooth.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Bookshelf built" }]
+        },
+        {
+            "id": "finish",
+            "text": "Fantastic job! You've progressed from basic carpentry to a piece of furniture you can proudly use at home.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "115", "count": 1 }],
+                    "text": "Take the bookshelf"
+                },
+                { "type": "finish", "text": "Thank you, Cedar" }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/step-stool"]
+}

--- a/frontend/src/pages/quests/json/woodworking/step-stool.json
+++ b/frontend/src/pages/quests/json/woodworking/step-stool.json
@@ -1,0 +1,59 @@
+{
+    "id": "woodworking/step-stool",
+    "title": "Build a step stool",
+    "description": "Create a sturdy stool to reach higher places safely.",
+    "image": "/assets/step_stool.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've mastered small projects. Let's tackle something bigger: a step stool sturdy enough to stand on.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "I'm ready" }]
+        },
+        {
+            "id": "gather",
+            "text": "We'll use several pine boards along with wood glue and your handsaw. Take these materials and lay them out on your bench.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "112", "count": 2 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "Gather parts"
+                },
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "requiresItems": [
+                        { "id": "112", "count": 2 },
+                        { "id": "110", "count": 1 },
+                        { "id": "109", "count": 1 }
+                    ],
+                    "text": "Parts ready"
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "Cut the boards to length, glue the frame, and add cross supports. Once dry, test the stool carefully before trusting your weight on it.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Stool assembled" }]
+        },
+        {
+            "id": "finish",
+            "text": "Nicely done! This step stool will serve you well and shows you've learned solid joinery basics.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "114", "count": 1 }],
+                    "text": "Take the stool"
+                },
+                { "type": "finish", "text": "Onward!" }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/birdhouse"]
+}

--- a/frontend/src/pages/quests/json/woodworking/workbench.json
+++ b/frontend/src/pages/quests/json/woodworking/workbench.json
@@ -1,0 +1,57 @@
+{
+    "id": "woodworking/workbench",
+    "title": "Build a simple workbench",
+    "description": "Construct a sturdy bench to support future projects.",
+    "image": "/assets/workbench.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there! I'm Cedar, your woodworking mentor. Before we dive into fancy projects, you'll need a dependable work surface.",
+            "options": [{ "type": "goto", "goto": "materials", "text": "What do I need?" }]
+        },
+        {
+            "id": "materials",
+            "text": "I'll supply a few pine boards and some wood glue. With those you can assemble a basic but solid bench frame.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 }
+                    ],
+                    "text": "Thanks for the supplies!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "build",
+                    "requiresItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 }
+                    ],
+                    "text": "I've got everything ready."
+                }
+            ]
+        },
+        {
+            "id": "build",
+            "text": "Arrange the boards into a rectangle, glue the joints, and clamp them until dry. Add legs and check that the bench is level and secure.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Bench assembled!" }]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! This bench will serve as the foundation for all your future woodworking quests.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "108", "count": 1 }],
+                    "text": "Claim my new workbench."
+                },
+                { "type": "finish", "text": "Thanks, Cedar!" }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- introduce Cedar NPC and add sample lines
- list Woodworking in quest trees doc
- add new woodworking items and images
- add four woodworking quests with beginner to intermediate steps
- remove placeholder woodworking images
- update quest text to `Buy lumber`

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68638c471564832f9243f0d5a4bc6c15