### PR TITLE
Fix quest chart README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See [Quest Trees](/docs/quest-trees) for an overview of the different categories
 The repository includes a script that summarizes how many quests and lines of dialogue exist in each tree. Categories are sorted by quest count for readability.
 Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git, but CI artifacts attach the latest chart for reference.
 
-![Quest tree stats chart](https://nightly.link/democratizedspace/dspace/workflows/quest-chart.yml/branch/v3/quest-tree-chart.zip?path=quest-tree-stats.png)
+![Quest tree stats chart](https://nightly.link/democratizedspace/dspace/workflows/quest-chart.yml/branch/v3/quest-tree-chart.zip?path=frontend/src/pages/docs/images/quest-tree-stats.png)
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.


### PR DESCRIPTION
## Summary
- fix broken nightly.link path to quest chart

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6864e982e018832f86999235481900a6