### PR TITLE
Add coverage tests for UIResponsiveness

### DIFF
--- a/frontend/__tests__/UIResponsiveness.test.js
+++ b/frontend/__tests__/UIResponsiveness.test.js
@@ -1,11 +1,20 @@
 /** @jest-environment jsdom */
 import { describe, it, expect } from '@jest/globals';
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
 import UIResponsiveness from '../src/components/svelte/UIResponsiveness.svelte';
 
 describe('UIResponsiveness Component', () => {
     it('exports a valid Svelte component', () => {
         expect(typeof UIResponsiveness).toBe('function');
     });
+
+    it('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/components/svelte/UIResponsiveness.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
 });
-
-

--- a/frontend/__tests__/indexPage.test.js
+++ b/frontend/__tests__/indexPage.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from '@jest/globals';
+
+const indexFile = path.join(__dirname, '../src/pages/index.astro');
+
+describe('index.astro', () => {
+    it('includes hydration script and UIResponsiveness component', () => {
+        const content = fs.readFileSync(indexFile, 'utf8');
+        expect(content).toMatch(/window\.dspaceStart = performance\.now\(\)/);
+        expect(content).toMatch(/<UIResponsiveness client:load \/>/);
+    });
+});


### PR DESCRIPTION
## Summary
- add Jest test for `index.astro` page
- extend `UIResponsiveness` tests to compile the component

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885ac99d398832f851847debaacdaff