### PR TITLE
feat(ui): display PR link after quest submission

### DIFF
--- a/frontend/e2e/quest-pr-form.spec.ts
+++ b/frontend/e2e/quest-pr-form.spec.ts
@@ -5,3 +5,22 @@ test('quest PR form is accessible', async ({ page }) => {
     await expect(page.getByText('GitHub Token')).toBeVisible();
     await expect(page.getByRole('button', { name: /Create Pull Request/i })).toBeVisible();
 });
+
+test('quest PR form submits and shows link', async ({ page }) => {
+    await page.route('https://api.github.com/**', async (route) => {
+        if (route.request().url().endsWith('/pulls')) {
+            await route.fulfill({
+                status: 201,
+                contentType: 'application/json',
+                body: JSON.stringify({ html_url: 'https://example.com/pr/1' }),
+            });
+        } else {
+            await route.fulfill({ status: 201, body: '{}' });
+        }
+    });
+    await page.goto('/quests/submit');
+    await page.fill('#token', 't');
+    await page.fill('#quest', '{"title":"t","description":"d"}');
+    await page.click('button:has-text("Create Pull Request")');
+    await expect(page.getByTestId('pr-link')).toHaveAttribute('href', 'https://example.com/pr/1');
+});

--- a/frontend/src/components/svelte/QuestPRForm.svelte
+++ b/frontend/src/components/svelte/QuestPRForm.svelte
@@ -3,6 +3,7 @@
     export let token = '';
     export let branch = '';
     export let questJson = '';
+    let prUrl = '';
     const dispatch = createEventDispatcher();
 
     function b64(str) {
@@ -50,7 +51,9 @@
                 }
             );
             if (!prRes.ok) throw new Error(await prRes.text());
-            dispatch('success', { message: 'Pull request created' });
+            const prData = await prRes.json();
+            prUrl = prData.html_url;
+            dispatch('success', { message: 'Pull request created', url: prUrl });
         } catch (err) {
             console.error(err);
             dispatch('error', { message: 'Failed to submit quest' });
@@ -75,6 +78,13 @@
         <button type="submit">Create Pull Request</button>
     </div>
 </form>
+
+{#if prUrl}
+    <p class="success-message" data-testid="pr-success">
+        Pull request created:
+        <a href={prUrl} target="_blank" rel="noopener" data-testid="pr-link"> View PR </a>
+    </p>
+{/if}
 
 <style>
     .pr-form {
@@ -116,5 +126,9 @@
         border: none;
         border-radius: 8px;
         cursor: pointer;
+    }
+    .success-message {
+        margin-top: 10px;
+        color: #90ee90;
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -18,7 +18,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Quest contribution workflow
         -   [x] Implement quest PR submission form
         -   [x] Add quest review interface
-        -   [ ] Create pull request generation system
+        -   [x] Create pull request generation system ✅
     -   [ ] Quest validation and testing
         -   [ ] Expand test suite for custom quests
         -   [x] Add validation for quest dependencies


### PR DESCRIPTION
## Summary
- show PR URL after a quest PR is created
- test quest PR workflow via Playwright
- mark "Create pull request generation system" as complete

## Testing
- `npm run lint`
- `npm test`
- `npx playwright test`
- `npm run coverage` *(fails: SyntaxError import.meta)*

------
https://chatgpt.com/codex/tasks/task_e_6885a429ad88832fb0306e4d4e41dd85