### PR TITLE
Add Manage Processes page

### DIFF
--- a/frontend/__tests__/ManageProcesses.test.js
+++ b/frontend/__tests__/ManageProcesses.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('ManageProcesses component', () => {
+    it('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/processes/svelte/ManageProcesses.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
+});

--- a/frontend/e2e/manage-processes.spec.ts
+++ b/frontend/e2e/manage-processes.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData, waitForHydration, fillProcessForm } from './test-helpers';
+
+test.describe('Manage Processes', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('should list processes on manage page', async ({ page }) => {
+        await page.goto('/processes/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        const rows = page.locator('.process-row');
+        await expect(rows.first()).toBeVisible();
+    });
+
+    test('should create and delete a custom process via manage page', async ({ page }) => {
+        const title = `Delete Process ${Date.now()}`;
+
+        await page.goto('/processes/create');
+        await fillProcessForm(page, title, '1m', 0, 0, 0);
+        const submit = page.locator('button.submit-button');
+        await submit.click();
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/processes/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const row = page.locator('.process-row', { hasText: title }).first();
+        await expect(row).toBeVisible();
+
+        page.on('dialog', (d) => d.accept());
+        await row.locator('.delete-button').click();
+        await page.waitForTimeout(500);
+        await expect(page.locator(`text="${title}"`)).toHaveCount(0);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.locator(`text="${title}"`)).toHaveCount(0);
+
+        const exists = await page.evaluate(async (processTitle) => {
+            const openReq = indexedDB.open('CustomContent');
+            const db = await new Promise<IDBDatabase>((resolve, reject) => {
+                openReq.onsuccess = () => resolve(openReq.result);
+                openReq.onerror = () => reject(openReq.error);
+                openReq.onupgradeneeded = () => resolve(openReq.result);
+            });
+            const tx = db.transaction('processes', 'readonly');
+            const store = tx.objectStore('processes');
+            const req = store.getAll();
+            const processes = await new Promise<Array<{ title: string }>>((resolve, reject) => {
+                req.onsuccess = () => resolve(req.result as Array<{ title: string }>);
+                req.onerror = () => reject(req.error);
+            });
+            db.close();
+            return processes.some((p) => p.title === processTitle);
+        }, title);
+
+        expect(exists).toBe(false);
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -36,7 +36,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Item creation interface with ItemForm.svelte
     -   [x] Item validation schema
         -   [x] Item dependency tracking
-    -   [ ] Process System
+    -   [x] Process System
         -   [x] Process creation UI with duration handling
         -   [x] Required/consumed/created items selection
         -   [x] Process validation and testing

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -64,6 +64,12 @@ Starting with v3, you can create your own custom processes. When creating a cust
     - Consumed items are returned on cancellation
     - Progress is saved locally and persists between sessions
 
+## Process Management
+
+Use the **Manage Processes** page to review or delete custom entries. Built-in
+processes appear alongside any you've created locally. Access it at
+`/processes/manage`.
+
 ## Process Examples
 
 Here are some example processes from the base game:

--- a/frontend/src/pages/processes/manage.astro
+++ b/frontend/src/pages/processes/manage.astro
@@ -1,0 +1,9 @@
+---
+import Page from '../../components/Page.astro';
+import ManageProcesses from './svelte/ManageProcesses.svelte';
+import processes from './processes.json';
+---
+
+<Page title="Manage Processes">
+    <ManageProcesses client:load processes={processes} />
+</Page>

--- a/frontend/src/pages/processes/svelte/ManageProcesses.svelte
+++ b/frontend/src/pages/processes/svelte/ManageProcesses.svelte
@@ -1,0 +1,144 @@
+<script>
+    import { onMount } from 'svelte';
+    import Process from '../../../components/svelte/Process.svelte';
+    import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
+
+    export let processes = [];
+    let customProcesses = [];
+    let mounted = false;
+    let searchTerm = '';
+
+    onMount(async () => {
+        customProcesses = await db.list(ENTITY_TYPES.PROCESS);
+        mounted = true;
+    });
+
+    $: allProcesses = [...processes, ...customProcesses];
+    $: filteredProcesses = allProcesses.filter((process) =>
+        process.title.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    function handleEdit(id) {
+        window.location.href = `/processes/${id}/edit`;
+    }
+
+    async function handleDelete(id) {
+        if (confirm('Are you sure you want to delete this process?')) {
+            try {
+                await db.processes.delete(id);
+                customProcesses = customProcesses.filter((p) => p.id !== id);
+            } catch (err) {
+                console.error('Error deleting process:', err);
+                alert('Failed to delete process');
+            }
+        }
+    }
+</script>
+
+<div class="manage-processes">
+    {#if mounted}
+        <div class="controls">
+            <input type="text" bind:value={searchTerm} placeholder="Search processes..." />
+        </div>
+
+        <div class="processes-list">
+            {#if filteredProcesses.length === 0}
+                <div class="no-processes">No processes found</div>
+            {:else}
+                {#each filteredProcesses as process (process.id)}
+                    <div class="process-row">
+                        <Process processId={process.id} />
+                        {#if process.custom}
+                            <div class="process-actions">
+                                <button class="edit-button" on:click={() => handleEdit(process.id)}>
+                                    Edit
+                                </button>
+                                <button
+                                    class="delete-button"
+                                    on:click={() => handleDelete(process.id)}
+                                >
+                                    Delete
+                                </button>
+                            </div>
+                        {/if}
+                    </div>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .manage-processes {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .controls {
+        margin-bottom: 30px;
+    }
+
+    .controls input {
+        padding: 10px;
+        border-radius: 8px;
+        background: #68d46d;
+        color: black;
+        border: 2px solid #007006;
+        font-size: 16px;
+        width: 200px;
+    }
+
+    .process-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        padding: 15px;
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+    }
+
+    .process-actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    .edit-button,
+    .delete-button {
+        padding: 8px 16px;
+        border-radius: 6px;
+        border: none;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background-color 0.2s;
+    }
+
+    .edit-button {
+        background-color: #007006;
+        color: white;
+    }
+
+    .delete-button {
+        background-color: #dd3333;
+        color: white;
+    }
+
+    .edit-button:hover {
+        background-color: #005004;
+    }
+
+    .delete-button:hover {
+        background-color: #bb2222;
+    }
+
+    .no-processes {
+        text-align: center;
+        padding: 40px;
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+        color: white;
+    }
+</style>


### PR DESCRIPTION
## Summary
- implement a Manage Processes page and component
- document process management
- check off `Process System` in changelog
- add tests for ManageProcesses

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6885d1d35970832fbb300e7d2074415f