### PR TITLE
Implement item dependency tracking

### DIFF
--- a/frontend/__tests__/itemValidation.test.js
+++ b/frontend/__tests__/itemValidation.test.js
@@ -13,12 +13,19 @@ const validate = ajv.compile(schema);
 describe('item validation', () => {
     test('items.json conforms to schema', () => {
         const items = JSON.parse(fs.readFileSync(itemsFile));
+        const ids = new Set(items.map((it) => it.id));
         for (const item of items) {
             const valid = validate(item);
             if (!valid) {
                 console.error(validate.errors);
             }
             expect(valid).toBe(true);
+
+            if (item.dependencies) {
+                for (const dep of item.dependencies) {
+                    expect(ids.has(dep)).toBe(true);
+                }
+            }
         }
     });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dspace",
-    "version": "2.1",
+    "version": "3.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dspace",
-            "version": "2.1",
+            "version": "3.0.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -34,8 +34,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [ ] Custom Items and Processes (using the same system as quests)
     -   [ ] Item Management
         -   [x] Item creation interface with ItemForm.svelte
-        -   [ ] Item validation schema
-        -   [ ] Item dependency tracking
+    -   [x] Item validation schema
+        -   [x] Item dependency tracking
     -   [ ] Process System
         -   [ ] Process creation UI with duration handling
         -   [ ] Required/consumed/created items selection

--- a/frontend/src/pages/docs/md/inventory.md
+++ b/frontend/src/pages/docs/md/inventory.md
@@ -74,7 +74,7 @@ The inventory interface allows you to:
 
 -   View item details and counts
 -   See related processes
--   Track item dependencies
+-   Track item dependencies using the new `dependencies` field
 -   Manage custom items
 
 All inventory data is now stored locally using IndexedDB, with optional cloud sync for backup and cross-device access.

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -860,7 +860,8 @@
         "id": "132",
         "name": "Pi cluster node",
         "description": "A Raspberry Pi assembled with HAT, SSD and cooling.",
-        "image": "/assets/quests/basic_circuit.svg"
+        "image": "/assets/quests/basic_circuit.svg",
+        "dependencies": ["129", "131"]
     },
     {
         "id": "133",
@@ -872,7 +873,8 @@
         "id": "134",
         "name": "basic telescope",
         "description": "A simple refracting telescope for backyard astronomy.",
-        "image": "/assets/quests/solar.jpg"
+        "image": "/assets/quests/solar.jpg",
+        "dependencies": ["0", "3"]
     },
     {
         "id": "135",

--- a/frontend/src/pages/inventory/jsonSchemas/item.json
+++ b/frontend/src/pages/inventory/jsonSchemas/item.json
@@ -8,7 +8,12 @@
         "image": { "type": "string" },
         "price": { "type": "string" },
         "unit": { "type": "string" },
-        "type": { "type": "string" }
+        "type": { "type": "string" },
+        "dependencies": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+        }
     },
     "required": ["id", "name", "description", "image"],
     "additionalProperties": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspace",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dspace",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "chart.js": "^4.5.0",


### PR DESCRIPTION
## Summary
- support new `dependencies` field in item schema
- check dependencies in item validation test
- document dependencies field in the inventory docs
- note completion of item validation tasks in the 2025 changelog
- add example dependencies for two items

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68831ad48d64832f9c30b4b15d39cdd2