### PR TITLE
Add quests across all trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,15 @@ Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` an
 ![Quest tree stats chart](https://nightly.link/democratizedspace/dspace/workflows/quest-chart.yml/branch/v3/quest-tree-chart.zip?path=frontend%2Fsrc%2Fpages%2Fdocs%2Fimages%2Fquest-tree-stats.png)
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
-Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation.
-The new DevOps chain explains how to deploy DSPACE on a small Raspberry Pi cluster using Docker and k3s.
+Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation. Each tree has been extended with follow-up tasks, such as tuning 3D printer retraction and refreshing hydroponic nutrients.
+The DevOps chain now covers deploying DSPACE on a Raspberry Pi cluster with Docker and k3s, setting up monitoring with Prometheus and Grafana, and scheduling nightly backups.
 
 To validate that quests use a canonical structure with clear start and finish
 steps, run the dedicated test:
 
 ```bash
 [Quest Development Guidelines](/docs/quest-guidelines), the [Quest Template Example](/docs/quest-template), and the [Quest Submission Guide](/docs/quest-submission) to streamline content creation and sharing.
+Use `npm run generate-quest` to scaffold a new quest with placeholder dialogue.
 ```
 
 Additional quality checks are available:

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -127,6 +127,7 @@ Every quest JSON file must include:
 > **Note:** The full quest editing interface is still under development. The current implementation in `QuestForm.svelte` supports basic quest properties (title, description, image) with more complete dialogue editing planned for future updates.
 
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
+You can run `npm run generate-quest` to scaffold a template JSON file with placeholder dialogue.
 
 -   Dialogue node creation and editing
 -   Process and item requirement selection
@@ -145,7 +146,7 @@ Before submitting a quest, verify:
 
 ## Contribution Workflow
 
-1. Develop your quest locally following these guidelines
+1. Develop your quest locally following these guidelines (start with `npm run generate-quest` for a ready-made template)
 2. Test thoroughly in your local environment
 3. Submit a [pull request](https://github.com/democratizedspace/dspace/pulls) with your quest JSON file
 4. Respond to feedback during code review

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -14,7 +14,7 @@ This guide describes how to submit your custom quests to become part of the offi
 
 ## Steps
 
-1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`.
+1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. The command `npm run generate-quest` can scaffold a template for you.
 2. **Validate** the quest structure by running:
     ```bash
     npm test -- questValidation

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -10,16 +10,16 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 ## Existing Quest Trees
 
 -   **Welcome** – introductory tutorial showing how to accept and complete quests
--   **3D Printing** – receive a printer, then tackle small projects and larger print runs
--   **Aquaria** – set up a Walstad tank, test the water, install a sponge filter, position the tank, add shrimp, keep guppies, perform water changes, breed them, and graduate to goldfish
--   **Hydroponics** – grow basil, expand to bucket systems, experiment with lettuce, and cultivate stevia for homemade sweetener
--   **Electronics** – wire a basic circuit, program an Arduino, and build a dimmer
--   **Robotics** – assemble a line follower and learn servo control after completing electronics basics
--   **Rocketry** – print and launch a model rocket with parachute recovery
--   **Energy** – harvest solar power and accumulate dWatts toward higher milestones
--   **UBI** – an optional quest explaining the metaguild's basic income concept
+-   **3D Printing** – receive a printer, tackle small projects, fine-tune settings, and work up to larger print runs
+-   **Aquaria** – set up a Walstad tank, test the water, install a sponge filter, position the tank, add shrimp, introduce floating plants, keep guppies, perform water changes, breed them, and graduate to goldfish
+-   **Hydroponics** – grow basil, expand to bucket systems, refresh nutrients, experiment with lettuce, and cultivate stevia for homemade sweetener
+-   **Electronics** – wire a basic circuit, program an Arduino, read sensors, and build a dimmer
+-   **Robotics** – assemble a line follower, build a servo gripper, and learn advanced control after completing electronics basics
+-   **Rocketry** – print and launch a model rocket with parachute recovery and perform a static engine test
+-   **Energy** – harvest solar power, expand battery capacity, and accumulate dWatts toward higher milestones
+-   **UBI** – an optional quest explaining the metaguild's basic income concept with daily payouts
 -   **Completionist** – track progress toward finishing all available quests
--   **Woodworking** – build a sturdy workbench, then craft birdhouses, stools and shelves
+-   **Woodworking** – build a sturdy workbench, sand projects smooth, then craft birdhouses, stools and shelves
 
 ## Planned Quest Trees
 
@@ -28,7 +28,7 @@ The following quest lines are being drafted to help achieve the "10x More Quests
 -   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles and extract stevia into an artificial sweetener
 -   **Astronomy** – observational tasks that prepare players for future rocketry missions
 -   **Programming** – simple scripts for automating sensors and data collection
--   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s
+-   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s, then add monitoring and nightly backups
 
 Check back as these new quests are fleshed out and integrated into the main progression.
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -861,5 +861,17 @@
         "name": "Pi cluster node",
         "description": "A Raspberry Pi assembled with HAT, SSD and cooling.",
         "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "133",
+        "name": "external backup SSD",
+        "description": "Stores nightly database dumps from your cluster.",
+        "image": "/assets/quests/basic_circuit.svg"
+    },
+    {
+        "id": "134",
+        "name": "basic telescope",
+        "description": "A simple refracting telescope for backyard astronomy.",
+        "image": "/assets/quests/solar.jpg"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1125,5 +1125,40 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "5m"
+    },
+    {
+        "id": "install-monitoring-stack",
+        "title": "Install Prometheus and Grafana",
+        "requireItems": [{ "id": "132", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [{ "id": "133", "count": 1 }],
+        "duration": "10m"
+    },
+    {
+        "id": "configure-daily-backups",
+        "title": "Configure daily backups to SSD",
+        "requireItems": [
+            { "id": "132", "count": 1 },
+            { "id": "133", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
+        "id": "assemble-basic-telescope",
+        "title": "Assemble a basic telescope",
+        "requireItems": [],
+        "consumeItems": [],
+        "createItems": [{ "id": "134", "count": 1 }],
+        "duration": "5m"
+    },
+    {
+        "id": "measure-ph",
+        "title": "Measure solution pH",
+        "requireItems": [{ "id": "59", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
     }
 ]

--- a/frontend/src/pages/quests/json/3dprinting/retraction-test.json
+++ b/frontend/src/pages/quests/json/3dprinting/retraction-test.json
@@ -1,0 +1,35 @@
+{
+    "id": "3dprinting/retraction-test",
+    "title": "Tune Retraction Settings",
+    "description": "Print a single Benchy while adjusting retraction to reduce stringing.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Retraction distance controls how far the filament pulls back between moves. Let's print another Benchy to dial it in.",
+            "options": [{ "type": "goto", "goto": "print", "text": "Let's try it." }]
+        },
+        {
+            "id": "print",
+            "text": "Slice the model with a 1 mm retraction setting and start the job. Compare the surface finish to your last print.",
+            "options": [
+                { "type": "process", "process": "3dprint-benchy", "text": "Printing now." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Looks smoother!",
+                    "requiresItems": [{ "id": "1", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep experimenting with small adjustments until stringing disappears.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinting/phone-stand"]
+}

--- a/frontend/src/pages/quests/json/aquaria/floating-plants.json
+++ b/frontend/src/pages/quests/json/aquaria/floating-plants.json
@@ -1,0 +1,34 @@
+{
+    "id": "aquaria/floating-plants",
+    "title": "Add Floating Plants",
+    "description": "Introduce guppy grass to help balance nutrients in your tank.",
+    "image": "/assets/guppy_grass.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your shrimp are thriving. To keep algae in check, let's add some floating plants that soak up excess nutrients.",
+            "options": [{ "type": "goto", "goto": "place", "text": "Sounds good." }]
+        },
+        {
+            "id": "place",
+            "text": "Gently place a handful of guppy grass on the surface. It will multiply quickly and provide shelter for fry.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Plants added",
+                    "requiresItems": [{ "id": "104", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep an eye out so it doesn't block the light for other plants.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["aquaria/shrimp"]
+}

--- a/frontend/src/pages/quests/json/astronomy/basic-telescope.json
+++ b/frontend/src/pages/quests/json/astronomy/basic-telescope.json
@@ -1,0 +1,39 @@
+{
+    "id": "astronomy/basic-telescope",
+    "title": "Assemble a Simple Telescope",
+    "description": "Build a small refractor to observe Jupiter's moons.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Sketching the Moon was a great start. Now let's build a basic telescope so you can see much farther into the sky.",
+            "options": [{ "type": "goto", "goto": "build", "text": "I'm ready." }]
+        },
+        {
+            "id": "build",
+            "text": "Combine two lenses in a cardboard tube and align the optics carefully. A stable tripod will help keep the view steady.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "assemble-basic-telescope",
+                    "text": "Putting it together."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I can see Jupiter!",
+                    "requiresItems": [{ "id": "134", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent craftsmanship! Regular stargazing will sharpen your navigation skills for future missions.",
+            "options": [{ "type": "finish", "text": "Thanks, Nova." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/observe-moon"]
+}

--- a/frontend/src/pages/quests/json/chemistry/ph-test.json
+++ b/frontend/src/pages/quests/json/chemistry/ph-test.json
@@ -1,0 +1,35 @@
+{
+    "id": "chemistry/ph-test",
+    "title": "Measure Solution pH",
+    "description": "Use test strips to check the acidity of your latest experiment.",
+    "image": "/assets/pH_strip.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Before we mix anything more reactive, let's practice measuring pH so you can record accurate data in future trials.",
+            "options": [{ "type": "goto", "goto": "measure", "text": "Got it." }]
+        },
+        {
+            "id": "measure",
+            "text": "Dip a strip into your solution and compare the color to the chart. Precision here helps keep reactions predictable.",
+            "options": [
+                { "type": "process", "process": "measure-ph", "text": "Reading the strip." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Logged my result",
+                    "requiresItems": [{ "id": "59", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! We'll use those readings when formulating safer propellants.",
+            "options": [{ "type": "finish", "text": "Looking forward to it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["chemistry/safe-reaction"]
+}

--- a/frontend/src/pages/quests/json/completionist/reminder.json
+++ b/frontend/src/pages/quests/json/completionist/reminder.json
@@ -1,0 +1,34 @@
+{
+    "id": "completionist/reminder",
+    "title": "Check for New Quests",
+    "description": "Return regularly to see what fresh challenges await you.",
+    "image": "/assets/quests/completionist.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "More quests are added all the time. Keep an eye on the board so you can maintain that shiny Completionist trophy!",
+            "options": [{ "type": "goto", "goto": "remind", "text": "I'll check back" }]
+        },
+        {
+            "id": "remind",
+            "text": "Set a weekly reminder so you never miss new content and can claim it before anyone else.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Reminder set",
+                    "requiresItems": [{ "id": "87", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your dedication keeps the metaguild growing.",
+            "options": [{ "type": "finish", "text": "Happy to help." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["completionist/v2"]
+}

--- a/frontend/src/pages/quests/json/devops/daily-backups.json
+++ b/frontend/src/pages/quests/json/devops/daily-backups.json
@@ -1,0 +1,39 @@
+{
+    "id": "devops/daily-backups",
+    "title": "Configure Daily Backups",
+    "description": "Use a cron job to archive your game data each night.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's protect your work by backing up the cluster.",
+            "options": [{ "type": "goto", "goto": "script", "text": "Good plan." }]
+        },
+        {
+            "id": "script",
+            "text": "Plug an external SSD into the control plane and create a cron job that runs `docker exec dspace-postgres pg_dumpall > /mnt/backup/dspace.sql` each night.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "configure-daily-backups",
+                    "text": "Cron job added."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Backup script running.",
+                    "requiresItems": [{ "id": "133", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Backups are running daily. Store them off-site for extra safety.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/monitoring"]
+}

--- a/frontend/src/pages/quests/json/devops/monitoring.json
+++ b/frontend/src/pages/quests/json/devops/monitoring.json
@@ -1,0 +1,39 @@
+{
+    "id": "devops/monitoring",
+    "title": "Set Up Monitoring",
+    "description": "Install Prometheus and Grafana to monitor your Pi cluster.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "With the cluster online it's time to keep an eye on resource usage.",
+            "options": [{ "type": "goto", "goto": "install", "text": "Show me how." }]
+        },
+        {
+            "id": "install",
+            "text": "Use docker compose to run Prometheus and Grafana. Expose Grafana on port 3000.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "install-monitoring-stack",
+                    "text": "Installing now."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Dashboard up.",
+                    "requiresItems": [{ "id": "133", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! You can now track CPU load and memory usage from the browser.",
+            "options": [{ "type": "finish", "text": "Looks good." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/k3s-deploy"]
+}

--- a/frontend/src/pages/quests/json/electronics/thermistor-reading.json
+++ b/frontend/src/pages/quests/json/electronics/thermistor-reading.json
@@ -1,0 +1,34 @@
+{
+    "id": "electronics/thermistor-reading",
+    "title": "Read a Thermistor",
+    "description": "Wire a thermistor to your Arduino and log temperature values.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's expand your sensor skills. A simple thermistor can report ambient temperature for all sorts of projects.",
+            "options": [{ "type": "goto", "goto": "wire", "text": "Show me." }]
+        },
+        {
+            "id": "wire",
+            "text": "Connect the thermistor to an analog pin with a 10k resistor as a divider. Use the serial monitor to see the readings.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Numbers are scrolling!",
+                    "requiresItems": [{ "id": "58", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice job! Logging data over time will help automate your experiments.",
+            "options": [{ "type": "finish", "text": "Neat!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/potentiometer-dimmer"]
+}

--- a/frontend/src/pages/quests/json/energy/battery-upgrade.json
+++ b/frontend/src/pages/quests/json/energy/battery-upgrade.json
@@ -1,0 +1,39 @@
+{
+    "id": "energy/battery-upgrade",
+    "title": "Install a Larger Battery",
+    "description": "Expand your solar setup with a 1 kWh storage pack and enclosure.",
+    "image": "/assets/quests/solar_200Wh.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your first panel works well. To store more energy, let's install a 1 kWh battery and matching enclosure.",
+            "options": [{ "type": "goto", "goto": "install", "text": "Let's do it." }]
+        },
+        {
+            "id": "install",
+            "text": "Mount the new battery and controller in the enclosure, then connect your existing panel to start charging the bigger pack.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "setup-solar-enclosure-1kWh",
+                    "text": "Installing."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "All set",
+                    "requiresItems": [{ "id": "6", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! With more storage you can run equipment longer into the night.",
+            "options": [{ "type": "finish", "text": "Awesome!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["energy/solar"]
+}

--- a/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
@@ -1,0 +1,34 @@
+{
+    "id": "hydroponics/nutrient-check",
+    "title": "Refresh Nutrient Solution",
+    "description": "Top off your tub with fresh hydroponic nutrients for healthy growth.",
+    "image": "/assets/hydroponics_nutrients.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Plants can quickly deplete minerals. Let's replenish the solution so your basil stays strong.",
+            "options": [{ "type": "goto", "goto": "add", "text": "Okay." }]
+        },
+        {
+            "id": "add",
+            "text": "Mix this bottle according to the label and pour it into the reservoir. Keep the pump running so everything circulates well.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Done",
+                    "requiresItems": [{ "id": "103", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Monitor the water level every few days and add more as needed.",
+            "options": [{ "type": "finish", "text": "Thanks!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/basil"]
+}

--- a/frontend/src/pages/quests/json/programming/temp-logger.json
+++ b/frontend/src/pages/quests/json/programming/temp-logger.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-logger",
+    "title": "Log Temperature Data",
+    "description": "Write a simple script that records hourly temperature readings.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Now that you've read a sensor, let's automate data collection with a short program that logs temperature over time.",
+            "options": [{ "type": "goto", "goto": "code", "text": "Let's code." }]
+        },
+        {
+            "id": "code",
+            "text": "Use your favorite language to read the thermistor every hour and append the value to a file. We'll graph it later.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Script running",
+                    "requiresItems": [{ "id": "58", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! With regular logs you'll spot interesting patterns in your environment.",
+            "options": [{ "type": "finish", "text": "Cool!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/thermistor-reading"]
+}

--- a/frontend/src/pages/quests/json/robotics/servo-gripper.json
+++ b/frontend/src/pages/quests/json/robotics/servo-gripper.json
@@ -1,0 +1,34 @@
+{
+    "id": "robotics/servo-gripper",
+    "title": "Build a Servo Gripper",
+    "description": "Use a small servo to make a claw that can pick up objects.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A gripper is a simple way to interact with the world. Let's add one to your robot using a standard servo motor.",
+            "options": [{ "type": "goto", "goto": "attach", "text": "Sounds fun." }]
+        },
+        {
+            "id": "attach",
+            "text": "Mount the servo vertically and connect two fingers with a linkage so they open and close when the servo turns.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Works great",
+                    "requiresItems": [{ "id": "96", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! You can now grab and carry small parts for future builds.",
+            "options": [{ "type": "finish", "text": "Sweet!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["robotics/servo-control"]
+}

--- a/frontend/src/pages/quests/json/rocketry/static-test.json
+++ b/frontend/src/pages/quests/json/rocketry/static-test.json
@@ -1,0 +1,34 @@
+{
+    "id": "rocketry/static-test",
+    "title": "Perform a Static Engine Test",
+    "description": "Fire your rocket engine while it's secured to verify thrust and stability.",
+    "image": "/assets/rocketry.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Before launch day let's conduct a static burn. Secure the rocket to a stand and record the thrust curve.",
+            "options": [{ "type": "goto", "goto": "burn", "text": "Ready." }]
+        },
+        {
+            "id": "burn",
+            "text": "Ignite the engine remotely and keep clear. Use a scale under the mount to capture thrust data for analysis.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Data captured",
+                    "requiresItems": [{ "id": "66", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! Reviewing the numbers will help ensure a safe first flight.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["rocketry/parachute"]
+}

--- a/frontend/src/pages/quests/json/ubi/first-payment.json
+++ b/frontend/src/pages/quests/json/ubi/first-payment.json
@@ -1,0 +1,35 @@
+{
+    "id": "ubi/first-payment",
+    "title": "Claim Your First UBI",
+    "description": "Withdraw your daily dUSD for the first time.",
+    "image": "/assets/quests/basicincome.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready to try out the basic income system? Let's trigger your first payout so you see how it works.",
+            "options": [{ "type": "goto", "goto": "claim", "text": "Absolutely." }]
+        },
+        {
+            "id": "claim",
+            "text": "Open the wallet page and click the claim button. Your balance will increase instantly once the transaction finishes.",
+            "options": [
+                { "type": "process", "process": "basic-income", "text": "Claiming now." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Funds received",
+                    "requiresItems": [{ "id": "72", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Come back tomorrow for another payment and watch your savings grow.",
+            "options": [{ "type": "finish", "text": "See you then." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["ubi/basicincome"]
+}

--- a/frontend/src/pages/quests/json/welcome/intro-inventory.json
+++ b/frontend/src/pages/quests/json/welcome/intro-inventory.json
@@ -1,0 +1,34 @@
+{
+    "id": "welcome/intro-inventory",
+    "title": "Check Your Inventory",
+    "description": "Learn how to view items you've collected so far.",
+    "image": "/assets/quests/howtodoquests.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Before diving into bigger tasks, open the inventory page and make sure your new smart plug shows up.",
+            "options": [{ "type": "goto", "goto": "view", "text": "Opening inventory" }]
+        },
+        {
+            "id": "view",
+            "text": "Great! Seeing your items helps track progress. You'll use many of them in upcoming quests.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Smart plug is there",
+                    "requiresItems": [{ "id": "29", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Keep an eye on this list as you craft and discover new gear.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["welcome/howtodoquests"]
+}

--- a/frontend/src/pages/quests/json/woodworking/finish-sanding.json
+++ b/frontend/src/pages/quests/json/woodworking/finish-sanding.json
@@ -1,0 +1,34 @@
+{
+    "id": "woodworking/finish-sanding",
+    "title": "Finish Sand Your Project",
+    "description": "Smooth the surface of your latest build with fine-grit paper before applying finish.",
+    "image": "/assets/sandpaper.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Sanding is the secret to a professional look. Use a light touch and work up to 220 grit for a silky feel.",
+            "options": [{ "type": "goto", "goto": "sand", "text": "Got it." }]
+        },
+        {
+            "id": "sand",
+            "text": "Move with the grain and wipe away dust between grits. It takes patience but the results are worth it.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Looks smooth",
+                    "requiresItems": [{ "id": "111", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Beautiful work! A coat of finish will really make the wood shine.",
+            "options": [{ "type": "finish", "text": "Thanks, Cedar." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/step-stool"]
+}


### PR DESCRIPTION
## Summary
- extend every quest tree with a small follow-up quest
- add telescope item and new processes for telescope assembly and pH testing
- document the broader quest lines and mention `npm run generate-quest`
- note expanded quest progression in README

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_687ed1e46c00832f8db7d82a4b706092