### PR TITLE
Add mobile responsive item/process forms

### DIFF
--- a/frontend/e2e/mobile-item-form.spec.ts
+++ b/frontend/e2e/mobile-item-form.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+// Verify the item creation form is usable on a small screen
+
+test('item creation page is usable on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/inventory/create');
+    await page.waitForLoadState('networkidle');
+
+    const form = page.locator('form.item-form');
+    await expect(form).toBeVisible();
+
+    const padding = await form.evaluate((el) => getComputedStyle(el).paddingLeft);
+    expect(padding).toBe('10px');
+
+    await page.screenshot({ path: './test-artifacts/mobile-item-form.png' });
+});

--- a/frontend/e2e/mobile-process-form.spec.ts
+++ b/frontend/e2e/mobile-process-form.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+// Verify the process creation form layout on mobile
+
+test('process creation page is usable on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/processes/create');
+    await page.waitForLoadState('networkidle');
+
+    const form = page.locator('form.process-form');
+    await expect(form).toBeVisible();
+
+    const padding = await form.evaluate((el) => getComputedStyle(el).paddingLeft);
+    expect(padding).toBe('10px');
+
+    await page.screenshot({ path: './test-artifacts/mobile-process-form.png' });
+});

--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -187,4 +187,16 @@
     .submit-button:hover {
         background-color: #005004;
     }
+
+    @media (max-width: 480px) {
+        .item-form {
+            padding: 10px;
+        }
+
+        input,
+        textarea {
+            width: 100%;
+            font-size: 14px;
+        }
+    }
 </style>

--- a/frontend/src/components/svelte/ProcessForm.svelte
+++ b/frontend/src/components/svelte/ProcessForm.svelte
@@ -409,4 +409,20 @@
         text-align: center;
         margin-top: 20px;
     }
+
+    @media (max-width: 480px) {
+        .process-form {
+            padding: 10px;
+        }
+
+        input[type='text'] {
+            width: 100%;
+            font-size: 14px;
+        }
+
+        .item-row {
+            flex-direction: column;
+            align-items: flex-start;
+        }
+    }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -73,7 +73,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Test IndexedDB in all major browsers
         -   [x] Verify UI components across browsers
         -   [x] Check offline functionality
-    -   [ ] Mobile responsiveness
+    -   [x] Mobile responsiveness
         -   [x] Adapt quest creation UI for mobile
         -   [x] Test touch interactions ✅
         -   [x] Verify mobile layouts

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -46,7 +46,7 @@ Every item requires the following basic properties:
 
 Currently, the `ItemForm.svelte` component supports creating items with the properties listed above. The current implementation focuses on the fundamental aspects of items, with more advanced features planned for future updates.
 
-As you fill out the form, an `ItemPreview` component displays a live preview so you can confirm the details before submitting.
+As you fill out the form, an `ItemPreview` component displays a live preview so you can confirm the details before submitting. The layout automatically adjusts on small screens so form fields expand to the full width for easier touch input.
 
 All items must now conform to the JSON schema located at `frontend/src/pages/inventory/jsonSchemas/item.json`. Run the `itemValidation` test to ensure any additions meet the schema requirements.
 

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -44,7 +44,7 @@ Fractional values are allowed, so `0.5h` will be interpreted as thirty minutes.
 
 ### Implementation State
 
-The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation now accepts seconds and fractional durations in addition to hours and minutes.
+The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation now accepts seconds and fractional durations in addition to hours and minutes. The form is also mobile-friendly with controls stacked vertically on small screens.
 
 ## Process Categories
 


### PR DESCRIPTION
## Summary
- make ItemForm and ProcessForm adapt to small screens
- add mobile E2E tests for item and process forms
- document responsive layout for custom items & processes
- check off mobile responsiveness in changelog

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: module not found)*
- `npx playwright install chromium --yes` *(prompted for install, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6885d871901c832f91e212ea67af920b