### PR TITLE
docs: add emoji promotion instructions to codex prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -62,3 +62,38 @@ REQUIREMENTS
 OUTPUT
 Return **only** the patch (diff) needed.
 ```
+
+## Implementation Prompt
+
+Use this template when you want Codex to automatically clear items from the
+[September&nbsp;1,&nbsp;2025 changelog](/docs/changelog/20250901). Tasks are
+tracked with Markdown checkboxes and an emoji status:
+
+-   `- [ ]` – work not started
+-   `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
+-   `- [x] 💯` – thoroughly tested and reviewed
+
+Codex should pick a single entry that is either unchecked or checked without a
+💯 and implement it completely. After all tests pass, update that row so the line
+ends with `💯`. When possible, also promote any previously completed rows lacking
+the 💯 emoji.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Choose one item
+from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
+`[x]` without 💯. Implement it fully, completing any sub-tasks. Provide all code,
+tests and documentation required. Always run `npm run test:pr` before
+committing. If Playwright browsers are missing run `npx playwright install
+chromium` or prefix commands with `SKIP_E2E=1`.
+
+USER:
+1. Follow the steps above.
+2. After verifying the implementation, mark the corresponding changelog line
+   with `💯` (replacing any other emoji).
+3. Document new functionality as needed.
+
+OUTPUT:
+A pull request implementing the chosen item with all tests green. Summarize the
+completed task and test results in the PR body.
+```


### PR DESCRIPTION
## Summary
- clarify DSPACE Codex Implementation Prompt
- instruct Codex to mark completed changelog tasks with the 💯 emoji

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6888833f333c832f8e688284c8aae42c