### PR TITLE
Add custom content bundle system

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ steps, run the dedicated test:
 Use `npm run generate-quest` to scaffold a new quest with placeholder dialogue.
 ```
 
+Custom quests often rely on new items or processes. Use [`scripts/create-content-bundle.js`](./scripts/create-content-bundle.js) to package these together. See the [Custom Content Bundles](docs/custom-bundles) guide for details.
+
 Additional quality checks are available:
 
 ```bash
@@ -264,3 +266,4 @@ files help prevent accidental removals.
 ## License
 
 DSPACE is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/frontend/src/pages/docs/md/custom-content-bundles.md
+++ b/frontend/src/pages/docs/md/custom-content-bundles.md
@@ -1,0 +1,24 @@
+---
+title: 'Custom Content Bundles'
+slug: 'custom-bundles'
+---
+
+# Custom Content Bundles
+
+To keep quests, items, and processes in sync, submissions should include all related content in a single **bundle** file. Bundles live under `submissions/bundles` and use a simple JSON format:
+
+```json
+{
+    "quests": [],
+    "items": [],
+    "processes": []
+}
+```
+
+Each array contains standard objects that follow the existing schemas for quests, items, and processes. You can create a bundle with the script:
+
+```bash
+node scripts/create-content-bundle.js submissions/bundles/my-bundle.json path/to/quest.json --items path/to/item.json --processes path/to/process.json
+```
+
+The script resolves glob patterns so multiple files can be included at once. Commit the generated file in your pull request. Reviewers can load the bundle locally to verify your custom content.

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -15,20 +15,21 @@ This guide describes how to submit your custom quests to become part of the offi
 ## Steps
 
 1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. The command `npm run generate-quest` can scaffold a template for you.
-2. **Validate** the quest structure by running:
+2. **Bundle related items and processes** using `scripts/create-content-bundle.js`. This script collects quests, items, and processes into a single JSON file under `submissions/bundles`.
+3. **Validate** the quest structure by running:
     ```bash
     npm test -- questValidation
     ```
     Ensure your quest file passes all schema checks.
-3. **Check quest quality** with:
+4. **Check quest quality** with:
     ```bash
     npm test -- questQuality
     ```
     Review any warnings and make improvements where necessary.
-4. **Open the Quest Submission form** at `/quests/submit`.
-5. **Authorize GitHub** by entering a personal access token with `repo` scope. The token is only used client-side to push your quest.
-6. **Create the pull request** directly from the form. This uploads your quest to a new branch and opens a draft PR.
-7. **Respond to feedback** from reviewers until your quest meets project standards.
+5. **Open the Quest Submission form** at `/quests/submit`.
+6. **Authorize GitHub** by entering a personal access token with `repo` scope. The token is only used client-side to push your quest.
+7. **Create the pull request** directly from the form. This uploads your quest to a new branch and opens a draft PR.
+8. **Respond to feedback** from reviewers until your quest meets project standards.
 
 Once merged, your quest will be included in the next game update!
 

--- a/scripts/create-content-bundle.js
+++ b/scripts/create-content-bundle.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+function collect(patterns) {
+  const files = patterns.flatMap((p) => glob.sync(p));
+  return files.map((f) => JSON.parse(fs.readFileSync(f, 'utf8')));
+}
+
+function parseArgs(args) {
+  const quests = [];
+  const items = [];
+  const processes = [];
+  let current = quests;
+  for (const arg of args) {
+    if (arg === '--items') {
+      current = items;
+    } else if (arg === '--processes') {
+      current = processes;
+    } else {
+      current.push(arg);
+    }
+  }
+  return { quests, items, processes };
+}
+
+function main() {
+  if (process.argv.length < 4) {
+    console.error('Usage: node scripts/create-content-bundle.js <output> <quest-glob...> [--items <item-glob...>] [--processes <process-glob...>]');
+    process.exit(1);
+  }
+  const output = path.resolve(process.argv[2]);
+  const { quests, items, processes } = parseArgs(process.argv.slice(3));
+
+  const bundle = {
+    quests: collect(quests),
+    items: collect(items),
+    processes: collect(processes),
+  };
+
+  fs.writeFileSync(output, JSON.stringify(bundle, null, 4));
+  console.log(`Bundle written to ${output}`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- document how to bundle quests, items and processes for PRs
- mention bundling in the Quest Submission Guide and README
- add helper script `create-content-bundle.js` to generate bundle files

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885bf9d7810832fa2182839332c1217