### PR TITLE
Expand aquaria line and upgrade quest generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ These guidelines apply to all files in this repository.
     existing quests. Keep these examples updated when quests change.
 -   Review `frontend/src/pages/docs/md/quest-submission.md` for the submission workflow when contributing new quests.
 -   See `frontend/src/pages/docs/md/quest-template.md` for a minimal quest JSON template that works with [token.place](https://github.com/futuroptimist/token.place).
+-   Use `npm run generate-quest` to scaffold a new quest with placeholder dialogue.
+-   The script is interactive; it lists categories and NPC usage statistics so you can assign the quest to an appropriate guide.
 -   Document any new or updated NPCs in `frontend/src/pages/docs/md/npcs.md`.
 -   Update quest progression tests in `frontend/__tests__/questQuality.test.js`
     when introducing new aquaria quests or changing their order.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Quest files are organized by category in subfolders, so feel free to expand any
 area—electronics, hydroponics, rocketry and more—with additional quests.
 See [Quest Trees](/docs/quest-trees) for an overview of the different categories and their progression.
 
-Aquarium quests progress through a gentle learning curve: set up a Walstad tank, ask Atlas to help position it, add dwarf shrimp, introduce guppies, practice breeding, and finally keep a goldfish in a large tank.
+Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.
 
 To validate that quests use a canonical structure with clear start and finish

--- a/frontend/__tests__/questQuality.test.js
+++ b/frontend/__tests__/questQuality.test.js
@@ -271,8 +271,18 @@ function checkQuestProgression() {
     // Check for category progression (e.g., aquaria quests follow proper sequence)
     for (const [category, questIds] of questsByCategory.entries()) {
         if (category === 'aquaria') {
-            // Verify aquaria progression: walstad -> shrimp -> guppy -> breeding -> goldfish
-            const expectedOrder = ['walstad', 'shrimp', 'guppy', 'breeding', 'goldfish'];
+            // Verify aquaria progression: walstad -> water-testing -> sponge-filter -> position-tank -> shrimp -> guppy -> water-change -> breeding -> goldfish
+            const expectedOrder = [
+                'walstad',
+                'water-testing',
+                'sponge-filter',
+                'position-tank',
+                'shrimp',
+                'guppy',
+                'water-change',
+                'breeding',
+                'goldfish',
+            ];
 
             // Get all relevant quests and sort by their position in the expected order
             const aquariaQuests = questIds

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
         "lint:fix": "ESLINT_USE_FLAT_CONFIG=false npx eslint . --fix",
         "format": "prettier --write \"**/*.{js,ts,svelte,json,md}\"",
         "format:check": "prettier --check \"**/*.{js,ts,svelte,json,md}\"",
+        "generate-quest": "node scripts/generate-quest.mjs",
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "npm run sync",

--- a/frontend/scripts/generate-quest.mjs
+++ b/frontend/scripts/generate-quest.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { writeFileSync, mkdirSync, readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+async function ask(question, rl) {
+    return new Promise((resolve) => rl.question(question, resolve));
+}
+
+function gatherStats() {
+    const questRoot = path.join('frontend', 'src', 'pages', 'quests', 'json');
+    const categories = readdirSync(questRoot).filter((f) =>
+        statSync(path.join(questRoot, f)).isDirectory()
+    );
+    const npcCounts = new Map();
+    for (const cat of categories) {
+        const files = readdirSync(path.join(questRoot, cat));
+        for (const file of files) {
+            if (!file.endsWith('.json')) continue;
+            const data = JSON.parse(readFileSync(path.join(questRoot, cat, file), 'utf8'));
+            const npc = path.basename(data.npc || '', path.extname(data.npc || ''));
+            if (!npc) continue;
+            const entry = npcCounts.get(npc) || {};
+            entry[cat] = (entry[cat] || 0) + 1;
+            npcCounts.set(npc, entry);
+        }
+    }
+    return { categories, npcCounts };
+}
+
+async function main() {
+    const { categories, npcCounts } = gatherStats();
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    let questId = process.argv[2];
+    if (!questId) {
+        console.log('Available categories:', categories.join(', '));
+        const category = (await ask('Choose a category or type a new one: ', rl)).trim();
+        const slug = (await ask('Quest id (slug-with-dashes): ', rl)).trim();
+        questId = `${category}/${slug}`;
+    }
+
+    const title = questId
+        .split('/')
+        .pop()
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+
+    console.log('\nNPC usage stats:');
+    const npcs = Array.from(npcCounts.keys()).sort();
+    npcs.forEach((npc, idx) => {
+        const counts = npcCounts.get(npc);
+        const summary = Object.entries(counts)
+            .map(([c, n]) => `${c}: ${n}`)
+            .join(', ');
+        console.log(`${idx + 1}) ${npc} (${summary})`);
+    });
+    const npcChoice = await ask('Select an NPC by number: ', rl);
+    const npcName = npcs[parseInt(npcChoice, 10) - 1] || 'vega';
+    rl.close();
+
+    const quest = {
+        id: questId,
+        title,
+        description: 'Describe the quest objectives here.',
+        image: '/assets/quests/howtodoquests.jpg',
+        npc: `/assets/npc/${npcName}.jpg`,
+        start: 'start',
+        dialogue: [
+            {
+                id: 'start',
+                text: 'Replace this text with your opening dialogue.',
+                options: [{ type: 'finish', text: 'Finish' }],
+            },
+        ],
+        rewards: [],
+        requiresQuests: [],
+    };
+
+    const outputPath = path.join('frontend', 'src', 'pages', 'quests', 'json', `${questId}.json`);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify(quest, null, 4));
+    console.log(`Created quest at ${outputPath}`);
+}
+
+main();

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -223,6 +223,16 @@ Suggest several logical next quests that would follow it. For each quest propose
 4. Key items or processes that should be introduced, focusing on hands-on steps rather than purely conversational beats
 ```
 
+### Custom Quest Scaffolding
+
+Use this when you want help creating a bare-bones quest JSON for the custom quest system.
+
+```
+Create a minimal DSPACE quest with the id `[CATEGORY]/[SHORT_ID]`. Populate the required fields according to the quest schema but keep dialogue text short and clearly marked as placeholders. Return only the JSON object.
+```
+
+After generating the JSON, run `npm run generate-quest` and follow the prompts to save it under the correct category and assign an NPC.
+
 ## Example: Complete Quest Creation
 
 Here's an example of how to use these prompts to create a complete quest:

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -11,7 +11,7 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 
 -   **Welcome** – introductory tutorial showing how to accept and complete quests
 -   **3D Printing** – receive a printer, then tackle small projects and larger print runs
--   **Aquaria** – set up a Walstad tank, add shrimp, keep guppies, breed them, and graduate to goldfish
+-   **Aquaria** – set up a Walstad tank, test the water, install a sponge filter, position the tank, add shrimp, keep guppies, perform water changes, breed them, and graduate to goldfish
 -   **Hydroponics** – grow basil, expand to bucket systems, and experiment with lettuce
 -   **Electronics** – wire a basic circuit, program an Arduino, and build a dimmer
 -   **Robotics** – assemble a line follower and learn servo control after completing electronics basics

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -755,5 +755,12 @@
         "description": "A simple wooden shelf ready to hold your growing library.",
         "image": "/assets/bookshelf.jpg",
         "price": "45 dUSD"
+    },
+    {
+        "id": "116",
+        "name": "Sponge filter",
+        "description": "A gentle air-driven filter ideal for small aquariums.",
+        "image": "/assets/aquarium_filter.jpg",
+        "price": "6 dUSD"
     }
 ]

--- a/frontend/src/pages/quests/json/aquaria/sponge-filter.json
+++ b/frontend/src/pages/quests/json/aquaria/sponge-filter.json
@@ -1,0 +1,29 @@
+{
+    "id": "aquaria/sponge-filter",
+    "title": "Install a sponge filter",
+    "description": "Add gentle filtration to keep your tank clean without harming shrimp.",
+    "image": "/assets/aquarium_filter.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A sponge filter keeps water clean without too much flow. Let's set it up.",
+            "options": [{ "type": "goto", "goto": "prepare", "text": "Sounds good, what's first?" }]
+        },
+        {
+            "id": "prepare",
+            "text": "Rinse the sponge in tank water, then attach it to an air pump with tubing.",
+            "options": [
+                { "type": "goto", "goto": "install", "text": "Sponge rinsed and tubing attached." }
+            ]
+        },
+        {
+            "id": "install",
+            "text": "Place the filter in a corner and plug in the pump. Bubbles show it's working.",
+            "options": [{ "type": "finish", "text": "Filter bubbling nicely!" }]
+        }
+    ],
+    "rewards": [{ "id": "116", "count": 1 }],
+    "requiresQuests": ["aquaria/water-testing"]
+}

--- a/frontend/src/pages/quests/json/aquaria/water-change.json
+++ b/frontend/src/pages/quests/json/aquaria/water-change.json
@@ -1,0 +1,27 @@
+{
+    "id": "aquaria/water-change",
+    "title": "Perform a partial water change",
+    "description": "Learn how to remove dirty water and refill your tank with conditioned water.",
+    "image": "/assets/quests/goldfish.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Regular water changes keep your fish healthy. Let's remove about 25% of the water.",
+            "options": [{ "type": "goto", "goto": "remove", "text": "Got it. How do I start?" }]
+        },
+        {
+            "id": "remove",
+            "text": "Use a siphon to vacuum debris while draining into a bucket. Stop when you've removed about a quarter of the volume.",
+            "options": [{ "type": "goto", "goto": "refill", "text": "Water removed." }]
+        },
+        {
+            "id": "refill",
+            "text": "Refill slowly with dechlorinated water that's close to the tank's temperature.",
+            "options": [{ "type": "finish", "text": "Tank refilled and fish are happy!" }]
+        }
+    ],
+    "rewards": [{ "id": "106", "count": 1 }],
+    "requiresQuests": ["aquaria/guppy"]
+}

--- a/frontend/src/pages/quests/json/aquaria/water-testing.json
+++ b/frontend/src/pages/quests/json/aquaria/water-testing.json
@@ -1,0 +1,27 @@
+{
+    "id": "aquaria/water-testing",
+    "title": "Test water parameters",
+    "description": "Use a liquid test kit to check for ammonia, nitrite and nitrate before adding shrimp.",
+    "image": "/assets/quests/walstad.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "The tank should be cycling nicely. Let's test the water to make sure it's safe for shrimp.",
+            "options": [{ "type": "goto", "goto": "explain", "text": "How do I test it?" }]
+        },
+        {
+            "id": "explain",
+            "text": "Use a liquid test kit. Check ammonia and nitrite first—they should read zero. Nitrate should stay under 40 ppm.",
+            "options": [{ "type": "goto", "goto": "results", "text": "Okay, I'll test now." }]
+        },
+        {
+            "id": "results",
+            "text": "If you see ammonia or nitrite, give the tank more time. If nitrate is high, perform a partial water change.",
+            "options": [{ "type": "finish", "text": "All clear! Levels look good." }]
+        }
+    ],
+    "rewards": [{ "id": "105", "count": 1 }],
+    "requiresQuests": ["aquaria/walstad"]
+}


### PR DESCRIPTION
## Summary
- add an interactive quest scaffold script
- insert sponge filter quest between water testing and positioning
- describe new aquarium order in README and quest trees docs
- document interactive generator usage in prompts and AGENTS
- update quest progression test and items list

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6864497661c4832f92d962cef0702693