### PR TITLE
Improve custom content e2e coverage

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -183,6 +183,9 @@ npm run dev
 # Test custom content functionality
 npm run test:e2e:custom
 
+The custom content suite also verifies that created items, processes and quests
+are persisted to IndexedDB and can be removed via the Manage Quests interface.
+
 # Test quest functionality
 npm run test:e2e:quests
 

--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -4,6 +4,8 @@ import {
     createTestItems,
     fillProcessForm,
     ItemSelectorHelper,
+    clearCustomContentDB,
+    getCustomContentEntities,
 } from './test-helpers';
 
 test.describe('Custom Content Management', () => {
@@ -483,5 +485,66 @@ test.describe('Custom Content Management', () => {
 
         // As long as we got through all the steps without major errors, consider the integration test a success
         expect(true).toBe(true);
+    });
+
+    test('should create a custom item persisted in IndexedDB', async ({ page }) => {
+        await clearCustomContentDB(page);
+        await page.goto('/inventory/create');
+        await page.waitForLoadState('networkidle');
+
+        const itemName = `DB Item ${Date.now()}`;
+        await page.fill('#name', itemName);
+        await page.fill('#description', 'Stored via e2e test');
+        await page.click('button.submit-button');
+        await page.waitForLoadState('networkidle');
+
+        const items = await getCustomContentEntities(page, 'items');
+        expect(items.some((i) => (i as { name?: string }).name === itemName)).toBe(true);
+    });
+
+    test('should create a custom process persisted in IndexedDB', async ({ page }) => {
+        await clearCustomContentDB(page);
+        await createTestItems(page, 1);
+        await page.goto('/processes/create');
+        await page.waitForLoadState('networkidle');
+
+        const title = `DB Process ${Date.now()}`;
+        await fillProcessForm(page, title, '10m', 1, 0, 0);
+        await page.locator('button.submit-button').first().click();
+        await page.waitForLoadState('networkidle');
+
+        const processes = await getCustomContentEntities(page, 'processes');
+        expect(processes.some((p) => (p as { title?: string }).title === title)).toBe(true);
+    });
+
+    test('Quest Management - delete custom quest via Manage Quests', async ({ page }) => {
+        await clearCustomContentDB(page);
+        const questTitle = `Managed Quest ${Date.now()}`;
+
+        await page.goto('/quests/create');
+        await page.waitForLoadState('networkidle');
+        await page.fill('#title', questTitle);
+        await page.fill('#description', 'Quest for deletion test');
+        await page.locator('button.submit-button').click();
+        await page.waitForLoadState('networkidle');
+
+        const quests = await getCustomContentEntities(page, 'quests');
+        expect(quests.some((q) => (q as { title?: string }).title === questTitle)).toBe(true);
+
+        await page.goto('/quests/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const questItem = page.locator('.quest-item', { hasText: questTitle }).first();
+        await expect(questItem).toBeVisible();
+
+        page.on('dialog', (dialog) => dialog.accept());
+        const deleteButton = questItem.locator('button.delete-button').first();
+        await deleteButton.click();
+
+        await expect(questItem).toHaveCount(0);
+
+        const remaining = await getCustomContentEntities(page, 'quests');
+        expect(remaining.some((q) => (q as { title?: string }).title === questTitle)).toBe(false);
     });
 });

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -440,3 +440,49 @@ export async function addTestItems(page: Page): Promise<void> {
         console.log('Added test items to inventory');
     });
 }
+
+/**
+ * Deletes the CustomContent IndexedDB database to ensure a clean state
+ */
+export async function clearCustomContentDB(page: Page): Promise<void> {
+    await page.goto('/');
+    await page.evaluate(() => {
+        indexedDB.deleteDatabase('CustomContent');
+    });
+}
+
+/**
+ * Retrieves all entities from a specific store in the CustomContent DB
+ */
+export async function getCustomContentEntities(
+    page: Page,
+    store: 'items' | 'processes' | 'quests'
+): Promise<Record<string, unknown>[]> {
+    await page.goto('/');
+    return page.evaluate(async (store) => {
+        function openDb() {
+            return new Promise<IDBDatabase>((resolve, reject) => {
+                const req = indexedDB.open('CustomContent', 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    ['items', 'processes', 'quests'].forEach((name) => {
+                        if (!db.objectStoreNames.contains(name)) {
+                            db.createObjectStore(name, { keyPath: 'id' });
+                        }
+                    });
+                };
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => reject(req.error);
+            });
+        }
+
+        const db = await openDb();
+        return new Promise<Record<string, unknown>[]>((resolve, reject) => {
+            const tx = db.transaction(store, 'readonly');
+            const os = tx.objectStore(store);
+            const q = os.getAll();
+            q.onsuccess = () => resolve(q.result as Record<string, unknown>[]);
+            q.onerror = () => reject(q.error);
+        });
+    }, store);
+}


### PR DESCRIPTION
## Summary
- add helpers to interact with custom content IndexedDB
- verify item, process, and quest persistence and deletion
- document the custom content suite

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_687f30c989e4832fba61e78b1d2a9a41