### PR TITLE
Add gist clearing to Cloud Sync

### DIFF
--- a/frontend/__tests__/SyncerCompile.test.js
+++ b/frontend/__tests__/SyncerCompile.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const svelte = require('svelte/compiler');
+
+describe('Syncer component', () => {
+    test('compiles without error', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../src/pages/cloudsync/svelte/Syncer.svelte'),
+            'utf8'
+        );
+        expect(() => svelte.compile(source)).not.toThrow();
+    });
+});

--- a/frontend/__tests__/cloudSync.test.js
+++ b/frontend/__tests__/cloudSync.test.js
@@ -6,6 +6,7 @@ import {
     uploadGameStateToGist,
     downloadGameStateFromGist,
     loadCloudGistId,
+    clearCloudGistId,
 } from '../src/utils/cloudSync.js';
 import { saveGameState, loadGameState } from '../src/utils/gameState/common.js';
 import { saveGitHubToken } from '../src/utils/githubToken.js';
@@ -55,5 +56,13 @@ describe('cloudSync', () => {
         await downloadGameStateFromGist('ghp_x', '1');
         expect(loadGameState().quests.q).toBe(true);
         expect(loadCloudGistId()).toBe('1');
+    });
+
+    test('clearCloudGistId resets stored id', () => {
+        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: '42' } }));
+        clearCloudGistId();
+        expect(loadCloudGistId()).toBe('');
+        const state = JSON.parse(localStorage.getItem('gameState'));
+        expect(state.cloudSync.gistId).toBe('');
     });
 });

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -4,6 +4,7 @@
         loadCloudGistId,
         uploadGameStateToGist,
         downloadGameStateFromGist,
+        clearCloudGistId,
     } from '../../../utils/cloudSync.js';
     import {
         isValidGitHubToken,
@@ -43,6 +44,11 @@
         }
     };
 
+    const clearGistId = () => {
+        gistId = '';
+        clearCloudGistId();
+    };
+
     const handleDownload = async () => {
         try {
             if (!gistId) {
@@ -72,7 +78,12 @@
         </div>
         <div class="form-group">
             <label for="gist">Gist ID</label>
-            <input id="gist" type="text" bind:value={gistId} />
+            <div class="token-input">
+                <input id="gist" type="text" bind:value={gistId} />
+                <button type="button" on:click={clearGistId} data-testid="clear-gist-id"
+                    >Clear</button
+                >
+            </div>
         </div>
         <div class="buttons">
             <Chip text="Upload" on:click={handleUpload} inverted={true} />

--- a/frontend/src/pages/docs/md/cloud-sync.md
+++ b/frontend/src/pages/docs/md/cloud-sync.md
@@ -10,4 +10,4 @@ You can now back up your game progress to a private GitHub gist. On the **Cloud 
 4. Copy the resulting Gist ID to use on other devices.
 5. On another device, enter the same token and Gist ID and click **Download**.
 
-Your gist ID is stored locally along with your token so you don't have to re-enter it.
+Your gist ID is stored locally along with your token so you don't have to re-enter it. Use the **Clear** buttons to remove the stored token or ID at any time.

--- a/frontend/src/utils/cloudSync.js
+++ b/frontend/src/utils/cloudSync.js
@@ -19,6 +19,14 @@ function saveCloudGistId(id) {
     localStorage.setItem(storageKey, JSON.stringify(state));
 }
 
+function clearCloudGistId() {
+    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    if (state.cloudSync) {
+        state.cloudSync.gistId = '';
+    }
+    localStorage.setItem(storageKey, JSON.stringify(state));
+}
+
 async function uploadGameStateToGist(token) {
     if (!token) {
         token = loadGitHubToken();
@@ -68,4 +76,4 @@ async function downloadGameStateFromGist(token, gistId = loadCloudGistId()) {
     saveCloudGistId(gistId);
 }
 
-export { loadCloudGistId, uploadGameStateToGist, downloadGameStateFromGist };
+export { loadCloudGistId, uploadGameStateToGist, downloadGameStateFromGist, clearCloudGistId };


### PR DESCRIPTION
## Summary
- support clearing stored gist ID in Cloud Sync utilities
- expose Clear button in the Cloud Sync UI
- document how to clear saved credentials
- test gist ID clearing and ensure Syncer.svelte compiles

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68887d2aab34832f80a6739e59e65fec