### PR TITLE
Add failover procedures docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The server exposes two monitoring endpoints:
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).
 To add Prometheus and Grafana monitoring, follow the steps in [docs/monitoring_setup.md](./docs/monitoring_setup.md).
 For high availability, configure Cloudflare Load Balancing as described in [docs/cloudflare_load_balancing.md](./docs/cloudflare_load_balancing.md).
+See [docs/failover_procedures.md](./docs/failover_procedures.md) for handling outages and restoring nodes.
 
 ### Automated Raspberry Pi Deployment
 

--- a/docs/failover_procedures.md
+++ b/docs/failover_procedures.md
@@ -1,0 +1,30 @@
+# Failover Procedures
+
+This guide outlines how to handle downtime when running multiple DSPACE instances with Cloudflare Load Balancing.
+
+## Overview
+
+If an instance becomes unreachable, Cloudflare automatically routes traffic to a healthy node. However, you should still investigate the failed instance and restore it as soon as possible.
+
+## Steps
+
+1. **Confirm the outage**
+   - Visit your Cloudflare dashboard and check the Load Balancing pool health.
+   - You can also open `/health` on each instance directly.
+
+2. **Restart the container**
+   - SSH into the affected host and run:
+     ```bash
+     docker compose restart app
+     ```
+   - Wait a few seconds and verify that `curl http://localhost:3002/health` returns `{ "status": "ok" }`.
+
+3. **Check Prometheus metrics**
+   - Navigate to your Grafana dashboard (default `http://localhost:3001`) and ensure the `up` metric shows `1` for all instances.
+
+4. **Fallback option**
+   - If a node is corrupted or unreachable, spin up a new instance using the same deployment steps from [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md).
+   - Once the new node is running, add it to your Cloudflare load balancer as an origin.
+
+Cloudflare will automatically bring the restored instance back into rotation once it reports healthy.
+

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -60,7 +60,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Redundancy implementation
         -   [x] Load balancer setup
         -   [x] Backup system ✅
-        -   [x] Failover procedures ✅
+        -   [x] Failover procedures 💯
         -   [x] Monitoring setup
     -   [x] Migration from Netlify
 -   [x] License Migration


### PR DESCRIPTION
## Summary
- document failover procedures for Cloudflare load-balanced setups
- link new guide from README
- mark `Failover procedures` in changelog as complete

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `node scripts/checkPatchCoverage.cjs` *(fails: `fatal: Not a valid object name origin/main`)*

------
https://chatgpt.com/codex/tasks/task_e_6889cfc471a8832f957460ec588dcf5f