### PR TITLE
Add Svelte CompactItemList component

### DIFF
--- a/frontend/__tests__/CompactItemListCompile.test.js
+++ b/frontend/__tests__/CompactItemListCompile.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('CompactItemList.svelte compilation', () => {
+    it('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/components/svelte/ui/CompactItemList.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source, {})).not.toThrow();
+    });
+});

--- a/frontend/src/components/svelte/ui/CompactItemList.svelte
+++ b/frontend/src/components/svelte/ui/CompactItemList.svelte
@@ -1,0 +1,169 @@
+<script>
+    import { afterUpdate } from 'svelte';
+
+    export let items = [];
+    export let onSelect = null;
+    export let maxHeight = 320;
+    export let itemHeight = 32;
+    export let className = '';
+    export let renderItem = null;
+
+    let activeId;
+    let container;
+    let scrollTop = 0;
+
+    $: if (activeId === undefined) {
+        const first = items.find((i) => !i.disabled);
+        activeId = first && first.id;
+    }
+
+    const virtualized = () => items.length * itemHeight > maxHeight;
+    let start = 0;
+    let end = items.length;
+
+    $: if (virtualized()) {
+        const perPage = Math.ceil(maxHeight / itemHeight);
+        start = Math.floor(scrollTop / itemHeight);
+        end = Math.min(items.length, start + perPage + 1);
+    }
+
+    function handleScroll() {
+        scrollTop = container.scrollTop;
+    }
+
+    function setNextActive(delta) {
+        if (!items.length) return;
+        let idx = items.findIndex((i) => i.id === activeId);
+        if (idx === -1) idx = 0;
+        for (let i = 0; i < items.length; i++) {
+            idx = (idx + delta + items.length) % items.length;
+            if (!items[idx].disabled) {
+                activeId = items[idx].id;
+                break;
+            }
+        }
+    }
+
+    function handleKeyDown(e) {
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                setNextActive(1);
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                setNextActive(-1);
+                break;
+            case 'Enter':
+            case ' ': {
+                e.preventDefault();
+                const item = items.find((i) => i.id === activeId);
+                if (item && !item.disabled && onSelect) onSelect(item.id);
+                break;
+            }
+        }
+    }
+
+    function handleClick(item) {
+        if (item.disabled) return;
+        activeId = item.id;
+        if (onSelect) onSelect(item.id);
+    }
+
+    afterUpdate(() => {
+        if (container && activeId !== undefined) {
+            const el = container.querySelector(`[data-id="${activeId}"]`);
+            if (el) el.focus();
+        }
+    });
+</script>
+
+<div
+    role="listbox"
+    bind:this={container}
+    class={className}
+    style="max-height:{maxHeight}px;overflow-y:auto;"
+    tabindex="0"
+    aria-activedescendant={activeId !== undefined ? `item-${activeId}` : undefined}
+    on:keydown={handleKeyDown}
+    on:scroll={virtualized() ? handleScroll : undefined}
+    data-testid={virtualized() ? 'virtualized' : 'static'}
+>
+    {#if virtualized()}
+        <div style="height:{items.length * itemHeight}px;position:relative;">
+            <div style="position:absolute;top:{start * itemHeight}px;left:0;right:0;">
+                {#each items.slice(start, end) as item (item.id)}
+                    {#key item.id}
+                        <div
+                            role="option"
+                            aria-selected={item.id === activeId}
+                            tabindex={item.id === activeId ? 0 : -1}
+                            data-id={item.id}
+                            id={`item-${item.id}`}
+                            style="display:flex;align-items:center;padding:4px;gap:8px;"
+                            style:height={`${itemHeight}px`}
+                            style:opacity={item.disabled ? 0.5 : 1}
+                            style:cursor={item.disabled ? 'default' : 'pointer'}
+                            style:outline={item.id === activeId ? '2px solid #2684FF' : null}
+                            style:backgroundColor={item.id === activeId
+                                ? 'rgba(38,132,255,0.1)'
+                                : null}
+                            on:click={() => handleClick(item)}
+                            on:keydown={handleKeyDown}
+                        >
+                            {#if renderItem}
+                                {@html renderItem(item)}
+                            {:else}
+                                {#if item.iconSrc}
+                                    <img src={item.iconSrc} alt="" width="24" height="24" />
+                                {/if}
+                                <div style="display:flex;flex-direction:column;">
+                                    <span>{item.label}</span>
+                                    {#if item.subLabel}
+                                        <span style="font-size:0.875em;color:#666"
+                                            >{item.subLabel}</span
+                                        >
+                                    {/if}
+                                </div>
+                            {/if}
+                        </div>
+                    {/key}
+                {/each}
+            </div>
+        </div>
+    {:else}
+        {#each items as item (item.id)}
+            {#key item.id}
+                <div
+                    role="option"
+                    aria-selected={item.id === activeId}
+                    tabindex={item.id === activeId ? 0 : -1}
+                    data-id={item.id}
+                    id={`item-${item.id}`}
+                    style="display:flex;align-items:center;padding:4px;gap:8px;"
+                    style:height={`${itemHeight}px`}
+                    style:opacity={item.disabled ? 0.5 : 1}
+                    style:cursor={item.disabled ? 'default' : 'pointer'}
+                    style:outline={item.id === activeId ? '2px solid #2684FF' : null}
+                    style:backgroundColor={item.id === activeId ? 'rgba(38,132,255,0.1)' : null}
+                    on:click={() => handleClick(item)}
+                    on:keydown={handleKeyDown}
+                >
+                    {#if renderItem}
+                        {@html renderItem(item)}
+                    {:else}
+                        {#if item.iconSrc}
+                            <img src={item.iconSrc} alt="" width="24" height="24" />
+                        {/if}
+                        <div style="display:flex;flex-direction:column;">
+                            <span>{item.label}</span>
+                            {#if item.subLabel}
+                                <span style="font-size:0.875em;color:#666">{item.subLabel}</span>
+                            {/if}
+                        </div>
+                    {/if}
+                </div>
+            {/key}
+        {/each}
+    {/if}
+</div>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -12,18 +12,18 @@ file‑scoped prompt. :contentReference[oaicite:0]{index=0}
 > **TL;DR**  
 > 1. Scope the task to one or two files.  
 > 2. Say **exactly** what output you expect (diff, test, docs, etc.).  
-> 3. Stop talking when the spec is complete. Codex treats *all* remaining text as
->    mandatory instructions. :contentReference[oaicite:1]{index=1}
+> 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
+> mandatory instructions. :contentReference[oaicite:1]{index=1}
 
 ---
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case | Codex Web (ChatGPT sidebar) | Codex CLI |
-|----------|----------------------------|-----------|
-| Ad‑hoc feature | “Code” button, attach repo | `codex "add buy‑button to ProcessView"` |
-| Ask a question | “Ask” button | `codex exec "explain utils/time.ts"` |
-| CI automation | – | `codex exec --full-auto "run npm test"` |
+| Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
+| -------------- | --------------------------- | --------------------------------------- |
+| Ad‑hoc feature | “Code” button, attach repo  | `codex "add buy‑button to ProcessView"` |
+| Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
+| CI automation  | –                           | `codex exec --full-auto "run npm test"` |
 
 See the upstream CLI reference for more flags. :contentReference[oaicite:2]{index=2}
 
@@ -31,11 +31,11 @@ See the upstream CLI reference for more flags. :contentReference[oaicite:2]{ind
 
 ## 2 Prompt ingredients
 
-| Ingredient | Why it matters |
-|------------|----------------|
-| **Goal sentence** | Gives the agent a north star (“Add sort dropdown to Item page”). |
-| **Files to touch** | Limits search space → faster & cheaper. |
-| **Constraints** | Coding style, a11y, perf, etc. |
+| Ingredient           | Why it matters                                                     |
+| -------------------- | ------------------------------------------------------------------ |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).   |
+| **Files to touch**   | Limits search space → faster & cheaper.                            |
+| **Constraints**      | Coding style, a11y, perf, etc.                                     |
 | **Acceptance check** | e.g. “All `npm test` suites pass” or “Return a unified diff only”. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep


### PR DESCRIPTION
## Summary
- implement CompactItemList.svelte UI component with keyboard nav and virtualization logic
- add compile test for the component
- format prompts-codex doc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688871980638832f97d7863f2e49c991