### PR TITLE
Add token tracking store and badge

### DIFF
--- a/frontend/__tests__/chatStore.test.js
+++ b/frontend/__tests__/chatStore.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import { messages, countTokens } from '../src/stores/chat.js';
+
+describe('messages store', () => {
+    beforeEach(() => {
+        messages.set([]);
+    });
+
+    test('starts empty', () => {
+        let value;
+        const unsub = messages.subscribe((v) => (value = v));
+        unsub();
+        expect(value).toEqual([]);
+    });
+
+    test('adds message with tokens', () => {
+        const msg = { role: 'user', content: 'hello world', tokens: countTokens('hello world') };
+        messages.update((m) => [...m, msg]);
+        let value;
+        const unsub = messages.subscribe((v) => (value = v));
+        unsub();
+        expect(value.length).toBe(1);
+        expect(value[0].tokens).toBe(2);
+    });
+});

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -1,7 +1,8 @@
 <script>
-    import { onMount } from 'svelte';
-    import { GPT35Turbo } from '../../../utils/openAI.js';
-    import { writable } from 'svelte/store';
+import { onMount } from 'svelte';
+import { GPT35Turbo } from '../../../utils/openAI.js';
+import { writable } from 'svelte/store';
+import { messages, countTokens } from '../../../stores/chat.js';
     import Message from './Message.svelte';
     import Spinner from '../../../components/svelte/Spinner.svelte';
 
@@ -11,28 +12,39 @@
     let welcomeMessage =
         "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any other topic. I may accidentally generate incorrect information, so please double-check anything I say. I'm still learning! I should have some shiny new upgrades soon!";
 
