### PR TITLE
Add tests for utils

### DIFF
--- a/frontend/__tests__/openAI.test.js
+++ b/frontend/__tests__/openAI.test.js
@@ -1,0 +1,50 @@
+const { jest } = require('@jest/globals');
+
+const createChatCompletionMock = jest.fn().mockResolvedValue({
+    data: { choices: [{ message: { content: 'mocked reply' } }] },
+});
+
+jest.mock('openai', () => {
+    return {
+        __esModule: true,
+        Configuration: jest.fn(),
+        OpenAIApi: jest.fn().mockImplementation(function () {
+            this.createChatCompletion = createChatCompletionMock;
+        }),
+    };
+});
+
+jest.mock('../src/utils/gameState/common.js', () => ({
+    loadGameState: jest.fn(() => ({ openAI: { apiKey: 'test-key' } })),
+}));
+
+const { GPT35Turbo } = require('../src/utils/openAI.js');
+
+describe('GPT35Turbo', () => {
+    beforeEach(() => {
+        createChatCompletionMock.mockClear();
+    });
+
+    test('uses opening message when no messages provided', async () => {
+        await GPT35Turbo([]);
+        expect(createChatCompletionMock).toHaveBeenCalledTimes(1);
+        const call = createChatCompletionMock.mock.calls[0][0];
+        expect(call.model).toBe('gpt-3.5-turbo');
+        expect(call.messages[0].role).toBe('system');
+        expect(call.messages[1].role).toBe('assistant');
+    });
+
+    test('prepends system message when messages supplied', async () => {
+        await GPT35Turbo([{ role: 'user', content: 'hello' }]);
+        const call = createChatCompletionMock.mock.calls[0][0];
+        expect(call.messages).toEqual([
+            expect.objectContaining({ role: 'system' }),
+            { role: 'user', content: 'hello' },
+        ]);
+    });
+
+    test('returns response content', async () => {
+        const result = await GPT35Turbo([]);
+        expect(result).toBe('mocked reply');
+    });
+});

--- a/frontend/__tests__/openCustomContentDB.test.js
+++ b/frontend/__tests__/openCustomContentDB.test.js
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { openCustomContentDB } from '../src/utils/indexeddb.js';
+
+describe('openCustomContentDB', () => {
+    test('creates stores and resolves with db on success', async () => {
+        const db = {
+            objectStoreNames: { contains: jest.fn().mockReturnValue(false) },
+            createObjectStore: jest.fn(),
+        };
+        const request = {
+            onupgradeneeded: null,
+            onsuccess: null,
+            onerror: null,
+            result: db,
+        };
+        global.indexedDB.open = jest.fn(() => request);
+
+        const promise = openCustomContentDB();
+        // trigger upgrade and success
+        request.onupgradeneeded({ target: { result: db } });
+        request.onsuccess();
+
+        const resultDb = await promise;
+        expect(resultDb).toBe(db);
+        expect(db.createObjectStore).toHaveBeenCalledWith('items', { keyPath: 'id' });
+        expect(db.createObjectStore).toHaveBeenCalledWith('processes', { keyPath: 'id' });
+        expect(db.createObjectStore).toHaveBeenCalledWith('quests', { keyPath: 'id' });
+    });
+
+    test('rejects on error', async () => {
+        const request = {
+            onupgradeneeded: null,
+            onsuccess: null,
+            onerror: null,
+            error: new Error('fail'),
+        };
+        global.indexedDB.open = jest.fn(() => request);
+
+        const promise = openCustomContentDB();
+        request.onerror();
+
+        await expect(promise).rejects.toBe(request.error);
+    });
+});

--- a/frontend/__tests__/utils.encoding.test.js
+++ b/frontend/__tests__/utils.encoding.test.js
@@ -1,0 +1,50 @@
+const {
+    base64ToObject,
+    jsonToQuery,
+    queryToJson,
+    constructLink,
+    getPriceStringComponents,
+    getSymbolFromId,
+} = require('../src/utils.js');
+
+describe('encoding helpers', () => {
+    test('jsonToQuery and queryToJson roundtrip', () => {
+        const obj = { a: 1, b: 'hi' };
+        const encoded = jsonToQuery(obj);
+        expect(queryToJson(encoded)).toEqual(obj);
+    });
+
+    test('base64ToObject decodes encoded string', () => {
+        const obj = { foo: 'bar', n: 42 };
+        const encoded = Buffer.from(encodeURIComponent(JSON.stringify(obj))).toString('base64');
+        expect(base64ToObject(encoded)).toEqual(obj);
+    });
+
+    test('base64ToObject returns empty object on invalid input', () => {
+        expect(base64ToObject('@@invalid@@')).toEqual({});
+    });
+});
+
+describe('URL helpers', () => {
+    test('constructLink adds redirect query', () => {
+        expect(constructLink(false, '/page', '/target')).toBe('/page?redirect=/target');
+    });
+
+    test('constructLink returns url without redirect', () => {
+        expect(constructLink(false, '/page')).toBe('/page');
+    });
+});
+
+describe('currency utilities', () => {
+    test('getPriceStringComponents parses currency', () => {
+        expect(getPriceStringComponents('10 dUSD')).toEqual({ price: 10, symbol: 'dUSD' });
+    });
+
+    test('getPriceStringComponents handles invalid input', () => {
+        expect(getPriceStringComponents(null)).toEqual({ price: 0, symbol: '' });
+    });
+
+    test('getSymbolFromId fetches symbol from items', () => {
+        expect(getSymbolFromId('0')).toBe('dUSD');
+    });
+});

