### PR TITLE
Fix root test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "cd frontend && npm run dev",
-    "test": "vitest",
+    "test": "vitest run --coverage",
     "test:backend": "jest --coverage backend tests && codecov -F backend",
     "test:frontend": "vitest run --passWithNoTests --coverage frontend/src/components/**/*.svelte --reporter=default && codecov -F frontend",
     "test:all": "pnpm run test:backend && pnpm run test:frontend",

--- a/tests/itemQuality.test.ts
+++ b/tests/itemQuality.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect } from "vitest";
 import items from "../frontend/src/pages/inventory/json/items.json";
 import { approximateIrlPrice } from "../backend/approximateIrlPrice";
 

--- a/tests/run-test-groups.test.ts
+++ b/tests/run-test-groups.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, vi } from 'vitest';
 import { execSync } from 'child_process';
 let runTestGroup: any;
 let TEST_GROUPS: any;
@@ -13,7 +13,7 @@ beforeAll(async () => {
   TEST_GROUPS = mod.TEST_GROUPS;
 });
 
-jest.mock('child_process', () => ({ execSync: jest.fn() }));
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
 
 // Basic sanity check that TEST_GROUPS is populated
 describe.skip('run-test-groups', () => {
@@ -23,7 +23,7 @@ describe.skip('run-test-groups', () => {
   });
 
   it('returns true when exec succeeds', () => {
-    const spy = jest.mocked(execSync);
+    const spy = vi.mocked(execSync);
     spy.mockImplementation(() => ({} as any));
     const result = runTestGroup({ name: 'Demo', files: ['demo.spec.ts'], parallel: false });
     expect(spy).toHaveBeenCalled();
@@ -32,7 +32,7 @@ describe.skip('run-test-groups', () => {
   });
 
   it('returns false when exec fails', () => {
-    const spy = jest.mocked(execSync);
+    const spy = vi.mocked(execSync);
     spy.mockImplementation(() => {
       throw new Error('fail');
     });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: ['tests/**/*.{test,spec}.{js,ts}'],
     setupFiles: [],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- limit Vitest to repo root tests
- update root test script
- convert Jest-style tests to Vitest API

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68887882f2dc832fbc62df23468db5a2