### PR TITLE
Improve monitoring endpoint coverage

### DIFF
--- a/frontend/__tests__/healthEndpoint.test.js
+++ b/frontend/__tests__/healthEndpoint.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { GET as healthGET } from '../src/pages/health.ts';
+import { GET as healthGET, prerender } from '../src/pages/health.ts';
 
 import { describe, it, expect } from '@jest/globals';
 
@@ -9,5 +9,8 @@ describe('health endpoint', () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body).toEqual({ status: 'ok' });
+    });
+    it('is not prerendered', () => {
+        expect(prerender).toBe(false);
     });
 });

--- a/frontend/__tests__/metricsEndpoint.test.js
+++ b/frontend/__tests__/metricsEndpoint.test.js
@@ -1,5 +1,6 @@
 /** @jest-environment node */
-import { GET as metricsGET } from '../src/pages/metrics.ts';
+import { GET as metricsGET, prerender } from '../src/pages/metrics.ts';
+import { register } from '../src/utils/metrics.js';
 
 import { describe, it, expect } from '@jest/globals';
 
@@ -9,5 +10,9 @@ describe('metrics endpoint', () => {
         expect(res.status).toBe(200);
         const text = await res.text();
         expect(text).toContain('# HELP');
+        expect(res.headers.get('content-type')).toBe(register.contentType);
+    });
+    it('is not prerendered', () => {
+        expect(prerender).toBe(false);
     });
 });

--- a/frontend/__tests__/metricsUtil.test.js
+++ b/frontend/__tests__/metricsUtil.test.js
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+import { register } from '../src/utils/metrics.js';
+import { describe, it, expect } from '@jest/globals';
+
+describe('metrics utils', () => {
+    it('exposes a Registry instance', () => {
+        expect(typeof register.metrics).toBe('function');
+        expect(typeof register.contentType).toBe('string');
+    });
+});


### PR DESCRIPTION
## Summary
- test metrics utils
- confirm `/health` and `/metrics` endpoints are not prerendered
- verify metrics endpoint returns the expected content-type

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885cf4ddba4832f91f34fdc5b4952e9