### PR TITLE
Expand custom quest tests

### DIFF
--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -67,4 +67,34 @@ describe('validateQuestData', () => {
 
         expect(result.valid).toBe(true);
     });
+
+    test('extra properties are allowed', () => {
+        const result = validateQuestData({
+            title: 'Extra Quest',
+            description: 'Valid description for quest.',
+            image: 'https://example.com/img.png',
+            unknown: 'field',
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('requiresQuests must be array of strings', () => {
+        const result = validateQuestData({
+            title: 'Bad Quest',
+            description: 'Valid description for quest.',
+            image: 'https://example.com/img.png',
+            requiresQuests: [1, 2],
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    test('requiresQuests as non-array fails', () => {
+        const result = validateQuestData({
+            title: 'Another Bad Quest',
+            description: 'Valid description for quest.',
+            image: 'https://example.com/img.png',
+            requiresQuests: 'q1',
+        });
+        expect(result.valid).toBe(false);
+    });
 });

--- a/frontend/__tests__/questSimulation.test.js
+++ b/frontend/__tests__/questSimulation.test.js
@@ -6,10 +6,22 @@ const path = require('path');
 const { questHasFinishPath } = require('../src/utils/simulateQuest.js');
 
 const questFile = path.join(__dirname, '../test-data/simple-quest.json');
+const loopQuestFile = path.join(__dirname, '../test-data/loop-quest.json');
+const loopFinishQuestFile = path.join(__dirname, '../test-data/loop-finish-quest.json');
 
 describe('Quest simulation', () => {
     test('sample quest has a path to finish', () => {
         const quest = JSON.parse(fs.readFileSync(questFile));
+        expect(questHasFinishPath(quest)).toBe(true);
+    });
+
+    test('quest without finish path fails', () => {
+        const quest = JSON.parse(fs.readFileSync(loopQuestFile));
+        expect(questHasFinishPath(quest)).toBe(false);
+    });
+
+    test('quest with loops and finish still passes', () => {
+        const quest = JSON.parse(fs.readFileSync(loopFinishQuestFile));
         expect(questHasFinishPath(quest)).toBe(true);
     });
 });

--- a/frontend/test-data/loop-finish-quest.json
+++ b/frontend/test-data/loop-finish-quest.json
@@ -1,0 +1,22 @@
+{
+    "id": "test/loop-with-finish",
+    "title": "Loop With Finish",
+    "description": "Quest with a finish path despite loops",
+    "image": "/assets/test.png",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Start",
+            "options": [{ "type": "goto", "goto": "middle", "text": "Middle" }]
+        },
+        {
+            "id": "middle",
+            "text": "Middle",
+            "options": [
+                { "type": "goto", "goto": "start", "text": "Loop" },
+                { "type": "finish", "text": "Finish" }
+            ]
+        }
+    ]
+}

--- a/frontend/test-data/loop-quest.json
+++ b/frontend/test-data/loop-quest.json
@@ -1,0 +1,19 @@
+{
+    "id": "test/loop-no-finish",
+    "title": "Loop Without Finish",
+    "description": "Quest with no finish path",
+    "image": "/assets/test.png",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Start",
+            "options": [{ "type": "goto", "goto": "middle", "text": "Next" }]
+        },
+        {
+            "id": "middle",
+            "text": "Middle",
+            "options": [{ "type": "goto", "goto": "start", "text": "Loop" }]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- expand validation tests for custom quests
- add quest simulation tests for loop handling

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688568c4af9c832f90b491d3294b9ef8