### PR TITLE
Add authentication docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -34,6 +34,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/realtime">Everything is real-time</a>
             <a href="/docs/inventory">Inventory</a>
             <a href="/docs/cloud-sync">Cloud Sync</a>
+            <a href="/docs/authentication">Authentication</a>
             <a href="/docs/achievements">Achievements</a>
             <a href="/docs/titles">Titles</a>
             <a href="/docs/processes">Processes</a>

--- a/frontend/src/pages/docs/md/authentication.md
+++ b/frontend/src/pages/docs/md/authentication.md
@@ -1,0 +1,26 @@
+---
+title: 'Authentication Flow'
+slug: 'authentication'
+---
+
+DSPACE uses GitHub authentication for features that interact with the official repository, such as submitting custom quest pull requests or syncing your save data with **Cloud Sync**.
+
+## Personal Access Tokens
+
+To authenticate, generate a GitHub personal access token with the `repo` and `gist` scopes. The token is used client-side only and never sent anywhere except directly to GitHub's API.
+
+1. Visit [GitHub Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens).
+2. Create a token granting **repo** and **gist** permissions.
+3. Paste the token into the relevant form in DSPACE and click **Save**.
+
+## Local Storage
+
+Your token is stored in `localStorage` under `gameState.github.token` so you don't need to re-enter it each time you open the game. You can clear the saved token using the **Clear** button next to the input field.
+
+## Security Considerations
+
+-   The token never leaves your browser except when making authenticated requests to GitHub.
+-   You can revoke the token at any time from your GitHub settings.
+-   If you share your device, remember to clear the token to prevent unauthorized submissions.
+
+With a valid token saved, features like quest submission and Cloud Sync will work seamlessly.


### PR DESCRIPTION
## Summary
- document authentication flow for GitHub tokens
- link the new doc from the docs index

## Testing
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68887eb0a730832fb037fec6507ed156