### PR TITLE
Expand quest trees with new first aid path

### DIFF
--- a/frontend/src/pages/docs/images/quest-tree-stats.txt
+++ b/frontend/src/pages/docs/images/quest-tree-stats.txt
@@ -5,11 +5,12 @@ devops: 7 quests, 318 lines
 hydroponics: 5 quests, 503 lines
 woodworking: 5 quests, 273 lines
 electronics: 4 quests, 214 lines
+astronomy: 3 quests, 103 lines
 chemistry: 3 quests, 100 lines
 robotics: 3 quests, 129 lines
 rocketry: 3 quests, 345 lines
-astronomy: 2 quests, 68 lines
 completionist: 2 quests, 94 lines
+firstaid: 2 quests, 70 lines
 programming: 2 quests, 63 lines
 ubi: 2 quests, 180 lines
 welcome: 2 quests, 232 lines

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -20,13 +20,14 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 -   **UBI** – an optional quest explaining the metaguild's basic income concept with daily payouts
 -   **Completionist** – track progress toward finishing all available quests
 -   **Woodworking** – build a sturdy workbench, sand projects smooth, then craft birdhouses, stools and shelves
+-   **First Aid** – assemble a kit and practice CPR so accidents don't derail progress
+-   **Astronomy** – observe the Moon, build a telescope and track Jupiter's moons
 
 ## Planned Quest Trees
 
 The following quest lines are being drafted to help achieve the "10x More Quests" goal announced for v3:
 
 -   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles and extract stevia into an artificial sweetener
--   **Astronomy** – observational tasks that prepare players for future rocketry missions
 -   **Programming** – simple scripts for automating sensors and data collection
 -   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s, then add monitoring and nightly backups
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -873,5 +873,11 @@
         "name": "basic telescope",
         "description": "A simple refracting telescope for backyard astronomy.",
         "image": "/assets/quests/solar.jpg"
+    },
+    {
+        "id": "135",
+        "name": "first aid kit",
+        "description": "Adhesive bandages, gauze and antiseptic packed for emergencies.",
+        "image": "/assets/quests/basic_circuit.svg"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1160,5 +1160,29 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "pack-first-aid-kit",
+        "title": "Pack a basic first aid kit",
+        "requireItems": [],
+        "consumeItems": [],
+        "createItems": [{ "id": "135", "count": 1 }],
+        "duration": "2m"
+    },
+    {
+        "id": "practice-cpr",
+        "title": "Practice CPR on a dummy",
+        "requireItems": [{ "id": "135", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
+        "id": "observe-jupiter-moons",
+        "title": "Observe Jupiter's moons",
+        "requireItems": [{ "id": "134", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m"
     }
 ]

--- a/frontend/src/pages/quests/json/astronomy/jupiter-moons.json
+++ b/frontend/src/pages/quests/json/astronomy/jupiter-moons.json
@@ -1,0 +1,39 @@
+{
+    "id": "astronomy/jupiter-moons",
+    "title": "Track Jupiter's Moons",
+    "description": "Observe the four largest moons nightly to understand orbital motion.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "With your telescope assembled, let's watch Jupiter. Its bright moons move quickly!",
+            "options": [{ "type": "goto", "goto": "observe", "text": "Pointing the scope." }]
+        },
+        {
+            "id": "observe",
+            "text": "Sketch Io, Europa, Ganymede and Callisto each night for a week and note how their positions change.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "observe-jupiter-moons",
+                    "text": "Logging observations."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [{ "id": "134", "count": 1 }],
+                    "text": "Week complete."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent diligence! Tracking these moons builds the skills needed for future navigation challenges.",
+            "options": [{ "type": "finish", "text": "Space feels closer already." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/basic-telescope"]
+}

--- a/frontend/src/pages/quests/json/firstaid/assemble-kit.json
+++ b/frontend/src/pages/quests/json/firstaid/assemble-kit.json
@@ -1,0 +1,35 @@
+{
+    "id": "firstaid/assemble-kit",
+    "title": "Assemble a First Aid Kit",
+    "description": "Gather basic medical supplies so you're ready for small emergencies.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "dChat here! Even experienced builders should keep a first aid kit nearby.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "What do I need?" }]
+        },
+        {
+            "id": "gather",
+            "text": "Include adhesive bandages, gauze, antiseptic wipes and gloves. Pack them so they stay clean and dry.",
+            "options": [
+                { "type": "process", "process": "pack-first-aid-kit", "text": "Packing now." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [{ "id": "135", "count": 1 }],
+                    "text": "Supplies packed."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep this kit handy so minor mishaps don't halt your progress.",
+            "options": [{ "type": "finish", "text": "Will do!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}

--- a/frontend/src/pages/quests/json/firstaid/learn-cpr.json
+++ b/frontend/src/pages/quests/json/firstaid/learn-cpr.json
@@ -1,0 +1,35 @@
+{
+    "id": "firstaid/learn-cpr",
+    "title": "Practice Basic CPR",
+    "description": "Use a dummy to rehearse chest compressions in case of emergencies.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Now that you have a kit, let's cover CPR so you're ready for serious situations.",
+            "options": [{ "type": "goto", "goto": "steps", "text": "I'm ready." }]
+        },
+        {
+            "id": "steps",
+            "text": "Place the heel of your hand in the center of the chest and press hard and fast about 100 times per minute until help arrives.",
+            "options": [
+                { "type": "process", "process": "practice-cpr", "text": "Practicing now." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [{ "id": "135", "count": 1 }],
+                    "text": "I know the basics."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent work! Regular practice could save a life one day.",
+            "options": [{ "type": "finish", "text": "I'll keep practicing." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}


### PR DESCRIPTION
## Summary
- add first aid kit item and related processes
- introduce a first aid quest line and a new astronomy follow-up quest
- document the new quest tree and regenerate stats

## Testing
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68806d388670832fb21efc14af5bad3f