### PR TITLE
Add contributing docs and pre-commit tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,6 +8,15 @@ elif command -v powershell >/dev/null 2>&1; then
 else
   echo "PowerShell not found, falling back to bash script"
   cd frontend
-  echo "Running linting and tests on modified files..."
+  echo "Running linting on staged files..."
   npx lint-staged
+  cd ..
+  echo "Running full code checks..."
+  npm run check
+  echo "Running full test suite (without e2e)..."
+  SKIP_E2E=1 npm run test:pr
+  if [ $? -ne 0 ]; then
+    echo "❌ Tests failed. Commit aborted."
+    exit 1
+  fi
 fi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+This project and community follow the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct, version 2.1. We are committed to providing a welcoming and harassment-free experience for everyone.
+
+## Our Pledge
+
+In the interest of fostering an open and inclusive environment, we pledge to make participation in the project a respectful and harassment-free experience for everyone, regardless of background or identity.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without consent
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project.
+
+## Reporting
+
+Instances of abusive or unacceptable behavior may be reported by opening an issue or contacting the maintainers on our [Discord server](https://discord.gg/A3UAfYvnxM). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to DSPACE
+
+Thank you for your interest in helping the project! Below is a quick overview of the workflow used in this repository.
+
+## Getting Started
+
+1. Fork and clone the repo.
+2. Install dependencies:
+   ```bash
+   npm ci
+   (cd frontend && npm ci)
+   npx husky install
+   ```
+   Husky installs Git hooks that run checks before each commit and push.
+
+## Development Workflow
+
+- Use `npm run dev` to start the game locally.
+- Before committing, verify formatting and linting with:
+  ```bash
+  npm run check
+  ```
+- The pre-commit hook runs `lint-staged`, `npm run check`, and then `SKIP_E2E=1 npm run test:pr` to make sure tests are green. You can run it manually with:
+  ```bash
+  SKIP_E2E=1 npm run test:pr
+  ```
+- If Playwright browsers are missing, install them with `npx playwright install chromium` or set `SKIP_E2E=1`.
+
+## Opening a Pull Request
+
+1. Run the full suite before submitting:
+   ```bash
+   npm run test:pr
+   ```
+   Include `SKIP_E2E=1` if you cannot run the browsers.
+2. Update documentation when adding or changing features.
+3. Open a PR using the provided template and describe your changes.
+
+See [AGENTS.md](./AGENTS.md) for additional guidelines that automated contributors follow.
+
+We look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ npm ci
 
 ## Want to contribute?
 
-Check out the [Contribution Guide](./CONTRIBUTORS.md) to get started.
+Check out the [Contributing Guide](./CONTRIBUTING.md) to get started. All community members are expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 Automated contributors like the Codex agent follow the rules in [AGENTS.md](./AGENTS.md). Feel free to consult it when preparing your own pull requests.
 
 If you have any questions, feel free to join the [Discord](https://discord.gg/A3UAfYvnxM) and say hello!


### PR DESCRIPTION
## Summary
- add project CODE_OF_CONDUCT
- add CONTRIBUTING guide with steps for running checks
- link new guides in the README
- run tests automatically in pre-commit hooks
- restore pre-commit.ps1 to avoid binary diff

## Testing
- `npm run check` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*
- `SKIP_E2E=1 npm run test:pr` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686c5073947c832f986eaa38799b59ea