### PR TITLE
Add Stevia hydroponics & extraction quests

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -58,6 +58,7 @@ Hydro, a relaxed and affable team member, has a gift for hydroponics and sustain
 -   "Excellent! First things first, I need you to accept this hydroponics tub."
 -   "Now that you've got your hydroponics tub, you'll need some dechlorinated water."
 -   "I know, right? It's almost like the gamedev is awkwardly reusing existing game systems."
+-   "Let's try stevia next. Its leaves are unbelievably sweet!"
 
 ## Orion
 
@@ -100,6 +101,7 @@ Phoenix is a professional chemist specializing in sustainable rocket fuel develo
 -   "You've shown great progress with your 3D printing! Your next goal is to print 25 Benchies."
 -   "Excellent job! Your fleet of Benchies is growing. Keep up the great work."
 -   "You've truly mastered the art of 3D printing Benchies. Now, let's take things to the next level. I want to see a fleet of 100 Benchies."
+-   "Dry those stevia leaves gently and we'll extract their sweetness."
 
 ## Atlas
 

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -12,7 +12,7 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 -   **Welcome** – introductory tutorial showing how to accept and complete quests
 -   **3D Printing** – receive a printer, then tackle small projects and larger print runs
 -   **Aquaria** – set up a Walstad tank, test the water, install a sponge filter, position the tank, add shrimp, keep guppies, perform water changes, breed them, and graduate to goldfish
--   **Hydroponics** – grow basil, expand to bucket systems, and experiment with lettuce
+-   **Hydroponics** – grow basil, expand to bucket systems, experiment with lettuce, and cultivate stevia for homemade sweetener
 -   **Electronics** – wire a basic circuit, program an Arduino, and build a dimmer
 -   **Robotics** – assemble a line follower and learn servo control after completing electronics basics
 -   **Rocketry** – print and launch a model rocket with parachute recovery
@@ -25,7 +25,7 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 
 The following quest lines are being drafted to help achieve the "10x More Quests" goal announced for v3:
 
--   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles
+-   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles and extract stevia into an artificial sweetener
 -   **Astronomy** – observational tasks that prepare players for future rocketry missions
 -   **Programming** – simple scripts for automating sensors and data collection
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -762,5 +762,44 @@
         "description": "A gentle air-driven filter ideal for small aquariums.",
         "image": "/assets/aquarium_filter.jpg",
         "price": "6 dUSD"
