### PR TITLE
Add tests for ManageItems page

### DIFF
--- a/frontend/__tests__/ManageItems.test.js
+++ b/frontend/__tests__/ManageItems.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('ManageItems component', () => {
+    it('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/inventory/svelte/ManageItems.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
+});

--- a/frontend/__tests__/manageInventoryPage.test.js
+++ b/frontend/__tests__/manageInventoryPage.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from '@jest/globals';
+
+const pageFile = path.join(__dirname, '../src/pages/inventory/manage.astro');
+
+describe('inventory manage page', () => {
+    it('loads ManageItems component', () => {
+        const content = fs.readFileSync(pageFile, 'utf8');
+        expect(content).toMatch(/import ManageItems from '.\/svelte\/ManageItems\.svelte'/);
+        expect(content).toMatch(/<ManageItems client:load/);
+    });
+});

--- a/frontend/__tests__/uiMetrics.test.js
+++ b/frontend/__tests__/uiMetrics.test.js
@@ -11,4 +11,3 @@ describe('calculateHydrationTime', () => {
         expect(() => calculateHydrationTime(1, 'b')).toThrow();
     });
 });
-

--- a/frontend/e2e/quest-form-validation.spec.ts
+++ b/frontend/e2e/quest-form-validation.spec.ts
@@ -2,21 +2,21 @@ import { test, expect } from '@playwright/test';
 import { clearUserData } from './test-helpers';
 
 test.describe('Quest Form Live Validation', () => {
-  test.beforeEach(async ({ page }) => {
-    await clearUserData(page);
-  });
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
 
-  test('shows validation errors while typing', async ({ page }) => {
-    await page.goto('/quests/create');
-    await page.waitForLoadState('networkidle');
+    test('shows validation errors while typing', async ({ page }) => {
+        await page.goto('/quests/create');
+        await page.waitForLoadState('networkidle');
 
-    const titleInput = page.locator('#title');
-    const descInput = page.locator('#description');
+        const titleInput = page.locator('#title');
+        const descInput = page.locator('#description');
 
-    await titleInput.fill('ab');
-    await expect(page.locator('.error-message')).toContainText('at least 3 characters');
+        await titleInput.fill('ab');
+        await expect(page.locator('.error-message')).toContainText('at least 3 characters');
 
-    await descInput.fill('short');
-    await expect(page.locator('.error-message')).toContainText('at least 10 characters');
-  });
+        await descInput.fill('short');
+        await expect(page.locator('.error-message')).toContainText('at least 10 characters');
+    });
 });

--- a/frontend/e2e/ui-responsiveness.spec.ts
+++ b/frontend/e2e/ui-responsiveness.spec.ts
@@ -13,4 +13,3 @@ test.describe('UI Responsiveness Metrics', () => {
         expect(text).toMatch(/Hydration time: \d+ ms/);
     });
 });
-

--- a/frontend/src/components/svelte/QuestPRForm.svelte
+++ b/frontend/src/components/svelte/QuestPRForm.svelte
@@ -78,7 +78,13 @@
 <form on:submit={handleSubmit} class="pr-form">
     <div class="form-group">
         <label for="token">GitHub Token*</label>
-        <input id="token" type="password" bind:value={token} class:error={validationErrors.token} required />
+        <input
+            id="token"
+            type="password"
+            bind:value={token}
+            class:error={validationErrors.token}
+            required
+        />
         {#if validationErrors.token}
             <span class="error-message">{validationErrors.token}</span>
         {/if}
@@ -89,7 +95,13 @@
     </div>
     <div class="form-group">
         <label for="quest">Quest JSON*</label>
-        <textarea id="quest" bind:value={questJson} rows="10" class:error={validationErrors.quest} required />
+        <textarea
+            id="quest"
+            bind:value={questJson}
+            rows="10"
+            class:error={validationErrors.quest}
+            required
+        />
         {#if validationErrors.quest}
             <span class="error-message">{validationErrors.quest}</span>
         {/if}

--- a/frontend/src/components/svelte/UIResponsiveness.svelte
+++ b/frontend/src/components/svelte/UIResponsiveness.svelte
@@ -19,4 +19,3 @@
         font-size: 0.9rem;
     }
 </style>
-

--- a/frontend/src/utils/githubToken.js
+++ b/frontend/src/utils/githubToken.js
@@ -1,9 +1,6 @@
 export function isValidGitHubToken(token) {
     if (!token) return false;
     const trimmed = token.trim();
-    const patterns = [
-        /^gh[pousr]_[A-Za-z0-9_]{36,}$/i,
-        /^github_pat_[A-Za-z0-9_]{22,}$/i,
-    ];
+    const patterns = [/^gh[pousr]_[A-Za-z0-9_]{36,}$/i, /^github_pat_[A-Za-z0-9_]{22,}$/i];
     return patterns.some((p) => p.test(trimmed));
 }

--- a/frontend/src/utils/uiMetrics.js
+++ b/frontend/src/utils/uiMetrics.js
@@ -4,4 +4,3 @@ export function calculateHydrationTime(start, end) {
     }
     return end - start;
 }
-


### PR DESCRIPTION
## Summary
- add compile test for ManageItems.svelte
- check manage inventory page imports ManageItems
- run Prettier on several frontend files to satisfy repo style checks

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885b7452954832f88520a31964efd6a