### PR TITLE
Update RPi workflow to skip when secrets missing

### DIFF
--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -20,22 +20,27 @@ on:
 
 jobs:
   deploy:
+    # Skip the job on push events unless all secrets are defined
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (secrets.RPI_HOST != '' && secrets.RPI_USER != '' &&
+       secrets.RPI_SSH_KEY != '' && secrets.GHCR_TOKEN != '')
     runs-on: ubuntu-latest
     env:
-      RPI_HOST: ${{ secrets.RPI_HOST }}
-      RPI_USER: ${{ secrets.RPI_USER }}
-      RPI_SSH_KEY: ${{ secrets.RPI_SSH_KEY }}
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      RPI_HOST: ${{ secrets.RPI_HOST || inputs.RPI_HOST }}
+      RPI_USER: ${{ secrets.RPI_USER || inputs.RPI_USER }}
+      RPI_SSH_KEY: ${{ secrets.RPI_SSH_KEY || inputs.RPI_SSH_KEY }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || inputs.GHCR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Verify secrets
+      - name: Verify credentials
         run: |
           if [ -z "$GHCR_TOKEN" ] || [ -z "$RPI_HOST" ] || [ -z "$RPI_USER" ] || [ -z "$RPI_SSH_KEY" ]; then
-            echo "Missing required secrets" && exit 1
+            echo "Missing required secrets or inputs" && exit 1
           fi
       - name: Login to registry
         uses: docker/login-action@v3

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYM
 
 The workflow `.github/workflows/rpi-deploy.yml` builds an ARM64 Docker image and optionally deploys it to a Raspberry Pi over SSH.
 Create a classic PAT with the [`write:packages` scope](https://github.com/settings/tokens/new?scopes=write:packages) (fine-grained tokens don’t work with Packages yet) and add it as the `GHCR_TOKEN` secret.
-Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment. If the workflow fails with a "Missing required secrets" message, add these values under **Settings → Secrets and variables → Actions** in your repository.
+Set `RPI_HOST`, `RPI_USER`, and `RPI_SSH_KEY` to enable SSH deployment. When these secrets aren't defined, the job is skipped instead of failing. Add the values under **Settings → Secrets and variables → Actions** when you're ready to deploy.
 Trigger the workflow manually or on pushes to `v3` to update the Pi and restart the `app` service.
 
 ## Project Architecture

--- a/docs/RPI_DEPLOYMENT_GUIDE.md
+++ b/docs/RPI_DEPLOYMENT_GUIDE.md
@@ -104,7 +104,7 @@ This repository provides a GitHub Actions workflow (`.github/workflows/rpi-deplo
 - `RPI_USER` – the SSH username
 - `RPI_SSH_KEY` – the private key used for authentication
 
-Add these secrets under **Settings → Secrets and variables → Actions**. If any are missing, the workflow will fail with a "Missing required secrets" message.
+Add these secrets under **Settings → Secrets and variables → Actions**. If any are missing, the GitHub job simply skips deployment instead of failing.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- skip the `rpi-deploy` job on pushes when secrets aren't set
- clarify secret handling in the README and deployment guide

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6882cb910bf8832fa0f353f51f4562cb