### PR TITLE
Implement item dependency tracking

### DIFF
--- a/frontend/__tests__/ItemForm.test.js
+++ b/frontend/__tests__/ItemForm.test.js
@@ -6,6 +6,12 @@ import '@testing-library/jest-dom';
 import { render, act, fireEvent, waitFor } from '@testing-library/svelte';
 import ItemForm from '../src/components/svelte/ItemForm.svelte';
 
+// Mock items import for dependency selection
+jest.mock('../src/pages/inventory/json/items.json', () => [
+    { id: '0', name: 'Printer' },
+    { id: '1', name: 'Filament' },
+]);
+
 // Mock the database operations using Jest instead of Vitest
 jest.mock('../src/utils/indexeddb.js', () => ({
     addEntity: jest.fn().mockResolvedValue('mocked-item-id'),
@@ -77,7 +83,7 @@ describe('ItemForm Component', () => {
     });
 
     it('renders form elements correctly', async () => {
-        const { getByLabelText } = render(ItemForm, {
+        const { getByLabelText, getByText } = render(ItemForm, {
             target: container,
             props: {
                 isEdit: false,
@@ -89,6 +95,7 @@ describe('ItemForm Component', () => {
             expect(getByLabelText(/name/i)).toBeInTheDocument();
             expect(getByLabelText(/description/i)).toBeInTheDocument();
             expect(getByLabelText(/upload an image/i)).toBeInTheDocument();
+            expect(getByText(/add dependency/i)).toBeInTheDocument();
         });
     });
 
@@ -115,6 +122,10 @@ describe('ItemForm Component', () => {
             fireEvent.change(getByLabelText(/upload an image/i), {
                 target: { files: [file] },
             });
+
+            fireEvent.click(getByText(/add dependency/i));
+            const select = container.querySelector('select');
+            fireEvent.change(select, { target: { value: '1' } });
         });
 
         // Submit the form
@@ -129,6 +140,7 @@ describe('ItemForm Component', () => {
                     name: 'Test Item',
                     description: 'This is a test item description',
                     image: 'mocked-image-url',
+                    requires: ['1']
                 })
             );
         });
@@ -165,6 +177,7 @@ describe('ItemForm Component', () => {
             name: 'Existing Item',
             description: 'Existing item description',
             image: 'existing-image-url',
+            requires: ['0'],
         };
 
         // No additional mocking needed - updateEntity is already mocked
@@ -196,6 +209,7 @@ describe('ItemForm Component', () => {
                     name: existingItem.name,
                     description: existingItem.description,
                     image: existingItem.image,
+                    requires: ['0'],
                 })
             );
         });

--- a/frontend/__tests__/itemValidation.test.js
+++ b/frontend/__tests__/itemValidation.test.js
@@ -13,12 +13,18 @@ const validate = ajv.compile(schema);
 describe('item validation', () => {
     test('items.json conforms to schema', () => {
         const items = JSON.parse(fs.readFileSync(itemsFile));
+        const ids = new Set(items.map((i) => i.id));
         for (const item of items) {
             const valid = validate(item);
             if (!valid) {
                 console.error(validate.errors);
             }
             expect(valid).toBe(true);
+            if (item.requires) {
+                for (const dep of item.requires) {
+                    expect(ids.has(dep)).toBe(true);
+                }
+            }
         }
     });
 });

--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -8,6 +8,9 @@
     export let price = '';
     export let unit = '';
     export let type = '';
+    export let requires = [];
+
+    import items from '../../pages/inventory/json/items.json';
 
     const dispatch = createEventDispatcher();
 
@@ -24,6 +27,18 @@
             previewUrl = null;
             image = null;
         }
+    }
+
+    function addDependency() {
+        requires = [...requires, ''];
+    }
+
+    function removeDependency(index) {
+        requires = requires.filter((_, i) => i !== index);
+    }
+
+    function handleDependencyChange(event, index) {
+        requires[index] = event.target.value;
     }
 
     function handleSubmit(event) {
@@ -43,6 +58,7 @@
         if (type) {
             formData.append('type', type);
         }
+        formData.append('requires', JSON.stringify(requires));
 
         dispatch('submit', formData);
     }
@@ -87,6 +103,22 @@
     <div class="form-group">
         <label for="type">Type (optional)</label>
         <input type="text" id="type" bind:value={type} placeholder="e.g. 3dprint" />
+    </div>
+
+    <div class="form-group">
+        <label>Dependencies (optional)</label>
+        {#each requires as req, index}
+            <div class="dependency-row">
+                <select on:change={(e) => handleDependencyChange(e, index)} bind:value={requires[index]}>
+                    <option value="">Select item</option>
+                    {#each items as item}
+                        <option value={item.id}>{item.name}</option>
+                    {/each}
+                </select>
+                <button type="button" class="remove-button" on:click={() => removeDependency(index)}>Remove</button>
+            </div>
+        {/each}
+        <button type="button" class="add-button" on:click={addDependency}>Add Dependency</button>
     </div>
 
     <div class="form-submit">
@@ -181,5 +213,39 @@
 
     .submit-button:hover {
         background-color: #005004;
+    }
+
+    .dependency-row {
+        display: flex;
+        align-items: center;
+        margin-bottom: 8px;
+    }
+
+    .remove-button {
+        margin-left: 8px;
+        padding: 5px 10px;
+        background-color: #ff4444;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .remove-button:hover {
+        background-color: #cc0000;
+    }
+
+    .add-button {
+        margin-top: 10px;
+        padding: 8px 16px;
+        background-color: #4488ff;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .add-button:hover {
+        background-color: #0055cc;
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -35,7 +35,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Item Management
         -   [ ] Item creation interface with ItemForm.svelte
         -   [ ] Item validation schema
-        -   [ ] Item dependency tracking
+        -   [x] Item dependency tracking
     -   [ ] Process System
         -   [ ] Process creation UI with duration handling
         -   [ ] Required/consumed/created items selection

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -41,10 +41,13 @@ Every item requires the following basic properties:
 -   **price**: Value in game currency (optional)
 -   **unit**: Measurement unit for the item (e.g., kg, L, watts) (optional)
 -   **type**: Classification or category (optional)
+-   **requires**: Array of item IDs this item depends on (optional)
 
 ### Implementation State
 
 Currently, the `ItemForm.svelte` component supports creating items with the properties listed above. The current implementation focuses on the fundamental aspects of items, with more advanced features planned for future updates.
+
+The form now includes optional dependency selection so you can specify other items required to craft the new item.
 
 All items must now conform to the JSON schema located at `frontend/src/pages/inventory/jsonSchemas/item.json`. Run the `itemValidation` test to ensure any additions meet the schema requirements.
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -202,7 +202,8 @@
         "id": "30",
         "name": "3D printed nosecone",
         "description": "A nosecone for a modular model rocket.",
-        "image": "/assets/3dprinted_rocket_nosecone.jpg"
+        "image": "/assets/3dprinted_rocket_nosecone.jpg",
+        "requires": ["0", "3"]
     },
     {
         "id": "31",

--- a/frontend/src/pages/inventory/jsonSchemas/item.json
+++ b/frontend/src/pages/inventory/jsonSchemas/item.json
@@ -9,6 +9,10 @@
         "price": { "type": "string" },
         "unit": { "type": "string" },
         "type": { "type": "string" }
+        ,"requires": {
+            "type": "array",
+            "items": { "type": "string" }
+        }
     },
     "required": ["id", "name", "description", "image"],
     "additionalProperties": false


### PR DESCRIPTION
## Summary
- add `requires` field to item schema and JSON data
- include item dependencies in item form with new selectors
- track dependencies in item validation tests
- update guidelines and changelog with dependency info

## Testing
- `npm run check` *(fails: Need to install eslint)*
- `SKIP_E2E=1 npm run test:pr` *(fails: Need to install eslint)*

------
https://chatgpt.com/codex/tasks/task_e_688315b1f944832f9dc57d204a1bd686