### PR TITLE
Remove residual Vercel refs

### DIFF
--- a/frontend/e2e/touch-menu.spec.ts
+++ b/frontend/e2e/touch-menu.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 test('unpinned menu toggles via touch', async ({ page }) => {
-  await page.setViewportSize({ width: 375, height: 667 });
-  await page.goto('/');
-  await page.waitForLoadState('networkidle');
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
 
-  const unpinnedItem = page.locator('nav a[href="/gamesaves"]');
-  await expect(unpinnedItem).toBeHidden();
+    const unpinnedItem = page.locator('nav a[href="/gamesaves"]');
+    await expect(unpinnedItem).toBeHidden();
 
-  await page.locator('#unpinned-toggle').tap();
+    await page.locator('#unpinned-toggle').tap();
 
-  await expect(unpinnedItem).toBeVisible();
+    await expect(unpinnedItem).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- fix Prettier formatting in `touch-menu.spec.ts`
- confirm no Vercel config remains

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885a5323d90832fbe57eae36dc4fe22