### PR TITLE
Fix vitest run and CI root tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
             package-lock.json
             frontend/package-lock.json
       - run: npm ci
+      - run: npm test
       - run: cd frontend && npm ci
       - run: cd frontend && npm test
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "cd frontend && npm run dev",
-    "test": "vitest run --coverage tests/itemQuality.test.ts",
+    "test": "vitest run --coverage tests/*.test.ts",
     "test:watch": "cd frontend && npm run test:watch",
     "test:e2e": "cd frontend && npm run test:e2e",
     "test:e2e:coverage": "cd frontend && npm run test:e2e:coverage",

--- a/tests/run-test-groups.test.ts
+++ b/tests/run-test-groups.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as child from 'child_process';
+import { execSync } from 'child_process';
 import { runTestGroup, TEST_GROUPS } from '../frontend/scripts/run-test-groups.mjs';
+
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
 
 // Basic sanity check that TEST_GROUPS is populated
 describe('run-test-groups', () => {
@@ -10,7 +12,8 @@ describe('run-test-groups', () => {
   });
 
   it('returns true when exec succeeds', () => {
-    const spy = vi.spyOn(child, 'execSync').mockImplementation(() => {} as any);
+    const spy = vi.mocked(execSync);
+    spy.mockImplementation(() => ({} as any));
     const result = runTestGroup({ name: 'Demo', files: ['demo.spec.ts'], parallel: false });
     expect(spy).toHaveBeenCalled();
     expect(result).toBe(true);
@@ -18,7 +21,8 @@ describe('run-test-groups', () => {
   });
 
   it('returns false when exec fails', () => {
-    const spy = vi.spyOn(child, 'execSync').mockImplementation(() => {
+    const spy = vi.mocked(execSync);
+    spy.mockImplementation(() => {
       throw new Error('fail');
     });
     const result = runTestGroup({ name: 'Fail', files: ['fail.spec.ts'], parallel: true, workers: 2 });


### PR DESCRIPTION
## Summary
- include root unit tests in GitHub Actions
- run all vitest specs in `tests/`
- update mocking for `execSync` in run-test-groups tests

## Testing
- `npm test`
- `npm run test:pr` *(fails: End-to-end tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a7dfab88832faf56ecc9dfaa16b5