### PR TITLE
Skip RPi deploy job when secrets absent

### DIFF
--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ secrets.RPI_HOST != '' && secrets.RPI_USER != '' && secrets.RPI_SSH_KEY != '' && secrets.GHCR_TOKEN != '' }}
     runs-on: ubuntu-latest
     env:
       RPI_HOST: ${{ secrets.RPI_HOST }}
@@ -32,11 +33,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Verify secrets
-        run: |
-          if [ -z "$GHCR_TOKEN" ] || [ -z "$RPI_HOST" ] || [ -z "$RPI_USER" ] || [ -z "$RPI_SSH_KEY" ]; then
-            echo "Missing required secrets" && exit 1
-          fi
       - name: Login to registry
         uses: docker/login-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYM
 
 The workflow `.github/workflows/rpi-deploy.yml` builds an ARM64 Docker image and optionally deploys it to a Raspberry Pi over SSH.
 Create a classic PAT with the [`write:packages` scope](https://github.com/settings/tokens/new?scopes=write:packages) (fine-grained tokens don’t work with Packages yet) and add it as the `GHCR_TOKEN` secret.
-Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment. If the workflow fails with a "Missing required secrets" message, add these values under **Settings → Secrets and variables → Actions** in your repository.
+Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment.
+If these secrets are not defined, the workflow simply skips the deploy job.
 Trigger the workflow manually or on pushes to `v3` to update the Pi and restart the `app` service.
 
 ## Project Architecture

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -104,7 +104,8 @@ This repository provides a GitHub Actions workflow (`.github/workflows/rpi-deplo
 - `RPI_USER` – the SSH username
 - `RPI_SSH_KEY` – the private key used for authentication
 
-Add these secrets under **Settings → Secrets and variables → Actions**. If any are missing, the workflow will fail with a "Missing required secrets" message.
+Add these secrets under **Settings → Secrets and variables → Actions**.
+If any are missing, the workflow simply skips the deploy job.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- avoid failing CI when Raspberry Pi secrets aren't set
- document that the job is skipped if secrets are missing

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6882cb910bf8832fa0f353f51f4562cb