### PR TITLE
Improve docs for UI hydration workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ These guidelines apply to all files in this repository.
     when introducing new aquaria quests or changing their order.
 -   Provide simple Jest tests for any new Svelte components under
     `frontend/__tests__` to help maintain Codecov coverage.
+-   Follow the [UI Lifecycle Overview](frontend/src/pages/docs/md/ui-lifecycle.md)
+    when creating or modifying Svelte components. Ensure initialization code
+    runs in `onMount` and mark hydrated components with
+    `data-hydrated="true"` so tests can detect readiness.
 -   Avoid committing large binary assets (e.g., PSD files). Convert graphics to
     optimized formats before adding them to the repo.
 -   Continuous integration runs `npm run test:pr` on pushes and pull requests.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -71,6 +71,8 @@ DSPACE uses Astro's Server-Side Rendering (SSR) with partial hydration of Svelte
 
 Due to the SSR + client hydration architecture, components must follow a specific pattern:
 
+For a concise overview and debugging tips, see [UI Lifecycle Overview](./frontend/src/pages/docs/md/ui-lifecycle.md).
+
 ```svelte
 <script>
   import { onMount } from 'svelte';
@@ -457,6 +459,9 @@ By properly separating formatting (Prettier) from code quality (ESLint), you'll 
 - Keep components small and focused
 
 ## Component Development
+
+For an overview of the server-to-client lifecycle and hydration guidelines,
+see [UI Lifecycle Overview](./frontend/src/pages/docs/md/ui-lifecycle.md).
 
 ### Component Structure
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For comprehensive information about developing DSPACE, see our [Developer Guide]
 
 -   Detailed architecture overview
 -   Component development guidelines
+-   [UI Lifecycle Overview](./frontend/src/pages/docs/md/ui-lifecycle.md) for understanding Astro SSR and Svelte hydration
 -   Testing strategies
 -   Performance considerations
 -   Troubleshooting tips

--- a/frontend/src/pages/docs/md/ui-lifecycle.md
+++ b/frontend/src/pages/docs/md/ui-lifecycle.md
@@ -1,0 +1,48 @@
+---
+title: 'UI Lifecycle Overview'
+slug: 'ui-lifecycle'
+---
+
+# UI Lifecycle Overview
+
+DSPACE uses **Astro** for server-side rendering (SSR) and **Svelte** for interactive components. Pages are rendered on the server and then hydrated on the client. Understanding this lifecycle is crucial when developing or testing new components.
+
+## Rendering Flow
+
+1. **Server Render** – Astro renders HTML on the server. Interactive Svelte components output static markup at this stage.
+2. **Hydration** – When the page loads in the browser, Astro hydrates Svelte components. Client-side code runs starting inside the `onMount` hook.
+3. **Interactivity** – After hydration, the component can access browser APIs and respond to user input.
+
+## Component Pattern
+
+To avoid hydration mismatches and make tests predictable, follow this pattern in every Svelte component:
+
+```svelte
+<script>
+    import { onMount } from 'svelte';
+    let isClientSide = false;
+    onMount(() => {
+        isClientSide = true;
+        // client-only initialization here
+    });
+</script>
+
+<div data-hydrated={isClientSide ? 'true' : 'false'}>
+    {#if isClientSide}
+        <!-- interactive content -->
+    {:else}
+        <!-- server-rendered placeholder -->
+    {/if}
+</div>
+```
+
+-   Use `onMount` for any code that depends on the browser environment.
+-   Include a `data-hydrated="true"` attribute once the component is ready. Tests wait for this attribute before interacting with the component.
+
+## Debugging Tips
+
+-   Check the browser console for hydration warnings. They usually mean a mismatch between the server-rendered HTML and the hydrated component.
+-   When writing Playwright tests, wait for `[data-hydrated="true"]` before performing actions.
+-   If a component behaves differently in tests versus the browser, ensure initialization logic is wrapped in `onMount`.
+
+For additional details on testing strategies, see [Testing Guide](../../../../TESTING.md) and the broader [Developer Guide](../../../../DEVELOPER_GUIDE.md).

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,1 @@
+When adding or modifying UI components, remember that Astro renders pages on the server and then hydrates Svelte components on the client. Interactive code must run inside the `onMount` hook, and components should expose `data-hydrated="true"` when ready so tests can wait for hydration. See `frontend/src/pages/docs/md/ui-lifecycle.md` for details.


### PR DESCRIPTION
## Summary
- document the Astro/Svelte hydration lifecycle
- link the new doc from README, Developer Guide and AGENTS instructions
- provide quick reminder in `llms.txt`

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6869a9304d50832fb0d236415c34a201