### PR TITLE
Implement content preview for custom items

### DIFF
--- a/frontend/__tests__/ItemPreview.test.js
+++ b/frontend/__tests__/ItemPreview.test.js
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+import ItemPreview from '../src/components/svelte/ItemPreview.svelte';
+
+// Rendering this component directly causes issues with svelte-jester.
+// Instead, verify that it exports a valid Svelte component function.
+
+describe('ItemPreview component', () => {
+    it('exports a valid Svelte component', () => {
+        expect(typeof ItemPreview).toBe('function');
+    });
+});

--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -1,5 +1,6 @@
 <script>
     import { createEventDispatcher } from 'svelte';
+    import ItemPreview from './ItemPreview.svelte';
 
     export let name = '';
     export let description = '';
@@ -93,6 +94,10 @@
         <button type="submit" class="submit-button">Create Item</button>
     </div>
 </form>
+
+{#if name || description || previewUrl}
+    <ItemPreview {name} {description} imageUrl={previewUrl} {price} {unit} {type} />
+{/if}
 
 <style>
     .item-form {

--- a/frontend/src/components/svelte/ItemPreview.svelte
+++ b/frontend/src/components/svelte/ItemPreview.svelte
@@ -1,0 +1,45 @@
+<script>
+    export let name = '';
+    export let description = '';
+    export let imageUrl = '';
+    export let price = '';
+    export let unit = '';
+    export let type = '';
+</script>
+
+<div class="item-preview">
+    {#if imageUrl}
+        <img src={imageUrl} alt="Item preview" class="item-image" />
+    {/if}
+    <h3>{name}</h3>
+    <p>{description}</p>
+    {#if price}
+        <p class="detail">Price: {price}</p>
+    {/if}
+    {#if unit}
+        <p class="detail">Unit: {unit}</p>
+    {/if}
+    {#if type}
+        <p class="detail">Type: {type}</p>
+    {/if}
+</div>
+
+<style>
+    .item-preview {
+        border: 2px dashed #007006;
+        padding: 1rem;
+        margin-top: 1rem;
+        border-radius: 8px;
+        background: #19331f;
+        color: #fff;
+        text-align: left;
+    }
+    .item-image {
+        max-width: 100%;
+        border-radius: 4px;
+        margin-bottom: 0.5rem;
+    }
+    .detail {
+        margin: 0.25rem 0;
+    }
+</style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -33,7 +33,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Test quest chains and dependencies
 -   [ ] Custom Items and Processes (using the same system as quests)
     -   [ ] Item Management
-        -   [ ] Item creation interface with ItemForm.svelte
+        -   [x] Item creation interface with ItemForm.svelte
         -   [ ] Item validation schema
         -   [ ] Item dependency tracking
     -   [ ] Process System
@@ -42,7 +42,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Process validation and testing
         -   [ ] Process state management
     -   [ ] Preview and Testing
-        -   [ ] Content preview functionality
+        -   [x] Content preview functionality
         -   [ ] Testing environment for custom content
         -   [ ] Validation feedback system
 -   [x] Local-First Architecture

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -46,6 +46,8 @@ Every item requires the following basic properties:
 
 Currently, the `ItemForm.svelte` component supports creating items with the properties listed above. The current implementation focuses on the fundamental aspects of items, with more advanced features planned for future updates.
 
+As you fill out the form, an `ItemPreview` component displays a live preview so you can confirm the details before submitting.
+
 All items must now conform to the JSON schema located at `frontend/src/pages/inventory/jsonSchemas/item.json`. Run the `itemValidation` test to ensure any additions meet the schema requirements.
 
 ## Item Best Practices


### PR DESCRIPTION
## Summary
- add ItemPreview.svelte component
- show ItemPreview inside ItemForm for instant feedback
- test ItemPreview export
- document new preview functionality
- check off completed items in the September 2025 changelog

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688315b1f944832f9dc57d204a1bd686