### PR TITLE
Fix Docker build path for sync script

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 
 # Copy package.json and package-lock.json to install dependencies
 COPY package*.json ./
+COPY scripts ./scripts
 
 # Install dependencies
 RUN npm install --production

--- a/frontend/Dockerfile.test
+++ b/frontend/Dockerfile.test
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 # Copy package files
 COPY package*.json ./
+COPY scripts ./scripts
 
 # Install dependencies
 RUN npm install


### PR DESCRIPTION
## Summary
- copy `scripts/` before running `npm install` in Dockerfiles

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6864e3cc7b3c832f8d51f6b9dc854ee0