### PR TITLE
Increase test coverage

### DIFF
--- a/frontend/__tests__/ShoppingForm.test.js
+++ b/frontend/__tests__/ShoppingForm.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('ShoppingForm component', () => {
+    test('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/shop/ShoppingForm.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary
- add compile test for ShoppingForm Svelte component

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6868e065d8d4832f9581b02a26bc9a64