### PR TITLE
Add monitoring setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm hooks don't run during the build.
 The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).
+To add Prometheus and Grafana monitoring, follow the steps in [docs/monitoring_setup.md](./docs/monitoring_setup.md).
 
 ### Automated Raspberry Pi Deployment
 

--- a/docs/monitoring_setup.md
+++ b/docs/monitoring_setup.md
@@ -1,0 +1,32 @@
+# Monitoring Setup
+
+This guide explains how to run Prometheus and Grafana to monitor your self-hosted DSPACE instance.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- DSPACE running via `docker compose`
+
+## Quick Start
+
+1. From the repository root, run:
+   ```bash
+   cd monitoring
+   docker compose up -d
+   ```
+   This will start Prometheus on port **9090** and Grafana on **3001**.
+
+2. Open `http://localhost:3001` in your browser and log in with the default credentials (`admin`/`admin`). You'll be prompted to change the password on first login.
+
+3. Add Prometheus as a data source in Grafana using the URL `http://prometheus:9090`.
+
+You can now create dashboards to track container resource usage and any custom metrics you expose.
+
+## Configuration
+
+The `docker-compose.yml` file defines two services:
+
+- **prometheus** – stores metrics using the configuration in `prometheus/prometheus.yml`.
+- **grafana** – visualizes data from Prometheus and persists settings in the `grafana-data` volume.
+
+Feel free to modify `prometheus/prometheus.yml` to scrape additional targets such as node exporters.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -61,7 +61,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Load balancer setup
         -   [x] Backup system ✅
         -   [x] Failover procedures ✅
-        -   [ ] Monitoring setup
+        -   [x] Monitoring setup
     -   [x] Migration from Netlify
 -   [x] License Migration
 -   [ ] Testing & QA

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+volumes:
+  grafana-data:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- document how to run Prometheus/Grafana for monitoring
- include docker compose configuration
- link docs from README
- check off monitoring setup in changelog

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6885ccb8476c832f9ab0a3350a0326d7