### PR TITLE
Add tests for run-test-groups script

### DIFF
--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -132,48 +132,62 @@ function runTestGroup(group) {
     }
 }
 
-// Main execution
-console.log(`${colors.bright}${colors.magenta}Starting DSpace Test Suite in Groups${colors.reset}`);
-console.log(`${colors.yellow}Total groups: ${TEST_GROUPS.length}${colors.reset}`);
-console.log(`${colors.yellow}System has ${CPU_CORES} CPU cores, using up to ${MAX_WORKERS} workers for parallel tests${colors.reset}\n`);
-
-let startTime = Date.now();
-let successCount = 0;
-let failureCount = 0;
-
-// Run each group in sequence
-for (let i = 0; i < TEST_GROUPS.length; i++) {
-    const group = TEST_GROUPS[i];
+function main() {
     console.log(
-        `${colors.yellow}Group ${i + 1}/${TEST_GROUPS.length}: ${group.name}${colors.reset}`
+        `${colors.bright}${colors.magenta}Starting DSpace Test Suite in Groups${colors.reset}`
+    );
+    console.log(`${colors.yellow}Total groups: ${TEST_GROUPS.length}${colors.reset}`);
+    console.log(
+        `${colors.yellow}System has ${CPU_CORES} CPU cores, using up to ${MAX_WORKERS} workers for parallel tests${colors.reset}\n`
     );
 
-    const groupStartTime = Date.now();
-    const success = runTestGroup(group);
-    const groupEndTime = Date.now();
-    const groupDuration = (groupEndTime - groupStartTime) / 1000;
+    let startTime = Date.now();
+    let successCount = 0;
+    let failureCount = 0;
 
-    if (success) {
-        successCount++;
+    // Run each group in sequence
+    for (let i = 0; i < TEST_GROUPS.length; i++) {
+        const group = TEST_GROUPS[i];
         console.log(
-            `${colors.green}Group completed in ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
+            `${colors.yellow}Group ${i + 1}/${TEST_GROUPS.length}: ${group.name}${colors.reset}`
         );
-    } else {
-        failureCount++;
-        console.log(
-            `${colors.red}Group failed after ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
-        );
+
+        const groupStartTime = Date.now();
+        const success = runTestGroup(group);
+        const groupEndTime = Date.now();
+        const groupDuration = (groupEndTime - groupStartTime) / 1000;
+
+        if (success) {
+            successCount++;
+            console.log(
+                `${colors.green}Group completed in ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
+            );
+        } else {
+            failureCount++;
+            console.log(
+                `${colors.red}Group failed after ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
+            );
+        }
     }
+
+    // Print summary
+    const endTime = Date.now();
+    const totalDuration = (endTime - startTime) / 1000;
+
+    console.log(`${colors.bright}${colors.magenta}Test Suite Summary:${colors.reset}`);
+    console.log(`${colors.green}✓ ${successCount} groups passed${colors.reset}`);
+    console.log(`${colors.red}✗ ${failureCount} groups failed${colors.reset}`);
+    console.log(`${colors.yellow}Total time: ${totalDuration.toFixed(2)} seconds${colors.reset}`);
+
+    // Exit with appropriate code
+    process.exit(failureCount > 0 ? 1 : 0);
 }
 
-// Print summary
-const endTime = Date.now();
-const totalDuration = (endTime - startTime) / 1000;
+if (
+    import.meta.url === `file://${process.argv[1]}` ||
+    process.argv[1].endsWith('run-test-groups.mjs')
+) {
+    main();
+}
 
-console.log(`${colors.bright}${colors.magenta}Test Suite Summary:${colors.reset}`);
-console.log(`${colors.green}✓ ${successCount} groups passed${colors.reset}`);
-console.log(`${colors.red}✗ ${failureCount} groups failed${colors.reset}`);
-console.log(`${colors.yellow}Total time: ${totalDuration.toFixed(2)} seconds${colors.reset}`);
-
-// Exit with appropriate code
-process.exit(failureCount > 0 ? 1 : 0);
+export { TEST_GROUPS, runTestGroup, main, CPU_CORES, MAX_WORKERS };

--- a/tests/run-test-groups.test.ts
+++ b/tests/run-test-groups.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as child from 'child_process';
+import { runTestGroup, TEST_GROUPS } from '../frontend/scripts/run-test-groups.mjs';
+
+// Basic sanity check that TEST_GROUPS is populated
+describe('run-test-groups', () => {
+  it('exposes test groups', () => {
+    expect(Array.isArray(TEST_GROUPS)).toBe(true);
+    expect(TEST_GROUPS.length).toBeGreaterThan(0);
+  });
+
+  it('returns true when exec succeeds', () => {
+    const spy = vi.spyOn(child, 'execSync').mockImplementation(() => {} as any);
+    const result = runTestGroup({ name: 'Demo', files: ['demo.spec.ts'], parallel: false });
+    expect(spy).toHaveBeenCalled();
+    expect(result).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('returns false when exec fails', () => {
+    const spy = vi.spyOn(child, 'execSync').mockImplementation(() => {
+      throw new Error('fail');
+    });
+    const result = runTestGroup({ name: 'Fail', files: ['fail.spec.ts'], parallel: true, workers: 2 });
+    expect(spy).toHaveBeenCalled();
+    expect(result).toBe(false);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- export functions from `run-test-groups.mjs`
- add `main` guard so the script can be imported in tests
- create `run-test-groups.test.ts` with basic coverage

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6886a5c54be0832fa3fe7447695cadbb