### PR TITLE
Implement authentication audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ npx playwright install chromium
 
 This cross-platform script will:
 
--   Check code formatting and linting
--   Run all unit tests
--   Run all end-to-end tests in optimized groups
--   Provide helpful error messages if any tests fail
+- Check code formatting and linting
+- Run all unit tests
+- Run all end-to-end tests in optimized groups
+- Provide helpful error messages if any tests fail
 
 The `test:pr` command handles everything automatically, including starting and stopping the development server for end-to-end tests.
 
@@ -74,8 +74,8 @@ The `test:pr` command handles everything automatically, including starting and s
 
 For detailed information about our testing approach, please refer to:
 
--   [Testing Guide](./frontend/TESTING.md) - Comprehensive documentation on testing practices, common issues, and debugging techniques
--   [Developer Guide](./DEVELOPER_GUIDE.md#testing-strategy) - Higher-level overview of our testing strategy and approach
+- [Testing Guide](./frontend/TESTING.md) - Comprehensive documentation on testing practices, common issues, and debugging techniques
+- [Developer Guide](./DEVELOPER_GUIDE.md#testing-strategy) - Higher-level overview of our testing strategy and approach
 
 For common test commands, see the section below.
 
@@ -146,10 +146,10 @@ Trigger the workflow manually or on pushes to `v3` to update the Pi and restart 
 
 DSPACE uses a modern JavaScript architecture:
 
--   **ES Modules**: Native JavaScript modules with import/export syntax
--   **Astro SSR**: Server-side rendering with hydration of Svelte components
--   **Progressive Enhancement**: Core functionality works without JavaScript
--   **Continuous Testing**: Unit and e2e tests ensure consistent quality
+- **ES Modules**: Native JavaScript modules with import/export syntax
+- **Astro SSR**: Server-side rendering with hydration of Svelte components
+- **Progressive Enhancement**: Core functionality works without JavaScript
+- **Continuous Testing**: Unit and e2e tests ensure consistent quality
 
 For detailed information on the architecture, see our [Developer Guide](./DEVELOPER_GUIDE.md).
 
@@ -157,12 +157,12 @@ For detailed information on the architecture, see our [Developer Guide](./DEVELO
 
 For comprehensive information about developing DSPACE, see our [Developer Guide](./DEVELOPER_GUIDE.md). This guide includes:
 
--   Detailed architecture overview
--   Component development guidelines
--   [UI Lifecycle Overview](./frontend/src/pages/docs/md/ui-lifecycle.md) for understanding Astro SSR and Svelte hydration
--   Testing strategies
--   Performance considerations
--   Troubleshooting tips
+- Detailed architecture overview
+- Component development guidelines
+- [UI Lifecycle Overview](./frontend/src/pages/docs/md/ui-lifecycle.md) for understanding Astro SSR and Svelte hydration
+- Testing strategies
+- Performance considerations
+- Troubleshooting tips
 
 ## Built-in Quests
 
@@ -233,6 +233,10 @@ guide. It includes ready-made prompt templates for tools like GPT-4 or Claude to
 help you generate dialogue and structure quickly. Combine these with the
 [Quest Development Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template), and the [Quest Submission Guide](docs/quest-submission) to streamline content creation and sharing.
 
+## Authentication
+
+Quest submissions require a GitHub personal access token. See [Authentication Flow](docs/AUTHENTICATION.md) for details on how DSPACE handles these tokens securely.
+
 ### Staying Updated
 
 We frequently merge improvements from the `v3` branch. Keep your fork current:
@@ -266,4 +270,3 @@ files help prevent accidental removals.
 ## License
 
 DSPACE is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,10 @@
+# Authentication Flow
+
+DSPACE avoids traditional user accounts. The only time authentication occurs is when you submit a custom quest to GitHub.
+
+1. Generate a personal access token with `repo` scope on GitHub.
+2. Enter the token in the Quest Submission form at `/quests/submit`.
+3. The token is sent directly to the GitHub API to create a branch and pull request.
+4. After the request completes, the form clears the token field so it is not stored in the browser.
+
+Tokens are never saved to localStorage or sent to any server other than GitHub. You can revoke the token at any time from your GitHub settings.

--- a/frontend/__tests__/submitQuestPR.test.js
+++ b/frontend/__tests__/submitQuestPR.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import { submitQuestPR } from '../src/utils/submitQuestPR.js';
+
+describe('submitQuestPR', () => {
+    beforeEach(() => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValueOnce({ ok: true, text: () => '', json: () => ({}) })
+            .mockResolvedValueOnce({ ok: true, json: () => ({ html_url: 'http://pr' }) });
+    });
+
+    it('calls GitHub APIs with auth header and returns PR url', async () => {
+        const url = await submitQuestPR('ghp_123', '', '{"a":1}');
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const [firstCall] = global.fetch.mock.calls;
+        expect(firstCall[1].headers.Authorization).toBe('token ghp_123');
+        expect(url).toBe('http://pr');
+    });
+});

--- a/frontend/e2e/quest-pr-form.spec.ts
+++ b/frontend/e2e/quest-pr-form.spec.ts
@@ -23,4 +23,9 @@ test('quest PR form submits and shows link', async ({ page }) => {
     await page.fill('#quest', '{"title":"t","description":"d"}');
     await page.click('button:has-text("Create Pull Request")');
     await expect(page.getByTestId('pr-link')).toHaveAttribute('href', 'https://example.com/pr/1');
+    await expect(page.locator('#token')).toHaveValue('');
+    const tokenKeys = await page.evaluate(() =>
+        Object.keys(localStorage).filter((k) => k.toLowerCase().includes('token'))
+    );
+    expect(tokenKeys.length).toBe(0);
 });

--- a/frontend/src/components/svelte/QuestPRForm.svelte
+++ b/frontend/src/components/svelte/QuestPRForm.svelte
@@ -7,10 +7,7 @@
     let validationErrors = {};
     const dispatch = createEventDispatcher();
     import { isValidGitHubToken } from '../../utils/githubToken.js';
-
-    function b64(str) {
-        return btoa(unescape(encodeURIComponent(str)));
-    }
+    import { submitQuestPR } from '../../utils/submitQuestPR.js';
 
     function validateForm() {
         const errors = {};
@@ -31,48 +28,17 @@
             return;
         }
         try {
-            const branchName = branch || `quest-${Date.now()}`;
-            const headers = {
-                Authorization: `token ${token}`,
-                'Content-Type': 'application/json',
-            };
-            const content = b64(questJson);
-            const filePath = `submissions/quests/${branchName}.json`;
-            const res = await fetch(
-                `https://api.github.com/repos/democratizedspace/dspace/contents/${filePath}`,
-                {
-                    method: 'PUT',
-                    headers,
-                    body: JSON.stringify({
-                        message: 'Add quest submission',
-                        content,
-                        branch: branchName,
-                    }),
-                }
-            );
-            if (!res.ok) throw new Error(await res.text());
-            const prRes = await fetch(
-                'https://api.github.com/repos/democratizedspace/dspace/pulls',
-                {
-                    method: 'POST',
-                    headers,
-                    body: JSON.stringify({
-                        title: `Quest submission: ${branchName}`,
-                        head: branchName,
-                        base: 'v3',
-                        body: 'Automated quest submission.',
-                    }),
-                }
-            );
-            if (!prRes.ok) throw new Error(await prRes.text());
-            const prData = await prRes.json();
-            prUrl = prData.html_url;
+            prUrl = await submitQuestPR(token, branch, questJson);
             dispatch('success', { message: 'Pull request created', url: prUrl });
+            token = '';
         } catch (err) {
             console.error(err);
             dispatch('error', { message: 'Failed to submit quest' });
+            token = '';
         }
     }
+
+    export { handleSubmit };
 </script>
 
 <form on:submit={handleSubmit} class="pr-form">

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -80,7 +80,9 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Security audit
         -   [x] Review content validation
         -   [x] Check data sanitization
-        -   [ ] Audit authentication flow
+        -   [x] Audit authentication flow ✅
+
+Authentication for the quest submission form was audited. Tokens are now cleared after use and never stored locally. See the new [Authentication Flow](/docs/authentication) documentation for details.
 
 _Note: This checklist will be removed before the final release._
 

--- a/frontend/src/utils/submitQuestPR.js
+++ b/frontend/src/utils/submitQuestPR.js
@@ -1,0 +1,31 @@
+export async function submitQuestPR(token, branch, questJson) {
+    const branchName = branch || `quest-${Date.now()}`;
+    const headers = {
+        Authorization: `token ${token}`,
+        'Content-Type': 'application/json',
+    };
+    const content = btoa(unescape(encodeURIComponent(questJson)));
+    const filePath = `submissions/quests/${branchName}.json`;
+    const res = await fetch(
+        `https://api.github.com/repos/democratizedspace/dspace/contents/${filePath}`,
+        {
+            method: 'PUT',
+            headers,
+            body: JSON.stringify({ message: 'Add quest submission', content, branch: branchName }),
+        }
+    );
+    if (!res.ok) throw new Error(await res.text());
+    const prRes = await fetch('https://api.github.com/repos/democratizedspace/dspace/pulls', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            title: `Quest submission: ${branchName}`,
+            head: branchName,
+            base: 'v3',
+            body: 'Automated quest submission.',
+        }),
+    });
+    if (!prRes.ok) throw new Error(await prRes.text());
+    const prData = await prRes.json();
+    return prData.html_url;
+}


### PR DESCRIPTION
## Summary
- add Authentication Flow document
- clear GitHub token after quest submission
- extract submission logic to `submitQuestPR`
- test quest PR token handling and update e2e scenario
- document new auth section in README
- mark authentication audit complete in changelog

## Testing
- `npm run test:pr`
- `SKIP_E2E=1 npm run coverage` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6885ccb8476c832f9ab0a3350a0326d7