### PR TITLE
feat(ui): add item management page

### DIFF
--- a/frontend/e2e/manage-items.spec.ts
+++ b/frontend/e2e/manage-items.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+test.describe('Manage Items', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('should list items on manage page', async ({ page }) => {
+        await page.goto('/inventory/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        const items = page.locator('.item-row');
+        await expect(items.first()).toBeVisible();
+    });
+
+    test('should create and delete a custom item via manage page', async ({ page }) => {
+        const itemName = `Delete Item ${Date.now()}`;
+
+        await page.goto('/inventory/create');
+        await page.fill('#name', itemName);
+        await page.fill('#description', 'Item created for deletion test');
+        await page.fill('#price', '10');
+        const submit = page.locator('button.submit-button, input[type="submit"]');
+        await submit.click();
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/inventory/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const itemRow = page.locator('.item-row', { hasText: itemName }).first();
+        await expect(itemRow).toBeVisible();
+
+        page.on('dialog', (d) => d.accept());
+        await itemRow.locator('.delete-button').click();
+        await page.waitForTimeout(500);
+        await expect(page.locator(`text="${itemName}"`)).toHaveCount(0);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.locator(`text="${itemName}"`)).toHaveCount(0);
+
+        const exists = await page.evaluate(async (name) => {
+            const openReq = indexedDB.open('CustomContent');
+            const db = await new Promise<IDBDatabase>((resolve, reject) => {
+                openReq.onsuccess = () => resolve(openReq.result);
+                openReq.onerror = () => reject(openReq.error);
+                openReq.onupgradeneeded = () => resolve(openReq.result);
+            });
+            const tx = db.transaction('items', 'readonly');
+            const store = tx.objectStore('items');
+            const req = store.getAll();
+            const items = await new Promise<Array<{ name: string }>>((resolve, reject) => {
+                req.onsuccess = () => resolve(req.result as Array<{ name: string }>);
+                req.onerror = () => reject(req.error);
+            });
+            db.close();
+            return items.some((i) => i.name === name);
+        }, itemName);
+
+        expect(exists).toBe(false);
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -32,7 +32,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [ ] Balance progression curve across all quests
     -   [ ] Test quest chains and dependencies
 -   [ ] Custom Items and Processes (using the same system as quests)
-    -   [ ] Item Management
+    -   [x] Item Management ✅
         -   [x] Item creation interface with ItemForm.svelte
     -   [x] Item validation schema
         -   [x] Item dependency tracking

--- a/frontend/src/pages/inventory/manage.astro
+++ b/frontend/src/pages/inventory/manage.astro
@@ -1,0 +1,9 @@
+---
+import Page from '../../components/Page.astro';
+import ManageItems from './svelte/ManageItems.svelte';
+import items from './json/items.json';
+---
+
+<Page title="Manage Items">
+    <ManageItems client:load items={items} />
+</Page>

--- a/frontend/src/pages/inventory/svelte/ManageItems.svelte
+++ b/frontend/src/pages/inventory/svelte/ManageItems.svelte
@@ -1,0 +1,147 @@
+<script>
+    import { onMount } from 'svelte';
+    import ItemCard from '../../../components/svelte/ItemCard.svelte';
+    import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
+
+    export let items = [];
+    let customItems = [];
+    let mounted = false;
+    let searchTerm = '';
+
+    onMount(async () => {
+        customItems = await db.list(ENTITY_TYPES.ITEM);
+        mounted = true;
+    });
+
+    $: allItems = [...items, ...customItems];
+    $: filteredItems = allItems.filter((item) => {
+        const term = searchTerm.toLowerCase();
+        return (
+            item.name.toLowerCase().includes(term) || item.description.toLowerCase().includes(term)
+        );
+    });
+
+    function handleEdit(id) {
+        window.location.href = `/inventory/item/${id}/edit`;
+    }
+
+    async function handleDelete(id) {
+        if (confirm('Are you sure you want to delete this item?')) {
+            try {
+                await db.items.delete(id);
+                customItems = customItems.filter((i) => i.id !== id);
+            } catch (err) {
+                console.error('Error deleting item:', err);
+                alert('Failed to delete item');
+            }
+        }
+    }
+</script>
+
+<div class="manage-items">
+    {#if mounted}
+        <div class="controls">
+            <input type="text" bind:value={searchTerm} placeholder="Search items..." />
+        </div>
+
+        <div class="items-list">
+            {#if filteredItems.length === 0}
+                <div class="no-items">No items found</div>
+            {:else}
+                {#each filteredItems as item (item.id)}
+                    <div class="item-row">
+                        <ItemCard itemId={item.id} />
+                        {#if item.custom}
+                            <div class="item-actions">
+                                <button class="edit-button" on:click={() => handleEdit(item.id)}>
+                                    Edit
+                                </button>
+                                <button
+                                    class="delete-button"
+                                    on:click={() => handleDelete(item.id)}
+                                >
+                                    Delete
+                                </button>
+                            </div>
+                        {/if}
+                    </div>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .manage-items {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .controls {
+        margin-bottom: 30px;
+    }
+
+    .controls input {
+        padding: 10px;
+        border-radius: 8px;
+        background: #68d46d;
+        color: black;
+        border: 2px solid #007006;
+        font-size: 16px;
+        width: 200px;
+    }
+
+    .item-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        padding: 15px;
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+    }
+
+    .item-actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    .edit-button,
+    .delete-button {
+        padding: 8px 16px;
+        border-radius: 6px;
+        border: none;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background-color 0.2s;
+    }
+
+    .edit-button {
+        background-color: #007006;
+        color: white;
+    }
+
+    .delete-button {
+        background-color: #dd3333;
+        color: white;
+    }
+
+    .edit-button:hover {
+        background-color: #005004;
+    }
+
+    .delete-button:hover {
+        background-color: #bb2222;
+    }
+
+    .no-items {
+        text-align: center;
+        padding: 40px;
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+        color: white;
+    }
+</style>


### PR DESCRIPTION
## Summary
- implement item management page with search, edit and delete
- add Playwright test for item management
- mark `Item Management` complete in changelog

## Testing
- `npm run coverage`
- `SKIP_E2E=1 npm run test:pr`
- `npx playwright test` *(fails: Missing host dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885b1997e88832fa410dbda5b70838c