### PR TITLE
Improve quest dependency coverage

### DIFF
--- a/frontend/__tests__/questDependencies.test.js
+++ b/frontend/__tests__/questDependencies.test.js
@@ -46,4 +46,14 @@ describe('Quest dependency integrity', () => {
         const issues = findQuestDependencyIssues(new Map());
         expect(issues).toEqual([]);
     });
+
+    test('reports missing quests when map entry is undefined', () => {
+        const broken = new Map();
+        broken.set('a', { id: 'a', requiresQuests: ['b'] });
+        // Deliberately include the key but leave the value undefined
+        broken.set('b', undefined);
+
+        const issues = findQuestDependencyIssues(broken);
+        expect(issues).toContain('Missing quest b');
+    });
 });


### PR DESCRIPTION
## Summary
- add coverage for missing quest map entries

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6886a1db76cc832fab6639c172b99f5f