### PR TITLE
Expand stevia extraction quests

### DIFF
--- a/frontend/src/pages/docs/md/chemistry-lab.md
+++ b/frontend/src/pages/docs/md/chemistry-lab.md
@@ -1,0 +1,24 @@
+---
+title: 'Chemistry Lab Basics'
+slug: 'chemistry-lab'
+---
+
+A compact home lab lets you extract useful compounds from plants and practice sustainable chemistry.
+
+## Core tools
+
+-   **Hot plate** – provides steady heat for boiling or evaporation
+-   **Thermometer** – monitors solution temperature
+-   **Beakers** – hold and mix liquids
+-   **Glass funnel & filter paper** – remove plant solids from a solution
+-   **Scale** – measure ingredients accurately
+
+## Safety tips
+
+1. Wear eye protection and gloves when heating or pouring chemicals.
+2. Work in a well-ventilated area away from flames.
+3. Keep a fire extinguisher and first aid kit nearby.
+
+## Stevia extraction overview
+
+Homegrown stevia leaves contain steviol glycosides. Dry the leaves, steep them in hot water, then filter the liquid. To create a purer sweetener, dissolve the extract in a small amount of food-safe alcohol and let it evaporate slowly so white crystals form. See the [Refine Stevia Crystals](/quests/chemistry/stevia-crystals) quest for detailed steps.

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -103,6 +103,7 @@ Phoenix is a professional chemist specializing in sustainable rocket fuel develo
 -   "Excellent job! Your fleet of Benchies is growing. Keep up the great work."
 -   "You've truly mastered the art of 3D printing Benchies. Now, let's take things to the next level. I want to see a fleet of 100 Benchies."
 -   "Dry those stevia leaves gently and we'll extract their sweetness."
+-   "Add a splash of ethanol and you'll get pure stevia crystals as it dries."
 
 ## Atlas
 

--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -27,7 +27,7 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 
 The following quest lines are being drafted to help achieve the "10x More Quests" goal announced for v3:
 
--   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles and extract stevia into an artificial sweetener
+-   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles, extract stevia into a sweetener, and purify it into crystals
 -   **Programming** – simple scripts for automating sensors and data collection
 -   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s, then add monitoring and nightly backups
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -958,5 +958,12 @@
         "description": "Adhesive bandages, gauze and antiseptic packed for emergencies.",
         "image": "/assets/quests/basic_circuit.svg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "136",
+        "name": "stevia crystals",
+        "description": "Highly concentrated sweetener purified from stevia extract.",
+        "image": "/assets/dCarbon.jpg",
+        "price": "12 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -430,6 +430,14 @@
         "duration": "1h"
     },
     {
+        "id": "purify-stevia",
+        "title": "purify stevia extract into crystals",
+        "requireItems": [],
+        "consumeItems": [{ "id": "122", "count": 1 }],
+        "createItems": [{ "id": "136", "count": 1 }],
+        "duration": "6h"
+    },
+    {
         "id": "sink",
         "title": "find your sink",
         "requireItems": [],

--- a/frontend/src/pages/quests/json/chemistry/stevia-crystals.json
+++ b/frontend/src/pages/quests/json/chemistry/stevia-crystals.json
@@ -1,0 +1,35 @@
+{
+    "id": "chemistry/stevia-crystals",
+    "title": "Refine Stevia Crystals",
+    "description": "Purify your extract into concentrated crystals",
+    "image": "/assets/quests/testprint.png",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready to step up the purity? We'll separate the sweet compounds with a bit of alcohol.",
+            "options": [{ "type": "goto", "goto": "purify", "text": "Let's refine it." }]
+        },
+        {
+            "id": "purify",
+            "text": "Add a splash of food-grade ethanol and let the solution evaporate. Crystals will form as it dries.",
+            "options": [
+                { "type": "process", "process": "purify-stevia", "text": "Begin purification" },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I see white crystals!",
+                    "requiresItems": [{ "id": "136", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! These stevia crystals are intensely sweet and store well.",
+            "options": [{ "type": "finish", "text": "Thanks for the guidance!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["chemistry/stevia-extraction"]
+}

--- a/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
+++ b/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
@@ -13,7 +13,7 @@
         },
         {
             "id": "extract",
-            "text": "Dry the leaves and steep them in hot water to pull out the steviol glycosides.",
+            "text": "Dry your homegrown leaves, crush them slightly, and steep them just below boiling. Filter the liquid using a funnel and paper as shown in [/docs/chemistry-lab](/docs/chemistry-lab).",
             "options": [
                 { "type": "process", "process": "extract-stevia", "text": "Begin extraction" },
                 {
@@ -26,7 +26,7 @@
         },
         {
             "id": "finish",
-            "text": "Great work! This homemade stevia extract will sweeten drinks without any sugar.",
+            "text": "Great work! This homemade stevia extract will sweeten drinks without any sugar. Next we'll purify it into crystals for longer storage.",
             "options": [{ "type": "finish", "text": "Thanks, Phoenix!" }]
         }
     ],


### PR DESCRIPTION
## Summary
- teach fundamental lab gear in new Chemistry Lab doc
- refine stevia extraction quest with more details
- add quest to purify stevia crystals
- update item, process and NPC dialogue
- document chemistry quest tree progression

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68894c55f93c832f819ae2f390b8d6d4