### PR TITLE
Fix license references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/ci.yml?label=tests)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/democratizedspace/dspace/branch/v3/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
 [![Docs](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/quest-chart.yml?label=docs)](https://github.com/democratizedspace/dspace/actions/workflows/quest-chart.yml)
-[![License](https://img.shields.io/github/license/democratizedspace/dspace)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 You can find the game at [democratized.space](https://democratized.space).
 
@@ -253,3 +253,7 @@ If a quest, item, or process needs to be retired, move its JSON file to the
 `frontend/src/pages/quests/archive` directory instead of deleting it. The
 `contentIntegrity` test tracks the total count of built-in assets, so archived
 files help prevent accidental removals.
+
+## License
+
+DSPACE is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,5 +93,6 @@
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",
         "remarkable": "^2.0.1"
-    }
+    },
+    "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,28 +1,29 @@
 {
-    "name": "dspace",
-    "version": "2.1.0",
-    "main": "index.js",
-    "scripts": {
-        "dev": "cd frontend && npm run dev",
-        "test": "cd frontend && npm test",
-        "test:watch": "cd frontend && npm run test:watch",
-        "test:e2e": "cd frontend && npm run test:e2e",
-        "test:e2e:coverage": "cd frontend && npm run test:e2e:coverage",
-        "test:e2e:groups": "cd frontend && npm run test:e2e:groups",
-        "test:e2e:custom": "cd frontend && npm run test:e2e:custom",
-        "test:all": "cd frontend && npm run test:all",
-        "test:quick": "cd frontend && npm run test:quick",
-        "coverage": "cd frontend && npm run coverage",
-        "test:pr": "node run-tests.js",
-        "check": "cd frontend && npm run check",
-        "lint": "cd frontend && npm run lint",
-        "lint:fix": "cd frontend && npm run lint:fix",
-        "format": "cd frontend && npm run format",
-        "build": "cd frontend && npm run build"
-    },
-    "devDependencies": {
-        "fake-indexeddb": "^6.0.0",
-        "chart.js": "^4.5.0",
-        "chartjs-node-canvas": "^5.0.0"
-    }
+  "name": "dspace",
+  "version": "2.1.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "cd frontend && npm run dev",
+    "test": "cd frontend && npm test",
+    "test:watch": "cd frontend && npm run test:watch",
+    "test:e2e": "cd frontend && npm run test:e2e",
+    "test:e2e:coverage": "cd frontend && npm run test:e2e:coverage",
+    "test:e2e:groups": "cd frontend && npm run test:e2e:groups",
+    "test:e2e:custom": "cd frontend && npm run test:e2e:custom",
+    "test:all": "cd frontend && npm run test:all",
+    "test:quick": "cd frontend && npm run test:quick",
+    "coverage": "cd frontend && npm run coverage",
+    "test:pr": "node run-tests.js",
+    "check": "cd frontend && npm run check",
+    "lint": "cd frontend && npm run lint",
+    "lint:fix": "cd frontend && npm run lint:fix",
+    "format": "cd frontend && npm run format",
+    "build": "cd frontend && npm run build"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^6.0.0",
+    "chart.js": "^4.5.0",
+    "chartjs-node-canvas": "^5.0.0"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- update license badge to show MIT instead of 0BSD
- explicitly set `license` field in package.json files
- document MIT license in README

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_687b4731e5e4832f94e3d21d1a384b69