### PR TITLE
Fix changelog image paths

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20230105.md
+++ b/frontend/src/pages/docs/md/changelog/20230105.md
@@ -5,13 +5,13 @@ slug: '20230105'
 
 ### Your rescue has arrived!
 
-![](/assets/rescue.jpg)
+![](../../../../../public/assets/rescue.jpg)
 
 Some users may have been stranded in the [Hydroponics quest](/quests/play/2), but there's now a solution:
 
 Back and Forward links have been added to the hydroponics quest. If you were stuck before, try now and see if your issue is fixed!
 
-![](/assets/changelog/20230105/back_forward.jpg)
+![](../../../../../public/assets/changelog/20230105/back_forward.jpg)
 
 ### Other updates
 

--- a/frontend/src/pages/docs/md/changelog/20230131.md
+++ b/frontend/src/pages/docs/md/changelog/20230131.md
@@ -11,36 +11,36 @@ The following [quests](/quests) have been added:
 
 ## Reusable rocket with a parachute
 
-![](/assets/rocket_min.gif)
+![](../../../../../public/assets/rocket_min.gif)
 
 A quest that involves launching a virtual rocket with a parachute has been added to the game.
 
 ## Solar energy generation
 
-![](/assets/battery_1kwh.jpg)
+![](../../../../../public/assets/battery_1kwh.jpg)
 
 A new [solar](/docs/solar) quest has been added, which tasks the player with increasing their solar panel grid to a total of 1000 kW and buying the appropriate energy storage.
 
 ## Basic income
 
-![](/assets/dBI.jpg)
+![](../../../../../public/assets/dBI.jpg)
 
 A quest that introduces the game's basic income system. Earn 100 dUSD every week, no strings attached!
 
 ## Electric vehicle charger
 
-![](/assets/ev_charger.jpg)
+![](../../../../../public/assets/ev_charger.jpg)
 
 A quest that involves installing an electric vehicle charger, promoting the use of sustainable transportation.
 
 ## Offsets
 
-![](/assets/dOffset.jpg)
+![](../../../../../public/assets/dOffset.jpg)
 
 A quest teaching the player how to buy dOffset using dCarbon.
 
 ## Goldfish aquarium
 
-![](/assets/goldfish.jpg)
+![](../../../../../public/assets/goldfish.jpg)
 
 A quest that involves setting up a goldfish aquarium. You buy all the components needed to set up a healthy aquarium of an appropriate size, and then you add a goldfish. [Feed the goldfish](/processes/feed-goldfish) up to 3 times per day.

--- a/frontend/src/pages/docs/md/changelog/20230630.md
+++ b/frontend/src/pages/docs/md/changelog/20230630.md
@@ -22,7 +22,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome!!! I'm g
 
 Elevating your questing experience is my top priority. I've added engaging NPCs, branching dialogues, and more to make your journey exciting and immersive. Although the dialogues are linear for now, I've built a robust, expandable quest system which I'll continue to evolve in future updates!
 
-![a screenshot of the quest chat](/assets/changelog/20230630/screenshot_questchat.jpg)
+![a screenshot of the quest chat](../../../../../public/assets/changelog/20230630/screenshot_questchat.jpg)
 
 In the process of this revamp, I've removed some older quests and rearranged others. So, if you're a returning player from DSPACE v1, you may find some of the content familiar. I've made the tough call to reset everyone's quest progress, but don't worry! All the items you've collected are still safely stored in your inventory (there is a [known issue](https://github.com/democratizedspace/dspace/issues/51)). Plus, the updated quests now yield even better rewards.
 
@@ -46,7 +46,7 @@ I've worked on making [Processes](/docs/processes) more intuitive and visually p
 
 Your inventory now features a handy search bar, doing away with the need for Ctrl+F or endless scrolling. Just type in anything related to the item - be it a part of the name, description, or even the price, if you happen to remember it.
 
-![a screenshot of the inventory system](/assets/changelog/20230630/screenshot_inventory.jpg)
+![a screenshot of the inventory system](../../../../../public/assets/changelog/20230630/screenshot_inventory.jpg)
 
 And now, instead of displaying every item in the game, your inventory only shows what you actually own (with the option to view all items if you so choose). Item filters are also on the horizon! If you're keen to have this feature sooner, please upvote [this issue](https://github.com/democratizedspace/dspace/issues/36)!
 
@@ -78,7 +78,7 @@ I'm also working on a few experimental features, which you might find interestin
 
 Jumping on the AI Chat app trend, I've introduced my own version called dChat. It's a work in progress and may have a few bugs, but I'm continually improving it. While it doesn't know much about the game yet, that's changing soon!
 
-![a screenshot of the dChat, the in-game AI assistant](/assets/changelog/20230630/screenshot_dChat.jpg)
+![a screenshot of the dChat, the in-game AI assistant](../../../../../public/assets/changelog/20230630/screenshot_dChat.jpg)
 
 ### UI Improvements
 

--- a/scripts/fix-markdown-image-paths.js
+++ b/scripts/fix-markdown-image-paths.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.join(__dirname, '..', 'frontend', 'src', 'pages', 'docs', 'md', 'changelog');
+const changed = [];
+
+function walk(folder) {
+  for (const entry of fs.readdirSync(folder)) {
+    const p = path.join(folder, entry);
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) walk(p);
+    else if (entry.endsWith('.md')) fixFile(p);
+  }
+}
+
+function fixFile(file) {
+  let data = fs.readFileSync(file, 'utf8');
+  const orig = data;
+
+  data = data.replace(/!\[([^\]]*)\]\(\/assets\/([^\)]+)\)/g, (m, alt, rest) =>
+    `![${alt}](../../../../../public/assets/${rest})`);
+
+  data = data.replace(/【\d+†Image: ([^】]+)】/g, '<!-- image removed: $1 -->');
+
+  data = data.replace(/^---\r?\n([\s\S]*?)\r?\n---[\r\n]*/, (_m, body) =>
+    `---\n${body}\n---\n\n`);
+
+  if (data !== orig) {
+    fs.writeFileSync(file, data);
+    changed.push(path.relative(process.cwd(), file));
+  }
+}
+
+walk(dir);
+if (changed.length) {
+  console.log('Updated files:');
+  for (const f of changed) console.log(' - ' + f);
+} else {
+  console.log('No changes found.');
+}


### PR DESCRIPTION
## Summary
- add script to rewrite markdown image paths
- update three changelog entries with new public asset links

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr` *(tests output many warnings but finished with PASS)*

------
https://chatgpt.com/codex/tasks/task_e_688734ce6834832fa8abe63ed3f4e13c