### PR TITLE
Document secrets for RPI deploy workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYM
 
 The workflow `.github/workflows/rpi-deploy.yml` builds an ARM64 Docker image and optionally deploys it to a Raspberry Pi over SSH.
 Create a classic PAT with the [`write:packages` scope](https://github.com/settings/tokens/new?scopes=write:packages) (fine-grained tokens don’t work with Packages yet) and add it as the `GHCR_TOKEN` secret.
-Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment.
+Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment. If the workflow fails with a "Missing required secrets" message, add these values under **Settings → Secrets and variables → Actions** in your repository.
 Trigger the workflow manually or on pushes to `v3` to update the Pi and restart the `app` service.
 
 ## Project Architecture

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -95,6 +95,17 @@ kubectl apply -f k8s/
 
 `k8s/dspace-deployment.yaml` and `k8s/dspace-service.yaml` describe the DSPACE Deployment and Service.
 
+## GitHub Deployment Workflow
+
+This repository provides a GitHub Actions workflow (`.github/workflows/rpi-deploy.yml`) to build and push an ARM64 Docker image and optionally deploy it over SSH. Define the following secrets in your repository to enable the workflow:
+
+- `GHCR_TOKEN` – a personal access token with the `write:packages` scope
+- `RPI_HOST` – the hostname or IP address of your Raspberry Pi
+- `RPI_USER` – the SSH username
+- `RPI_SSH_KEY` – the private key used for authentication
+
+Add these secrets under **Settings → Secrets and variables → Actions**. If any are missing, the workflow will fail with a "Missing required secrets" message.
+
 ## Troubleshooting
 
 - **SSD not detected**: reseat cables, check `lsblk`, run `sudo fsck -fy /dev/sda2`.


### PR DESCRIPTION
## Summary
- clarify where to add GHCR_TOKEN, RPI_HOST, RPI_USER and RPI_SSH_KEY
- document workflow secrets in the Raspberry Pi deployment guide

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68815e45202c832f9a9ec2e569d9d244