### PR TITLE
Implement improved duration validation in ProcessForm

### DIFF
--- a/frontend/__tests__/ProcessForm.test.js
+++ b/frontend/__tests__/ProcessForm.test.js
@@ -134,7 +134,7 @@ describe('ProcessForm Component', () => {
         });
     });
 
-    test('should validate duration format', () => {
+    test('should validate duration format including seconds and decimals', () => {
         const component = new ProcessForm({
             target: container,
         });
@@ -159,12 +159,15 @@ describe('ProcessForm Component', () => {
         form.dispatchEvent(new Event('submit', { cancelable: true }));
         expect(submittedData).toBeFalsy();
 
-        // Test valid duration format
-        durationInput.value = '1h 30m';
-        durationInput.dispatchEvent(new Event('input'));
-
-        form.dispatchEvent(new Event('submit', { cancelable: true }));
-        expect(submittedData).toBeTruthy();
+        // Test valid duration formats
+        const validDurations = ['1h 30m 10s', '0.5h'];
+        for (const val of validDurations) {
+            durationInput.value = val;
+            durationInput.dispatchEvent(new Event('input'));
+            form.dispatchEvent(new Event('submit', { cancelable: true }));
+            expect(submittedData).toBeTruthy();
+            submittedData = null;
+        }
     });
 
     test('should validate item counts', () => {

--- a/frontend/e2e/process-creation.spec.ts
+++ b/frontend/e2e/process-creation.spec.ts
@@ -97,6 +97,23 @@ test.describe('Process Creation', () => {
         }
     });
 
+    test('should create process with seconds duration', async ({ page }) => {
+        await createTestItems(page, 1);
+        await page.goto('/processes/create');
+        await page.waitForLoadState('networkidle');
+
+        const processTitle = `Seconds Duration ${Date.now()}`;
+        const success = await fillProcessForm(page, processTitle, '2m 30s', 1, 0, 0);
+        expect(success).toBe(true);
+
+        const submitButton = page.locator('button.submit-button');
+        await submitButton.click();
+        await page.waitForTimeout(3000);
+
+        const errorMessages = page.locator('.error-message');
+        expect(await errorMessages.count()).toBe(0);
+    });
+
     test('should test item selector in isolation', async ({ page }) => {
         // Create test items first
         await createTestItems(page, 2);

--- a/frontend/src/components/svelte/ProcessForm.svelte
+++ b/frontend/src/components/svelte/ProcessForm.svelte
@@ -3,6 +3,7 @@
     import ItemSelector from './ItemSelector.svelte';
     import ProcessPreview from './ProcessPreview.svelte';
     import items from '../../pages/inventory/json/items.json';
+    import { durationInSeconds } from '../../utils.js';
 
     export let title = '';
     export let duration = '';
@@ -56,9 +57,13 @@
     }
 
     function validateDuration(duration) {
-        // Duration should be in format like "1h 30m", "2h", "45m", etc.
-        const pattern = /^(\d+h\s*)?(\d+m\s*)?$/;
-        return pattern.test(duration.trim());
+        // Accept durations like "1h 30m", "45s", "0.5h" or any combination
+        const pattern = /^(\d+(?:\.\d+)?[dhms]\s*)+$/;
+        const trimmed = duration.trim();
+        if (!pattern.test(trimmed)) {
+            return false;
+        }
+        return durationInSeconds(trimmed) > 0;
     }
 
     function validateItems() {

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -37,7 +37,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Item validation schema
         -   [x] Item dependency tracking
     -   [ ] Process System
-        -   [ ] Process creation UI with duration handling
+        -   [x] Process creation UI with duration handling
         -   [ ] Required/consumed/created items selection
         -   [x] Process validation and testing
         -   [x] Process state management

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -44,7 +44,7 @@ Fractional values are allowed, so `0.5h` will be interpreted as thirty minutes.
 
 ### Implementation State
 
-The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation highlights any missing fields or invalid durations.
+The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation now accepts seconds and fractional durations in addition to hours and minutes.
 
 ## Process Categories
 


### PR DESCRIPTION
## Summary
- support seconds and fractional values in `ProcessForm`
- cover new duration formats in unit tests
- add Playwright test for seconds-based durations
- mark changelog checklist item complete
- document new validation capabilities in guidelines

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68855a0a45a4832f90fd6c851346d820