### PR TITLE
Improve coverage settings

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -27,6 +27,8 @@ const config = {
         '!**/vendor/**',
         '!e2e/**',
         '!scripts/**',
+        '!**/__tests__/**',
+        '!src/pages/**/*.svelte',
     ],
 
     // The directory where Jest should output its coverage files


### PR DESCRIPTION
## Summary
- exclude test files and Svelte pages from coverage collection

## Testing
- `npm run coverage`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6869ad7025bc832f862dcf0ab564a45e