### PR TITLE
Fix coverage for questDependencies

### DIFF
--- a/frontend/__tests__/questDependencies.test.js
+++ b/frontend/__tests__/questDependencies.test.js
@@ -34,6 +34,13 @@ describe('Quest dependency integrity', () => {
         expect(cycle).toBeTruthy();
     });
 
+    test('handles explicit missing quest entries', () => {
+        const broken = new Map();
+        broken.set('missing', undefined);
+        const issues = findQuestDependencyIssues(broken);
+        expect(issues).toEqual(['Missing quest missing']);
+    });
+
     test('handles quests without dependencies', () => {
         const simple = new Map();
         simple.set('root', { id: 'root' });


### PR DESCRIPTION
## Summary
- cover missing quest case in questDependencies tests

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6886a1db76cc832fab6639c172b99f5f