### PR TITLE
Update GHCR secret docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYM
 ### Automated Raspberry Pi Deployment
 
 The workflow `.github/workflows/rpi-deploy.yml` builds an ARM64 Docker image and optionally deploys it to a Raspberry Pi over SSH.
-Add registry credentials in `GHCR_TOKEN` (or another registry) and set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` secrets.
+Create a personal access token with **write:packages** scope and add it as a repository secret named `GHCR_TOKEN` (or use an alternative registry token). Also set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` secrets under **Settings → Secrets → Actions**.
 Trigger the workflow manually or on pushes to `v3` to update the Pi and restart the `app` service.
 
 ## Project Architecture


### PR DESCRIPTION
## Summary
- clarify that `GHCR_TOKEN` should be a PAT with `write:packages` scope

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6864db424058832fbfb438438b45281a