### PR TITLE
Add simple AvatarPicker test

### DIFF
--- a/frontend/__tests__/AvatarPicker.test.js
+++ b/frontend/__tests__/AvatarPicker.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import AvatarPicker from '../src/components/svelte/AvatarPicker.svelte';
+import '@testing-library/jest-dom';
+
+describe('AvatarPicker component', () => {
+    let container;
+
+    beforeEach(() => {
+        localStorage.clear();
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    test('exports a valid Svelte component', () => {
+        expect(typeof AvatarPicker).toBe('function');
+    });
+
+    test('module exports a Svelte component', () => {
+        expect(typeof AvatarPicker).toBe('function');
+    });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "test:e2e:custom": "cd frontend && npm run test:e2e:custom",
         "test:all": "cd frontend && npm run test:all",
         "test:quick": "cd frontend && npm run test:quick",
+        "coverage": "cd frontend && npm run coverage",
         "test:pr": "node run-tests.js",
         "check": "cd frontend && npm run check",
         "lint": "cd frontend && npm run lint",


### PR DESCRIPTION
## Summary
- add a minimal AvatarPicker test that just checks the component export
- keep the root `npm run coverage` helper

## Testing
- `npm run coverage`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868c28cb20c832fab1908690baafea0