### PR TITLE
feat(docs): expand quest test coverage

### DIFF
--- a/frontend/__tests__/questSimulation.test.js
+++ b/frontend/__tests__/questSimulation.test.js
@@ -8,6 +8,8 @@ const { questHasFinishPath } = require('../src/utils/simulateQuest.js');
 const questFile = path.join(__dirname, '../test-data/simple-quest.json');
 const loopQuestFile = path.join(__dirname, '../test-data/loop-quest.json');
 const loopFinishQuestFile = path.join(__dirname, '../test-data/loop-finish-quest.json');
+const missingStartFile = path.join(__dirname, '../test-data/missing-start-quest.json');
+const noDialogueFile = path.join(__dirname, '../test-data/no-dialogue-quest.json');
 
 describe('Quest simulation', () => {
     test('sample quest has a path to finish', () => {
@@ -23,5 +25,15 @@ describe('Quest simulation', () => {
     test('quest with loops and finish still passes', () => {
         const quest = JSON.parse(fs.readFileSync(loopFinishQuestFile));
         expect(questHasFinishPath(quest)).toBe(true);
+    });
+
+    test('quest with missing start node fails', () => {
+        const quest = JSON.parse(fs.readFileSync(missingStartFile));
+        expect(questHasFinishPath(quest)).toBe(false);
+    });
+
+    test('quest without dialogue returns false', () => {
+        const quest = JSON.parse(fs.readFileSync(noDialogueFile));
+        expect(questHasFinishPath(quest)).toBe(false);
     });
 });

--- a/frontend/e2e/manage-quests-search.spec.ts
+++ b/frontend/e2e/manage-quests-search.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+test.describe('Manage Quests Search', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('filters quests by search term', async ({ page }) => {
+        const titles = ['Search Quest A', 'Search Quest B'];
+        for (const title of titles) {
+            await page.goto('/quests/create');
+            await page.fill('#title', title);
+            await page.fill('#description', 'desc');
+            const submit = page.locator('button.submit-button, input[type="submit"]').first();
+            await submit.click();
+            await page.waitForLoadState('networkidle');
+        }
+
+        await page.goto('/quests/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const search = page.locator('input[placeholder="Search quests..."]');
+        await search.fill('Quest B');
+
+        const quests = page.locator('.quest-item');
+        await expect(quests).toHaveCount(1);
+        await expect(quests.first()).toContainText('Quest B');
+
+        await search.fill('NoMatch');
+        await expect(page.locator('.no-quests')).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -20,7 +20,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add quest review interface
         -   [ ] Create pull request generation system
     -   [ ] Quest validation and testing
-        -   [ ] Expand test suite for custom quests
+        -   [x] Expand test suite for custom quests ✅
         -   [x] Add validation for quest dependencies
         -   [x] Implement quest simulation testing
     -   [x] Quest submission process documentation

--- a/frontend/test-data/missing-start-quest.json
+++ b/frontend/test-data/missing-start-quest.json
@@ -1,0 +1,14 @@
+{
+    "id": "test/missing-start",
+    "title": "Missing Start",
+    "description": "Quest with start id that does not exist",
+    "image": "/assets/test.png",
+    "start": "does-not-exist",
+    "dialogue": [
+        {
+            "id": "only",
+            "text": "Lonely node",
+            "options": [{ "type": "finish", "text": "Finish" }]
+        }
+    ]
+}

--- a/frontend/test-data/no-dialogue-quest.json
+++ b/frontend/test-data/no-dialogue-quest.json
@@ -1,0 +1,7 @@
+{
+    "id": "test/no-dialogue",
+    "title": "No Dialogue",
+    "description": "Quest without dialogue",
+    "image": "/assets/test.png",
+    "start": "start"
+}


### PR DESCRIPTION
## Summary
- expand questHasFinishPath tests
- add Playwright test for Manage Quests search
- check off changelog item

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `npx playwright test frontend/e2e/manage-quests-search.spec.ts` *(fails: Need to install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6885a429ad88832fb0306e4d4e41dd85