### PR TITLE
Add quest dependency tests

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -230,6 +230,9 @@ We have specialized tests to ensure content quality:
 5. **Process Quality Tests** (`processQuality.test.js`):
     - Validates duration strings and item references
     - Warns when processes lack items or have extreme durations
+6. **Quest Dependency Tests** (`questDependencies.test.js`):
+    - Ensures quest chains reference existing quests
+    - Detects circular dependencies that could block progress
 
 These tests are designed to produce warnings rather than failures, allowing for ongoing development while still identifying quality issues to address.
 
@@ -241,6 +244,7 @@ npm test -- itemQuality
 npm test -- processQuality
 npm test -- imageReferences
 npm test -- questCanonical
+npm test -- questDependencies
 ```
 
 ### Performance Benchmarks

--- a/frontend/__tests__/questDependencies.test.js
+++ b/frontend/__tests__/questDependencies.test.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const { findQuestDependencyIssues } = require('../src/utils/questDependencies.js');
+
+describe('Quest dependency integrity', () => {
+    const questDir = path.join(__dirname, '../src/pages/quests/json');
+    const files = glob.sync(path.join(questDir, '**/*.json'));
+    const quests = new Map();
+
+    files.forEach((file) => {
+        const quest = JSON.parse(fs.readFileSync(file));
+        quests.set(quest.id, quest);
+    });
+
+    test('all dependencies exist and contain no cycles', () => {
+        const issues = findQuestDependencyIssues(quests);
+        expect(issues).toEqual([]);
+    });
+
+    test('detects missing quests and circular dependencies', () => {
+        const custom = new Map();
+        custom.set('a', { id: 'a', requiresQuests: ['b'] });
+        custom.set('b', { id: 'b', requiresQuests: ['c', 'd'] });
+        custom.set('d', { id: 'd', requiresQuests: ['a'] });
+
+        const issues = findQuestDependencyIssues(custom);
+        const missing = issues.find((i) => i.includes('missing quest c'));
+        const cycle = issues.find((i) => i.includes('Circular dependency'));
+        expect(missing).toBeTruthy();
+        expect(cycle).toBeTruthy();
+    });
+
+    test('handles quests without dependencies', () => {
+        const simple = new Map();
+        simple.set('root', { id: 'root' });
+        simple.set('child', { id: 'child', requiresQuests: ['root'] });
+        const issues = findQuestDependencyIssues(simple);
+        expect(issues).toEqual([]);
+    });
+
+    test('handles empty quest list', () => {
+        const issues = findQuestDependencyIssues(new Map());
+        expect(issues).toEqual([]);
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -30,7 +30,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [ ] 10x More Quests
     -   [x] Create new official quests using the custom quest system
     -   [ ] Balance progression curve across all quests
-    -   [ ] Test quest chains and dependencies
+    -   [x] Test quest chains and dependencies
 -   [ ] Custom Items and Processes (using the same system as quests)
     -   [x] Item Management ✅
         -   [x] Item creation interface with ItemForm.svelte

--- a/frontend/src/utils/questDependencies.js
+++ b/frontend/src/utils/questDependencies.js
@@ -1,0 +1,36 @@
+export function findQuestDependencyIssues(quests) {
+    const issues = [];
+    const visited = new Set();
+    const stack = new Set();
+
+    function dfs(id) {
+        if (stack.has(id)) {
+            issues.push(`Circular dependency involving ${id}`);
+            return;
+        }
+        if (visited.has(id)) return;
+        visited.add(id);
+        stack.add(id);
+        const quest = quests.get(id);
+        if (!quest) {
+            issues.push(`Missing quest ${id}`);
+            /* istanbul ignore next */
+            stack.delete(id);
+            return;
+        }
+        const deps = quest.requiresQuests || [];
+        for (const dep of deps) {
+            if (!quests.has(dep)) {
+                issues.push(`${id} depends on missing quest ${dep}`);
+            } else {
+                dfs(dep);
+            }
+        }
+        stack.delete(id);
+    }
+
+    for (const id of quests.keys()) {
+        dfs(id);
+    }
+    return issues;
+}


### PR DESCRIPTION
## Summary
- implement `findQuestDependencyIssues` utility
- verify quest chains with `questDependencies.test.js`
- document new Quest Dependency Tests in TESTING.md
- check off changelog item for testing quest chains

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6885e3ef0cc8832f84b7af12a62f47ea