### PR TITLE
feat(ui): add UI responsiveness metrics

### DIFF
--- a/frontend/__tests__/UIResponsiveness.test.js
+++ b/frontend/__tests__/UIResponsiveness.test.js
@@ -1,0 +1,11 @@
+/** @jest-environment jsdom */
+import { describe, it, expect } from '@jest/globals';
+import UIResponsiveness from '../src/components/svelte/UIResponsiveness.svelte';
+
+describe('UIResponsiveness Component', () => {
+    it('exports a valid Svelte component', () => {
+        expect(typeof UIResponsiveness).toBe('function');
+    });
+});
+
+

--- a/frontend/__tests__/uiMetrics.test.js
+++ b/frontend/__tests__/uiMetrics.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from '@jest/globals';
+import { calculateHydrationTime } from '../src/utils/uiMetrics.js';
+
+describe('calculateHydrationTime', () => {
+    it('calculates difference between end and start', () => {
+        expect(calculateHydrationTime(100, 150)).toBe(50);
+    });
+
+    it('throws when inputs are invalid', () => {
+        expect(() => calculateHydrationTime('a', 2)).toThrow();
+        expect(() => calculateHydrationTime(1, 'b')).toThrow();
+    });
+});
+

--- a/frontend/e2e/ui-responsiveness.spec.ts
+++ b/frontend/e2e/ui-responsiveness.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('UI Responsiveness Metrics', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('home page shows hydration metric', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForSelector('[data-testid="hydration-time"]');
+        const text = await page.textContent('[data-testid="hydration-time"]');
+        expect(text).toMatch(/Hydration time: \d+ ms/);
+    });
+});
+

--- a/frontend/src/components/svelte/UIResponsiveness.svelte
+++ b/frontend/src/components/svelte/UIResponsiveness.svelte
@@ -1,0 +1,22 @@
+<script>
+    import { onMount } from 'svelte';
+    import { calculateHydrationTime } from '../../utils/uiMetrics.js';
+
+    export let startTime = 0;
+    let hydration = 0;
+
+    onMount(() => {
+        const start = startTime || (window.dspaceStart ?? performance.timing.navigationStart);
+        hydration = calculateHydrationTime(start, performance.now());
+    });
+</script>
+
+<div data-testid="hydration-time">Hydration time: {Math.round(hydration)} ms</div>
+
+<style>
+    div {
+        margin-top: 1rem;
+        font-size: 0.9rem;
+    }
+</style>
+

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -68,7 +68,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Performance testing
         -   [ ] Load testing custom content system
         -   [ ] Database performance benchmarks
-        -   [ ] UI responsiveness metrics
+        -   [x] UI responsiveness metrics ✅
     -   [x] Cross-browser compatibility
         -   [x] Test IndexedDB in all major browsers
         -   [x] Verify UI components across browsers

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,10 +1,13 @@
 ---
 import Page from '../components/Page.astro';
 import WhatsNew from '../components/WhatsNew.astro';
+import UIResponsiveness from '../components/svelte/UIResponsiveness.svelte';
 ---
 
 <Page columns="1">
+    <script>window.dspaceStart = performance.now();</script>
     <WhatsNew />
+    <UIResponsiveness client:load />
 </Page>
 
 <style>

--- a/frontend/src/utils/uiMetrics.js
+++ b/frontend/src/utils/uiMetrics.js
@@ -1,0 +1,7 @@
+export function calculateHydrationTime(start, end) {
+    if (typeof start !== 'number' || typeof end !== 'number') {
+        throw new Error('start and end must be numbers');
+    }
+    return end - start;
+}
+


### PR DESCRIPTION
## Summary
- show hydration metrics on the home page
- support measuring hydration time
- add unit tests and e2e test for UI metrics
- document completion of the UI responsiveness metrics checklist item

## Testing
- `npm test`
- `npx playwright test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6885a96b1908832fafea826d4598375c