### PR TITLE
Fix Docker build script path

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /app
 
 # Copy package.json and package-lock.json to install dependencies
 COPY package*.json ./
+# The postinstall script depends on scripts/sync-package.js, so copy it early
+COPY scripts ./scripts
 
 # Install dependencies
 RUN npm install --production


### PR DESCRIPTION
## Summary
- ensure sync-package.js is available during Docker build

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6864e3cc7b3c832f8d51f6b9dc854ee0