### PR TITLE
Fix coverage for jest setup

### DIFF
--- a/frontend/__tests__/jestSetup.test.js
+++ b/frontend/__tests__/jestSetup.test.js
@@ -29,6 +29,8 @@ describe('jest.setup.js', () => {
 
     test('polyfills browser globals when none exist', () => {
         require(PATH);
+        const svelteInternal = require('svelte/internal');
+        expect(svelteInternal.globals.Error).toBe(Error);
 
         // Setup script overrides the initial href during configuration
         expect(global.window.location.href).toBe('http://localhost:3000/');


### PR DESCRIPTION
## Summary
- add coverage check for svelte Error polyfill

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885c490957c832fb77795224355c31b