### PR TITLE
Implement game state validation and rollback

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -482,6 +482,23 @@ For component state:
 - Leverage the game state system for persistent game data
 - During development you can quickly wipe progress by calling
   `resetGameState()` from `frontend/src/utils/gameState/common.js`.
+- If something goes wrong, use `rollbackGameState()` to restore the last
+  saved state. The helper `validateGameState()` runs on load to keep the
+  structure intact.
+
+#### Rollback Use Cases
+
+Game state rollbacks provide a safety net during development and early
+access testing. Automatic backups are written before each save so you
+can undo the most recent change when things go sideways. Typical
+scenarios include:
+
+- **Buggy updates** that corrupt local saves
+- **Failed imports** of custom content or manually edited game state
+- **Early custom content** that doesn't pass validation yet
+
+Invoking `rollbackGameState()` restores the previous snapshot,
+preventing data loss while you debug the issue.
 
 ### Creating New Components
 

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -4,6 +4,8 @@ const {
     exportGameStateString,
     importGameStateString,
     resetGameState,
+    rollbackGameState,
+    validateGameState,
 } = require('../../src/utils/gameState/common.js');
 
 describe('gameState - common utilities', () => {
@@ -38,5 +40,25 @@ describe('gameState - common utilities', () => {
         importGameStateString(encoded);
         const loaded = loadGameState();
         expect(loaded).toEqual(newState);
+    });
+
+    test('validateGameState should fill missing sections', () => {
+        const corrupted = { quests: null };
+        const validated = validateGameState(corrupted);
+        expect(validated).toEqual({ quests: {}, inventory: {}, processes: {} });
+    });
+
+    test('rollbackGameState should restore previous state', () => {
+        const state = loadGameState();
+        state.inventory['1'] = 1;
+        saveGameState(state);
+
+        const updated = loadGameState();
+        updated.inventory['1'] = 2;
+        saveGameState(updated);
+
+        rollbackGameState();
+        const rolled = loadGameState();
+        expect(rolled.inventory['1']).toBe(1);
     });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -50,8 +50,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Data migration system
         -   [x] Schema version tracking
         -   [ ] Migration scripts for v2 to v3
-        -   [ ] Data integrity validation
-        -   [ ] Rollback functionality
+        -   [x] Data integrity validation
+        -   [x] Rollback functionality
 -   [ ] AI Integration
     -   [ ] token.place integration
 -   [x] Infrastructure

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 
 const gameStateKey = 'gameState';
+const gameStateBackupKey = 'gameStateBackup';
 
 const initializeGameState = () => {
     return {
@@ -10,16 +11,35 @@ const initializeGameState = () => {
     };
 };
 
+export const validateGameState = (state) => {
+    if (!state || typeof state !== 'object') {
+        return initializeGameState();
+    }
+
+    if (typeof state.quests !== 'object' || state.quests === null) {
+        state.quests = {};
+    }
+    if (typeof state.inventory !== 'object' || state.inventory === null) {
+        state.inventory = {};
+    }
+    if (typeof state.processes !== 'object' || state.processes === null) {
+        state.processes = {};
+    }
+
+    return state;
+};
+
 export const loadGameState = () => {
     const storedGameState = localStorage.getItem(gameStateKey);
     if (storedGameState) {
-        return JSON.parse(storedGameState);
+        return validateGameState(JSON.parse(storedGameState));
     }
     return initializeGameState();
 };
 
 export const saveGameState = (newState) => {
-    gameState = newState;
+    localStorage.setItem(gameStateBackupKey, JSON.stringify(gameState));
+    gameState = validateGameState(newState);
     localStorage.setItem(gameStateKey, JSON.stringify(gameState));
     state.set(gameState); // Update the state store directly
 };
@@ -47,4 +67,13 @@ export const importGameStateString = (gameStateString) => {
 export const resetGameState = () => {
     const freshState = initializeGameState();
     saveGameState(freshState);
+};
+
+export const rollbackGameState = () => {
+    const backup = localStorage.getItem(gameStateBackupKey);
+    if (!backup) return;
+    const previous = validateGameState(JSON.parse(backup));
+    gameState = previous;
+    localStorage.setItem(gameStateKey, JSON.stringify(gameState));
+    state.set(gameState);
 };


### PR DESCRIPTION
## Summary
- validate saved game data on load and add rollback feature
- backup previous game state before saving
- add tests for validateGameState and rollbackGameState
- document new utilities in the Developer Guide
- mark checklist items complete in changelog
- elaborate on real-world rollback use cases

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688315b1f944832f9dc57d204a1bd686