### PR TITLE
Expand custom quest tests

### DIFF
--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -21,4 +21,49 @@ describe('validateQuestData', () => {
         });
         expect(result.valid).toBe(false);
     });
+
+    test('missing description fails', () => {
+        const result = validateQuestData({
+            title: 'A',
+            image: 'img',
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('missing image fails', () => {
+        const result = validateQuestData({
+            title: 'A',
+            description: 'B',
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('non-array requiresQuests fails', () => {
+        const result = validateQuestData({
+            title: 'A',
+            description: 'B',
+            image: 'img',
+            requiresQuests: 'q1',
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('requiresQuests with non-string entries fails', () => {
+        const result = validateQuestData({
+            title: 'A',
+            description: 'B',
+            image: 'img',
+            requiresQuests: [1, 2],
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('valid without requiresQuests passes', () => {
+        const result = validateQuestData({
+            title: 'A',
+            description: 'B',
+            image: 'img',
+        });
+        expect(result.valid).toBe(true);
+    });
 });

--- a/frontend/e2e/quest-form-validation.spec.ts
+++ b/frontend/e2e/quest-form-validation.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+// Basic validation test for QuestForm
+// Ensures required fields trigger validation errors
+
+test('quest form requires description and image', async ({ page }) => {
+    await page.goto('/quests/create');
+    await page.waitForLoadState('networkidle');
+
+    // Fill only the title
+    await page.fill('#title', 'Validation Test Quest');
+
+    // Attempt to submit without description or image
+    await page.click('button.submit-button');
+
+    // Expect error messages to appear
+    const errors = page.locator('.error-message');
+    await expect(errors.first()).toBeVisible();
+
+    // Ensure we stay on the creation page
+    await expect(page).toHaveURL(/\/quests\/create/);
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -20,7 +20,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add quest review interface
         -   [ ] Create pull request generation system
     -   [ ] Quest validation and testing
-        -   [ ] Expand test suite for custom quests
+        -   [x] Expand test suite for custom quests
         -   [x] Add validation for quest dependencies
         -   [x] Implement quest simulation testing
     -   [x] Quest submission process documentation


### PR DESCRIPTION
## Summary
- mark test suite item complete in the v3 changelog
- expand unit tests for custom quest validation
- add Playwright test for quest form validation

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885651289b0832f82e2792f300d5363