### PR TITLE
Fix Node version in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json


### PR DESCRIPTION
## Summary
- align tests workflow with Node.js 20 to match main CI jobs

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build` *(fails: Could not resolve "../../components/Page.astro")*

------
https://chatgpt.com/codex/tasks/task_e_68882c81e7e8832fa10881e023936bb1