### PR TITLE
Add constellations quest example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ See [Quest Trees](docs/quest-trees) for an overview of the different categories 
 The repository includes a script that summarizes how many quests and lines of dialogue exist in each tree. Categories are sorted by quest count for readability.
 Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git. Check the "Quest Chart" workflow artifacts for the latest generated image.
 
+Looking for a concrete walkthrough? The Playwright test `constellations-quest.spec.ts` demonstrates creating the "Map the Constellations" quest end to end and validating it using our quest checks.
+
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation. Each tree has been extended with follow-up tasks, such as tuning 3D printer retraction and refreshing hydroponic nutrients.
 The DevOps chain now covers deploying DSPACE on a Raspberry Pi cluster with Docker and k3s, setting up monitoring with Prometheus and Grafana, and scheduling nightly backups.

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -64,6 +64,10 @@ npm run test:e2e:groups
 # Run a specific test file
 npx playwright test e2e/custom-content.spec.ts
 
+# The `constellations-quest.spec.ts` file demonstrates creating a full quest
+# in the UI and validating it. Run it directly with:
+npx playwright test e2e/constellations-quest.spec.ts
+
 # Run tests with a specific tag or pattern
 npx playwright test -g "create a custom item"
 ```

--- a/frontend/__tests__/questSimulation.test.js
+++ b/frontend/__tests__/questSimulation.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { questHasFinishPath } = require('../src/utils/simulateQuest.js');
 
-const questFile = path.join(__dirname, '../test-data/simple-quest.json');
+const questFile = path.join(__dirname, '../test-data/constellations-quest.json');
 const loopQuestFile = path.join(__dirname, '../test-data/loop-quest.json');
 const loopFinishQuestFile = path.join(__dirname, '../test-data/loop-finish-quest.json');
 const missingStartFile = path.join(__dirname, '../test-data/missing-start-quest.json');

--- a/frontend/__tests__/seedCustomContent.test.js
+++ b/frontend/__tests__/seedCustomContent.test.js
@@ -15,6 +15,6 @@ describe('seedCustomContent script', () => {
 
         expect(item.name).toBe('Seeded Item');
         expect(process.title).toBe('Seeded Process');
-        expect(quest.title).toBe('Test Quest');
+        expect(quest.title).toBe('Map the Constellations');
     });
 });

--- a/frontend/e2e/constellations-quest.spec.ts
+++ b/frontend/e2e/constellations-quest.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { clearUserData } from './test-helpers';
+
+const questPath = path.resolve(__dirname, '../test-data/constellations-quest.json');
+const questTemplate = JSON.parse(fs.readFileSync(questPath, 'utf8'));
+
+/**
+ * End-to-end creation of the constellations quest using the in-game UI.
+ * After creation, the quest JSON is patched with the full example and
+ * validated with the quest simulation helper.
+ */
+
+test.describe('Constellations Quest Creation', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('create and validate constellations quest', async ({ page }) => {
+        // Step 1: create the quest via the UI
+        await page.goto('/quests/create');
+        await page.waitForLoadState('networkidle');
+
+        await page.fill('#title', questTemplate.title);
+        await page.fill('#description', questTemplate.description);
+
+        const imageInput = page.locator('input[type="file"]');
+        if ((await imageInput.count()) > 0) {
+            await imageInput.setInputFiles(path.resolve(__dirname, '../test-data/test-image.jpg'));
+        }
+
+        await page.click('button.submit-button');
+        await page.waitForLoadState('networkidle');
+
+        // Step 2: find the created quest id in IndexedDB
+        const questId: number = await page.evaluate(async (title) => {
+            const mod = await import('/src/utils/customcontent.js');
+            const quests = await mod.db.list(mod.ENTITY_TYPES.QUEST);
+            const match = quests.find((q: { title: string; id: number }) => q.title === title);
+            return match ? match.id : -1;
+        }, questTemplate.title);
+
+        expect(questId).toBeGreaterThan(0);
+
+        // Step 3: patch quest with full JSON
+        await page.evaluate(
+            async (id, quest) => {
+                const mod = await import('/src/utils/customcontent.js');
+                quest.id = id;
+                await mod.updateQuest(id, quest);
+            },
+            questId,
+            questTemplate
+        );
+
+        // Retrieve quest back from IndexedDB
+        const storedQuest = await page.evaluate(async (id) => {
+            const mod = await import('/src/utils/customcontent.js');
+            return mod.getQuest(id);
+        }, questId);
+
+        // Validate with questHasFinishPath helper
+        const { questHasFinishPath } = await import('../src/utils/simulateQuest.js');
+        expect(questHasFinishPath(storedQuest)).toBe(true);
+
+        // Verify it appears in quests list
+        await page.goto('/quests');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator(`text="${questTemplate.title}"`)).toBeVisible();
+    });
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -52,7 +52,13 @@ const TEST_GROUPS = [
     },
     {
         name: 'Quest Tests',
-        files: ['test-quest-chat.spec.ts', 'tutorial-quest.spec.ts', 'quests.spec.ts', 'custom-content.spec.ts'],
+        files: [
+            'test-quest-chat.spec.ts',
+            'tutorial-quest.spec.ts',
+            'quests.spec.ts',
+            'constellations-quest.spec.ts',
+            'custom-content.spec.ts',
+        ],
         grep: 'create and view a custom quest|Quest Management',
         parallel: true,
         workers: 2,

--- a/frontend/scripts/seed-custom-content.js
+++ b/frontend/scripts/seed-custom-content.js
@@ -15,7 +15,7 @@ export async function seedCustomContent() {
     const itemId = await createItem('Seeded Item', 'Item added by seed script');
     const processId = await createProcess('Seeded Process', '15m', [{ id: itemId, count: 1 }]);
 
-    const questPath = path.join(process.cwd(), 'test-data', 'simple-quest.json');
+    const questPath = path.join(process.cwd(), 'test-data', 'constellations-quest.json');
     const questTemplate = JSON.parse(fs.readFileSync(questPath, 'utf8'));
     const questId = await createQuest(
         questTemplate.title,

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -66,7 +66,7 @@ For contributors who want to leverage artificial intelligence in their content c
 -   Best practices for working with AI assistants
 -   Scientific accuracy verification techniques
 -   Dialogue refinement strategies
--   Full examples of AI-assisted content creation
+-   Full examples of AI-assisted content creation. Our Playwright test `constellations-quest.spec.ts` walks through creating the `constellations` quest end to end.
 
 These prompt engineering templates were initially created to help develop the first batches of quests for DSPACE and can be valuable tools for brainstorming ideas, refining dialogue, and ensuring scientific accuracy in your own content.
 

--- a/frontend/src/pages/docs/md/custom-content-bundles.md
+++ b/frontend/src/pages/docs/md/custom-content-bundles.md
@@ -22,3 +22,5 @@ node scripts/create-content-bundle.js submissions/bundles/my-bundle.json path/to
 ```
 
 The script resolves glob patterns so multiple files can be included at once. Commit the generated file in your pull request. Reviewers can load the bundle locally to verify your custom content.
