### PR TITLE
Add conduct, contributing, pre-commit and unit tests

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq/>. Translations are available at
+<https://www.contributor-covenant.org/translations/>.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
       - run: cd frontend && npx playwright install chromium
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run Pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
       - run: npm run test:pr
+      - name: Unit tests
+        run: npm run test:unit
       - run: cd frontend && npm run coverage
         if: env.CODECOV_TOKEN != ''
       - uses: actions/upload-artifact@v4

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no -- pre-commit install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-black
+    rev: 24.4.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.8
+    hooks:
+      - id: bandit
+        args: ["-ll", "--skip", "B101"]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.0
+    hooks:
+      - id: prettier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ These guidelines apply to all files in this repository.
 -   If E2E tests complain that the browser executable is missing, run `npx playwright install chromium` to download the required browser.
 -   If Playwright browsers aren't available, prefix the command with `SKIP_E2E=1`.
 -   Use `npm run check` to verify formatting and linting prior to commit.
+-   Run `pre-commit run --files <file>...` to auto-format staged changes. Install
+    it with `pip install pre-commit` if the command is missing.
 -   If these checks fail due to missing dev dependencies, mention the error in
     your pull request summary.
 -   If ESLint reports missing plugins, run `npm install` in both the repo root and the `frontend` directory to restore dev dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## How to Contribute
+Thank you for considering a contribution to **DSPACE**!
+
+### Ground Rules
+* **One feature / bug-fix per PR**.
+* Follow Conventional Commits (`feat:`, `fix:`, etc.).
+* Run `npm run test:pr` locally; CI will fail if coverage <90%.
+
+### Getting Started
+1. `git clone --branch v3 https://github.com/democratizedspace/dspace`
+2. `npm ci && cd frontend && npm ci`
+3. `pre-commit install` – installs Git hooks.
+4. Hack away!
+
+### Need help?
+See `DEVELOPER_GUIDE.md` or open a discussion.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ npm ci
 
 ## Want to contribute?
 
-Check out the [Contribution Guide](./CONTRIBUTORS.md) to get started.
+Check out the [Contribution Guide](./CONTRIBUTORS.md) and [Contributing Guidelines](./CONTRIBUTING.md) to get started. We follow a [Code of Conduct](./.github/CODE_OF_CONDUCT.md) to keep the community welcoming.
 Automated contributors like the Codex agent follow the rules in [AGENTS.md](./AGENTS.md). Feel free to consult it when preparing your own pull requests.
 
 If you have any questions, feel free to join the [Discord](https://discord.gg/A3UAfYvnxM) and say hello!

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -1,0 +1,3 @@
+| Repository | Branch | Coverage | Package | CI | Codecov | Code of Conduct | Contributing | Pre-commit |
+|------------|--------|----------|---------|----|---------|----------------|--------------|-----------|
+| democratizedspace/dspace | v3 | ✅ (77%) | npm | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "lint": "cd frontend && npm run lint",
         "lint:fix": "cd frontend && npm run lint:fix",
         "format": "cd frontend && npm run format",
-        "build": "cd frontend && npm run build"
+        "build": "cd frontend && npm run build",
+        "test:unit": "node --test tests/unit"
     },
     "devDependencies": {
         "fake-indexeddb": "^6.0.0",

--- a/scripts/generate-quest-chart.js
+++ b/scripts/generate-quest-chart.js
@@ -12,6 +12,8 @@ function countLines(filePath) {
     return data.split(/\r?\n/).length;
 }
 
+module.exports = { countLines };
+
 function gatherStats() {
     const categories = fs.readdirSync(questsDir).filter((name) => {
         const p = path.join(questsDir, name);

--- a/tests/unit/run-tests.test.js
+++ b/tests/unit/run-tests.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const child = require('child_process');
+
+function mockExec() {
+  const calls = [];
+  const original = child.execSync;
+  child.execSync = (...args) => { calls.push(args); };
+  return () => {
+    child.execSync = original;
+    return calls;
+  };
+}
+
+test('calls PowerShell on Windows', () => {
+  const restoreExec = mockExec();
+  const original = os.platform;
+  os.platform = () => 'win32';
+  const exit = process.exit;
+  process.exit = () => {};
+  delete require.cache[require.resolve('../../run-tests')];
+  require('../../run-tests');
+  process.exit = exit;
+  os.platform = original;
+  const calls = restoreExec();
+  assert.ok(calls[0][0].includes('prepare-pr.ps1'));
+});
+
+test('calls Bash on Unix', () => {
+  const restoreExec = mockExec();
+  const original = os.platform;
+  os.platform = () => 'linux';
+  const exit = process.exit;
+  process.exit = () => {};
+  delete require.cache[require.resolve('../../run-tests')];
+  require('../../run-tests');
+  process.exit = exit;
+  os.platform = original;
+  const calls = restoreExec();
+  assert.ok(calls[0][0].includes('prepare-pr.sh'));
+});

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { countLines } = require('../../scripts/generate-quest-chart.js');
+
+test('counts newline separated lines', () => {
+  const tmp = path.join(__dirname, 'temp.txt');
+  fs.writeFileSync(tmp, 'a\nb\nc\n');
+  try {
+    assert.strictEqual(countLines(tmp), 4);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});


### PR DESCRIPTION
## Summary
- add Contributor Covenant code of conduct
- document how to contribute
- configure pre-commit hooks and husky post-merge integration
- add Node unit tests and export util for coverage
- update CI workflow to run pre-commit and unit tests
- update docs feature summary
- link contributing docs in README
- install pre-commit before running hooks
- update coverage in summary table

## Testing
- `npm run test:unit`
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `pre-commit run --files docs/repo-feature-summary.md` *(fails: could not download hooks due to missing GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_686b665d3648832fb6da473b064d045c