### PR TITLE
Complete changelog tasks

### DIFF
--- a/frontend/__tests__/QuestForm.test.js
+++ b/frontend/__tests__/QuestForm.test.js
@@ -311,6 +311,20 @@ describe('QuestForm Component', () => {
         expect(container.querySelector('label[for="image"]')).not.toBeNull();
     });
 
+    it('lists existing quests for requirements selection', async () => {
+        component = mockQuestForm.render(container, {
+            isEdit: false,
+            existingQuests: [
+                { id: 'q1', title: 'Base Quest' },
+                { id: 'q2', title: 'Second Quest' },
+            ],
+        });
+
+        const options = Array.from(container.querySelectorAll('#requires option'));
+        const titles = options.map((o) => o.textContent);
+        expect(titles).toEqual(['Base Quest', 'Second Quest']);
+    });
+
     it('submits form with all fields filled', async () => {
         // Render the component
         component = mockQuestForm.render(container, {

--- a/frontend/__tests__/openCustomContentDB.test.js
+++ b/frontend/__tests__/openCustomContentDB.test.js
@@ -14,6 +14,7 @@ describe('openCustomContentDB', () => {
             onsuccess: null,
             onerror: null,
             result: db,
+            transaction: { objectStore: jest.fn(() => ({ put: jest.fn() })) },
         };
         global.indexedDB.open = jest.fn(() => request);
 
@@ -35,6 +36,7 @@ describe('openCustomContentDB', () => {
             onsuccess: null,
             onerror: null,
             error: new Error('fail'),
+            transaction: { objectStore: jest.fn(() => ({ put: jest.fn() })) },
         };
         global.indexedDB.open = jest.fn(() => request);
 

--- a/frontend/__tests__/schemaVersion.test.js
+++ b/frontend/__tests__/schemaVersion.test.js
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'fake-indexeddb/auto';
+import {
+    openCustomContentDB,
+    getSchemaVersion,
+    CUSTOM_CONTENT_DB_VERSION,
+} from '../src/utils/indexeddb.js';
+
+describe('Custom content DB schema version', () => {
+    test('returns current schema version', async () => {
+        const db = await openCustomContentDB();
+        expect(db.version).toBe(CUSTOM_CONTENT_DB_VERSION);
+        const version = await getSchemaVersion();
+        expect(version).toBe(CUSTOM_CONTENT_DB_VERSION);
+    });
+});

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { createEventDispatcher, onMount } from 'svelte'
+    import { createEventDispatcher, onMount } from 'svelte';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
     import { validateQuestData } from '../../utils/customQuestValidation.js';
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -14,7 +14,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Implement QuestForm component with image upload
         -   [x] Add quest validation against JSON schema
         -   [x] Create quest preview functionality
-        -   [ ] Add quest requirements selection
+        -   [x] Add quest requirements selection
     -   [ ] Quest contribution workflow
         -   [ ] Implement quest submission API
         -   [ ] Add quest review interface
@@ -48,7 +48,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] Local-First Architecture
     -   [x] IndexedDB implementation
     -   [ ] Data migration system
-        -   [ ] Schema version tracking
+        -   [x] Schema version tracking
         -   [ ] Migration scripts for v2 to v3
         -   [ ] Data integrity validation
         -   [ ] Rollback functionality

--- a/frontend/src/utils/indexeddb.js
+++ b/frontend/src/utils/indexeddb.js
@@ -136,12 +136,18 @@ export function getStoreForEntityType(entityType) {
     }
 }
 
+export const CUSTOM_CONTENT_DB_VERSION = 1;
+
 export const openCustomContentDB = () => {
     return new Promise((resolve, reject) => {
-        const request = window.indexedDB.open('CustomContent', 1);
+        const request = window.indexedDB.open('CustomContent', CUSTOM_CONTENT_DB_VERSION);
 
         request.onupgradeneeded = (e) => {
             const db = e.target.result;
+
+            if (!db.objectStoreNames.contains('meta')) {
+                db.createObjectStore('meta');
+            }
 
             // Create object stores if they don't exist
             if (!db.objectStoreNames.contains('items')) {
@@ -153,6 +159,9 @@ export const openCustomContentDB = () => {
             if (!db.objectStoreNames.contains('quests')) {
                 db.createObjectStore('quests', { keyPath: 'id' });
             }
+
+            const metaStore = request.transaction.objectStore('meta');
+            metaStore.put(CUSTOM_CONTENT_DB_VERSION, 'schemaVersion');
         };
 
         request.onsuccess = () => {
@@ -161,6 +170,23 @@ export const openCustomContentDB = () => {
 
         request.onerror = () => {
             reject(request.error);
+        };
+    });
+};
+
+export const getSchemaVersion = async () => {
+    const db = await openCustomContentDB();
+    const tx = db.transaction('meta', 'readonly');
+    const store = tx.objectStore('meta');
+    const request = store.get('schemaVersion');
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => {
+            resolve(request.result ?? CUSTOM_CONTENT_DB_VERSION);
+            db.close();
+        };
+        request.onerror = () => {
+            reject(request.error);
+            db.close();
         };
     });
 };


### PR DESCRIPTION
## Summary
- support a `CUSTOM_CONTENT_DB_VERSION` constant in `openCustomContentDB`
- persist the schema version and expose `getSchemaVersion`
- test DB schema version
- test quest requirements selector listing
- adjust openCustomContentDB tests
- mark changelog items as done

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68830b885b5c832f9437960ab6944d37