### PR TITLE
Add Codex implementation prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -47,6 +47,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prs">Pull Requests</a>
             <a href="/docs/bounties">Bounties</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
+            <a href="/docs/prompts-codex">Codex prompts</a>
         </nav>
      </span>
 </Page>

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -60,7 +60,7 @@ Instructions for creating processes that transform or utilize items. Topics incl
 
 ## AI Assistance for Content Creation
 
-For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests) that can be used with modern AI assistants. This guide includes:
+For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex). It walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. This guide includes:
 
 -   Effective prompt templates for different content types
 -   Best practices for working with AI assistants

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Implementation Prompt'
+slug: 'prompts-codex'
+---
+
+# OpenAI Codex Implementation Prompt
+
+Use this prompt whenever you want Codex to automatically clear backlog tasks.
+It instructs the agent to choose **any** unchecked item from the
+[September 1, 2025 changelog](/docs/changelog/20250901) and fully implement it.
+Each run should pick a different item until the checklist is complete.
+
+```
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Choose **one** unchecked item from `frontend/src/pages/docs/md/changelog/20250901.md` and implement it completely. If the item has unchecked sub-tasks, complete those as well. Provide all required code, configuration, and documentation. Where browser interaction is relevant, write Playwright tests to verify functionality. Ensure all new code is fully covered by unit and integration tests.
+
+Always run `npm run test:pr` before committing to ensure code style and all tests pass. If browsers are missing run `npx playwright install chromium` or prefix commands with `SKIP_E2E=1`.
+
+USER:
+1. Open `frontend/src/pages/docs/md/changelog/20250901.md` and select an unchecked item that you are confident you can implement.
+2. Implement the selected feature, including all unchecked sub-tasks, using the existing project architecture and style.
+3. Add or update documentation describing the new functionality.
+4. Provide comprehensive unit tests and Playwright tests (when applicable) to achieve complete coverage for the newly added code.
+5. Run `npm run test:pr` and ensure all checks pass before committing.
+6. After the pull request is merged, revise this prompt to incorporate any lessons learned so the next run is even smoother.
+
+OUTPUT:
+A pull request implementing the chosen changelog item with all tests green. Summarize which task was completed and highlight test results in the PR body.
+```
+
+Copy this entire block into Codex to automate the feature. After each successful run, refine the instructions in this file to keep them effective.


### PR DESCRIPTION
## Summary
- document a repeatable Codex prompt that chooses any unchecked changelog item to implement
- clarify prompt behavior in the Content Development guide

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885c33fbc3c832fbb13ae42e122c1fb