### PR TITLE
Fix Docker build with ignore-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Run the game in Docker (works on Raspberry Pi) using:
 docker compose up --build -d
 ```
 
-Husky is disabled during installation in the Dockerfile via `HUSKY=0` to avoid
-missing git hook errors.
+The Dockerfile installs dependencies with `--ignore-scripts` so Husky and other
+npm hooks don't run during the build.
 
 The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -82,8 +82,8 @@ Build the container images and load them into k3s:
 docker build -t dspace-app:latest -f frontend/Dockerfile ./frontend
 k3s ctr images import dspace-app:latest
 
-The Dockerfile sets `HUSKY=0` during `npm install` so build steps succeed even
-without dev dependencies.
+The Dockerfile installs dependencies with `--ignore-scripts` so build steps
+work even without dev dependencies.
 
 ```
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 COPY package*.json ./
 COPY scripts ./scripts
 
-# Install dependencies without running Husky
-RUN HUSKY=0 npm install --production
+# Install dependencies without executing any npm scripts
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
## Summary
- prevent Husky failures during Docker build by skipping npm scripts
- update README and Raspberry Pi guide

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6868d0ab1230832fa9257d6df1dcb62b