### PR TITLE
Add item schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ npm test -- imageReferences     # verifies quest and NPC image files
 ## Built-in Items
 
 Item definitions live in `frontend/src/pages/inventory/json/items.json`. Assign new sequential `id` numbers and include an image path when adding items. See `frontend/src/pages/docs/md/item-guidelines.md` for detailed guidance.
+All item files must satisfy `frontend/src/pages/inventory/jsonSchemas/item.json`. Run `npm test -- itemValidation` to check the schema.
 
 ## Built-in Processes
 

--- a/frontend/__tests__/itemValidation.test.js
+++ b/frontend/__tests__/itemValidation.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const schema = require('../src/pages/inventory/jsonSchemas/item.json');
+const itemsFile = path.join(__dirname, '../src/pages/inventory/json/items.json');
+
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+
+describe('item validation', () => {
+    test('items.json conforms to schema', () => {
+        const items = JSON.parse(fs.readFileSync(itemsFile));
+        for (const item of items) {
+            const valid = validate(item);
+            if (!valid) {
+                console.error(validate.errors);
+            }
+            expect(valid).toBe(true);
+        }
+    });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
         "test:e2e:integration": "npm run setup-test-env && playwright test -g \"integrate custom items, processes, and quests\"",
         "test:e2e:fast": "npm run setup-test-env && playwright test --workers=2 page-structure.spec.ts custom-content.spec.ts",
         "coverage": "npm run setup-test-env && npx jest --config jest.config.cjs --coverage",
+        "itemValidation": "npm run setup-test-env && jest --config jest.config.cjs itemValidation.test.js",
         "lint": "ESLINT_USE_FLAT_CONFIG=false npx eslint . --max-warnings=0",
         "lint:fix": "ESLINT_USE_FLAT_CONFIG=false npx eslint . --fix",
         "format": "prettier --write \"**/*.{js,ts,svelte,json,md}\"",

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -46,6 +46,8 @@ Every item requires the following basic properties:
 
 Currently, the `ItemForm.svelte` component supports creating items with the properties listed above. The current implementation focuses on the fundamental aspects of items, with more advanced features planned for future updates.
 
+All items must now conform to the JSON schema located at `frontend/src/pages/inventory/jsonSchemas/item.json`. Run the `itemValidation` test to ensure any additions meet the schema requirements.
+
 ## Item Best Practices
 
 ### Naming Conventions

--- a/frontend/src/pages/inventory/jsonSchemas/item.json
+++ b/frontend/src/pages/inventory/jsonSchemas/item.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "image": { "type": "string" },
+        "price": { "type": "string" },
+        "unit": { "type": "string" },
+        "type": { "type": "string" }
+    },
+    "required": ["id", "name", "description", "image"],
+    "additionalProperties": false
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "coverage": "cd frontend && npm run coverage",
     "test:pr": "node run-tests.js",
     "check": "cd frontend && npm run check",
+    "itemValidation": "cd frontend && npm run itemValidation",
     "lint": "cd frontend && npm run lint",
     "lint:fix": "cd frontend && npm run lint:fix",
     "format": "cd frontend && npm run format",


### PR DESCRIPTION
## Summary
- add `item.json` schema for built-in items
- validate items against new schema with `itemValidation` test
- update docs and README with schema info
- expose `itemValidation` npm script

## Testing
- `npm run check` *(fails: eslint plugin missing)*
- `SKIP_E2E=1 npm run test:pr` *(fails during lint step)*

------
https://chatgpt.com/codex/tasks/task_e_688306a33fa8832f8c12888c841828c5