--- a/frontend/__tests__/utils.more.test.js
+++ b/frontend/__tests__/utils.more.test.js
@@ -1,0 +1,111 @@
+const {
+    prettyPrintNumber,
+    parseBool,
+    datetimeAfterDuration,
+    getWalletBalance,
+    burnCurrency,
+    addWalletBalance,
+    fixMarkdownText,
+    getPriceStringComponents,
+    getSymbolFromId,
+    constructLink,
+    base64ToObject,
+    jsonToQuery,
+    queryToJson,
+} = require('../src/utils.js');
+
+describe('number and boolean utilities', () => {
+    test('prettyPrintNumber handles small and large numbers', () => {
+        expect(prettyPrintNumber(0.0003)).toBe('3.E-4');
+        expect(prettyPrintNumber(10000)).toBe('1.E4');
+        expect(prettyPrintNumber(1.234)).toBe('1.234');
+    });
+
+    test('parseBool returns true only for "true"', () => {
+        expect(parseBool('true')).toBe(true);
+        expect(parseBool('false')).toBe(false);
+        expect(parseBool('random')).toBe(false);
+    });
+});
+
+describe('date utilities', () => {
+    test('datetimeAfterDuration adds seconds', () => {
+        jest.useFakeTimers();
+        const now = new Date('2023-01-01T00:00:00Z');
+        jest.setSystemTime(now);
+        const result = datetimeAfterDuration(60);
+        expect(result.getTime()).toBe(now.getTime() + 60000);
+        jest.useRealTimers();
+    });
+});
+
+describe('wallet utilities', () => {
+    let req;
+    let res;
+    beforeEach(() => {
+        req = { headers: { get: () => 'currency-balance-dUSD=5' } };
+        res = { headers: { append: jest.fn() } };
+    });
+
+    test('getWalletBalance parses balance', () => {
+        expect(getWalletBalance(req, 'dUSD')).toBe(5);
+    });
+
+    test('burnCurrency updates balance when sufficient', () => {
+        expect(burnCurrency(req, res, 'dUSD', 2)).toBe(true);
+        expect(res.headers.append).toHaveBeenCalledWith(
+            'Set-Cookie',
+            'currency-balance-dUSD=3; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/'
+        );
+    });
+
+    test('burnCurrency fails when insufficient balance', () => {
+        const req2 = { headers: { get: () => 'currency-balance-dUSD=1' } };
+        expect(burnCurrency(req2, res, 'dUSD', 2)).toBe(false);
+    });
+
+    test('addWalletBalance increments balance', () => {
+        expect(addWalletBalance(req, res, 'dUSD', 5)).toBe(10);
+        expect(res.headers.append).toHaveBeenCalledWith(
+            'Set-Cookie',
+            'currency-balance-dUSD=10; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/'
+        );
+    });
+});
+
+describe('string and object helpers', () => {
+    test('fixMarkdownText keeps straight quotes', () => {
+        expect(fixMarkdownText("it's fine")).toBe("it's fine");
+    });
+
+    test('getPriceStringComponents parses currency', () => {
+        expect(getPriceStringComponents('10 dUSD')).toEqual({ price: 10, symbol: 'dUSD' });
+        expect(getPriceStringComponents()).toEqual({ price: 0, symbol: '' });
+    });
+
+    test('getSymbolFromId reads item price', () => {
+        expect(getSymbolFromId('0')).toBe('dUSD');
+        expect(getSymbolFromId('1')).toBe('');
+    });
+
+    test('constructLink appends redirect', () => {
+        expect(constructLink(false, '/foo', '/bar')).toBe('/foo?redirect=/bar');
+        expect(constructLink(false, '/foo')).toBe('/foo');
+    });
+
+    test('base64ToObject decodes valid string', () => {
+        const obj = { a: 1 };
+        const base64 = Buffer.from(encodeURIComponent(JSON.stringify(obj))).toString('base64');
+        expect(base64ToObject(base64)).toEqual(obj);
+    });
+
+    test('base64ToObject handles invalid input', () => {
+        expect(base64ToObject('not-base64')).toEqual({});
+    });
+
+    test('jsonToQuery and queryToJson roundtrip', () => {
+        const obj = { foo: 'bar' };
+        const query = jsonToQuery(obj);
+        expect(queryToJson(query)).toEqual(obj);
+    });
+});


### PR DESCRIPTION
## Summary
- add more test coverage for encoding and openAI helpers
- test the openCustomContentDB wrapper

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6867711b9560832fab38973207062ac9