### PR TITLE
Increase IndexedDB test coverage

### DIFF
--- a/frontend/__tests__/customDBOperations.test.js
+++ b/frontend/__tests__/customDBOperations.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'fake-indexeddb/auto';
+import {
+    saveItem,
+    getItems,
+    getItem,
+    saveProcess,
+    getProcesses,
+    getProcess,
+    deleteProcess,
+    saveQuest,
+    getQuests,
+    getQuest,
+} from '../src/utils/indexeddb.js';
+
+describe('Custom DB operations', () => {
+    test('saveItem and getItem work correctly', async () => {
+        const item = { id: '123', name: 'Widget' };
+        await saveItem(item);
+        const result = await getItem('123');
+        expect(result).toEqual(item);
+    });
+
+    test('getItems returns all stored items', async () => {
+        const itemA = { id: 'a', name: 'A' };
+        const itemB = { id: 'b', name: 'B' };
+        await saveItem(itemA);
+        await saveItem(itemB);
+        const items = await getItems();
+        expect(items).toEqual(expect.arrayContaining([itemA, itemB]));
+    });
+
+    test('process functions save and delete correctly', async () => {
+        const process = { id: 'proc1', title: 'Run' };
+        await saveProcess(process);
+        const found = await getProcess('proc1');
+        expect(found).toEqual(process);
+
+        await deleteProcess('proc1');
+        const afterDelete = await getProcess('proc1');
+        expect(afterDelete).toBeUndefined();
+    });
+
+    test('quest functions save and list correctly', async () => {
+        const quest = { id: 'quest1', title: 'Start' };
+        await saveQuest(quest);
+        const result = await getQuest('quest1');
+        expect(result).toEqual(quest);
+        const quests = await getQuests();
+        expect(quests).toEqual(expect.arrayContaining([quest]));
+    });
+});


### PR DESCRIPTION
## Summary
- add test suite for custom DB operations to cover more of `indexeddb.js`

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6868e065d8d4832f9581b02a26bc9a64