### PR TITLE
Add process buy button

### DIFF
--- a/frontend/src/pages/process/[slug].astro
+++ b/frontend/src/pages/process/[slug].astro
@@ -1,0 +1,10 @@
+---
+import Page from '../../components/Page.astro';
+import ProcessView from './[slug]/ProcessView.svelte';
+
+const { slug } = Astro.params;
+---
+
+<Page columns="1">
+    <ProcessView slug={slug} client:load />
+</Page>

--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -1,0 +1,95 @@
+<script>
+    import Process from '../../../components/svelte/Process.svelte';
+    import processes from '../../processes/processes.json';
+    import items from '../../inventory/json/items.json';
+    import { buyItems, getItemCount } from '../../../utils/gameState/inventory.js';
+    import { getPriceStringComponents } from '../../../utils.js';
+    import { onMount } from 'svelte';
+
+    export let slug;
+
+    let process = processes.find((p) => p.id === slug);
+    let disableBuy = true;
+    let toastVisible = false;
+    let toastMessage = '';
+
+    const updateDisabled = () => {
+        if (!process || !process.requireItems) {
+            disableBuy = true;
+            return;
+        }
+        disableBuy = process.requireItems.every((item) => getItemCount(item.id) >= item.count);
+    };
+
+    const buyItem = (id, qty) => {
+        const item = items.find((i) => i.id === id);
+        if (!item) return;
+        const { price } = getPriceStringComponents(item.price);
+        buyItems([{ id, quantity: qty, price }]);
+    };
+
+    const buyRequired = () => {
+        if (!process) return;
+        let added = 0;
+        process.requireItems.forEach((req) => {
+            const have = getItemCount(req.id);
+            const need = req.count - have;
+            if (need > 0) {
+                buyItem(req.id, need);
+                added += need;
+            }
+        });
+        if (added > 0) {
+            toastMessage = `\u2713 Added ${added} items to inventory`;
+            toastVisible = true;
+            setTimeout(() => (toastVisible = false), 3000);
+        }
+        updateDisabled();
+    };
+
+    onMount(updateDisabled);
+</script>
+
+<div class="process-view">
+    <Process processId={slug} />
+    {#if process && process.requireItems && process.requireItems.length > 0}
+        <button class="primary" on:click={buyRequired} aria-disabled={disableBuy} disabled={disableBuy}>
+            Buy required items
+        </button>
+    {/if}
+    {#if toastVisible}
+        <div class="toast">{toastMessage}</div>
+    {/if}
+</div>
+
+<style>
+    .primary {
+        background-color: #2f5b2f;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        padding: 8px 16px;
+        margin-top: 10px;
+        cursor: pointer;
+    }
+    .primary[disabled] {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+    .process-view {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+    .toast {
+        position: fixed;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: #cacaca;
+        color: #fff;
+        padding: 10px 20px;
+        border-radius: 5px;
+        text-align: center;
+    }
+</style>

--- a/frontend/src/pages/processes/[processId].astro
+++ b/frontend/src/pages/processes/[processId].astro
@@ -1,10 +1,10 @@
 ---
 import Page from '../../components/Page.astro';
-import Process from '../../components/svelte/Process.svelte';
+import ProcessView from '../process/[slug]/ProcessView.svelte';
 
 const { processId } = Astro.params;
 ---
 
 <Page columns="1">
-    <Process processId={processId.toString()} client:load />
+    <ProcessView slug={processId.toString()} client:load />
 </Page>


### PR DESCRIPTION
## Summary
- add new ProcessView.svelte page with Buy required items button
- expose it at `/process/[slug]` and use in existing process page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68886da52178832f9d3664aae313ad70