### PR TITLE
feat(ui): live quest form validation

### DIFF
--- a/frontend/__tests__/QuestForm.test.js
+++ b/frontend/__tests__/QuestForm.test.js
@@ -127,8 +127,16 @@ const mockQuestForm = {
 
             // Validate form
             const errors = {};
-            if (!formData.title.trim()) errors.title = 'Title is required';
-            if (!formData.description.trim()) errors.description = 'Description is required';
+            if (!formData.title.trim()) {
+                errors.title = 'Title is required';
+            } else if (formData.title.trim().length < 3) {
+                errors.title = 'Title must be at least 3 characters';
+            }
+            if (!formData.description.trim()) {
+                errors.description = 'Description is required';
+            } else if (formData.description.trim().length < 10) {
+                errors.description = 'Description must be at least 10 characters';
+            }
             if (!props.isEdit && !formData.image && !props.image)
                 errors.image = 'Image is required';
 
@@ -440,6 +448,23 @@ describe('QuestForm Component', () => {
                 requiresQuests: [],
             })
         );
+    });
+
+    it('validates minimum lengths', async () => {
+        component = mockQuestForm.render(container, { isEdit: false });
+
+        const { titleInput, descTextarea } = component.elements;
+        titleInput.value = 'ab';
+        descTextarea.value = 'short';
+
+        await act(async () => {
+            await component.handleSubmit();
+        });
+
+        await waitFor(() => {
+            expect(container.textContent).toContain('at least 3 characters');
+            expect(container.textContent).toContain('at least 10 characters');
+        });
     });
 });
 

--- a/frontend/e2e/quest-form-validation.spec.ts
+++ b/frontend/e2e/quest-form-validation.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Quest Form Live Validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearUserData(page);
+  });
+
+  test('shows validation errors while typing', async ({ page }) => {
+    await page.goto('/quests/create');
+    await page.waitForLoadState('networkidle');
+
+    const titleInput = page.locator('#title');
+    const descInput = page.locator('#description');
+
+    await titleInput.fill('ab');
+    await expect(page.locator('.error-message')).toContainText('at least 3 characters');
+
+    await descInput.fill('short');
+    await expect(page.locator('.error-message')).toContainText('at least 10 characters');
+  });
+});

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -15,6 +15,10 @@
     let allQuests = [];
     let validationErrors = {};
     let isSubmitting = false;
+    const MIN_TITLE_LENGTH = 3;
+    const MIN_DESC_LENGTH = 10;
+
+    let touched = { title: false, description: false };
 
     const dispatch = createEventDispatcher();
 
@@ -54,9 +58,11 @@
             };
             reader.readAsDataURL(file);
             image = file;
+            validateForm();
         } else {
             previewUrl = null;
             image = null;
+            validateForm();
         }
     }
 
@@ -64,15 +70,33 @@
         requiresQuests = Array.from(event.target.selectedOptions).map((opt) => opt.value);
     }
 
+    function handleTitleInput(event) {
+        title = event.target.value;
+        touched.title = true;
+        validateForm();
+    }
+
+    function handleDescriptionInput(event) {
+        description = event.target.value;
+        touched.description = true;
+        validateForm();
+    }
+
     async function validateForm() {
         const errors = {};
 
-        if (!title.trim()) {
+        const trimmedTitle = title.trim();
+        if (!trimmedTitle) {
             errors.title = 'Title is required';
+        } else if (trimmedTitle.length < MIN_TITLE_LENGTH) {
+            errors.title = `Title must be at least ${MIN_TITLE_LENGTH} characters`;
         }
 
-        if (!description.trim()) {
+        const trimmedDesc = description.trim();
+        if (!trimmedDesc) {
             errors.description = 'Description is required';
+        } else if (trimmedDesc.length < MIN_DESC_LENGTH) {
+            errors.description = `Description must be at least ${MIN_DESC_LENGTH} characters`;
         }
 
         if (!isEdit && !image && !previewUrl) {
@@ -182,6 +206,7 @@
             bind:value={title}
             placeholder="Gather resources"
             class:error={validationErrors.title}
+            on:input={handleTitleInput}
         />
         {#if validationErrors.title}
             <span class="error-message">{validationErrors.title}</span>
@@ -195,6 +220,7 @@
             bind:value={description}
             placeholder="Describe the quest in detail. What needs to be done?"
             class:error={validationErrors.description}
+            on:input={handleDescriptionInput}
         />
         {#if validationErrors.description}
             <span class="error-message">{validationErrors.description}</span>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -19,7 +19,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Implement quest PR submission form
         -   [x] Add quest review interface
         -   [x] Create pull request generation system ✅
-    -   [ ] Quest validation and testing
+    -   [x] Quest validation and testing ✅
         -   [x] Expand test suite for custom quests ✅
         -   [x] Add validation for quest dependencies
         -   [x] Implement quest simulation testing


### PR DESCRIPTION
## Summary
- validate min lengths in QuestForm as user types
- test validation in unit and e2e suites
- mark checklist item for quest validation and testing

## Testing
- `npm run coverage`
- `npx playwright test` *(failed: playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_6885a96b1908832fafea826d4598375c