### PR TITLE
docs: switch to cloudflare load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The server exposes two monitoring endpoints:
 
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).
 To add Prometheus and Grafana monitoring, follow the steps in [docs/monitoring_setup.md](./docs/monitoring_setup.md).
+For high availability, configure Cloudflare Load Balancing as described in [docs/cloudflare_load_balancing.md](./docs/cloudflare_load_balancing.md).
 
 ### Automated Raspberry Pi Deployment
 

--- a/docs/cloudflare_load_balancing.md
+++ b/docs/cloudflare_load_balancing.md
@@ -1,0 +1,30 @@
+# Cloudflare Load Balancing
+
+This guide explains how to load balance multiple DSPACE instances using Cloudflare Tunnel and Cloudflare Load Balancing.
+
+## Overview
+
+Instead of running an Nginx reverse proxy, each DSPACE instance exposes port **3002** through its own Cloudflare Tunnel. Cloudflare's load balancer distributes incoming traffic across these tunnels, providing high availability without additional infrastructure.
+
+## Steps
+
+1. **Create a tunnel for each instance**
+   ```bash
+   cloudflared tunnel create dspace-1
+   cloudflared tunnel route dns dspace-1 dspace.example.com
+   ```
+   Repeat for `dspace-2`, `dspace-3`, etc.
+
+2. **Enable Cloudflare Load Balancing**
+   - In the Cloudflare dashboard, open **Traffic → Load Balancing**.
+   - Create a load balancer with your domain (e.g. `dspace.example.com`).
+   - Add each tunnel as an origin. Cloudflare automatically health checks them.
+   - Optionally configure session affinity or geographic routing.
+
+3. **Update DNS**
+   Cloudflare manages the DNS records automatically for each tunnel. Once the load balancer is active, users are directed to a healthy instance.
+
+## Related Guides
+
+- [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md) – shows how to run DSPACE on a k3s cluster with Cloudflare Tunnel.
+- [Monitoring Setup](./monitoring_setup.md) – add Prometheus and Grafana to watch the health of each instance.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -58,7 +58,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Self-hosted setup documentation
     -   [x] Docker deployment
     -   [x] Redundancy implementation
-        -   [ ] Load balancer setup
+        -   [x] Load balancer setup
         -   [x] Backup system ✅
         -   [x] Failover procedures ✅
         -   [x] Monitoring setup


### PR DESCRIPTION
## Summary
- replace nginx load balancer guide with Cloudflare Load Balancing instructions
- drop unused docker-compose, nginx example, and related tests
- link to the new doc from the README

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885cf822e48832fa0ffc48e70eafbbe