### PR TITLE
Fix bad contributors link

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -335,7 +335,7 @@ Custom content integrates seamlessly with built-in game content.
 
 ## Contributing
 
-Please see the [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v2.1/CONTRIBUTORS.md) and our [Developer Guide](../DEVELOPER_GUIDE.md) for detailed information on contributing to DSPACE.
+Please see the [Contribution Guide](../CONTRIBUTORS.md) and our [Developer Guide](../DEVELOPER_GUIDE.md) for detailed information on contributing to DSPACE.
 
 ## Community
 


### PR DESCRIPTION
## Summary
- repair the CONTRIBUTING link in frontend README

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885cbf5dbd0832f9cd8650b09e9d9b4