### PR TITLE
Add quest dependency validation

### DIFF
--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -1,7 +1,10 @@
 /**
  * @jest-environment node
  */
-import { validateQuestData } from '../src/utils/customQuestValidation.js';
+import {
+    validateQuestData,
+    validateQuestDependencies,
+} from '../src/utils/customQuestValidation.js';
 
 describe('validateQuestData', () => {
     test('valid quest passes', () => {
@@ -96,5 +99,15 @@ describe('validateQuestData', () => {
             requiresQuests: 'q1',
         });
         expect(result.valid).toBe(false);
+    });
+
+    test('validateQuestDependencies passes for existing ids', () => {
+        const result = validateQuestDependencies(['q1', 'q2'], ['q1', 'q2', 'q3']);
+        expect(result).toBe(true);
+    });
+
+    test('validateQuestDependencies fails for unknown ids', () => {
+        const result = validateQuestDependencies(['q1', 'q4'], ['q1', 'q2']);
+        expect(result).toBe(false);
     });
 });

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -1,7 +1,10 @@
 <script>
     import { createEventDispatcher, onMount } from 'svelte';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
-    import { validateQuestData } from '../../utils/customQuestValidation.js';
+    import {
+        validateQuestData,
+        validateQuestDependencies,
+    } from '../../utils/customQuestValidation.js';
 
     export let isEdit = false;
     export let questId = null;
@@ -111,6 +114,16 @@
         });
         if (!valid) {
             errors.schema = 'Invalid quest data';
+        }
+
+        if (
+            requiresQuests.length > 0 &&
+            !validateQuestDependencies(
+                requiresQuests,
+                allQuests.map((q) => q.id)
+            )
+        ) {
+            errors.requiresQuests = 'Unknown quest dependency';
         }
 
         validationErrors = errors;
@@ -255,6 +268,9 @@
                 </option>
             {/each}
         </select>
+        {#if validationErrors.requiresQuests}
+            <span class="error-message">{validationErrors.requiresQuests}</span>
+        {/if}
     </div>
 
     <div class="form-submit">

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -21,7 +21,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Create pull request generation system ✅
     -   [x] Quest validation and testing ✅
         -   [x] Expand test suite for custom quests ✅
-        -   [x] Add validation for quest dependencies
+        -   [x] Add validation for quest dependencies 💯
         -   [x] Implement quest simulation testing
     -   [x] Quest submission process documentation
         -   [x] Write contribution guidelines

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -26,3 +26,8 @@ export function validateQuestData(data) {
     const valid = validate(data);
     return { valid, errors: validate.errors };
 }
+
+export function validateQuestDependencies(depIds = [], existingQuestIds = []) {
+    const set = new Set(existingQuestIds);
+    return depIds.every((id) => set.has(id));
+}


### PR DESCRIPTION
## Summary
- validate quest dependency IDs against existing quests
- display dependency errors in QuestForm
- test dependency validator
- changelog updated

## Testing
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6889cfc471a8832f957460ec588dcf5f