### PR TITLE
Restore test workflow and link check

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -1,0 +1,12 @@
+name: ci-sentinel
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  ensure-tests-exist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: test -f .github/workflows/tests.yml
+

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,22 @@
+name: link-check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v1.9.0
+        with:
+          args: >-
+            --accept 403,429
+            --no-progress --verbose
+            "**/*.md"
+          fail: true
+          format: markdown
+          output: lychee/out.md
+          jobSummary: true
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm test
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSPACE - Democratized Space
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/ci.yml?label=lint%20%26%20format)](https://github.com/democratizedspace/dspace/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/test-pr.yml?label=tests)](https://github.com/democratizedspace/dspace/actions/workflows/test-pr.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/tests.yml?label=tests)](https://github.com/democratizedspace/dspace/actions/workflows/tests.yml)
 [![Coverage](https://codecov.io/gh/democratizedspace/dspace/branch/v3/graph/badge.svg)](https://codecov.io/gh/democratizedspace/dspace)
 [![Docs](https://img.shields.io/github/actions/workflow/status/democratizedspace/dspace/quest-chart.yml?label=docs)](https://github.com/democratizedspace/dspace/actions/workflows/quest-chart.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)


### PR DESCRIPTION
## Summary
- enable tests on main and PRs using Node 22
- add link checking for Markdown
- ensure tests workflow can't be deleted
- update README CI badge

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68830a599330832fb72346fe6ec7148e