### PR TITLE
Improve content bundle coverage

### DIFF
--- a/scripts/create-content-bundle.js
+++ b/scripts/create-content-bundle.js
@@ -25,14 +25,7 @@ function parseArgs(args) {
   return { quests, items, processes };
 }
 
-function main() {
-  if (process.argv.length < 4) {
-    console.error('Usage: node scripts/create-content-bundle.js <output> <quest-glob...> [--items <item-glob...>] [--processes <process-glob...>]');
-    process.exit(1);
-  }
-  const output = path.resolve(process.argv[2]);
-  const { quests, items, processes } = parseArgs(process.argv.slice(3));
-
+function createBundle(output, { quests = [], items = [], processes = [] }) {
   const bundle = {
     quests: collect(quests),
     items: collect(items),
@@ -40,9 +33,23 @@ function main() {
   };
 
   fs.writeFileSync(output, JSON.stringify(bundle, null, 4));
+  return bundle;
+}
+
+function main() {
+  if (process.argv.length < 4) {
+    console.error('Usage: node scripts/create-content-bundle.js <output> <quest-glob...> [--items <item-glob...>] [--processes <process-glob...>]');
+    process.exit(1);
+  }
+  const output = path.resolve(process.argv[2]);
+  const args = parseArgs(process.argv.slice(3));
+
+  createBundle(output, args);
   console.log(`Bundle written to ${output}`);
 }
 
 if (require.main === module) {
   main();
 }
+
+module.exports = { parseArgs, createBundle, collect };

--- a/scripts/tests/createContentBundle.test.js
+++ b/scripts/tests/createContentBundle.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { parseArgs, createBundle } = require('../create-content-bundle');
+
+describe('create-content-bundle script', () => {
+  test('parseArgs groups patterns correctly', () => {
+    const args = ['q1.json', 'q2.json', '--items', 'item.json', '--processes', 'proc1.json', 'proc2.json'];
+    const parsed = parseArgs(args);
+    expect(parsed.quests).toEqual(['q1.json', 'q2.json']);
+    expect(parsed.items).toEqual(['item.json']);
+    expect(parsed.processes).toEqual(['proc1.json', 'proc2.json']);
+  });
+
+  test('createBundle collects files and writes bundle', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-test-'));
+    const q = path.join(dir, 'quest.json');
+    const i = path.join(dir, 'item.json');
+    const p = path.join(dir, 'proc.json');
+    fs.writeFileSync(q, JSON.stringify({ id: 1 }));
+    fs.writeFileSync(i, JSON.stringify({ id: 2 }));
+    fs.writeFileSync(p, JSON.stringify({ id: 3 }));
+    const output = path.join(dir, 'bundle.json');
+
+    const result = createBundle(output, { quests: [q], items: [i], processes: [p] });
+    const data = JSON.parse(fs.readFileSync(output, 'utf8'));
+
+    expect(result).toEqual(data);
+    expect(data.quests[0].id).toBe(1);
+    expect(data.items[0].id).toBe(2);
+    expect(data.processes[0].id).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- export functions from `create-content-bundle.js`
- add unit tests for the bundle script

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6885c27520f8832f9c970474a035610a