### PR TITLE
Improve dbBenchmark test coverage

### DIFF
--- a/frontend/__tests__/dbBenchmark.test.js
+++ b/frontend/__tests__/dbBenchmark.test.js
@@ -13,4 +13,13 @@ describe('runDbBenchmark', () => {
         expect(result.insertMs).toBeGreaterThan(0);
         expect(result.readMs).toBeGreaterThan(0);
     });
+
+    test('works with default options', async () => {
+        const result = await runDbBenchmark();
+        expect(result.itemCount).toBe(50);
+        expect(result.processCount).toBe(50);
+        expect(result.questCount).toBe(50);
+        expect(result.insertMs).toBeGreaterThan(0);
+        expect(result.readMs).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
## Summary
- expand dbBenchmark tests to exercise default options

## Testing
- `npm run check`
- `npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6885e07309f0832fab0221814211a7c2