### PR TITLE
Add Cloud Sync via GitHub Gist

### DIFF
--- a/frontend/__tests__/cloudSync.test.js
+++ b/frontend/__tests__/cloudSync.test.js
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'fake-indexeddb/auto';
+import {
+    uploadGameStateToGist,
+    downloadGameStateFromGist,
+    loadCloudGistId,
+} from '../src/utils/cloudSync.js';
+import { saveGameState, loadGameState } from '../src/utils/gameState/common.js';
+import { saveGitHubToken } from '../src/utils/githubToken.js';
+
+describe('cloudSync', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        global.fetch = jest.fn();
+    });
+
+    test('uploadGameStateToGist creates gist when none exists', async () => {
+        saveGitHubToken('ghp_x');
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ id: '1' }),
+        });
+        const id = await uploadGameStateToGist();
+        expect(id).toBe('1');
+        expect(loadCloudGistId()).toBe('1');
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://api.github.com/gists',
+            expect.any(Object)
+        );
+    });
+
+    test('uploadGameStateToGist patches existing gist', async () => {
+        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: 'a' } }));
+        saveGitHubToken('ghp_x');
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ id: 'a' }),
+        });
+        await uploadGameStateToGist();
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://api.github.com/gists/a',
+            expect.any(Object)
+        );
+    });
+
+    test('downloadGameStateFromGist updates state', async () => {
+        saveGitHubToken('ghp_x');
+        const encoded = btoa(JSON.stringify({ quests: { q: true }, inventory: {}, processes: {} }));
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ files: { 'dspace-save.json': { content: encoded } } }),
+        });
+        await downloadGameStateFromGist('ghp_x', '1');
+        expect(loadGameState().quests.q).toBe(true);
+        expect(loadCloudGistId()).toBe('1');
+    });
+});

--- a/frontend/e2e/cloud-sync.spec.ts
+++ b/frontend/e2e/cloud-sync.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('cloud sync page renders', async ({ page }) => {
+    await page.goto('/cloudsync');
+    await expect(page.getByText('GitHub Token')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Upload/i })).toBeVisible();
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -32,6 +32,7 @@ const TEST_GROUPS = [
             'svelte-component-hydration.spec.ts',
             'builtin-quests.spec.ts',
             'custom-backup.spec.ts',
+            'cloud-sync.spec.ts',
         ],
         parallel: true,
         workers: MAX_WORKERS,
@@ -75,7 +76,6 @@ const TEST_GROUPS = [
         parallel: true,
         workers: 2,
     },
-
 ];
 
 // Colors for console output
