### PR TITLE
Add process sorting to item details

### DIFF
--- a/frontend/src/pages/item/[slug]/ItemProcesses.svelte
+++ b/frontend/src/pages/item/[slug]/ItemProcesses.svelte
@@ -1,0 +1,32 @@
+<script>
+    import Process from '../../../components/svelte/Process.svelte';
+    import { writable, derived } from 'svelte/store';
+
+    export let processes = [];
+
+    let order = writable('name');
+    const processesStore = writable(processes);
+    $: processesStore.set(processes);
+
+    const sorted = derived([order, processesStore], ([$order, $processes]) => {
+        const arr = [...$processes];
+        if ($order === 'timeAsc') {
+            arr.sort((a, b) => a.duration - b.duration);
+        } else if ($order === 'timeDesc') {
+            arr.sort((a, b) => b.duration - a.duration);
+        } else {
+            arr.sort((a, b) => (a.name || a.title).localeCompare(b.name || b.title));
+        }
+        return arr;
+    });
+</script>
+
+<select bind:value={order}>
+    <option value="name">Name A→Z</option>
+    <option value="timeAsc">Time ↑</option>
+    <option value="timeDesc">Time ↓</option>
+</select>
+
+{#each $sorted as p}
+    <Process processId={p.id} />
+{/each}


### PR DESCRIPTION
## Summary
- add selectable ordering to processes displayed on item pages
- sort processes by name or duration in ItemProcesses.svelte

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `cd frontend && npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: Not a valid object name origin/main)*

------
https://chatgpt.com/codex/tasks/task_e_68886db045f4832f892f693a2ec2b7c0