### PR TITLE
Add upgrade prompt section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,5 +60,7 @@ All checks must pass before an agent-created PR is merged.
 
 - [Quest Submission Guide](frontend/src/pages/docs/md/quest-submission.md)
 - [UI Lifecycle Overview](frontend/src/pages/docs/md/ui-lifecycle.md)
+- [Codex Implementation Prompt](frontend/src/pages/docs/md/prompts-codex.md#implementation-prompt)
+- [Codex Upgrade Prompt](frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)
 - [AGENTS.md Spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6)
 - [Agents.md Guide](https://agentsmd.net/)

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -48,6 +48,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/bounties">Bounties</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
+            <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
         </nav>
      </span>
 </Page>

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -60,7 +60,8 @@ Instructions for creating processes that transform or utilize items. Topics incl
 
 ## AI Assistance for Content Creation
 
-For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex). It walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. This guide includes:
+For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex#implementation-prompt). It walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. This guide includes:
+For general repository maintenance, the [Codex Upgrade Prompt](/docs/prompts-codex#upgrade-prompt) instructs Codex to scan the project for improvements and implement them automatically.
 
 -   Effective prompt templates for different content types
 -   Best practices for working with AI assistants

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -1,7 +1,9 @@
 ---
-title: 'Codex Implementation Prompt'
+title: 'Codex Prompts'
 slug: 'prompts-codex'
 ---
+
+## Implementation Prompt
 
 Copy the prompt below into Codex to automatically address backlog tasks.
 
@@ -65,4 +67,23 @@ A pull‑request that turns one ❌ row into 💯 with all tests passing, plus u
 
 ```
 
+```
+
+## Upgrade Prompt
+
+Copy the prompt below into Codex to incrementally improve DSPACE.
+
+```text
+SYSTEM:
+You are an automated contributor for the **DSPACE** repository.
+Perform a thorough review of the project and implement incremental improvements without waiting for approval.
+Follow all guidelines in `AGENTS.md`, run the required checks, and keep pull requests focused on single concerns.
+The maintainers will review your PRs and can reject unwanted diffs.
+
+USER:
+Look for outdated patterns, TODOs, or possible optimizations.
+Propose your plan in the PR description and implement the improvements directly.
+
+OUTPUT:
+A pull request containing the enhancements with all tests and checks passing.
 ```

--- a/frontend/src/pages/quests/[id]/edit.astro
+++ b/frontend/src/pages/quests/[id]/edit.astro
@@ -1,6 +1,6 @@
 ---
-import Page from '../../components/Page.astro';
-import QuestForm from '../../components/svelte/QuestForm.svelte';
+import Page from '../../../components/Page.astro';
+import QuestForm from '../../../components/svelte/QuestForm.svelte';
 
 const { id } = Astro.params;
 ---


### PR DESCRIPTION
## Summary
- combine upgrade instructions into prompts-codex.md
- crosslink new anchors from docs and AGENTS guidelines
- update docs index to link directly to the upgrade prompt
- fix references in content development guide

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6888361e2324832f9cf1dd4d7e234503