### PR TITLE
Improve patch coverage workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ These guidelines apply to all files in this repository.
 -   Continuous integration runs `npm run test:pr` on pushes and pull requests.
     Coverage uploads to Codecov when the `CODECOV_TOKEN` secret is set. You'll
     see the results in the **Checks** tab of your PR. Ensure the README's Codecov badge tracks the `v3` branch so it reflects CI results.
-    Run `npm run coverage` locally to generate a detailed report before submitting changes.
+    Run `npm run coverage` locally and then `node scripts/checkPatchCoverage.cjs` to confirm changed files stay at 100% coverage before submitting changes.
 -   Archive deprecated quests by moving them to `frontend/src/pages/quests/archive`.
 -   token.place only provides open-source LLM inference. It does not host quests, but you can reuse the same prompts to generate dialogue here or in other projects.
 -   After merging, run `npm ci` in the repo root and `(cd frontend && npm ci)` to

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ npm run test:e2e:coverage
 
 # Generate unit test coverage
 npm run coverage
+# Verify 100% coverage for changed files
+node scripts/checkPatchCoverage.cjs
 # View the HTML report at
 frontend/coverage/lcov-report/index.html
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -28,7 +28,8 @@ Constraints:
   1. Global: Maintain ≥ 90 % line and branch coverage.
   2. Patch: For any file listed by
      git diff --name-only $(git merge-base origin/main HEAD)
-     ensure no metric falls below 90 % and no metric drops by > 0.20 percentage points compared with `origin/main`.
+     ensure lines, branches, statements and functions each reach **100 %**.
+     No metric may drop more than 0.20 percentage points compared with `origin/main`.
   3. Fail the job if either threshold is violated. Use one of:
      - Native Vitest: `vitest run --coverage --coverage.thresholds.perFile --coverage.thresholds.lines=90 ...`
      - Danger JS with `danger-plugin-istanbul-coverage` for per‑patch diffs
@@ -47,6 +48,6 @@ Output format
 2. Summary
 3. Tests & coverage
    npm run coverage
-   node scripts/checkPatchCoverage.cjs   # exit 1 on drop >0.2 pp
+   node scripts/checkPatchCoverage.cjs   # verifies 100% patch coverage
    npx playwright test
 ```

--- a/scripts/checkPatchCoverage.cjs
+++ b/scripts/checkPatchCoverage.cjs
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function getChangedFiles() {
+  const base = execSync('git merge-base origin/main HEAD').toString().trim();
+  if (!base) return [];
+  const diff = execSync(`git diff --name-only ${base}`).toString();
+  return diff.split('\n').filter(Boolean);
+}
+
+function loadCoverage() {
+  const coveragePath = path.join(__dirname, '..', 'frontend', 'coverage', 'coverage-summary.json');
+  if (!fs.existsSync(coveragePath)) {
+    console.error(`Coverage file not found at ${coveragePath}`);
+    process.exit(1);
+  }
+  return JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+}
+
+function checkCoverage() {
+  const changed = getChangedFiles();
+  if (changed.length === 0) return;
+  const summary = loadCoverage();
+  let failed = false;
+  for (const file of changed) {
+    const entry = Object.entries(summary).find(([key]) => key.endsWith(file));
+    if (!entry) continue;
+    const data = entry[1];
+    const metrics = ['lines', 'statements', 'functions', 'branches'];
+    metrics.forEach(m => {
+      if (data[m] && data[m].pct < 100) {
+        console.error(`${file} ${m} coverage ${data[m].pct}% is below 100%`);
+        failed = true;
+      }
+    });
+  }
+  if (failed) {
+    process.exit(1);
+  } else {
+    console.log('Patch coverage 100%');
+  }
+}
+
+checkCoverage();


### PR DESCRIPTION
## Summary
- add checkPatchCoverage script
- document 100% patch coverage requirements in Codex prompt
- mention patch coverage script in AGENTS guide and README

## Testing
- `npm run test:pr` *(fails: Failed to collect coverage from db-benchmark.js due to import.meta parsing)*
- `node scripts/checkPatchCoverage.cjs` *(fails: `git merge-base origin/main HEAD` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a71ee058832facdac71dcd9ccfb0