### PR TITLE
Implement process pause/resume

### DIFF
--- a/frontend/__tests__/gameState/processes.test.js
+++ b/frontend/__tests__/gameState/processes.test.js
@@ -7,6 +7,8 @@ const {
     getProcessProgress,
     finishProcess,
     cancelProcess,
+    pauseProcess,
+    resumeProcess,
     getProcessesForItem,
     skipProcess,
 } = require('../../src/utils/gameState/processes.js');
@@ -81,6 +83,8 @@ describe('gameState - processes', () => {
         expect(mockGameState.processes['foo']).toEqual({
             startedAt: expect.any(Number),
             duration: expect.any(Number),
+            pausedAt: null,
+            elapsedBeforePause: 0,
         });
     });
 
@@ -89,6 +93,8 @@ describe('gameState - processes', () => {
         expect(mockGameState.processes['foo']).toEqual({
             startedAt: expect.any(Number),
             duration: expect.any(Number),
+            pausedAt: null,
+            elapsedBeforePause: 0,
         });
     });
 
@@ -207,6 +213,23 @@ describe('gameState - processes', () => {
         startProcess('foo');
         cancelProcess('foo');
         expect(mockGameState.inventory['2']).toBe(50);
+    });
+
+    test('pauseProcess should move process to paused state', () => {
+        startProcess('foo');
+        pauseProcess('foo');
+        expect(mockGameState.processes['foo'].pausedAt).toEqual(expect.any(Number));
+        expect(getProcessState('foo').state).toBe(ProcessStates.PAUSED);
+    });
+
+    test('resumeProcess should resume a paused process', () => {
+        startProcess('foo');
+        pauseProcess('foo');
+        const pausedAt = mockGameState.processes['foo'].pausedAt;
+        resumeProcess('foo');
+        expect(mockGameState.processes['foo'].pausedAt).toBeNull();
+        expect(mockGameState.processes['foo'].startedAt).toBeGreaterThanOrEqual(pausedAt);
+        expect(getProcessState('foo').state).toBe(ProcessStates.IN_PROGRESS);
     });
 
     test('getProcessesForItem should return the correct processes', () => {

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -40,7 +40,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Process creation UI with duration handling
         -   [ ] Required/consumed/created items selection
         -   [x] Process validation and testing
-        -   [ ] Process state management
+        -   [x] Process state management
     -   [ ] Preview and Testing
         -   [x] Content preview functionality
         -   [ ] Testing environment for custom content

--- a/frontend/src/utils/gameState/processes.js
+++ b/frontend/src/utils/gameState/processes.js
@@ -25,6 +25,8 @@ export const startProcess = (processId) => {
     gameState.processes[processId] = {
         startedAt: Date.now(),
         duration: durationInSeconds(process.duration) * 1000,
+        pausedAt: null,
+        elapsedBeforePause: 0,
     };
     saveGameState(gameState);
     burnItems(process.consumeItems);
@@ -34,6 +36,7 @@ export const ProcessStates = {
     NOT_STARTED: 'not started',
     IN_PROGRESS: 'in progress',
     FINISHED: 'finished',
+    PAUSED: 'paused',
 };
 
 export const getProcessState = (processId) => {
@@ -44,13 +47,22 @@ export const getProcessState = (processId) => {
         return { state: ProcessStates.NOT_STARTED, progress: 0 };
     }
 
-    const elapsed = Date.now() - process.startedAt;
-    let progress = Math.min(1, elapsed / process.duration);
+    let elapsed = process.elapsedBeforePause || 0;
+    if (process.pausedAt) {
+        elapsed += process.pausedAt - process.startedAt;
+    } else {
+        elapsed += Date.now() - process.startedAt;
+    }
 
+    let progress = Math.min(1, elapsed / process.duration);
     progress = progress < 0.001 ? 0 : progress;
 
-    if (process.startedAt + process.duration <= Date.now()) {
-        return { state: ProcessStates.FINISHED, progress: progress * 100 };
+    if (progress >= 1) {
+        return { state: ProcessStates.FINISHED, progress: 100 };
+    }
+
+    if (process.pausedAt) {
+        return { state: ProcessStates.PAUSED, progress: progress * 100 };
     }
 
     return { state: ProcessStates.IN_PROGRESS, progress: progress * 100 };
@@ -110,6 +122,31 @@ export const cancelProcess = (processId) => {
     gameState.processes[processId] = undefined;
     saveGameState(gameState);
     addItems(consumeItems);
+};
+
+export const pauseProcess = (processId) => {
+    const stateInfo = getProcessState(processId);
+    if (stateInfo.state !== ProcessStates.IN_PROGRESS) {
+        return;
+    }
+
+    const gameState = loadGameState();
+    const process = gameState.processes[processId];
+    const now = Date.now();
+    process.elapsedBeforePause = (process.elapsedBeforePause || 0) + (now - process.startedAt);
+    process.pausedAt = now;
+    saveGameState(gameState);
+};
+
+export const resumeProcess = (processId) => {
+    const gameState = loadGameState();
+    const process = gameState.processes[processId];
+    if (!process || process.pausedAt === null) {
+        return;
+    }
+    process.startedAt = Date.now();
+    process.pausedAt = null;
+    saveGameState(gameState);
 };
 
 export const ProcessItemTypes = {


### PR DESCRIPTION
## Summary
- support pausing and resuming processes in game state
- document completion of process state management
- test pause/resume helpers

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688468b10f88832f95b02d960e557515