### PR TITLE
Expand custom quest validation tests

### DIFF
--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -6,9 +6,9 @@ import { validateQuestData } from '../src/utils/customQuestValidation.js';
 describe('validateQuestData', () => {
     test('valid quest passes', () => {
         const result = validateQuestData({
-            title: 'A',
-            description: 'B',
-            image: 'img',
+            title: 'Valid Quest',
+            description: 'This quest has a sufficiently long description.',
+            image: 'https://example.com/image.png',
             requiresQuests: ['q1'],
         });
         expect(result.valid).toBe(true);
@@ -20,5 +20,51 @@ describe('validateQuestData', () => {
             image: 'img',
         });
         expect(result.valid).toBe(false);
+    });
+
+    test('short fields or invalid image fail', () => {
+        const cases = [
+            {
+                title: 'AB',
+                description: 'This description is long enough',
+                image: 'https://example.com/img.png',
+            },
+            {
+                title: 'Valid',
+                description: 'Too short',
+                image: 'https://example.com/img.png',
+            },
+            {
+                title: 'Valid',
+                description: 'Long enough description',
+                image: 'invalid-image-path',
+            },
+        ];
+
+        for (const data of cases) {
+            const result = validateQuestData(data);
+            expect(result.valid).toBe(false);
+        }
+    });
+
+    test('duplicate requirements fail validation', () => {
+        const result = validateQuestData({
+            title: 'Quest',
+            description: 'This quest has duplicates in requiresQuests.',
+            image: 'data:image/png;base64,abcd',
+            requiresQuests: ['q1', 'q1'],
+        });
+
+        expect(result.valid).toBe(false);
+    });
+
+    test('data URL image passes validation', () => {
+        const result = validateQuestData({
+            title: 'Quest',
+            description: 'This quest uses a data URL image.',
+            image: 'data:image/png;base64,abcd',
+        });
+
+        expect(result.valid).toBe(true);
     });
 });

--- a/frontend/e2e/quests.spec.ts
+++ b/frontend/e2e/quests.spec.ts
@@ -83,6 +83,17 @@ test.describe('Quest Management', () => {
         }
     });
 
+    test('should enforce schema validation on short fields', async ({ page }) => {
+        await page.fill('#title', 'ab');
+        await page.fill('#description', 'too short');
+
+        const submitButton = page.locator('button.submit-button, input[type="submit"]');
+        await submitButton.click();
+
+        await expect(page.locator('.error-message')).toBeVisible();
+        await expect(page).toHaveURL(/\/quests\/create/);
+    });
+
     test('should handle image upload', async ({ page }) => {
         // Fill in required fields
         await page.fill('#title', 'Quest with Image');

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -3,12 +3,17 @@ import Ajv from 'ajv';
 export const customQuestSchema = {
     type: 'object',
     properties: {
-        title: { type: 'string', minLength: 1 },
-        description: { type: 'string', minLength: 1 },
-        image: { type: 'string', minLength: 1 },
+        title: { type: 'string', minLength: 3 },
+        description: { type: 'string', minLength: 10 },
+        image: {
+            type: 'string',
+            minLength: 1,
+            pattern: '^(data:image/|https?://)',
+        },
         requiresQuests: {
             type: 'array',
             items: { type: 'string' },
+            uniqueItems: true,
         },
     },
     required: ['title', 'description', 'image'],


### PR DESCRIPTION
## Summary
- enforce stricter rules in `validateQuestData`
- expand unit test coverage for custom quest validation
- add e2e test for schema validation errors

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885651289b0832f82e2792f300d5363