### PR TITLE
Fix CI vitest install with pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         with: { version: 9 }
       - run: pnpm install --frozen-lockfile
-      - run: cd frontend && npm ci
+      - run: cd frontend && pnpm install --frozen-lockfile
       - name: Run & upload coverage
         run: |
           pnpm test:all

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "scripts": {
     "dev": "cd frontend && npm run dev",
     "test": "vitest",
-    "test:backend": "vitest run --coverage backend/**/*.ts --reporter=default && codecov -F backend",
-    "test:frontend": "vitest run --coverage frontend/src/components/**/*.svelte --reporter=default && codecov -F frontend",
     "test:backend": "jest --coverage backend tests && codecov -F backend",
+    "test:frontend": "vitest run --coverage frontend/src/components/**/*.svelte --reporter=default && codecov -F frontend",
     "test:all": "pnpm run test:backend && pnpm run test:frontend",
     "coverage:upload": "codecov",
     "test:watch": "cd frontend && npm run test:watch",
@@ -43,7 +42,8 @@
     "jsdom": "^26.1.0",
     "prettier-plugin-svelte": "^3.4.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "3.2.4"
   },
   "dependencies": {
     "openai": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@24.1.0)(jsdom@26.1.0(canvas@3.1.2))
 
 packages:
 
@@ -2932,10 +2935,8 @@ snapshots:
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
-    optional: true
 
-  '@types/deep-eql@4.0.2':
-    optional: true
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2977,7 +2978,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.1
       tinyrainbow: 2.0.0
-    optional: true
 
   '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.1.0))':
     dependencies:
@@ -2986,38 +2986,32 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 7.0.6(@types/node@24.1.0)
-    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
-    optional: true
 
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.0.0
-    optional: true
 
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.17
       pathe: 2.0.3
-    optional: true
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
-    optional: true
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.0
       tinyrainbow: 2.0.0
-    optional: true
 
   acorn@8.15.0: {}
 
@@ -3065,8 +3059,7 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  assertion-error@2.0.1:
-    optional: true
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
@@ -3180,8 +3173,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  cac@6.7.14:
-    optional: true
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3208,7 +3200,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.0
       pathval: 2.0.1
-    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -3227,8 +3218,7 @@ snapshots:
       chart.js: 4.5.0
       tslib: 2.8.1
 
-  check-error@2.1.1:
-    optional: true
+  check-error@2.1.1: {}
 
   chownr@1.1.4: {}
 
@@ -3316,8 +3306,7 @@ snapshots:
 
   dedent@1.6.0: {}
 
-  deep-eql@5.0.2:
-    optional: true
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -3365,8 +3354,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0:
-    optional: true
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3423,7 +3411,6 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
-    optional: true
 
   execa@5.1.1:
     dependencies:
@@ -3441,8 +3428,7 @@ snapshots:
 
   expand-template@2.0.3: {}
 
-  expect-type@1.2.2:
-    optional: true
+  expect-type@1.2.2: {}
 
   expect@29.7.0:
     dependencies:
@@ -4000,8 +3986,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1:
-    optional: true
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -4061,8 +4046,7 @@ snapshots:
 
   lodash.memoize@4.1.2: {}
 
-  loupe@3.2.0:
-    optional: true
+  loupe@3.2.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -4195,11 +4179,9 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  pathe@2.0.3:
-    optional: true
+  pathe@2.0.3: {}
 
-  pathval@2.0.1:
-    optional: true
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4350,8 +4332,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  siginfo@2.0.0:
-    optional: true
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -4382,11 +4363,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  stackback@0.0.2:
-    optional: true
+  stackback@0.0.2: {}
 
-  std-env@3.9.0:
-    optional: true
+  std-env@3.9.0: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -4422,7 +4401,6 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
-    optional: true
 
   stubs@3.0.0: {}
 
@@ -4487,25 +4465,20 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
-  tinybench@2.9.0:
-    optional: true
+  tinybench@2.9.0: {}
 
-  tinyexec@0.3.2:
-    optional: true
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1:
-    optional: true
+  tinypool@1.1.1: {}
 
-  tinyrainbow@2.0.0:
-    optional: true
+  tinyrainbow@2.0.0: {}
 
-  tinyspy@4.0.3:
-    optional: true
+  tinyspy@4.0.3: {}
 
   tldts-core@6.1.86: {}
 
@@ -4605,7 +4578,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   vite@7.0.6(@types/node@24.1.0):
     dependencies:
@@ -4664,7 +4636,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -4702,7 +4673,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- ensure vitest is installed
- use pnpm for frontend install in CI

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68885fcf03d8832fa65a7d04b1d352bf