### PR TITLE
Add items and processes to devops quests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ These guidelines apply to all files in this repository.
     with at least one option per node.
 -   Include a `finish` option in the final node so quests end cleanly. Quests
     without a finish option will fail canonical tests.
+-   Reference at least one inventory item or process in every quest. The
+    `questQuality` test now fails if a quest lacks both.
 -   For rapid quest creation, reference `frontend/src/pages/docs/md/prompts-quests.md`
     which contains AI prompt templates, including a **Quest Sequence Expansion**
     section for brainstorming follow-up quests.
@@ -63,6 +65,7 @@ These guidelines apply to all files in this repository.
 -   When adding inventory items in `frontend/src/pages/inventory/json/items.json`, assign the next numeric `id` and provide an image if possible.
 -   Update `frontend/__tests__/itemQuality.test.js` when adding items so the quality ratio stays accurate.
 -   Update `frontend/__tests__/processQuality.test.js` when introducing new processes or unusual durations.
+-   The `questQuality` test enforces item or process usage in quests; fix any failures before committing.
 -   If you add a quest that changes the tech tree order, document the new sequence in `README.md` and update `frontend/__tests__/questQuality.test.js` accordingly.
 -   Summarize new categories in `frontend/src/pages/docs/md/quest-trees.md` when they are introduced.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` an
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.
+The new DevOps chain explains how to deploy DSPACE on a small Raspberry Pi cluster using Docker and k3s.
 
 To validate that quests use a canonical structure with clear start and finish
 steps, run the dedicated test:

--- a/frontend/__tests__/questQuality.test.js
+++ b/frontend/__tests__/questQuality.test.js
@@ -371,6 +371,9 @@ function checkItemProcessUsage() {
 
         if (usedItem) questsUsingItems++;
         if (usedProcess) questsUsingProcesses++;
+        if (!usedItem && !usedProcess) {
+            issues.push(`Quest ${id} has no item or process references`);
+        }
     }
 
     const itemRatio = questsUsingItems / quests.size;
@@ -459,7 +462,6 @@ describe('Quest Quality Validation', () => {
             console.warn('Item/Process Usage Issues:');
             issues.forEach((issue) => console.warn(`- ${issue}`));
         }
-
-        expect(true).toBe(true);
+        expect(issues.length).toBe(0);
     });
 });

--- a/frontend/src/pages/docs/images/quest-tree-stats.txt
+++ b/frontend/src/pages/docs/images/quest-tree-stats.txt
@@ -1,6 +1,7 @@
 energy: 10 quests, 695 lines
 aquaria: 9 quests, 373 lines
 3dprinting: 5 quests, 324 lines
+devops: 5 quests, 209 lines
 hydroponics: 4 quests, 468 lines
 woodworking: 4 quests, 238 lines
 electronics: 3 quests, 171 lines

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -64,7 +64,7 @@ Hydro, a relaxed and affable team member, has a gift for hydroponics and sustain
 
 <img src="/assets/npc/orion.jpg" />
 
-Orion is an electrical engineer whose enthusiasm for robotics and microprocessors knows no bounds. He specializes in designing and building intelligent robotic systems to assist the metaguild in various tasks. Orion's technical prowess and innovative thinking make him a valuable team member in the quest to push the boundaries of space exploration.
+Orion is an electrical engineer whose enthusiasm for robotics and microprocessors knows no bounds. He specializes in designing and building intelligent robotic systems to assist the metaguild in various tasks. Orion also maintains the guild's servers and enjoys automating deployment pipelines. His technical prowess and innovative thinking make him a valuable team member in the quest to push the boundaries of space exploration.
 
 ### Sample Dialogue
 
@@ -73,6 +73,7 @@ Orion is an electrical engineer whose enthusiasm for robotics and microprocessor
 -   "Place the LED on the breadboard and connect the resistor in series with the long leg."
 -   "Hey there! Orion here. Ready to do something a bit more exciting? Let's make that LED blink with a microcontroller."
 -   "Open the Arduino IDE, load the Blink example, select the correct port, and hit upload."
+-   "Need a server check? I'm happy to spin up a fresh Pi and deploy the stack."
 
 ## Vega
 

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -28,6 +28,7 @@ The following quest lines are being drafted to help achieve the "10x More Quests
 -   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles and extract stevia into an artificial sweetener
 -   **Astronomy** – observational tasks that prepare players for future rocketry missions
 -   **Programming** – simple scripts for automating sensors and data collection
+-   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s
 
 Check back as these new quests are fleshed out and integrated into the main progression.
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -801,5 +801,65 @@
         "description": "Concentrated sweetener derived from stevia leaves.",
         "image": "/assets/dCarbon.jpg",
         "price": "8 dUSD"
+    },
+    {
+        "id": "123",
+        "name": "Raspberry Pi 5 board",
+        "description": "A compact single-board computer with plenty of power for small clusters.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "124",
+        "name": "M.2 PoE+ HAT",
+        "description": "Provides power over Ethernet and an M.2 slot for NVMe drives.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "125",
+        "name": "1TB 2230 M.2 SSD",
+        "description": "A tiny NVMe drive perfect for booting a Pi.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "126",
+        "name": "64GB microSD card",
+        "description": "Used to flash the operating system before cloning to the SSD.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "127",
+        "name": "PoE+ switch",
+        "description": "Powers multiple devices and provides network connectivity.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "128",
+        "name": "Ethernet cable",
+        "description": "A simple cable for wired network connections.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "129",
+        "name": "fan case",
+        "description": "Keeps a Raspberry Pi cool during heavy workloads.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "130",
+        "name": "flashed microSD card",
+        "description": "Contains Raspberry Pi OS ready for cloning to SSD.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "131",
+        "name": "bootable 1TB SSD",
+        "description": "An M.2 drive with the OS cloned and ready to boot.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "132",
+        "name": "Pi cluster node",
+        "description": "A Raspberry Pi assembled with HAT, SSD and cooling.",
+        "image": "/assets/quests/basic_circuit.svg"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1077,5 +1077,53 @@
             }
         ],
         "duration": "30m"
+    },
+    {
+        "id": "flash-sd-card",
+        "title": "Flash Raspberry Pi OS to microSD",
+        "requireItems": [],
+        "consumeItems": [{ "id": "126", "count": 1 }],
+        "createItems": [{ "id": "130", "count": 1 }],
+        "duration": "5m"
+    },
+    {
+        "id": "clone-os-to-ssd",
+        "title": "Clone OS to M.2 SSD",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "130", "count": 1 },
+            { "id": "125", "count": 1 }
+        ],
+        "createItems": [{ "id": "131", "count": 1 }],
+        "duration": "10m"
+    },
+    {
+        "id": "assemble-pi-node",
+        "title": "Assemble a Pi cluster node",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "123", "count": 1 },
+            { "id": "124", "count": 1 },
+            { "id": "131", "count": 1 },
+            { "id": "129", "count": 1 }
+        ],
+        "createItems": [{ "id": "132", "count": 1 }],
+        "duration": "5m"
+    },
+    {
+        "id": "run-docker-compose",
+        "title": "Launch DSPACE with Docker Compose",
+        "requireItems": [{ "id": "132", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
+        "id": "join-k3s-cluster",
+        "title": "Join nodes to a k3s cluster",
+        "requireItems": [{ "id": "132", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
     }
 ]

--- a/frontend/src/pages/quests/json/devops/docker-compose.json
+++ b/frontend/src/pages/quests/json/devops/docker-compose.json
@@ -1,0 +1,45 @@
+{
+    "id": "devops/docker-compose",
+    "title": "Launch DSPACE in Docker",
+    "description": "Start the container and open a Cloudflare Tunnel.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "From the project directory run `docker compose up --build -d` to launch the game on port 3002.",
+            "options": [
+                { "type": "process", "process": "run-docker-compose", "text": "Starting it up." },
+                {
+                    "type": "goto",
+                    "goto": "tunnel",
+                    "text": "Container running.",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "tunnel",
+            "text": "Create a Cloudflare Tunnel pointing at `http://localhost:3002` so friends can reach your Pi from anywhere.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Tunnel online.",
+                    "requiresItems": [
+                        { "id": "127", "count": 1 },
+                        { "id": "128", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Everything is up and running! For a multi-node setup you can follow Orion's k3s guide later.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/ssd-boot"]
+}

--- a/frontend/src/pages/quests/json/devops/k3s-deploy.json
+++ b/frontend/src/pages/quests/json/devops/k3s-deploy.json
@@ -1,0 +1,47 @@
+{
+    "id": "devops/k3s-deploy",
+    "title": "Deploy with k3s",
+    "description": "Orion teaches you how to run DSPACE across multiple Pis with k3s.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "If you want high availability, let's turn the cluster into a k3s setup.",
+            "options": [{ "type": "goto", "goto": "install", "text": "Sounds good." }]
+        },
+        {
+            "id": "install",
+            "text": "Install k3s on the control plane with `curl -sfL https://get.k3s.io | sh -` and grab the join token from `/var/lib/rancher/k3s/server/node-token`.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "join",
+                    "text": "Token ready.",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "join",
+            "text": "Run the installer on each extra node with `curl -sfL https://get.k3s.io | K3S_URL=https://<CONTROL_PLANE_IP>:6443 K3S_TOKEN=<NODE_TOKEN> sh -`. Verify all nodes with `sudo kubectl get nodes -o wide`.",
+            "options": [
+                { "type": "process", "process": "join-k3s-cluster", "text": "Joining now." },
+                { "type": "goto", "goto": "load", "text": "Nodes joined." }
+            ]
+        },
+        {
+            "id": "load",
+            "text": "Build the DSPACE image and import it: `docker build -t dspace-app:latest -f frontend/Dockerfile ./frontend && k3s ctr images import dspace-app:latest`. Apply the manifests from `k8s/` to deploy.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Deployed." }]
+        },
+        {
+            "id": "finish",
+            "text": "That's it! Your cluster now runs DSPACE via k3s. Expose the service with a Cloudflare Tunnel and enjoy.",
+            "options": [{ "type": "finish", "text": "Mission accomplished." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/docker-compose"]
+}

--- a/frontend/src/pages/quests/json/devops/pi-cluster-hardware.json
+++ b/frontend/src/pages/quests/json/devops/pi-cluster-hardware.json
@@ -1,0 +1,42 @@
+{
+    "id": "devops/pi-cluster-hardware",
+    "title": "Plan Your Pi Cluster",
+    "description": "Orion lists the parts needed to build a Raspberry Pi cluster.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Hey there! Orion here. Ready to build a little cluster to run DSPACE on your own hardware?",
+            "options": [{ "type": "goto", "goto": "list", "text": "Absolutely!" }]
+        },
+        {
+            "id": "list",
+            "text": "You'll need Raspberry Pi 5 boards, PoE+ HATs with M.2 slots, 1TB NVMe SSDs, a PoE+ switch with cables and a microSD card for flashing the OS. Don't forget a fan case or heatsink so everything stays cool.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I've gathered the parts.",
+                    "requiresItems": [
+                        { "id": "123", "count": 1 },
+                        { "id": "124", "count": 1 },
+                        { "id": "125", "count": 1 },
+                        { "id": "126", "count": 1 },
+                        { "id": "127", "count": 1 },
+                        { "id": "128", "count": 1 },
+                        { "id": "129", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! With the hardware ready we can prepare the first node.",
+            "options": [{ "type": "finish", "text": "Let's do it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}

--- a/frontend/src/pages/quests/json/devops/prepare-first-node.json
+++ b/frontend/src/pages/quests/json/devops/prepare-first-node.json
@@ -1,0 +1,47 @@
+{
+    "id": "devops/prepare-first-node",
+    "title": "Prepare the First Node",
+    "description": "Flash the OS and install Docker under Orion's guidance.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's get that first Pi running. Flash Raspberry Pi OS to a microSD card so we can update everything.",
+            "options": [
+                { "type": "process", "process": "flash-sd-card", "text": "Flashing now." },
+                {
+                    "type": "goto",
+                    "goto": "update",
+                    "text": "Card flashed and booted.",
+                    "requiresItems": [{ "id": "130", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "update",
+            "text": "Run `sudo apt update && sudo apt full-upgrade` then install the latest firmware with `sudo rpi-eeprom-update -a`.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "docker",
+                    "text": "System updated.",
+                    "requiresItems": [{ "id": "123", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "docker",
+            "text": "Clone the DSPACE repo and install Docker. Use `sudo apt install -y docker.io docker-compose`, add yourself to the docker group, and run `newgrp docker` to refresh.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Docker ready." }]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! The first node is set up and waiting for an SSD.",
+            "options": [{ "type": "finish", "text": "Onward!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/pi-cluster-hardware"]
+}

--- a/frontend/src/pages/quests/json/devops/ssd-boot.json
+++ b/frontend/src/pages/quests/json/devops/ssd-boot.json
@@ -1,0 +1,52 @@
+{
+    "id": "devops/ssd-boot",
+    "title": "Boot from SSD",
+    "description": "Clone the OS to an SSD and enable M.2 boot.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Next we'll copy the OS to the SSD so the Pi boots quicker and lasts longer.",
+            "options": [{ "type": "goto", "goto": "clone", "text": "I'm ready." }]
+        },
+        {
+            "id": "clone",
+            "text": "Run `lsblk` to locate the drive then use `sudo rpi-clone /dev/sda` to clone the system. Set the boot order to USB boot in raspi-config and power down when it finishes.",
+            "options": [
+                { "type": "process", "process": "clone-os-to-ssd", "text": "Cloning now." },
+                {
+                    "type": "goto",
+                    "goto": "move",
+                    "text": "Clone complete.",
+                    "requiresItems": [{ "id": "131", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "move",
+            "text": "Insert the SSD into the PoE HAT's M.2 slot and add `dtparam=nvme` to `/boot/config.txt`. Boot again and confirm the partitions mount from the SSD.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "assemble-pi-node",
+                    "text": "Installing HAT and SSD."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Booted from SSD.",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! The Pi now runs from the SSD. Time to launch DSPACE.",
+            "options": [{ "type": "finish", "text": "Let's launch it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/prepare-first-node"]
+}

--- a/frontend/src/pages/quests/json/electronics/potentiometer-dimmer.json
+++ b/frontend/src/pages/quests/json/electronics/potentiometer-dimmer.json
@@ -24,7 +24,15 @@
                 {
                     "type": "goto",
                     "goto": "program",
-                    "text": "Wired up! What's the code?"
+                    "text": "Wired up! What's the code?",
+                    "requiresItems": [
+                        { "id": "90", "count": 1 },
+                        { "id": "91", "count": 1 },
+                        { "id": "92", "count": 3 },
+                        { "id": "93", "count": 1 },
+                        { "id": "94", "count": 1 },
+                        { "id": "98", "count": 1 }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- enforce item or process usage for quests
- add Pi cluster hardware items and related processes
- embed these items and processes in the devops quest chain
- reference proper gear in the potentiometer quest
- document the new DevOps line in README
- clarify quest rules in AGENTS guidelines
- update quest tree stats

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6875e29dd490832f9cb1f4266035af94