### PR TITLE
Add preview buttons for custom items and processes

### DIFF
--- a/frontend/__tests__/ManageItems.test.js
+++ b/frontend/__tests__/ManageItems.test.js
@@ -13,4 +13,12 @@ describe('ManageItems component', () => {
         );
         expect(() => svelte.compile(source)).not.toThrow();
     });
+
+    it('contains preview button markup', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/inventory/svelte/ManageItems.svelte'),
+            'utf8'
+        );
+        expect(source).toMatch(/preview-button/);
+    });
 });

--- a/frontend/__tests__/ManageProcesses.test.js
+++ b/frontend/__tests__/ManageProcesses.test.js
@@ -13,4 +13,12 @@ describe('ManageProcesses component', () => {
         );
         expect(() => svelte.compile(source)).not.toThrow();
     });
+
+    it('contains preview button markup', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/processes/svelte/ManageProcesses.svelte'),
+            'utf8'
+        );
+        expect(source).toMatch(/preview-button/);
+    });
 });

--- a/frontend/e2e/manage-items.spec.ts
+++ b/frontend/e2e/manage-items.spec.ts
@@ -62,4 +62,24 @@ test.describe('Manage Items', () => {
 
         expect(exists).toBe(false);
     });
+
+    test('should preview a custom item', async ({ page }) => {
+        const name = `Preview Item ${Date.now()}`;
+
+        await page.goto('/inventory/create');
+        await page.fill('#name', name);
+        await page.fill('#description', 'Preview desc');
+        const submit = page.locator('button.submit-button, input[type="submit"]');
+        await submit.click();
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/inventory/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const row = page.locator('.item-row', { hasText: name }).first();
+        await expect(row).toBeVisible();
+        await row.locator('.preview-button').click();
+        await expect(row.locator('.item-preview')).toBeVisible();
+    });
 });

--- a/frontend/e2e/manage-processes.spec.ts
+++ b/frontend/e2e/manage-processes.spec.ts
@@ -60,4 +60,23 @@ test.describe('Manage Processes', () => {
 
         expect(exists).toBe(false);
     });
+
+    test('should preview a custom process', async ({ page }) => {
+        const title = `Preview Process ${Date.now()}`;
+
+        await page.goto('/processes/create');
+        await fillProcessForm(page, title, '1m', 0, 0, 0);
+        const submit = page.locator('button.submit-button');
+        await submit.click();
+        await page.waitForLoadState('networkidle');
+
+        await page.goto('/processes/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const row = page.locator('.process-row', { hasText: title }).first();
+        await expect(row).toBeVisible();
+        await row.locator('.preview-button').click();
+        await expect(row.locator('.process-preview')).toBeVisible();
+    });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -41,7 +41,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Required/consumed/created items selection
         -   [x] Process validation and testing
         -   [x] Process state management
-    -   [ ] Preview and Testing
+    -   [x] Preview and Testing
         -   [x] Content preview functionality
         -   [x] Testing environment for custom content
         -   [x] Validation feedback system

--- a/frontend/src/pages/docs/md/inventory.md
+++ b/frontend/src/pages/docs/md/inventory.md
@@ -75,6 +75,7 @@ The inventory interface allows you to:
 -   View item details and counts
 -   See related processes
 -   Track item dependencies using the new `dependencies` field
--   Manage custom items
+-   Manage custom items and preview them from the **Manage Items** page using
+    the **Preview** button next to each entry
 
 All inventory data is now stored locally using IndexedDB, with optional cloud sync for backup and cross-device access.

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -69,6 +69,8 @@ Starting with v3, you can create your own custom processes. When creating a cust
 Use the **Manage Processes** page to review or delete custom entries. Built-in
 processes appear alongside any you've created locally. Access it at
 `/processes/manage`.
+Each row includes a **Preview** button that displays a live summary of the
+process so you can verify the details before editing or deleting it.
 
 ## Process Examples
 

--- a/frontend/src/pages/inventory/svelte/ManageItems.svelte
+++ b/frontend/src/pages/inventory/svelte/ManageItems.svelte
@@ -1,12 +1,14 @@
 <script>
     import { onMount } from 'svelte';
     import ItemCard from '../../../components/svelte/ItemCard.svelte';
+    import ItemPreview from '../../../components/svelte/ItemPreview.svelte';
     import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
 
     export let items = [];
     let customItems = [];
     let mounted = false;
     let searchTerm = '';
+    let previewItemId = null;
 
     onMount(async () => {
         customItems = await db.list(ENTITY_TYPES.ITEM);
@@ -36,6 +38,10 @@
             }
         }
     }
