### PR TITLE
Add quest requirements selection and schema validation

### DIFF
--- a/frontend/__tests__/QuestForm.test.js
+++ b/frontend/__tests__/QuestForm.test.js
@@ -82,6 +82,27 @@ const mockQuestForm = {
         imageGroup.appendChild(imageLabel);
         imageGroup.appendChild(imageInput);
 
+        // Add requirements select
+        const reqGroup = document.createElement('div');
+        reqGroup.className = 'form-group';
+
+        const reqLabel = document.createElement('label');
+        reqLabel.setAttribute('for', 'requires');
+        reqLabel.textContent = 'Quest Requirements';
+
+        const reqSelect = document.createElement('select');
+        reqSelect.id = 'requires';
+        reqSelect.multiple = true;
+        (props.existingQuests || []).forEach((q) => {
+            const opt = document.createElement('option');
+            opt.value = q.id;
+            opt.textContent = q.title;
+            reqSelect.appendChild(opt);
+        });
+
+        reqGroup.appendChild(reqLabel);
+        reqGroup.appendChild(reqSelect);
+
         // Add submit button
         const submitDiv = document.createElement('div');
         submitDiv.className = 'form-submit';
@@ -101,6 +122,7 @@ const mockQuestForm = {
                 title: titleInput.value,
                 description: descTextarea.value,
                 image: imageInput.files?.[0] || (props.image ? 'existing-image' : null),
+                requiresQuests: Array.from(reqSelect.selectedOptions).map((o) => o.value),
             };
 
             // Validate form
@@ -131,12 +153,14 @@ const mockQuestForm = {
                     title: formData.title,
                     description: formData.description,
                     image: 'mocked-image-url',
+                    requiresQuests: formData.requiresQuests,
                 });
             } else {
                 await mockDb.quests.add({
                     title: formData.title,
                     description: formData.description,
                     image: 'mocked-image-url',
+                    requiresQuests: formData.requiresQuests,
                 });
             }
 
