### PR TITLE
Fix vitest coverage provider

### DIFF
--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { approximateIrlPrice } from './approximateIrlPrice'
+
+describe('approximateIrlPrice', () => {
+  it('returns price for known item', () => {
+    expect(approximateIrlPrice('3d_printer')).toBe(350)
+  })
+
+  it('returns null for unknown item', () => {
+    expect(approximateIrlPrice('nonexistent')).toBeNull()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "cd frontend && npm run dev",
     "test": "vitest",
-    "test:backend": "vitest run --coverage backend/**/*.ts --reporter=default && codecov -F backend",
+    "test:backend": "vitest run --coverage \"backend/**/*.ts\" --reporter=default && codecov -F backend",
     "test:frontend": "vitest run --coverage frontend/src/components/**/*.svelte --reporter=default && codecov -F frontend",
     "test:all": "pnpm run test:backend && pnpm run test:frontend",
     "coverage:upload": "codecov",
@@ -31,7 +31,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.1.0",
     "@vitest/coverage-c8": "^0.33.0",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
     "ajv": "^8.12.0",
     "chart.js": "^4.5.0",
     "chartjs-node-canvas": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0(vitest@3.2.4(@types/node@24.1.0)(jsdom@26.1.0(canvas@3.1.2)))
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.1.0)(jsdom@26.1.0(canvas@3.1.2)))
       ajv:
         specifier: ^8.12.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
     globals: true,
     setupFiles: [],
     coverage: {
-      provider: 'c8',
-      reporter: ['text', 'html', 'lcov'],
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
       all: false,
       include: [
         'backend/**/*.ts',


### PR DESCRIPTION
## Summary
- use Vitest's built-in v8 coverage provider
- pin `@vitest/coverage-v8` version
- add a small backend test so `test:backend` has a target
- quote the glob pattern in the backend test script

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `pnpm test:backend` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688824c4b4f0832f9a376420f900c60d