### PR TITLE
v3: final low-hanging fruit

### DIFF
--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -2,6 +2,19 @@ name: Build and Deploy to RPi
 
 on:
   workflow_dispatch:
+    inputs:
+      GHCR_TOKEN:
+        required: true
+        description: 'Token for GHCR'
+      RPI_HOST:
+        required: true
+        description: 'Pi host'
+      RPI_USER:
+        required: true
+        description: 'SSH user'
+      RPI_SSH_KEY:
+        required: true
+        description: 'SSH key'
   push:
     branches: [v3]
 
@@ -19,6 +32,11 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Verify secrets
+        run: |
+          if [ -z "$GHCR_TOKEN" ] || [ -z "$RPI_HOST" ] || [ -z "$RPI_USER" ] || [ -z "$RPI_SSH_KEY" ]; then
+            echo "Missing required secrets" && exit 1
+          fi
       - name: Login to registry
         uses: docker/login-action@v3
         with:
@@ -41,5 +59,6 @@ jobs:
           username: ${{ env.RPI_USER }}
           key: ${{ env.RPI_SSH_KEY }}
           script: |
+            docker system prune -fa
             docker pull ghcr.io/${{ github.repository }}:latest
             docker compose -f /home/${{ env.RPI_USER }}/dspace/docker-compose.yml up -d app

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSPACE - Democratized Space
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/ci.yml?label=lint%20%26%20format)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/ci.yml?label=tests)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/test-pr.yml?label=tests)](https://github.com/democratizedspace/dspace/actions/workflows/test-pr.yml)
 [![Coverage](https://codecov.io/gh/democratizedspace/dspace/branch/v3/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
 [![Docs](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/quest-chart.yml?label=docs)](https://github.com/democratizedspace/dspace/actions/workflows/quest-chart.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,8 @@ services:
             - PORT=3002
             - HOST=0.0.0.0
         restart: unless-stopped
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3002/health"]
+            interval: 30s
+            timeout: 10s
+            retries: 3

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -22,3 +22,7 @@
 -   Added detailed instructions for preventing Playwright artifact errors
 -   Added documentation for image reference tests
 -   Updated root README with `dev:safe` command information
+
+## [3.0.0] - 2024-04-01
+
+Initial 3.0.0 stable release.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,5 +23,7 @@ ENV HOST=0.0.0.0
 # Expose port 3002
 EXPOSE 3002
 
+HEALTHCHECK CMD curl -f http://localhost:3002/health || exit 1
+
 # Run the application
 CMD ["npm", "run", "dev"]

--- a/frontend/__tests__/processQuality.test.js
+++ b/frontend/__tests__/processQuality.test.js
@@ -22,8 +22,12 @@ function checkProcess(proc) {
     if (!seconds || seconds <= 0) {
         issues.push(`invalid duration ${proc.duration}`);
     }
-    if (seconds > 31536000) {
-        issues.push('duration longer than one year');
+    if (seconds < 30) {
+        issues.push('duration under 30s');
+    }
+    const max = 72 * 3600;
+    if (seconds > max && !proc.long) {
+        issues.push('duration longer than 72h');
     }
 
     const hasItems =
@@ -68,5 +72,23 @@ describe('Process Quality Validation', () => {
         }
 
         expect(true).toBe(true);
+    });
+
+    test('duration sanity checks', () => {
+        const shortProc = {
+            id: 'short',
+            title: 't',
+            duration: '10s',
+            requireItems: [{ id: items[0].id, count: 1 }],
+        };
+        const longProc = {
+            id: 'long',
+            title: 't',
+            duration: '100h',
+            long: true,
+            requireItems: [{ id: items[0].id, count: 1 }],
+        };
+        expect(checkProcess(shortProc)).toContain('duration under 30s');
+        expect(checkProcess(longProc)).not.toContain('duration longer than 72h');
     });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dspace",
-    "version": "2.1",
+    "version": "3.0.0",
     "type": "module",
     "description": "A free and open source web-based space exploration idle game",
     "scripts": {

--- a/frontend/scripts/generate-quest.mjs
+++ b/frontend/scripts/generate-quest.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { writeFileSync, mkdirSync, readdirSync, readFileSync, statSync } from 'fs';
+import glob from 'glob';
+import { fileURLToPath } from 'url';
 import path from 'path';
 import readline from 'readline';
 
@@ -31,13 +33,21 @@ function gatherStats() {
 async function main() {
     const { categories, npcCounts } = gatherStats();
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const questRoot = path.join('frontend', 'src', 'pages', 'quests', 'json');
+    const existing = glob.sync(path.join(questRoot, '**/*.json')).map((f) => path.relative(questRoot, f).replace(/\.json$/, ''));
 
-    let questId = process.argv[2];
+    const noLlm = process.argv.includes('--no-llm');
+    let questId = process.argv[2] && !process.argv[2].startsWith('--') ? process.argv[2] : null;
     if (!questId) {
         console.log('Available categories:', categories.join(', '));
         const category = (await ask('Choose a category or type a new one: ', rl)).trim();
         const slug = (await ask('Quest id (slug-with-dashes): ', rl)).trim();
         questId = `${category}/${slug}`;
+    }
+
+    if (existing.includes(`${questId}`)) {
+        console.error(`Quest ${questId} already exists.`);
+        process.exit(1);
     }
 
     const title = questId
@@ -69,13 +79,25 @@ async function main() {
         dialogue: [
             {
                 id: 'start',
-                text: 'Replace this text with your opening dialogue.',
+                text: 'Generating...',
                 options: [{ type: 'finish', text: 'Finish' }],
             },
         ],
         rewards: [],
         requiresQuests: [],
     };
+
+    if (!noLlm) {
+        const { scoreQuest } = await import('../../scripts/utils/llm.js');
+        try {
+            const text = await scoreQuest(`Write a short greeting from ${npcName} for the quest ${title}.`);
+            quest.dialogue[0].text = text;
+        } catch (e) {
+            console.warn('LLM generation failed:', e.message);
+        }
+    } else {
+        quest.dialogue[0].text = 'Replace this text with your opening dialogue.';
+    }
 
     const outputPath = path.join('frontend', 'src', 'pages', 'quests', 'json', `${questId}.json`);
     mkdirSync(path.dirname(outputPath), { recursive: true });

--- a/k8s/dspace-deployment.yaml
+++ b/k8s/dspace-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: dspace
-        image: dspace-app:latest
+        image: ghcr.io/democratizedspace/dspace:v3
         ports:
         - containerPort: 3002
         env:
@@ -26,3 +26,9 @@ spec:
           value: "3002"
         - name: HOST
           value: "0.0.0.0"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3002
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "main": "index.js",
   "scripts": {
     "dev": "cd frontend && npm run dev",

--- a/scripts/baselines/contentCounts.json
+++ b/scripts/baselines/contentCounts.json
@@ -1,0 +1,6 @@
+{
+  "quests": 70,
+  "items": 136,
+  "processes": 55,
+  "npcImages": 8
+}

--- a/scripts/tests/contentIntegrity.test.js
+++ b/scripts/tests/contentIntegrity.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const baselineFile = path.join(__dirname, '../baselines/contentCounts.json');
+const baseline = JSON.parse(fs.readFileSync(baselineFile));
+const questDir = path.join(__dirname, '../../frontend/src/pages/quests/json');
+const itemsFile = path.join(__dirname, '../../frontend/src/pages/inventory/json/items.json');
+const processesFile = path.join(__dirname, '../../frontend/src/pages/processes/processes.json');
+const npcDir = path.join(__dirname, '../../frontend/public/assets/npc');
+
+function getCounts() {
+    const quests = glob.sync(path.join(questDir, '**/*.json')).length;
+    const items = JSON.parse(fs.readFileSync(itemsFile)).length;
+    const processes = JSON.parse(fs.readFileSync(processesFile)).length;
+    const npcImages = fs.readdirSync(npcDir).filter(f => /\.(png|jpe?g|webp)$/.test(f)).length;
+    return { quests, items, processes, npcImages };
+}
+
+describe('Content integrity counts', () => {
+    const counts = getCounts();
+    const update = process.env.UPDATE_BASELINE === 'true';
+
+    test('counts meet or exceed baseline', () => {
+        const failures = [];
+        for (const key of Object.keys(baseline)) {
+            if (counts[key] < baseline[key]) {
+                failures.push(`${key}: ${counts[key]} < ${baseline[key]}`);
+            }
+        }
+
+        if (update) {
+            fs.writeFileSync(baselineFile, JSON.stringify(counts, null, 2));
+            console.log('Baseline updated');
+        }
+
+        if (failures.length) {
+            console.warn('Content count regressions:\n' + failures.join('\n'));
+        }
+
+        expect(failures.length).toBe(0);
+    });
+});

--- a/scripts/tests/imageReferences.test.js
+++ b/scripts/tests/imageReferences.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const { listMissingImages } = require('../utils/fs-checks');
+
+const questsDir = path.join(__dirname, '../../frontend/src/pages/quests/json');
+const itemsFile = path.join(__dirname, '../../frontend/src/pages/inventory/json/items.json');
+const npcFile = path.join(__dirname, '../../frontend/src/pages/docs/md/npcs.md');
+
+function collectQuestImages() {
+    const files = glob.sync(path.join(questsDir, '**/*.json'));
+    const imgs = [];
+    files.forEach((file) => {
+        const data = JSON.parse(fs.readFileSync(file));
+        if (data.image) imgs.push(data.image);
+        if (data.npc) imgs.push(data.npc);
+    });
+    return imgs;
+}
+
+function collectItemImages() {
+    const items = JSON.parse(fs.readFileSync(itemsFile));
+    return items.map((i) => i.image).filter(Boolean);
+}
+
+function collectNpcImages() {
+    const md = fs.readFileSync(npcFile, 'utf8');
+    const regex = /<img src="(.*?)"/g;
+    const imgs = [];
+    let match;
+    while ((match = regex.exec(md))) {
+        imgs.push(match[1]);
+    }
+    return imgs;
+}
+
+describe('Image references', () => {
+    test('all referenced images exist', () => {
+        const images = [
+            ...collectQuestImages(),
+            ...collectItemImages(),
+            ...collectNpcImages(),
+        ];
+        const missing = listMissingImages(images);
+        if (missing.length) {
+            console.warn('Missing images:', missing);
+        }
+        expect(missing.length).toBe(0);
+    });
+});

--- a/scripts/tests/questQuality.test.js
+++ b/scripts/tests/questQuality.test.js
@@ -1,0 +1,29 @@
+const { scoreQuest } = require('../utils/llm');
+
+jest.mock('openai', () => {
+    return {
+        Configuration: jest.fn(),
+        OpenAIApi: jest.fn().mockImplementation(() => ({
+            createChatCompletion: jest.fn().mockResolvedValue({
+                data: { choices: [{ message: { content: '0.9' } }] }
+            })
+        }))
+    };
+});
+
+describe('scoreQuest', () => {
+    afterEach(() => {
+        delete process.env.OPENAI_API_KEY;
+    });
+
+    test('falls back to heuristic when api key missing', async () => {
+        const score = await scoreQuest('short');
+        expect(score).toBe(0.5);
+    });
+
+    test('uses openai when api key provided', async () => {
+        process.env.OPENAI_API_KEY = 'test';
+        const score = await scoreQuest('some long dialogue text that is definitely longer than one hundred characters so that heuristics would not override the openai result.');
+        expect(score).toBe(0.9);
+    });
+});

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '..', 'frontend', 'public')) {
+    const missing = [];
+    imagePaths.forEach((img) => {
+        const rel = img.startsWith('/') ? img.slice(1) : img;
+        const full = path.join(publicDir, rel);
+        if (!fs.existsSync(full)) {
+            missing.push(img);
+        }
+    });
+    return missing;
+}
+
+module.exports = { listMissingImages };

--- a/scripts/utils/llm.js
+++ b/scripts/utils/llm.js
@@ -1,0 +1,22 @@
+const { Configuration, OpenAIApi } = require('openai');
+
+async function scoreQuest(dialogue) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+        // simple heuristic fallback
+        return dialogue.length > 100 ? 0.8 : 0.5;
+    }
+    const openai = new OpenAIApi(new Configuration({ apiKey }));
+    const prompt = `Rate the following quest dialogue from 0 to 1 for quality only return the number:\n${dialogue}`;
+    const res = await openai.createChatCompletion({
+        model: 'gpt-3.5-turbo',
+        messages: [
+            { role: 'user', content: prompt }
+        ],
+    });
+    const text = res.data.choices[0].message.content.trim();
+    const num = parseFloat(text);
+    return isNaN(num) ? 0.5 : num;
+}
+
+module.exports = { scoreQuest };


### PR DESCRIPTION
## Summary
- add llm helper with OpenAI support and tests
- ensure content counts don't regress
- validate image references across quests, items and NPCs
- polish quest generator with id checks and optional LLM dialogue
- tighten process duration heuristics
- add health checks to Docker and Compose
- update k8s deployment image and readiness probe
- enforce secrets in Pi deploy workflow and prune before pulling
- update CI badge and bump version

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68808421c694832fad9ed6bf2bd71e51