### PR TITLE
Implement quest edit page

### DIFF
--- a/frontend/e2e/manage-quests.spec.ts
+++ b/frontend/e2e/manage-quests.spec.ts
@@ -66,4 +66,33 @@ test.describe('Manage Quests', () => {
 
         expect(exists).toBe(false);
     });
+
+    test('should edit a custom quest title', async ({ page }) => {
+        const questTitle = `Edit Quest ${Date.now()}`;
+        const updatedTitle = questTitle + ' Updated';
+
+        await page.goto('/quests/create');
+        await page.fill('#title', questTitle);
+        await page.fill('#description', 'Quest to edit');
+        await page.click('button.submit-button');
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/quests/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const questRow = page.locator('.quest-item', { hasText: questTitle }).first();
+        await questRow.locator('.edit-button').click();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        await page.fill('#title', updatedTitle);
+        await page.click('button.submit-button');
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/quests/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.locator('.quest-item', { hasText: updatedTitle })).toBeVisible();
+    });
 });

--- a/frontend/src/pages/quests/[id]/edit.astro
+++ b/frontend/src/pages/quests/[id]/edit.astro
@@ -1,0 +1,10 @@
+---
+import Page from '../../components/Page.astro';
+import QuestForm from '../../components/svelte/QuestForm.svelte';
+
+const { id } = Astro.params;
+---
+
+<Page title="Edit Custom Quest">
+    <QuestForm client:load isEdit={true} questId={id} existingQuests={[]} />
+</Page>


### PR DESCRIPTION
## Summary
- add `/quests/[id]/edit` route using existing QuestForm component
- add Playwright test covering custom quest editing workflow

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_688568c4af9c832f90b491d3294b9ef8