### PR TITLE
Fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,7 @@ Quest files are organized by category in subfolders, so feel free to expand any
 area—electronics, hydroponics, rocketry and more—with additional quests.
 See [Quest Trees](docs/quest-trees) for an overview of the different categories and their progression.
 The repository includes a script that summarizes how many quests and lines of dialogue exist in each tree. Categories are sorted by quest count for readability.
-Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git, but CI artifacts attach the latest chart for reference.
-
-![Quest tree stats chart](https://nightly.link/democratizedspace/dspace/workflows/quest-chart.yml/branch/v3/quest-tree-chart.zip?path=frontend%2Fsrc%2Fpages%2Fdocs%2Fimages%2Fquest-tree-stats.png)
+Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git. Check the "Quest Chart" workflow artifacts for the latest generated image.
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation. Each tree has been extended with follow-up tasks, such as tuning 3D printer retraction and refreshing hydroponic nutrients.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -345,4 +345,4 @@ Please see the [Contribution Guide](https://github.com/democratizedspace/dspace/
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.

--- a/frontend/src/pages/docs/md/changelog/20221005.md
+++ b/frontend/src/pages/docs/md/changelog/20221005.md
@@ -7,6 +7,6 @@ slug: '20221005'
 -   The [homepage](/) now shows the most recent changelog entry, with a button to view the older entries.
 -   Each [Docs](docs) page (e.g. [/docs/about](/docs/about)) now takes up the entire width of the main content area, as opposed to only half of it before.
 -   [Settings](/settings) page now has an appearance similar to the Docs page.
--   Made the [Inventory](/inventory) page dynamically load a list of items from [items.json](https://github.com/democratizedspace/dspace/blob/main/frontend/src/config/items.json).
+-   Made the [Inventory](/inventory) page dynamically load a list of items from [items.json](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/inventory/json/items.json).
 -   Added a small bit of [Roadmap](/docs/roadmap).
 -   Some docs updates (namely, [About](/docs/about), [Mission](/docs/mission), [Roadmap](/docs/roadmap), [Frequently Asked Questions](/docs/faq), [Glossary](/docs/glossary), and [Contribute](/docs/contribute)).

--- a/frontend/src/pages/docs/md/changelog/20221019.md
+++ b/frontend/src/pages/docs/md/changelog/20221019.md
@@ -5,7 +5,7 @@ slug: '20221019'
 
 -   Overhauled the [Inventory](/inventory) and [Quests](/quests) pages.
 -   You can now manually create any of the items on the item page (e.g. [/inventory/item/1](/inventory/item/1)).
--   Set cooldowns for all [items](https://github.com/democratizedspace/dspace/blob/main/frontend/src/pages/inventory/json/items.json). If cooldown is not specified, default to 5 minutes.
+-   Set cooldowns for all [items](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/inventory/json/items.json). If cooldown is not specified, default to 5 minutes.
 -   You can now finish the [first 3D printing quest](/quests/play/0) and collect your reward.
 -   Material and machine requirements don't apply yet but will in the future.
 -   Path for quests is now `/quests/play/\[id\]` instead of `/quests/\[id\]` (e.g. [/quests/play/0](/quests/play/0)).

--- a/frontend/src/pages/docs/md/changelog/20230915.md
+++ b/frontend/src/pages/docs/md/changelog/20230915.md
@@ -34,4 +34,4 @@ In the short term, you can now export your game state on the [gamesaves](/gamesa
 
 ## Reliability improvements and code health improvements
 
-This is a pretty minor update content-wise, but this update also adds a lot of important code, like instructions on what meta tags to inject in the HTML pages for SEO purposes. Additionally, game state related code has significantly increased test coverage. This is all in [preparation](https://github.com/democratizedspace/dspace/blob/main/CONTRIBUTORS.md) for finding incentives (e.g. bounties) for third-party contributors.
+This is a pretty minor update content-wise, but this update also adds a lot of important code, like instructions on what meta tags to inject in the HTML pages for SEO purposes. Additionally, game state related code has significantly increased test coverage. This is all in [preparation](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTORS.md) for finding incentives (e.g. bounties) for third-party contributors.

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -96,7 +96,7 @@ Before submitting:
 For more advanced contributors interested in extending core game functionality:
 
 -   Review the [DSPACE Architecture](/docs/architecture) documentation
--   Follow the [Developer Guide](https://github.com/democratizedspace/dspace/blob/main/DEVELOPER_GUIDE.md)
+-   Follow the [Developer Guide](https://github.com/democratizedspace/dspace/blob/v3/DEVELOPER_GUIDE.md)
 -   Start with small enhancements before proposing major changes
 
 ## Community Resources
@@ -104,6 +104,6 @@ For more advanced contributors interested in extending core game functionality:
 -   [Discord Community](https://discord.gg/A3UAfYvnxM): Discuss ideas and get feedback
 -   [GitHub Repository](https://github.com/democratizedspace/dspace): View source code and submit changes
 -   [Documentation](/docs): Browse all game documentation
--   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/main/CONTRIBUTORS.md): General contribution guidelines
+-   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTORS.md): General contribution guidelines
 
 By following these guidelines, you'll create high-quality content that enhances the DSPACE experience while contributing to our mission of democratizing space exploration through practical, hands-on education.

--- a/frontend/src/pages/docs/md/contribute.md
+++ b/frontend/src/pages/docs/md/contribute.md
@@ -32,7 +32,7 @@ Our [Content Development Guide](/docs/content-development) provides a comprehens
 -   Improve documentation
 -   Enhance the user interface
 
-For technical contributions, please review our [Developer Guide](https://github.com/democratizedspace/dspace/blob/main/DEVELOPER_GUIDE.md) first.
+For technical contributions, please review our [Developer Guide](https://github.com/democratizedspace/dspace/blob/v3/DEVELOPER_GUIDE.md) first.
 
 ## Testing and Feedback
 

--- a/frontend/src/pages/docs/md/team.md
+++ b/frontend/src/pages/docs/md/team.md
@@ -21,7 +21,7 @@ Esp is the founding human developer of the game. Software engineer by day, and a
 
 ChatGPT is a computer program that has been trained to understand and generate human-like text. It was created by OpenAI and is capable of answering questions, completing tasks, and even generating creative content like stories and poems. ChatGPT can interact with people in a conversational manner and is often used for things like customer service, personal assistants, and more.
 
-### [DALL-E 2](https://labs.openai.com)
+### [DALL-E 2](https://openai.com/dall-e-2)
 
 ![Variation of the DALL-E 2 logo](/assets/team_dalle.jpg)
 

--- a/frontend/src/pages/docs/md/ui-lifecycle.md
+++ b/frontend/src/pages/docs/md/ui-lifecycle.md
@@ -45,4 +45,4 @@ To avoid hydration mismatches and make tests predictable, follow this pattern in
 -   When writing Playwright tests, wait for `[data-hydrated="true"]` before performing actions.
 -   If a component behaves differently in tests versus the browser, ensure initialization logic is wrapped in `onMount`.
 
-For additional details on testing strategies, see [Testing Guide](../../../../TESTING.md) and the broader [Developer Guide](../../../../DEVELOPER_GUIDE.md).
+For additional details on testing strategies, see [Testing Guide](../../../../TESTING.md) and the broader [Developer Guide](../../../../../DEVELOPER_GUIDE.md).


### PR DESCRIPTION
## Summary
- update instructions for quest chart image
- fix license link in frontend README
- correct Developer Guide paths
- update GitHub links for v3 branch
- fix DALL-E link

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6883346fbb20832fad5f9cf3a4920a4a