### PR TITLE
Add docs index test for new link

### DIFF
--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from '@jest/globals';
+
+const docsIndexFile = path.join(__dirname, '../src/pages/docs/index.astro');
+
+describe('docs index.astro', () => {
+    it('links to the Codex prompts docs page', () => {
+        const content = fs.readFileSync(docsIndexFile, 'utf8');
+        expect(content).toMatch(/<a href="\/docs\/prompts-codex">Codex prompts<\/a>/);
+    });
+});


### PR DESCRIPTION
## Summary
- add a Jest test to cover the Codex prompts link in `docs/index.astro`

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885c6bca6d4832f99ca91ba09d00689