@@ -150,6 +174,7 @@ const mockQuestForm = {
         form.appendChild(titleGroup);
         form.appendChild(descGroup);
         form.appendChild(imageGroup);
+        form.appendChild(reqGroup);
         form.appendChild(submitDiv);
 
         // Add to the target
@@ -165,6 +190,7 @@ const mockQuestForm = {
                 titleInput,
                 descTextarea,
                 imageInput,
+                reqSelect,
                 submitButton,
             },
             handleSubmit,
@@ -274,7 +300,10 @@ describe('QuestForm Component', () => {
 
     it('renders form elements correctly', async () => {
         // Render the component
-        component = mockQuestForm.render(container, { isEdit: false });
+        component = mockQuestForm.render(container, {
+            isEdit: false,
+            existingQuests: [{ id: 'q1', title: 'Base Quest' }],
+        });
 
         // Verify form fields are present
         expect(container.querySelector('label[for="title"]')).not.toBeNull();
@@ -284,7 +313,10 @@ describe('QuestForm Component', () => {
 
     it('submits form with all fields filled', async () => {
         // Render the component
-        component = mockQuestForm.render(container, { isEdit: false });
+        component = mockQuestForm.render(container, {
+            isEdit: false,
+            existingQuests: [{ id: 'q1', title: 'Base Quest' }],
+        });
 
         // Fill form fields
         await act(async () => {
@@ -302,13 +334,14 @@ describe('QuestForm Component', () => {
             // Add a file to the image input
             await act(async () => {
                 // Get the image input from the component elements
-                const { imageInput } = component.elements;
+                const { imageInput, reqSelect } = component.elements;
 
                 // Set the files property directly
                 Object.defineProperty(imageInput, 'files', {
                     value: [mockFile],
                     writable: true,
                 });
+                reqSelect.options[0].selected = true;
 
                 // No need to dispatch event, we'll directly call handleSubmit which reads from files
             });
@@ -325,6 +358,7 @@ describe('QuestForm Component', () => {
                 title: 'Test Quest',
                 description: 'This is a test quest description',
                 image: 'mocked-image-url',
+                requiresQuests: ['q1'],
             })
         );
     });
@@ -370,6 +404,7 @@ describe('QuestForm Component', () => {
             title: existingQuest.title,
             description: existingQuest.description,
             image: existingQuest.image,
+            existingQuests: [{ id: 'q1', title: 'Base Quest' }],
         });
 
         // Check if form is pre-filled with existing data
@@ -388,6 +423,7 @@ describe('QuestForm Component', () => {
                 title: existingQuest.title,
                 description: existingQuest.description,
                 image: 'mocked-image-url',
+                requiresQuests: [],
             })
         );
     });

--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+import { validateQuestData } from '../src/utils/customQuestValidation.js';
+
+describe('validateQuestData', () => {
+    test('valid quest passes', () => {
+        const result = validateQuestData({
+            title: 'A',
+            description: 'B',
+            image: 'img',
+            requiresQuests: ['q1'],
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('missing title fails', () => {
+        const result = validateQuestData({
+            description: 'B',
+            image: 'img',
+        });
+        expect(result.valid).toBe(false);
+    });
+});

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -1,14 +1,18 @@
 <script>
     import { createEventDispatcher, onMount } from 'svelte';
-    import { db } from '../../utils/customcontent.js';
+    import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
+    import { validateQuestData } from '../../utils/customQuestValidation.js';
 
     export let isEdit = false;
     export let questId = null;
+    export let existingQuests = [];
 
     let title = '';
     let description = '';
     let image = null;
     let previewUrl = null;
+    let requiresQuests = [];
+    let allQuests = [];
     let validationErrors = {};
     let isSubmitting = false;
 
@@ -21,12 +25,23 @@
                 const questData = await db.quests.get(questId);
                 title = questData.title;
                 description = questData.description;
+                requiresQuests = questData.requiresQuests || [];
                 if (questData.image) {
                     previewUrl = questData.image;
                 }
             } catch (error) {
                 console.error('Error loading quest:', error);
             }
+        }
+
+        if (existingQuests.length === 0) {
+            try {
+                allQuests = await db.list(ENTITY_TYPES.QUEST);
+            } catch (error) {
+                console.error('Error loading quests:', error);
+            }
+        } else {
+            allQuests = existingQuests;
         }
     });
 
@@ -45,6 +60,10 @@
         }
     }
 
+    function handleRequirementsChange(event) {
+        requiresQuests = Array.from(event.target.selectedOptions).map((opt) => opt.value);
+    }
+
     async function validateForm() {
         const errors = {};
 
@@ -58,6 +77,16 @@
 
         if (!isEdit && !image && !previewUrl) {
             errors.image = 'Image is required';
+        }
+
+        const { valid } = validateQuestData({
+            title: title.trim(),
+            description: description.trim(),
+            image: previewUrl || '',
+            requiresQuests,
+        });
+        if (!valid) {
+            errors.schema = 'Invalid quest data';
         }
 
         validationErrors = errors;
@@ -112,6 +141,7 @@
                     title,
                     description,
                     image: imageUrl,
+                    requiresQuests,
                     updatedAt: new Date().toISOString(),
                 });
 
@@ -122,6 +152,7 @@
                     title,
                     description,
                     image: imageUrl,
+                    requiresQuests,
                 });
 
                 dispatch('success', { message: 'Quest created successfully', id: newQuestId });
@@ -131,6 +162,7 @@
                 description = '';
                 image = null;
                 previewUrl = null;
+                requiresQuests = [];
             }
         } catch (error) {
             console.error('Error saving quest:', error);
@@ -188,6 +220,17 @@
         {/if}
     </div>
 
+    <div class="form-group">
+        <label for="requires">Quest Requirements</label>
+        <select id="requires" multiple on:change={handleRequirementsChange}>
+            {#each allQuests as q}
+                <option value={q.id} selected={requiresQuests.includes(q.id)}>
+                    {q.title}
+                </option>
+            {/each}
+        </select>
+    </div>
+
     <div class="form-submit">
         <button type="submit" class="submit-button" disabled={isSubmitting}>
             {#if isSubmitting}
@@ -237,6 +280,17 @@
         border: 2px solid #007006;
         outline: none;
         transition: border-color 0.2s, box-shadow 0.2s;
+    }
+
+    select {
+        width: 95%;
+        padding: 10px;
+        border-radius: 8px;
+        background: #68d46d;
+        color: black;
+        font-size: 16px;
+        border: 2px solid #007006;
+        outline: none;
     }
 
     input.error,

--- a/frontend/src/pages/quests/create.astro
+++ b/frontend/src/pages/quests/create.astro
@@ -1,8 +1,10 @@
 ---
 import Page from '../../components/Page.astro';
 import QuestForm from '../../components/svelte/QuestForm.svelte';
+
+const quests = await Astro.glob('./json/*/*.json');
 ---
 
 <Page title="Create a New Quest">
-    <QuestForm client:load />
+    <QuestForm client:load existingQuests={quests.map((q) => q.default)} />
 </Page>

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -1,0 +1,23 @@
+import Ajv from 'ajv';
+
+export const customQuestSchema = {
+    type: 'object',
+    properties: {
+        title: { type: 'string', minLength: 1 },
+        description: { type: 'string', minLength: 1 },
+        image: { type: 'string', minLength: 1 },
+        requiresQuests: {
+            type: 'array',
+            items: { type: 'string' },
+        },
+    },
+    required: ['title', 'description', 'image'],
+};
+
+const ajv = new Ajv();
+const validate = ajv.compile(customQuestSchema);
+
+export function validateQuestData(data) {
+    const valid = validate(data);
+    return { valid, errors: validate.errors };
+}


### PR DESCRIPTION
## Summary
- implement custom quest JSON schema and validator
- extend QuestForm with requirements selection and schema validation
- pass built-in quests to QuestForm in create page
- update QuestForm tests and add validation tests

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_688306a33fa8832f8c12888c841828c5