### PR TITLE
Add unit tests for devLog and localStorage utils

### DIFF
--- a/frontend/__tests__/devLog.test.js
+++ b/frontend/__tests__/devLog.test.js
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+const { log } = require('../src/utils/devLog.js');
+
+describe('devLog', () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+        console.log = jest.fn();
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalEnv;
+    });
+
+    test('logs when NODE_ENV is development', () => {
+        process.env.NODE_ENV = 'development';
+        log('hello', 'world');
+        expect(console.log).toHaveBeenCalledWith('hello', 'world');
+    });
+
+    test('does not log when NODE_ENV is not development', () => {
+        process.env.NODE_ENV = 'production';
+        log('hi');
+        expect(console.log).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/__tests__/localStorage.test.js
+++ b/frontend/__tests__/localStorage.test.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getLocalStorage } from '../src/utils/localStorage.js';
+
+describe('getLocalStorage', () => {
+    let originalLocalStorage;
+
+    beforeEach(() => {
+        originalLocalStorage = window.localStorage;
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'localStorage', {
+            value: originalLocalStorage,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(global, 'localStorage', {
+            value: originalLocalStorage,
+            configurable: true,
+            writable: true,
+        });
+        jest.restoreAllMocks();
+    });
+
+    test('returns entries when localStorage is available', () => {
+        Object.defineProperty(global, 'localStorage', {
+            value: { a: '1', b: '2' },
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(window, 'localStorage', {
+            value: global.localStorage,
+            configurable: true,
+            writable: true,
+        });
+        const result = getLocalStorage();
+        expect(result).toEqual([
+            { key: 'a', value: '1' },
+            { key: 'b', value: '2' },
+        ]);
+    });
+
+    test('returns empty array and logs when localStorage missing', () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        Object.defineProperty(global, 'localStorage', {
+            value: undefined,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(window, 'localStorage', {
+            value: undefined,
+            configurable: true,
+            writable: true,
+        });
+        const result = getLocalStorage();
+        expect(result).toEqual([]);
+        expect(logSpy).toHaveBeenCalledWith('Local storage is not supported by this browser.');
+    });
+
+    test('returns empty array when enumeration fails', () => {
+        Object.defineProperty(global, 'localStorage', {
+            value: {},
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(window, 'localStorage', {
+            value: global.localStorage,
+            configurable: true,
+            writable: true,
+        });
+        jest.spyOn(Object, 'entries').mockImplementation(() => {
+            throw new Error('fail');
+        });
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const result = getLocalStorage();
+        expect(result).toEqual([]);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- add new Jest tests for `devLog.js`
- add new Jest tests for `localStorage.js`

All tests pass with `SKIP_E2E=1 npm run test:pr`.


------
https://chatgpt.com/codex/tasks/task_e_6864cd3c6be4832f8d0e9528f047cc97