### PR TITLE
Fix CI dependency install order

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
             package-lock.json
             frontend/package-lock.json
       - run: npm ci
-      - run: npm test
       - run: cd frontend && npm ci
+      - run: npm test
       - run: cd frontend && npm test
 


### PR DESCRIPTION
## Summary
- install frontend node_modules before running tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68887b7fac14832fbe50fc11cc4f9cb7