### PR TITLE
Fix token.place link

### DIFF
--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -5,7 +5,7 @@ slug: 'quest-template'
 
 # Quest Template Example
 
-This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://github.com/futuroptimist/token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
+This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- fix link to token.place in quest template doc

## Testing
- `npm run check` *(fails: eslint plugin missing)*
- `SKIP_E2E=1 npm run test:pr` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885d19ade54832fa374e74fa7cd1caf