+
+An example quest JSON used in our automated tests lives at `frontend/test-data/constellations-quest.json`. You can reference this file when experimenting with the bundle script.

--- a/frontend/test-data/constellations-quest.json
+++ b/frontend/test-data/constellations-quest.json
@@ -1,13 +1,3 @@
----
-title: 'Quest Template Example'
-slug: 'quest-template'
----
-
-# Quest Template Example
-
-This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
-
-```json
 {
     "id": "astronomy/constellations",
     "title": "Map the Constellations",
@@ -47,7 +37,3 @@ This page provides a minimal quest JSON structure that you can use as a starting
     "rewards": [],
     "requiresQuests": ["astronomy/jupiter-moons"]
 }
-```
-
-Use this template as a baseline and expand it with additional dialogue nodes, processes, item requirements, and rewards. For more in-depth guidance, see the [Quest Development Guidelines](/docs/quest-guidelines).
-An automated Playwright example (`constellations-quest.spec.ts`) walks through creating this quest step by step if you prefer a hands-on reference.


### PR DESCRIPTION
## Summary
- use `constellations-quest.json` as the sample quest for tests
- update docs to reference the new constellations quest example
- adjust seed script and tests accordingly
- document new Playwright example and include it in test groups

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6885e27c6130832fa6a7f62ec46b2ad4