### PR TITLE
feat(ui): validate token in quest PR form

### DIFF
--- a/frontend/__tests__/githubToken.test.js
+++ b/frontend/__tests__/githubToken.test.js
@@ -1,0 +1,15 @@
+const { describe, it, expect } = require('@jest/globals');
+const { isValidGitHubToken } = require('../src/utils/githubToken.js');
+
+describe('isValidGitHubToken', () => {
+    it('validates typical tokens', () => {
+        expect(isValidGitHubToken('ghp_123456789012345678901234567890123456')).toBe(true);
+        expect(isValidGitHubToken('github_pat_abcdefghijklmnopqrstuvwxyz12')).toBe(true);
+    });
+
+    it('rejects invalid tokens', () => {
+        expect(isValidGitHubToken('')).toBe(false);
+        expect(isValidGitHubToken('short')).toBe(false);
+        expect(isValidGitHubToken('ghp_invalid')).toBe(false);
+    });
+});

--- a/frontend/e2e/quest-pr-validation.spec.ts
+++ b/frontend/e2e/quest-pr-validation.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.beforeEach(async ({ page }) => {
+    await clearUserData(page);
+});
+
+test('invalid token shows validation message', async ({ page }) => {
+    await page.goto('/quests/submit');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('#token', 'bad');
+    await page.fill('#quest', '{}');
+
+    await page.click('button:has-text("Create Pull Request")');
+
+    const error = page.locator('.error-message');
+    await expect(error).toBeVisible();
+});

--- a/frontend/src/components/svelte/QuestPRForm.svelte
+++ b/frontend/src/components/svelte/QuestPRForm.svelte
@@ -4,16 +4,30 @@
     export let branch = '';
     export let questJson = '';
     let prUrl = '';
+    let validationErrors = {};
     const dispatch = createEventDispatcher();
+    import { isValidGitHubToken } from '../../utils/githubToken.js';
 
     function b64(str) {
         return btoa(unescape(encodeURIComponent(str)));
     }
 
+    function validateForm() {
+        const errors = {};
+        if (!isValidGitHubToken(token)) {
+            errors.token = 'GitHub token looks invalid';
+        }
+        if (!questJson.trim()) {
+            errors.quest = 'Quest JSON is required';
+        }
+        validationErrors = errors;
+        return Object.keys(errors).length === 0;
+    }
+
     async function handleSubmit(event) {
         event.preventDefault();
-        if (!questJson.trim()) {
-            dispatch('error', { message: 'Quest JSON is required' });
+        if (!validateForm()) {
+            dispatch('error', { message: 'Validation failed' });
             return;
         }
         try {
@@ -64,7 +78,10 @@
 <form on:submit={handleSubmit} class="pr-form">
     <div class="form-group">
         <label for="token">GitHub Token*</label>
-        <input id="token" type="password" bind:value={token} required />
+        <input id="token" type="password" bind:value={token} class:error={validationErrors.token} required />
+        {#if validationErrors.token}
+            <span class="error-message">{validationErrors.token}</span>
+        {/if}
     </div>
     <div class="form-group">
         <label for="branch">Branch Name</label>
@@ -72,7 +89,10 @@
     </div>
     <div class="form-group">
         <label for="quest">Quest JSON*</label>
-        <textarea id="quest" bind:value={questJson} rows="10" required />
+        <textarea id="quest" bind:value={questJson} rows="10" class:error={validationErrors.quest} required />
+        {#if validationErrors.quest}
+            <span class="error-message">{validationErrors.quest}</span>
+        {/if}
     </div>
     <div class="form-submit">
         <button type="submit">Create Pull Request</button>
@@ -130,5 +150,18 @@
     .success-message {
         margin-top: 10px;
         color: #90ee90;
+    }
+
+    input.error,
+    textarea.error {
+        border-color: #ff3e3e;
+        background-color: #ffecec;
+    }
+
+    .error-message {
+        color: #ff3e3e;
+        font-size: 14px;
+        display: block;
+        margin-top: 5px;
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -15,7 +15,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add quest validation against JSON schema
         -   [x] Create quest preview functionality
         -   [x] Add quest requirements selection
-    -   [ ] Quest contribution workflow
+    -   [x] Quest contribution workflow ✅
         -   [x] Implement quest PR submission form
         -   [x] Add quest review interface
         -   [x] Create pull request generation system ✅

--- a/frontend/src/utils/githubToken.js
+++ b/frontend/src/utils/githubToken.js
@@ -1,0 +1,9 @@
+export function isValidGitHubToken(token) {
+    if (!token) return false;
+    const trimmed = token.trim();
+    const patterns = [
+        /^gh[pousr]_[A-Za-z0-9_]{36,}$/i,
+        /^github_pat_[A-Za-z0-9_]{22,}$/i,
+    ];
+    return patterns.some((p) => p.test(trimmed));
+}


### PR DESCRIPTION
## Summary
- add GitHub token validation helper
- show validation errors in QuestPRForm
- test token validator logic
- add e2e test for invalid token message
- mark quest contribution workflow complete

## Testing
- `npm run lint`
- `npm test`
- `npm run coverage`
- `SKIP_E2E=1 npx playwright test` *(failed: playwright install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6885a96b1908832fafea826d4598375c