### PR TITLE
Improve QuestPRForm test coverage

### DIFF
--- a/frontend/__tests__/QuestPRFormComponent.test.js
+++ b/frontend/__tests__/QuestPRFormComponent.test.js
@@ -1,0 +1,10 @@
+/**
+ * @jest-environment jsdom
+ */
+import QuestPRForm from '../src/components/svelte/QuestPRForm.svelte';
+
+describe('QuestPRForm component', () => {
+    it('exports a valid Svelte component', () => {
+        expect(typeof QuestPRForm).toBe('function');
+    });
+});

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -265,6 +265,7 @@ jest.mock('svelte/internal', () => {
                 console.warn('Error in dispatch_dev:', error);
             }
         },
+        globals: { Error },
         validate_component: jest.fn(),
         validate_slots: jest.fn(),
         validate_store: jest.fn(),


### PR DESCRIPTION
## Summary
- add minimal Jest test for QuestPRForm component
- expose `globals` in Jest setup for Svelte tests

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885c1f0b270832fb5cdb034b63424ca