@@ -121,7 +121,11 @@ function runTestGroup(group) {
 
     try {
         console.log(`${colors.cyan}Command: ${command}${colors.reset}`);
-        console.log(`${colors.cyan}Using ${group.parallel ? (group.workers || MAX_WORKERS) : 1} worker(s)${colors.reset}`);
+        console.log(
+            `${colors.cyan}Using ${group.parallel ? group.workers || MAX_WORKERS : 1} worker(s)${
+                colors.reset
+            }`
+        );
         execSync(command, { stdio: 'inherit', cwd: rootDir });
         console.log(`${colors.green}✓ ${group.name} completed successfully${colors.reset}`);
         return true;
@@ -160,12 +164,16 @@ function main() {
         if (success) {
             successCount++;
             console.log(
-                `${colors.green}Group completed in ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
+                `${colors.green}Group completed in ${groupDuration.toFixed(2)} seconds${
+                    colors.reset
+                }\n`
             );
         } else {
             failureCount++;
             console.log(
-                `${colors.red}Group failed after ${groupDuration.toFixed(2)} seconds${colors.reset}\n`
+                `${colors.red}Group failed after ${groupDuration.toFixed(2)} seconds${
+                    colors.reset
+                }\n`
             );
         }
     }

--- a/frontend/src/config/menu.json
+++ b/frontend/src/config/menu.json
@@ -49,6 +49,10 @@
         "href": "/gamesaves"
     },
     {
+        "name": "Cloud Sync",
+        "href": "/cloudsync"
+    },
+    {
         "name": "Custom Content Backup",
         "href": "/contentbackup"
     },

--- a/frontend/src/pages/cloudsync/index.astro
+++ b/frontend/src/pages/cloudsync/index.astro
@@ -1,0 +1,19 @@
+---
+import Page from '../../components/Page.astro';
+import Syncer from './svelte/Syncer.svelte';
+---
+
+<Page columns="1">
+    <div class="vertical">
+        <Syncer client:idle />
+    </div>
+</Page>
+
+<style>
+    .vertical {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+    }
+</style>

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -1,0 +1,114 @@
+<script>
+    import Chip from '../../../components/svelte/Chip.svelte';
+    import {
+        loadCloudGistId,
+        uploadGameStateToGist,
+        downloadGameStateFromGist,
+    } from '../../../utils/cloudSync.js';
+    import {
+        isValidGitHubToken,
+        loadGitHubToken,
+        saveGitHubToken,
+        clearGitHubToken,
+    } from '../../../utils/githubToken.js';
+
+    let token = '';
+    let gistId = '';
+    let message = '';
+
+    token = loadGitHubToken();
+    gistId = loadCloudGistId();
+
+    const saveToken = () => {
+        saveGitHubToken(token);
+    };
+
+    const clearTokenLocal = () => {
+        token = '';
+        clearGitHubToken();
+    };
+
+    const handleUpload = async () => {
+        try {
+            if (!isValidGitHubToken(token)) {
+                message = 'GitHub token looks invalid';
+                return;
+            }
+            const id = await uploadGameStateToGist(token);
+            gistId = id;
+            message = 'Upload successful';
+        } catch (err) {
+            console.error(err);
+            message = 'Upload failed';
+        }
+    };
+
+    const handleDownload = async () => {
+        try {
+            if (!gistId) {
+                message = 'Gist ID required';
+                return;
+            }
+            await downloadGameStateFromGist(token, gistId);
+            message = 'Download successful';
+        } catch (err) {
+            console.error(err);
+            message = 'Download failed';
+        }
+    };
+</script>
+
+<Chip text="">
+    <div class="vertical">
+        <div class="form-group">
+            <label for="token">GitHub Token*</label>
+            <div class="token-input">
+                <input id="token" type="password" bind:value={token} />
+                <button type="button" on:click={saveToken}>Save</button>
+                <button type="button" on:click={clearTokenLocal} data-testid="clear-sync-token"
+                    >Clear</button
+                >
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="gist">Gist ID</label>
+            <input id="gist" type="text" bind:value={gistId} />
+        </div>
+        <div class="buttons">
+            <Chip text="Upload" on:click={handleUpload} inverted={true} />
+            <Chip text="Download" on:click={handleDownload} inverted={true} />
+        </div>
+        {#if message}
+            <p class="message">{message}</p>
+        {/if}
+    </div>
+</Chip>
+
+<style>
+    .vertical {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+        width: 100%;
+    }
+    .token-input {
+        display: flex;
+        gap: 10px;
+    }
+    .form-group label {
+        font-weight: bold;
+    }
+    .buttons {
+        display: flex;
+        gap: 10px;
+    }
+    .message {
+        color: #90ee90;
+    }
+    input {
+        flex: 1;
+        padding: 5px;
+        border-radius: 6px;
+    }
+</style>

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -17,7 +17,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/team">Meet the team</a>
         </nav>
     </span>
-   
+
     <span>
         <h2>Skills</h2>
         <nav>
@@ -33,6 +33,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/npcs">NPCs</a>
             <a href="/docs/realtime">Everything is real-time</a>
             <a href="/docs/inventory">Inventory</a>
+            <a href="/docs/cloud-sync">Cloud Sync</a>
             <a href="/docs/achievements">Achievements</a>
             <a href="/docs/titles">Titles</a>
             <a href="/docs/processes">Processes</a>
@@ -41,7 +42,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/dCarbon">dCarbon</a>
         </nav>
     </span>
-     <span>
+    <span>
         <h2>Dev</h2>
         <nav>
             <a href="/docs/prs">Pull Requests</a>
@@ -49,7 +50,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
         </nav>
-     </span>
+    </span>
 </Page>
 
 <style>
@@ -63,7 +64,7 @@ import Page from '../../components/Page.astro';
 
     span {
         background-color: #2f5b2f;
-		border-radius: 2rem;
+        border-radius: 2rem;
         text-align: justify;
         text-justify: inter-word;
         text-align: center;
@@ -71,36 +72,36 @@ import Page from '../../components/Page.astro';
     }
     /* Navbar */
 
-	nav {
-		text-align: center;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
+    nav {
+        text-align: center;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
         padding: 0px;
-	}
+    }
 
-	nav a {
+    nav a {
         opacity: 0.8;
-		background-color: #84d484;
-		border-radius: 100px;
-		color: black;
-		text-decoration: none;
-		flex-direction: row;
-		padding-left: 5px;
-		padding-right: 5px;
+        background-color: #84d484;
+        border-radius: 100px;
+        color: black;
+        text-decoration: none;
+        flex-direction: row;
+        padding-left: 5px;
+        padding-right: 5px;
         text-align: center;
         white-space: nowrap;
         margin: 5px;
         padding: 10px;
     }
 
-	nav a:hover {
-		opacity: 1;
-	}
+    nav a:hover {
+        opacity: 1;
+    }
 
     p {
         background-color: #2f5b2f;
         padding: 15px;
-		border-radius: 2rem;
+        border-radius: 2rem;
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -135,7 +135,7 @@ A few technical details that might interest you:
 -   Your v2 progress will automatically migrate to v3
 -   All custom content includes rollback functionality (in case something goes wrong)
 
-**Coming in future updates:** Optional cloud sync functionality to back up your progress across devices.
+The new **Cloud Sync** feature lets you back up your progress across devices using a private GitHub gist. Visit the [Cloud Sync](/cloudsync) page to enable it.
 
 ## Refined Virtual Economy
 

--- a/frontend/src/pages/docs/md/cloud-sync.md
+++ b/frontend/src/pages/docs/md/cloud-sync.md
@@ -1,0 +1,13 @@
+---
+title: 'Cloud Sync'
+---
+
+You can now back up your game progress to a private GitHub gist. On the **Cloud Sync** page you can upload your current save or download it to another device.
+
+1. Generate a GitHub personal access token with the `gist` scope.
+2. Enter the token in the form and click **Save**.
+3. Click **Upload** to create/update the gist and store your save data.
+4. Copy the resulting Gist ID to use on other devices.
+5. On another device, enter the same token and Gist ID and click **Download**.
+
+Your gist ID is stored locally along with your token so you don't have to re-enter it.

--- a/frontend/src/pages/docs/md/inventory.md
+++ b/frontend/src/pages/docs/md/inventory.md
@@ -78,4 +78,4 @@ The inventory interface allows you to:
 -   Manage custom items and preview them from the **Manage Items** page using
     the **Preview** button next to each entry
 
-All inventory data is now stored locally using IndexedDB, with optional cloud sync for backup and cross-device access.
+All inventory data is now stored locally using IndexedDB. For cross-device backups you can use the new [Cloud Sync](/cloudsync) feature.

--- a/frontend/src/utils/cloudSync.js
+++ b/frontend/src/utils/cloudSync.js
@@ -1,0 +1,71 @@
+import { exportGameStateString, importGameStateString } from './gameState/common.js';
+import { loadGitHubToken } from './githubToken.js';
+
+const storageKey = 'gameState';
+
+function loadCloudGistId() {
+    try {
+        const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+        return state.cloudSync?.gistId || '';
+    } catch {
+        return '';
+    }
+}
+
+function saveCloudGistId(id) {
+    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    state.cloudSync = state.cloudSync || {};
+    state.cloudSync.gistId = id;
+    localStorage.setItem(storageKey, JSON.stringify(state));
+}
+
+async function uploadGameStateToGist(token) {
+    if (!token) {
+        token = loadGitHubToken();
+    }
+    const gistId = loadCloudGistId();
+    const headers = {
+        Authorization: `token ${token}`,
+        'Content-Type': 'application/json',
+    };
+    const content = exportGameStateString();
+    let res;
+    if (gistId) {
+        res = await fetch(`https://api.github.com/gists/${gistId}`, {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify({ files: { 'dspace-save.json': { content } } }),
+        });
+    } else {
+        res = await fetch('https://api.github.com/gists', {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+                description: 'DSPACE cloud save',
+                public: false,
+                files: { 'dspace-save.json': { content } },
+            }),
+        });
+    }
+    if (!res.ok) throw new Error('Failed to upload game state');
+    const data = await res.json();
+    saveCloudGistId(data.id);
+    return data.id;
+}
+
+async function downloadGameStateFromGist(token, gistId = loadCloudGistId()) {
+    if (!gistId) throw new Error('No gist id specified');
+    if (!token) {
+        token = loadGitHubToken();
+    }
+    const headers = token ? { Authorization: `token ${token}` } : {};
+    const res = await fetch(`https://api.github.com/gists/${gistId}`, { headers });
+    if (!res.ok) throw new Error('Failed to download game state');
+    const data = await res.json();
+    const content = data.files['dspace-save.json']?.content;
+    if (!content) throw new Error('Invalid gist content');
+    importGameStateString(content);
+    saveCloudGistId(gistId);
+}
+
+export { loadCloudGistId, uploadGameStateToGist, downloadGameStateFromGist };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "cd frontend && npm run dev",
     "test": "vitest",
-    "test:backend": "vitest run --coverage \"backend/**/*.ts\" --reporter=default && codecov -F backend",
+    "test:backend": "vitest run --coverage backend/**/*.ts --reporter=default && codecov -F backend",
     "test:frontend": "vitest run --coverage frontend/src/components/**/*.svelte --reporter=default && codecov -F frontend",
     "test:all": "pnpm run test:backend && pnpm run test:frontend",
     "coverage:upload": "codecov",


### PR DESCRIPTION
## Summary
- implement optional cloud backup using GitHub gists
- add Cloud Sync UI and docs
- expose menu link
- test cloud sync utilities and page
- fix backend test glob so vitest finds tests

## Testing
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68883acb9c8c832f9fa46a9b32cdde57