### PR TITLE
Fix vitest missing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         with: { version: 9 }
       - run: pnpm install --frozen-lockfile
-      - run: cd frontend && npm ci
+      - run: cd frontend && pnpm install --no-frozen-lockfile
       - name: Run & upload coverage
         run: |
           pnpm test:all

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "jsdom": "^26.1.0",
     "prettier-plugin-svelte": "^3.4.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "openai": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.1.0)(jsdom@26.1.0(canvas@3.1.2))
 
 packages:
 


### PR DESCRIPTION
## Summary
- add vitest dev dependency
- install frontend deps with pnpm
- update lock file

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68885fcf03d8832fa65a7d04b1d352bf