### PR TITLE
Add basic home page Playwright test

### DIFF
--- a/frontend/e2e/home-page-basic.spec.ts
+++ b/frontend/e2e/home-page-basic.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Home Page Basic Rendering', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('should display the latest update section', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const latestUpdate = page.getByRole('heading', { name: /latest update/i });
+        await expect(latestUpdate).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary
- add a small Playwright test to ensure the home page renders

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68798b5425a8832f89238a2b40af250f