+    },
+    {
+        "id": "117",
+        "name": "stevia seeds",
+        "description": "Seeds of the Stevia rebaudiana plant.",
+        "image": "/assets/basil_seeds.jpg",
+        "price": "5 dUSD"
+    },
+    {
+        "id": "118",
+        "name": "stevia seedling",
+        "description": "A young stevia plant sprouted in rockwool.",
+        "image": "/assets/basil_seedlings.jpg"
+    },
+    {
+        "id": "119",
+        "name": "harvestable stevia plant",
+        "description": "A mature stevia plant ready for leaf harvest.",
+        "image": "/assets/hydroponic_basil_adult.jpg"
+    },
+    {
+        "id": "120",
+        "name": "bundle of stevia leaves",
+        "description": "Fresh stevia leaves with natural sweetness.",
+        "image": "/assets/basil_harvested.jpg",
+        "price": "3 dUSD"
+    },
+    {
+        "id": "121",
+        "name": "harvested stevia plant",
+        "description": "A stevia plant trimmed of leaves but still alive.",
+        "image": "/assets/hydroponic_basil_harvested.jpg"
+    },
+    {
+        "id": "122",
+        "name": "stevia extract",
+        "description": "Concentrated sweetener derived from stevia leaves.",
+        "image": "/assets/dCarbon.jpg",
+        "price": "8 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -370,6 +370,66 @@
         "duration": "1m"
     },
     {
+        "id": "germinate-stevia",
+        "title": "germinate stevia seeds",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "117", "count": 1 },
+            { "id": "26", "count": 11 }
+        ],
+        "createItems": [{ "id": "118", "count": 11 }],
+        "duration": "7d"
+    },
+    {
+        "id": "grow-stevia",
+        "title": "grow stevia until it's ready to harvest",
+        "requireItems": [{ "id": "43", "count": 1 }],
+        "consumeItems": [
+            { "id": "118", "count": 11 },
+            { "id": "44", "count": 1 },
+            { "id": "22", "count": 16128 }
+        ],
+        "createItems": [
+            { "id": "119", "count": 11 },
+            { "id": "45", "count": 1 }
+        ],
+        "duration": "28d"
+    },
+    {
+        "id": "regrow-stevia",
+        "title": "regrow stevia after harvest",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "121", "count": 11 },
+            { "id": "44", "count": 1 },
+            { "id": "22", "count": 8064 }
+        ],
+        "createItems": [
+            { "id": "119", "count": 11 },
+            { "id": "45", "count": 1 }
+        ],
+        "duration": "14d"
+    },
+    {
+        "id": "harvest-stevia",
+        "title": "Harvest your hydroponic stevia plants",
+        "requireItems": [],
+        "consumeItems": [{ "id": "119", "count": 11 }],
+        "createItems": [
+            { "id": "120", "count": 11 },
+            { "id": "121", "count": 11 }
+        ],
+        "duration": "1m"
+    },
+    {
+        "id": "extract-stevia",
+        "title": "extract sweetener from stevia leaves",
+        "requireItems": [],
+        "consumeItems": [{ "id": "120", "count": 11 }],
+        "createItems": [{ "id": "122", "count": 1 }],
+        "duration": "1h"
+    },
+    {
         "id": "sink",
         "title": "find your sink",
         "requireItems": [],

--- a/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
+++ b/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
@@ -1,0 +1,35 @@
+{
+    "id": "chemistry/stevia-extraction",
+    "title": "Extract Stevia Sweetener",
+    "description": "Use simple chemistry to make a sweet extract from stevia leaves.",
+    "image": "/assets/quests/testprint.png",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Phoenix here. Those stevia leaves you grew can be turned into a potent sweetener. Interested in an extraction demo?",
+            "options": [{ "type": "goto", "goto": "extract", "text": "Show me how!" }]
+        },
+        {
+            "id": "extract",
+            "text": "Dry the leaves and steep them in hot water to pull out the steviol glycosides.",
+            "options": [
+                { "type": "process", "process": "extract-stevia", "text": "Begin extraction" },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "The extract looks ready!",
+                    "requiresItems": [{ "id": "122", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! This homemade stevia extract will sweeten drinks without any sugar.",
+            "options": [{ "type": "finish", "text": "Thanks, Phoenix!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/stevia", "chemistry/safe-reaction"]
+}

--- a/frontend/src/pages/quests/json/hydroponics/stevia.json
+++ b/frontend/src/pages/quests/json/hydroponics/stevia.json
@@ -1,0 +1,72 @@
+{
+    "id": "hydroponics/stevia",
+    "title": "Grow Stevia Hydroponically",
+    "description": "Cultivate stevia plants for a natural sweetener.",
+    "image": "/assets/quests/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hydro here! Ready to grow something sweet? Stevia leaves pack a sugary punch without the calories.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "plant",
+                    "text": "Absolutely, let's plant some stevia!"
+                }
+            ]
+        },
+        {
+            "id": "plant",
+            "text": "Soak your rockwool plugs, add the stevia seeds, and wait for them to germinate.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "germinate-stevia",
+                    "text": "Starting the germination process."
+                },
+                {
+                    "type": "goto",
+                    "goto": "grow",
+                    "text": "Seedlings look healthy!",
+                    "requiresItems": [{ "id": "118", "count": 11 }]
+                }
+            ]
+        },
+        {
+            "id": "grow",
+            "text": "Transfer the seedlings to your hydroponics tub and give them plenty of light for about a month.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "grow-stevia",
+                    "text": "Start growth cycle."
+                },
+                {
+                    "type": "goto",
+                    "goto": "harvest",
+                    "text": "They're full grown and smell sweet!",
+                    "requiresItems": [{ "id": "119", "count": 11 }]
+                }
+            ]
+        },
+        {
+            "id": "harvest",
+            "text": "Clip the leaves to make our sweetener. The plants will regrow if you keep them under the light.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "harvest-stevia",
+                    "text": "Harvesting the leaves."
+                },
+                {
+                    "type": "finish",
+                    "text": "Thanks for the tips, Hydro!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/lettuce"]
+}


### PR DESCRIPTION
## Summary
- add stevia items, processes, and quests
- document stevia questline in NPC and quest tree docs
- fix germination step for the stevia quest

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_686e3ddfc86c832fa51abe16db8293b6