### PR TITLE
Optimize Playwright setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ jobs:
             frontend/package-lock.json
       - run: npm ci
       - run: cd frontend && npm ci
-      - run: cd frontend && npx playwright install --with-deps
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - run: cd frontend && npx playwright install chromium
       - run: npm run test:pr
       - run: cd frontend && npm run coverage
         if: env.CODECOV_TOKEN != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ These guidelines apply to all files in this repository.
 ## Development
 
 -   Before submitting a pull request, run `npm run test:pr` to execute lint, unit and e2e tests.
--   If E2E tests complain that the browser executable is missing, run `npx playwright install` to download the required browsers.
+-   If E2E tests complain that the browser executable is missing, run `npx playwright install chromium` to download the required browser.
 -   If Playwright browsers aren't available, prefix the command with `SKIP_E2E=1`.
 -   Use `npm run check` to verify formatting and linting prior to commit.
 -   If these checks fail due to missing dev dependencies, mention the error in

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you encounter an error like `browserType.launch: Executable doesn't exist`,
 download the browsers with:
 
 ```bash
-npx playwright install
+npx playwright install chromium
 ```
 
 This cross-platform script will:

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -542,7 +542,7 @@ Remember that E2E tests require a running development server:
 If you encounter persistent issues, try:
 
 1. Clearing the test cache: `npx playwright clear-cache`
-2. Reinstalling browsers: `npx playwright install`
+2. Reinstalling browsers: `npx playwright install chromium`
 3. Restarting the dev server
 4. Checking the logs in the test artifacts directories
 


### PR DESCRIPTION
## Summary
- cache Playwright browsers during CI
- install only Chromium since it's the only browser we test
- update docs to reflect the new install command

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_686467aa68f8832f936b088be606bf17