### PR TITLE
Add tests for GitHub token validation

### DIFF
--- a/frontend/__tests__/githubToken.test.js
+++ b/frontend/__tests__/githubToken.test.js
@@ -1,7 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { loadGitHubToken, saveGitHubToken, clearGitHubToken } from '../src/utils/githubToken.js';
+import {
+    loadGitHubToken,
+    saveGitHubToken,
+    clearGitHubToken,
+    isValidGitHubToken,
+} from '../src/utils/githubToken.js';
 
 describe('githubToken utils', () => {
     beforeEach(() => {
@@ -21,5 +26,12 @@ describe('githubToken utils', () => {
         expect(loadGitHubToken()).toBe('');
         const state = JSON.parse(localStorage.getItem('gameState'));
         expect(state.github.token).toBe('');
+    });
+
+    test('validates token format', () => {
+        expect(isValidGitHubToken('')).toBe(false);
+        expect(isValidGitHubToken('ghp_short')).toBe(false);
+        expect(isValidGitHubToken('ghp_123456789012345678901234567890123456')).toBe(true);
+        expect(isValidGitHubToken('github_pat_abcdefghijklmnopqrstuvwxyz')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- expand `githubToken.test.js` to cover `isValidGitHubToken`

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885d37407b8832f86c402bf9de45858