### PR TITLE
Add compile test for QuestFormPage

### DIFF
--- a/frontend/__tests__/QuestFormPageCompile.test.js
+++ b/frontend/__tests__/QuestFormPageCompile.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('QuestFormPage component', () => {
+    test('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/components/svelte/QuestFormPage.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary
- add Jest test ensuring `QuestFormPage.svelte` compiles

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885b4be356c832f94fefa98fb222ed6