### PR TITLE
Implement migration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ Durations should mirror real-world expectations when possible. See
 `frontend/src/pages/docs/md/process-guidelines.md` for more tips on designing
 and balancing new processes.
 
+### Data Migration
+
+DSPACE stores custom content in IndexedDB. A migration system automatically
+updates old records when the database schema changes. On first run after an
+update, migrations add missing fields and bump the saved schema version to keep
+everything consistent.
+
 > **Tip:** We use the open-source LLM inference from
 > [`token.place`](https://github.com/futuroptimist/token.place) when generating quest
 > dialogue. Token.place itself doesn't host quests, but you can reuse the same

--- a/frontend/__tests__/migration.test.js
+++ b/frontend/__tests__/migration.test.js
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'fake-indexeddb/auto';
+import {
+    openCustomContentDB,
+    saveQuest,
+    getQuest,
+    getSchemaVersion,
+    CUSTOM_CONTENT_DB_VERSION,
+} from '../src/utils/indexeddb.js';
+import { setSchemaVersion, runMigrations } from '../src/utils/migrations.js';
+
+describe('data migration system', () => {
+    test('adds createdAt field and bumps version', async () => {
+        const db = await openCustomContentDB();
+        await saveQuest({ id: 'q1', title: 'Old Quest', description: 'Legacy' });
+        await setSchemaVersion(db, 1);
+        await runMigrations(db, CUSTOM_CONTENT_DB_VERSION);
+        const quest = await getQuest('q1');
+        expect(quest.createdAt).toBeDefined();
+        const version = await getSchemaVersion();
+        expect(version).toBe(CUSTOM_CONTENT_DB_VERSION);
+    });
+});

--- a/frontend/__tests__/openCustomContentDB.test.js
+++ b/frontend/__tests__/openCustomContentDB.test.js
@@ -2,9 +2,14 @@
  * @jest-environment jsdom
  */
 import { openCustomContentDB } from '../src/utils/indexeddb.js';
+import * as migrations from '../src/utils/migrations.js';
 
 describe('openCustomContentDB', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
     test('creates stores and resolves with db on success', async () => {
+        jest.spyOn(migrations, 'runMigrations').mockResolvedValue();
         const db = {
             objectStoreNames: { contains: jest.fn().mockReturnValue(false) },
             createObjectStore: jest.fn(),

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -47,7 +47,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Validation feedback system
 -   [x] Local-First Architecture
     -   [x] IndexedDB implementation
-    -   [ ] Data migration system
+    -   [x] Data migration system
         -   [x] Schema version tracking
         -   [x] Migration scripts for v2 to v3
         -   [x] Data integrity validation

--- a/frontend/src/utils/indexeddb.js
+++ b/frontend/src/utils/indexeddb.js
@@ -1,4 +1,5 @@
 // import { log } from './devLog.js';
+import { runMigrations } from './migrations.js';
 
 const DB_NAME = 'dspaceDB';
 const DB_VERSION = 1;
@@ -136,7 +137,7 @@ export function getStoreForEntityType(entityType) {
     }
 }
 
-export const CUSTOM_CONTENT_DB_VERSION = 1;
+export const CUSTOM_CONTENT_DB_VERSION = 2;
 
 export const openCustomContentDB = () => {
     return new Promise((resolve, reject) => {
@@ -161,11 +162,19 @@ export const openCustomContentDB = () => {
             }
 
             const metaStore = request.transaction.objectStore('meta');
-            metaStore.put(CUSTOM_CONTENT_DB_VERSION, 'schemaVersion');
+            const oldVersion = e.oldVersion || 0;
+            const versionToStore = oldVersion === 0 ? CUSTOM_CONTENT_DB_VERSION : oldVersion;
+            metaStore.put(versionToStore, 'schemaVersion');
         };
 
-        request.onsuccess = () => {
-            resolve(request.result);
+        request.onsuccess = async () => {
+            const db = request.result;
+            try {
+                await runMigrations(db, CUSTOM_CONTENT_DB_VERSION);
+                resolve(db);
+            } catch (err) {
+                reject(err);
+            }
         };
 
         request.onerror = () => {

--- a/frontend/src/utils/migrations.js
+++ b/frontend/src/utils/migrations.js
@@ -1,0 +1,57 @@
+export const MIGRATIONS = {
+    2: async (db) => {
+        const stores = ['items', 'processes', 'quests'];
+        for (const storeName of stores) {
+            const tx = db.transaction(storeName, 'readwrite');
+            const store = tx.objectStore(storeName);
+            const req = store.getAll();
+            const records = await new Promise((resolve, reject) => {
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = (e) => reject(e.target.error);
+            });
+            for (const record of records) {
+                if (!record.createdAt) {
+                    record.createdAt = new Date().toISOString();
+                    store.put(record);
+                }
+            }
+            await new Promise((resolve, reject) => {
+                tx.oncomplete = resolve;
+                tx.onerror = (e) => reject(e.target.error);
+            });
+        }
+    },
+};
+
+export async function getCurrentSchemaVersion(db) {
+    const tx = db.transaction('meta', 'readonly');
+    const store = tx.objectStore('meta');
+    const req = store.get('schemaVersion');
+    return new Promise((resolve, reject) => {
+        req.onsuccess = () => resolve(req.result ?? 0);
+        req.onerror = (e) => reject(e.target.error);
+    });
+}
+
+export async function setSchemaVersion(db, version) {
+    const tx = db.transaction('meta', 'readwrite');
+    const store = tx.objectStore('meta');
+    store.put(version, 'schemaVersion');
+    return new Promise((resolve, reject) => {
+        tx.oncomplete = resolve;
+        tx.onerror = (e) => reject(e.target.error);
+    });
+}
+
+export async function runMigrations(db, targetVersion) {
+    let current = await getCurrentSchemaVersion(db);
+    const end = targetVersion;
+    while (current < end) {
+        const next = current + 1;
+        if (MIGRATIONS[next]) {
+            await MIGRATIONS[next](db);
+        }
+        await setSchemaVersion(db, next);
+        current = next;
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic migration system for custom content DB
- bump DB version and run migrations on open
- document data migration feature
- mark migration task complete in changelog
- add migration unit test and update openCustomContentDB test

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68855a0a45a4832f90fd6c851346d820