### PR TITLE
Fix RPi deploy workflow secret check

### DIFF
--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -28,7 +28,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
       - name: Deploy on Raspberry Pi
-        if: ${{ secrets.RPI_HOST }}
+        # Only run this step if the Raspberry Pi host secret is set
+        if: ${{ secrets.RPI_HOST != '' }}
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.RPI_HOST }}


### PR DESCRIPTION
## Summary
- skip Raspberry Pi deploy step if `RPI_HOST` secret is missing

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68645e0aa2ec832f95640e32c1033357