### PR TITLE
Fix husky error in Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Run the game in Docker (works on Raspberry Pi) using:
 docker compose up --build -d
 ```
 
+Husky is disabled during installation in the Dockerfile via `HUSKY=0` to avoid
+missing git hook errors.
+
 The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -82,6 +82,9 @@ Build the container images and load them into k3s:
 docker build -t dspace-app:latest -f frontend/Dockerfile ./frontend
 k3s ctr images import dspace-app:latest
 
+The Dockerfile sets `HUSKY=0` during `npm install` so build steps succeed even
+without dev dependencies.
+
 ```
 
 Apply the manifests:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 COPY package*.json ./
 COPY scripts ./scripts
 
-# Install dependencies
-RUN npm install --production
+# Install dependencies without running Husky
+RUN HUSKY=0 npm install --production
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
## Summary
- prevent husky from running during Docker builds
- note the environment variable in README and deployment guide

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6868cd84ca40832fa35b3b22f7652b8d