### PR TITLE
Add Raspberry Pi deployment docs & workflow

### DIFF
--- a/.github/workflows/deploy-to-raspi.yml
+++ b/.github/workflows/deploy-to-raspi.yml
@@ -1,0 +1,47 @@
+name: Deploy to Raspberry Pi
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ssh-port:
+        description: 'SSH port'
+        default: '22'
+        required: false
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main' &&
+        secrets.RPI_HOST != '' &&
+        secrets.RPI_SSH_KEY != ''
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      RPI_HOST: ${{ secrets.RPI_HOST }}
+      RPI_USER: ${{ secrets.RPI_USER }}
+      RPI_SSH_KEY: ${{ secrets.RPI_SSH_KEY }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      INPUT_SSH_PORT: ${{ github.event.inputs.ssh-port || '22' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build and push Docker image
+        run: |
+          docker buildx build --platform linux/arm64,linux/amd64 \
+            -t $IMAGE_NAME --push frontend
+      - name: Deploy on Raspberry Pi
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ env.RPI_HOST }}
+          username: ${{ env.RPI_USER }}
+          key: ${{ env.RPI_SSH_KEY }}
+          port: ${{ env.INPUT_SSH_PORT }}
+          script: |
+            docker pull $IMAGE_NAME
+            docker compose -f /home/${{ env.RPI_USER }}/dspace/docker-compose.yml up -d app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+IMAGE ?= ghcr.io/$(shell basename $(git config --get remote.origin.url | sed -e 's#.*/##' -e 's/.git$//')):latest
+SSH_PORT ?= 22
+
+.PHONY: image deploy
+
+image:
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(IMAGE) --push frontend
+
+deploy:
+	ansible-playbook -i ansible/inventory.yml ansible/cluster.yml

--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -1,0 +1,32 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Ensure ~/.ssh directory exists
+      file:
+        path: "/home/{{ ansible_user }}/.ssh"
+        state: directory
+        mode: '0700'
+        owner: "{{ ansible_user }}"
+    - name: Copy authorized key
+      authorized_key:
+        user: "{{ ansible_user }}"
+        state: present
+        key: "{{ lookup('file', '~/.ssh/id_ed25519.pub') }}"
+
+- hosts: master
+  become: true
+  roles:
+    - role: xanmanning.k3s
+      vars:
+        k3s_become: true
+        k3s_control_node: true
+
+- hosts: workers
+  become: true
+  roles:
+    - role: xanmanning.k3s
+      vars:
+        k3s_become: true
+        k3s_server: "https://{{ hostvars['controlplane0'].ansible_host | default('controlplane0') }}:6443"
+        k3s_token: "{{ hostvars['controlplane0'].k3s_token | default('') }}"

--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -14,7 +14,7 @@
         state: present
         key: "{{ lookup('file', '~/.ssh/id_ed25519.pub') }}"
 
-- hosts: master
+- hosts: controlplane0
   become: true
   roles:
     - role: xanmanning.k3s
@@ -28,5 +28,5 @@
     - role: xanmanning.k3s
       vars:
         k3s_become: true
-        k3s_server: "https://{{ hostvars['controlplane0'].ansible_host | default('controlplane0') }}:6443"
-        k3s_token: "{{ hostvars['controlplane0'].k3s_token | default('') }}"
+        k3s_server: "https://{{ hostvars['rpi-controlplane0.local'].ansible_host | default('rpi-controlplane0.local') }}:6443"
+        k3s_token: "{{ hostvars['rpi-controlplane0.local'].k3s_token | default('') }}"

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,5 +1,13 @@
 all:
   hosts:
-    controlplane0:
+    rpi-controlplane0.local:
     rpi-node1.local:
     rpi-node2.local:
+  children:
+    controlplane0:
+      hosts:
+        rpi-controlplane0.local:
+    workers:
+      hosts:
+        rpi-node1.local:
+        rpi-node2.local:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    controlplane0:
+    rpi-node1.local:
+    rpi-node2.local:

--- a/docs/deploy/raspi.md
+++ b/docs/deploy/raspi.md
@@ -46,7 +46,7 @@ Add the following secrets under **Settings → Secrets and variables → Actions
 | Secret | When needed | Example (safe) value |
 |--------|-------------|-----------------------|
 | `GHCR_TOKEN` | Always | `ghp_xxxxx` |
-| `RPI_HOST` | LAN only | `controlplane0` |
+| `RPI_HOST` | LAN only | `rpi-controlplane0.local` |
 | `RPI_USER` | LAN only | `ubuntu` |
 | `RPI_SSH_KEY` | LAN only | *private-key-block* |
 | `CLOUDFLARE_API_TOKEN` | When tunnels enabled | `cf_...` |

--- a/docs/deploy/raspi.md
+++ b/docs/deploy/raspi.md
@@ -1,0 +1,64 @@
+# Raspberry Pi k3s Deployment
+
+This guide explains how to prepare Raspberry Pi nodes and deploy DSPACE using k3s. It references [k3s-ansible](https://github.com/k3s-io/k3s-ansible) for a more automated setup.
+
+## Hardware & OS Prep
+
+1. Flash Raspberry Pi OS 64‑bit to a microSD card and boot each Pi.
+2. Update the system and firmware:
+   ```bash
+   sudo apt update && sudo apt full-upgrade -y
+   sudo rpi-eeprom-update -a
+   ```
+3. Install Docker and Git, then clone this repository:
+   ```bash
+   sudo apt install -y docker.io git
+   git clone https://github.com/democratizedspace/dspace.git
+   ```
+4. (Optional) Use the [k3s-ansible](https://github.com/k3s-io/k3s-ansible) playbooks to install k3s across the cluster.
+
+## SSH Key Setup
+
+Generate an ED25519 key on your workstation and add the public key to `/home/$USER/.ssh/authorized_keys` on **every** node:
+
+```bash
+ssh-keygen -t ed25519 -C "dspace" -f ~/.ssh/id_ed25519
+ssh-copy-id -i ~/.ssh/id_ed25519.pub $USER@<node>
+```
+
+The private key will later be stored as `RPI_SSH_KEY` in GitHub secrets.
+
+## Building a Multi-arch Image
+
+Use `docker buildx` to build and push a multi-architecture image to GHCR:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/<owner>/dspace:latest \
+  --push frontend
+```
+
+## GitHub Secrets
+
+Add the following secrets under **Settings → Secrets and variables → Actions**. Leave them blank until your cluster is reachable; the deploy job will skip automatically.
+
+| Secret | When needed | Example (safe) value |
+|--------|-------------|-----------------------|
+| `GHCR_TOKEN` | Always | `ghp_xxxxx` |
+| `RPI_HOST` | LAN only | `controlplane0` |
+| `RPI_USER` | LAN only | `ubuntu` |
+| `RPI_SSH_KEY` | LAN only | *private-key-block* |
+| `CLOUDFLARE_API_TOKEN` | When tunnels enabled | `cf_...` |
+
+## Cloudflare Tunnel
+
+Once k3s is running you can expose services with Cloudflare:
+
+```bash
+cloudflared tunnel create dspace-prod
+cloudflared tunnel route dns dspace-prod dspace.example.com
+```
+
+External traffic arrives on port **443** and can map to any service/port inside the cluster.
+


### PR DESCRIPTION
## Summary
- document optional Raspberry Pi deployment
- add Ansible inventory and cluster playbook
- create Makefile helpers
- new deploy workflow for Pi with safe defaults
- rename master host to controlplane0

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6881640504c0832f9a07e73d7277fc4a