+    function addMessage(msg) {
+        messageHistory.update((history) => [...history, msg]);
+        messages.update((all) => [...all, msg]);
+    }
+
     async function submitMessage() {
-        const userMessage = { role: 'user', content: $message };
+        const userMessage = {
+            role: 'user',
+            content: $message,
+            tokens: countTokens($message)
+        };
 
         // Add the user message to the chat history immediately
-        messageHistory.update((history) => [...history, userMessage]);
+        addMessage(userMessage);
         showSpinner = true;
 
         try {
             const aiResponse = await GPT35Turbo([...$messageHistory, userMessage]);
-            const aiMessage = { role: 'assistant', content: aiResponse };
+            const aiMessage = {
+                role: 'assistant',
+                content: aiResponse,
+                tokens: countTokens(aiResponse)
+            };
 
             // Update the chat history with the assistant's message
-            messageHistory.update((history) => [...history, aiMessage]);
+            addMessage(aiMessage);
         } catch (error) {
             console.error(error);
-            messageHistory.update((history) => [
-                ...history,
-                {
-                    role: 'assistant',
-                    content: "Sorry, I'm having some trouble and can't generate a response.",
-                },
-            ]);
+            addMessage({
+                role: 'assistant',
+                content: "Sorry, I'm having some trouble and can't generate a response.",
+                tokens: countTokens("Sorry, I'm having some trouble and can't generate a response.")
+            });
         }
 
         message.set(''); // clear text area
@@ -48,10 +60,12 @@
 
     onMount(async () => {
         if ($messageHistory.length === 0) {
-            messageHistory.update((history) => [
-                ...history,
-                { role: 'assistant', content: welcomeMessage },
-            ]);
+            const welcome = {
+                role: 'assistant',
+                content: welcomeMessage,
+                tokens: countTokens(welcomeMessage)
+            };
+            addMessage(welcome);
         }
     });
 </script>

--- a/frontend/src/pages/chat/svelte/TokenPlaceChat.svelte
+++ b/frontend/src/pages/chat/svelte/TokenPlaceChat.svelte
@@ -1,7 +1,8 @@
 <script>
-    import { onMount } from 'svelte';
-    import { tokenPlaceChat } from '../../../utils/tokenPlace.js';
-    import { writable } from 'svelte/store';
+import { onMount } from 'svelte';
+import { tokenPlaceChat } from '../../../utils/tokenPlace.js';
+import { writable } from 'svelte/store';
+import { messages, countTokens } from '../../../stores/chat.js';
     import Message from './Message.svelte';
     import Spinner from '../../../components/svelte/Spinner.svelte';
 
@@ -11,24 +12,35 @@
     let welcomeMessage =
         "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any other topic. I may accidentally generate incorrect information, so please double-check anything I say.";
 
+    function addMessage(msg) {
+        messageHistory.update((history) => [...history, msg]);
+        messages.update((all) => [...all, msg]);
+    }
+
     async function submitMessage() {
-        const userMessage = { role: 'user', content: $message };
-        messageHistory.update((history) => [...history, userMessage]);
+        const userMessage = {
+            role: 'user',
+            content: $message,
+            tokens: countTokens($message)
+        };
+        addMessage(userMessage);
         showSpinner = true;
 
         try {
             const aiResponse = await tokenPlaceChat([...$messageHistory, userMessage]);
-            const aiMessage = { role: 'assistant', content: aiResponse };
-            messageHistory.update((history) => [...history, aiMessage]);
+            const aiMessage = {
+                role: 'assistant',
+                content: aiResponse,
+                tokens: countTokens(aiResponse)
+            };
+            addMessage(aiMessage);
         } catch (error) {
             console.error(error);
-            messageHistory.update((history) => [
-                ...history,
-                {
-                    role: 'assistant',
-                    content: "Sorry, I'm having some trouble and can't generate a response.",
-                },
-            ]);
+            addMessage({
+                role: 'assistant',
+                content: "Sorry, I'm having some trouble and can't generate a response.",
+                tokens: countTokens("Sorry, I'm having some trouble and can't generate a response.")
+            });
         }
 
         message.set('');
@@ -44,10 +56,12 @@
 
     onMount(() => {
         if ($messageHistory.length === 0) {
-            messageHistory.update((history) => [
-                ...history,
-                { role: 'assistant', content: welcomeMessage },
-            ]);
+            const welcome = {
+                role: 'assistant',
+                content: welcomeMessage,
+                tokens: countTokens(welcomeMessage)
+            };
+            addMessage(welcome);
         }
     });
 </script>

--- a/frontend/src/pages/dchat/TokenBadge.svelte
+++ b/frontend/src/pages/dchat/TokenBadge.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { messages } from '../../stores/chat.js';
+  $: tokenTotal = $messages.reduce((n, m) => n + (m.tokens || 0), 0);
+</script>
+
+<h2>
+  dChat
+  <span class="badge">{tokenTotal} tokens</span>
+</h2>
+
+<style>
+  .badge {
+    margin-left: 0.5rem;
+    padding: 0 0.4rem;
+    background: var(--grey-800);
+    color: white;
+    border-radius: 0.25rem;
+    font-size: 0.8rem;
+  }
+</style>

--- a/frontend/src/pages/dchat/index.astro
+++ b/frontend/src/pages/dchat/index.astro
@@ -1,0 +1,22 @@
+---
+import Page from '../../components/Page.astro';
+import TokenBadge from './TokenBadge.svelte';
+import Integrations from '../chat/svelte/Integrations.svelte';
+---
+
+<Page title="dChat" columns="1">
+    <img src="/assets/npc/dChat.jpg" alt="dChat" />
+    <TokenBadge client:load />
+    <Integrations client:idle />
+</Page>
+
+<style>
+    img {
+        width: 100%;
+        height: 100px;
+        object-fit: cover;
+        border-radius: 20px;
+        margin-bottom: -25px;
+    }
+</style>
+

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -1,0 +1,10 @@
+import { writable } from 'svelte/store';
+
+// Store for chat messages used across dChat components
+export const messages = writable([]);
+
+// Utility to count simple whitespace-separated tokens
+export function countTokens(content) {
+    if (!content) return 0;
+    return content.trim().split(/\s+/).filter(Boolean).length;
+}


### PR DESCRIPTION
## Summary
- track chat messages in a new Svelte store
- display total tokens with new `TokenBadge` component and page
- update existing chat components to populate the shared store
- add unit test for the new store

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `cd frontend && npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: Not a valid object name origin/main)*

------
https://chatgpt.com/codex/tasks/task_e_68886de75ed0832fbe63cfc01ba8ebe6