### PR TITLE
Add monitoring endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ npm hooks don't run during the build.
 
 The app will be available on port 3002. Point your Cloudflare Tunnel at `http://localhost:3002` to serve traffic.
 
+The server exposes two monitoring endpoints:
+
+- `GET /health` returns `{ "status": "ok" }` for basic liveness checks.
+- `GET /metrics` serves Prometheus-formatted metrics using `prom-client`.
+
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).
 
 ### Automated Raspberry Pi Deployment

--- a/frontend/__tests__/healthEndpoint.test.js
+++ b/frontend/__tests__/healthEndpoint.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+import { GET as healthGET } from '../src/pages/health.ts';
+
+import { describe, it, expect } from '@jest/globals';
+
+describe('health endpoint', () => {
+    it('returns status ok', async () => {
+        const res = await healthGET();
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toEqual({ status: 'ok' });
+    });
+});

--- a/frontend/__tests__/metricsEndpoint.test.js
+++ b/frontend/__tests__/metricsEndpoint.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+import { GET as metricsGET } from '../src/pages/metrics.ts';
+
+import { describe, it, expect } from '@jest/globals';
+
+describe('metrics endpoint', () => {
+    it('returns prometheus metrics', async () => {
+        const res = await metricsGET();
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain('# HELP');
+    });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
                 "openai": "^3.2.1",
                 "postcss": "^8.4.23",
                 "pretty-date": "^0.2.0",
+                "prom-client": "^15.1.0",
                 "remarkable": "^2.0.1"
             },
             "devDependencies": {
@@ -3153,6 +3154,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4440,6 +4450,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/bintrees": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+            "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+            "license": "MIT"
         },
         "node_modules/bl": {
             "version": "5.1.0",
@@ -11081,6 +11097,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/prom-client": {
+            "version": "15.1.3",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+            "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.4.0",
+                "tdigest": "^0.1.1"
+            },
+            "engines": {
+                "node": "^16 || ^18 || >=20"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12459,6 +12488,15 @@
             },
             "funding": {
                 "url": "https://opencollective.com/unts"
+            }
+        },
+        "node_modules/tdigest": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+            "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+            "license": "MIT",
+            "dependencies": {
+                "bintrees": "1.0.2"
             }
         },
         "node_modules/test-exclude": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,8 @@
         "openai": "^3.2.1",
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",
-        "remarkable": "^2.0.1"
+        "remarkable": "^2.0.1",
+        "prom-client": "^15.1.0"
     },
     "license": "MIT"
 }

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -61,7 +61,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Load balancer setup
         -   [x] Backup system ✅
         -   [x] Failover procedures ✅
-        -   [ ] Monitoring setup
+        -   [x] Monitoring setup
     -   [x] Migration from Netlify
 -   [x] License Migration
 -   [ ] Testing & QA

--- a/frontend/src/pages/health.ts
+++ b/frontend/src/pages/health.ts
@@ -1,0 +1,7 @@
+export const prerender = false;
+
+export async function GET() {
+    return new Response(JSON.stringify({ status: 'ok' }), {
+        headers: { 'Content-Type': 'application/json' },
+    });
+}

--- a/frontend/src/pages/metrics.ts
+++ b/frontend/src/pages/metrics.ts
@@ -1,0 +1,10 @@
+import { register } from '../utils/metrics.js';
+
+export const prerender = false;
+
+export async function GET() {
+    const metrics = await register.metrics();
+    return new Response(metrics, {
+        headers: { 'Content-Type': register.contentType },
+    });
+}

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,0 +1,6 @@
+import { Registry, collectDefaultMetrics } from 'prom-client';
+
+const register = new Registry();
+collectDefaultMetrics({ register });
+
+export { register };


### PR DESCRIPTION
## Summary
- add /health and /metrics endpoints
- expose metrics via prom-client and add docs
- mark monitoring setup complete in changelog
- test new endpoints

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6885ccb8476c832f9ab0a3350a0326d7