### PR TITLE
Increase quest dependency test coverage

### DIFF
--- a/frontend/__tests__/questDependencies.test.js
+++ b/frontend/__tests__/questDependencies.test.js
@@ -42,6 +42,22 @@ describe('Quest dependency integrity', () => {
         expect(issues).toEqual([]);
     });
 
+    test('detects self dependency', () => {
+        const map = new Map();
+        map.set('loop', { id: 'loop', requiresQuests: ['loop'] });
+        const issues = findQuestDependencyIssues(map);
+        expect(issues).toEqual(['Circular dependency involving loop']);
+    });
+
+    test('resolves linear chains without repeating nodes', () => {
+        const chain = new Map();
+        chain.set('a', { id: 'a', requiresQuests: ['b'] });
+        chain.set('b', { id: 'b', requiresQuests: ['c'] });
+        chain.set('c', { id: 'c' });
+        const issues = findQuestDependencyIssues(chain);
+        expect(issues).toEqual([]);
+    });
+
     test('handles empty quest list', () => {
         const issues = findQuestDependencyIssues(new Map());
         expect(issues).toEqual([]);


### PR DESCRIPTION
## Summary
- extend `questDependencies.test.js` with self-dependency and linear chain tests
- validate circular dependency detection

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6886a1db76cc832fab6639c172b99f5f