### PR TITLE
Add quest count table and new graphing quest

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -95,7 +95,12 @@ Work has begun on several new quest trees, including Chemistry, Astronomy, and P
 
 Astronomy now includes a meteor shower quest, bringing us closer to the full expansion.
 
-As of this release, DSPACE includes **72 official quests**. For reference, v2.1 contained only 22 quests, so we're about a third of the way to our 10x goal.
+As of this release, DSPACE includes **73 official quests**. For reference, v2.1 contained 22 quests.
+
+| Version   | Official Quests |
+| --------- | --------------- |
+| v2.1      | 22              |
+| v3 (HEAD) | 73              |
 
 ## Custom Quests
 

--- a/frontend/src/pages/quests/json/programming/temp-graph.json
+++ b/frontend/src/pages/quests/json/programming/temp-graph.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-graph",
+    "title": "Graph Temperature Trends",
+    "description": "Create a simple chart to visualize your logged temperature data.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've been collecting temperature data for days. Let's plot those readings into a simple line graph to spot patterns.",
+            "options": [{ "type": "goto", "goto": "prepare", "text": "How do I do that?" }]
+        },
+        {
+            "id": "prepare",
+            "text": "Use a library like Chart.js or even a spreadsheet program to turn your log file into a clear visual graph.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Graph generated!",
+                    "requiresItems": [{ "id": "58", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Visualizing data makes trends much easier to share and analyze.",
+            "options": [{ "type": "finish", "text": "Looks cool!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-logger"]
+}


### PR DESCRIPTION
## Summary
- document quest counts in the 20250901 changelog
- add a new `temp-graph` quest

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6887347f7990832fb8ed3cbd6ea026de