+
+    function togglePreview(id) {
+        previewItemId = previewItemId === id ? null : id;
+    }
 </script>
 
 <div class="manage-items">
@@ -51,8 +57,11 @@
                 {#each filteredItems as item (item.id)}
                     <div class="item-row">
                         <ItemCard itemId={item.id} />
-                        {#if item.custom}
-                            <div class="item-actions">
+                        <div class="item-actions">
+                            <button class="preview-button" on:click={() => togglePreview(item.id)}>
+                                Preview
+                            </button>
+                            {#if item.custom}
                                 <button class="edit-button" on:click={() => handleEdit(item.id)}>
                                     Edit
                                 </button>
@@ -62,7 +71,17 @@
                                 >
                                     Delete
                                 </button>
-                            </div>
+                            {/if}
+                        </div>
+                        {#if previewItemId === item.id}
+                            <ItemPreview
+                                name={item.name}
+                                description={item.description}
+                                imageUrl={item.image}
+                                price={item.price}
+                                unit={item.unit}
+                                type={item.type}
+                            />
                         {/if}
                     </div>
                 {/each}
@@ -108,6 +127,7 @@
         gap: 10px;
     }
 
+    .preview-button,
     .edit-button,
     .delete-button {
         padding: 8px 16px;
@@ -116,6 +136,11 @@
         cursor: pointer;
         font-size: 14px;
         transition: background-color 0.2s;
+    }
+
+    .preview-button {
+        background-color: #666;
+        color: white;
     }
 
     .edit-button {
@@ -134,6 +159,10 @@
 
     .delete-button:hover {
         background-color: #bb2222;
+    }
+
+    .preview-button:hover {
+        background-color: #555;
     }
 
     .no-items {

--- a/frontend/src/pages/processes/svelte/ManageProcesses.svelte
+++ b/frontend/src/pages/processes/svelte/ManageProcesses.svelte
@@ -1,12 +1,14 @@
 <script>
     import { onMount } from 'svelte';
     import Process from '../../../components/svelte/Process.svelte';
+    import ProcessPreview from '../../../components/svelte/ProcessPreview.svelte';
     import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
 
     export let processes = [];
     let customProcesses = [];
     let mounted = false;
     let searchTerm = '';
+    let previewProcessId = null;
 
     onMount(async () => {
         customProcesses = await db.list(ENTITY_TYPES.PROCESS);
@@ -33,6 +35,10 @@
             }
         }
     }
+
+    function togglePreview(id) {
+        previewProcessId = previewProcessId === id ? null : id;
+    }
 </script>
 
 <div class="manage-processes">
@@ -48,8 +54,14 @@
                 {#each filteredProcesses as process (process.id)}
                     <div class="process-row">
                         <Process processId={process.id} />
-                        {#if process.custom}
-                            <div class="process-actions">
+                        <div class="process-actions">
+                            <button
+                                class="preview-button"
+                                on:click={() => togglePreview(process.id)}
+                            >
+                                Preview
+                            </button>
+                            {#if process.custom}
                                 <button class="edit-button" on:click={() => handleEdit(process.id)}>
                                     Edit
                                 </button>
@@ -59,7 +71,16 @@
                                 >
                                     Delete
                                 </button>
-                            </div>
+                            {/if}
+                        </div>
+                        {#if previewProcessId === process.id}
+                            <ProcessPreview
+                                title={process.title}
+                                duration={process.duration}
+                                requireItems={process.requireItems}
+                                consumeItems={process.consumeItems}
+                                createItems={process.createItems}
+                            />
                         {/if}
                     </div>
                 {/each}
@@ -105,6 +126,7 @@
         gap: 10px;
     }
 
+    .preview-button,
     .edit-button,
     .delete-button {
         padding: 8px 16px;
@@ -113,6 +135,11 @@
         cursor: pointer;
         font-size: 14px;
         transition: background-color 0.2s;
+    }
+
+    .preview-button {
+        background-color: #666;
+        color: white;
     }
 
     .edit-button {
@@ -131,6 +158,10 @@
 
     .delete-button:hover {
         background-color: #bb2222;
+    }
+
+    .preview-button:hover {
+        background-color: #555;
     }
 
     .no-processes {


### PR DESCRIPTION
## Summary
- allow preview of items and processes from manage pages
- document preview buttons in inventory and processes docs
- mark "Preview and Testing" changelog item complete
- add simple compile tests for preview markup
- extend Playwright specs to verify preview buttons

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_688731160328832f9b1a94dd1f081651