### PR TITLE
Add item quest dependency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Quest files are organized by category in subfolders, so feel free to expand any
 area—electronics, hydroponics, rocketry and more—with additional quests.
 See [Quest Trees](docs/quest-trees) for an overview of the different categories and their progression.
 The repository includes a script that summarizes how many quests and lines of dialogue exist in each tree. Categories are sorted by quest count for readability.
-Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git. Check the "Quest Chart" workflow artifacts for the latest generated image. You can see how the quest catalog has grown by comparing the current count against v2.1 with `npm run quest:count`.
+Run `node scripts/generate-quest-chart.js` to recreate `quest-tree-stats.txt` and a PNG image saved locally. The PNG is ignored in Git. Check the "Quest Chart" workflow artifacts for the latest generated image. You can see how the quest catalog has grown by comparing the current count against v2.1 with `npm run quest:count`. Generate a map of which quests require or reward each item with `npm run generate:item-map`.
 
 Looking for a concrete walkthrough? The Playwright test `constellations-quest.spec.ts` demonstrates creating the "Map the Constellations" quest end to end and validating it using our quest checks.
 

--- a/frontend/__tests__/itemDependencies.test.js
+++ b/frontend/__tests__/itemDependencies.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+import { getQuestsForItem } from '../src/utils/itemDependencies.js';
+
+describe('item dependency tracking', () => {
+    it('returns quests that require an item', () => {
+        const q = getQuestsForItem('134');
+        expect(q.requires).toContain('astronomy/constellations');
+    });
+
+    it('returns quests that reward an item', () => {
+        const q = getQuestsForItem('5');
+        expect(q.rewards.length).toBeGreaterThan(0);
+        expect(q.rewards).toContain('energy/dWatt-1e3');
+    });
+
+    it('returns empty arrays for unknown item', () => {
+        const q = getQuestsForItem('nonexistent');
+        expect(q).toEqual({ requires: [], rewards: [] });
+    });
+});

--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -1,0 +1,423 @@
+{
+    "0": {
+        "requires": ["3dprinter/start"],
+        "rewards": []
+    },
+    "1": {
+        "requires": [
+            "3dprinting/benchy_10",
+            "3dprinting/benchy_100",
+            "3dprinting/benchy_25",
+            "3dprinting/retraction-test",
+            "3dprinter/start"
+        ],
+        "rewards": []
+    },
+    "5": {
+        "requires": ["energy/solar"],
+        "rewards": [
+            "energy/dSolar-100kW",
+            "energy/dSolar-10kW",
+            "energy/dSolar-1kW",
+            "energy/dWatt-1e3",
+            "energy/dWatt-1e4",
+            "energy/dWatt-1e5",
+            "energy/dWatt-1e6",
+            "energy/dWatt-1e7",
+            "energy/solar-1kWh",
+            "energy/solar"
+        ]
+    },
+    "6": {
+        "requires": ["energy/battery-upgrade", "energy/solar"],
+        "rewards": []
+    },
+    "8": {
+        "requires": [],
+        "rewards": ["3dprinter/start"]
+    },
+    "9": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "12": {
+        "requires": ["3dprinter/start"],
+        "rewards": ["3dprinting/benchy_10", "3dprinting/benchy_100", "3dprinting/benchy_25"]
+    },
+    "16": {
+        "requires": [],
+        "rewards": ["hydroponics/bucket_10"]
+    },
+    "17": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "20": {
+        "requires": ["welcome/howtodoquests"],
+        "rewards": []
+    },
+    "22": {
+        "requires": [
+            "energy/dWatt-1e3",
+            "energy/dWatt-1e4",
+            "energy/dWatt-1e5",
+            "energy/dWatt-1e6",
+            "energy/dWatt-1e7",
+            "welcome/howtodoquests"
+        ],
+        "rewards": []
+    },
+    "24": {
+        "requires": [],
+        "rewards": ["3dprinter/start", "ubi/basicincome", "welcome/howtodoquests"]
+    },
+    "25": {
+        "requires": ["hydroponics/basil", "hydroponics/bucket_10"],
+        "rewards": []
+    },
+    "26": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "27": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "28": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "29": {
+        "requires": ["welcome/howtodoquests", "welcome/intro-inventory"],
+        "rewards": []
+    },
+    "30": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "31": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "32": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "33": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "34": {
+        "requires": [],
+        "rewards": ["rocketry/parachute"]
+    },
+    "37": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": ["rocketry/parachute"]
+    },
+    "38": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "39": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "40": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "41": {
+        "requires": [],
+        "rewards": ["rocketry/firstlaunch"]
+    },
+    "42": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "44": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "47": {
+        "requires": ["hydroponics/basil"],
+        "rewards": []
+    },
+    "48": {
+        "requires": [],
+        "rewards": ["hydroponics/basil"]
+    },
+    "49": {
+        "requires": [],
+        "rewards": ["energy/solar"]
+    },
+    "52": {
+        "requires": ["aquaria/goldfish"],
+        "rewards": []
+    },
+    "56": {
+        "requires": ["aquaria/position-tank"],
+        "rewards": []
+    },
+    "58": {
+        "requires": ["electronics/thermistor-reading", "programming/temp-logger"],
+        "rewards": []
+    },
+    "59": {
+        "requires": ["chemistry/ph-test"],
+        "rewards": []
+    },
+    "60": {
+        "requires": ["aquaria/goldfish"],
+        "rewards": []
+    },
+    "61": {
+        "requires": [
+            "energy/dSolar-100kW",
+            "energy/dSolar-10kW",
+            "energy/dSolar-1kW",
+            "energy/solar"
+        ],
+        "rewards": []
+    },
+    "65": {
+        "requires": [],
+        "rewards": ["aquaria/goldfish"]
+    },
+    "66": {
+        "requires": ["rocketry/static-test"],
+        "rewards": []
+    },
+    "67": {
+        "requires": ["rocketry/parachute"],
+        "rewards": []
+    },
+    "68": {
+        "requires": [],
+        "rewards": ["rocketry/parachute"]
+    },
+    "69": {
+        "requires": ["rocketry/parachute"],
+        "rewards": []
+    },
+    "72": {
+        "requires": ["ubi/first-payment"],
+        "rewards": ["ubi/basicincome"]
+    },
+    "78": {
+        "requires": [],
+        "rewards": ["welcome/howtodoquests"]
+    },
+    "79": {
+        "requires": ["energy/solar"],
+        "rewards": []
+    },
+    "80": {
+        "requires": ["energy/solar"],
+        "rewards": []
+    },
+    "81": {
+        "requires": ["energy/solar"],
+        "rewards": []
+    },
+    "82": {
+        "requires": ["energy/solar-1kWh"],
+        "rewards": []
+    },
+    "83": {
+        "requires": ["rocketry/firstlaunch"],
+        "rewards": []
+    },
+    "87": {
+        "requires": ["completionist/reminder"],
+        "rewards": ["completionist/v2"]
+    },
+    "89": {
+        "requires": [],
+        "rewards": ["hydroponics/bucket_10"]
+    },
+    "90": {
+        "requires": ["electronics/arduino-blink", "electronics/potentiometer-dimmer"],
+        "rewards": []
+    },
+    "91": {
+        "requires": ["electronics/potentiometer-dimmer"],
+        "rewards": []
+    },
+    "92": {
+        "requires": ["electronics/potentiometer-dimmer"],
+        "rewards": []
+    },
+    "93": {
+        "requires": [
+            "electronics/arduino-blink",
+            "electronics/basic-circuit",
+            "electronics/potentiometer-dimmer"
+        ],
+        "rewards": []
+    },
+    "94": {
+        "requires": [
+            "electronics/arduino-blink",
+            "electronics/basic-circuit",
+            "electronics/potentiometer-dimmer"
+        ],
+        "rewards": []
+    },
+    "95": {
+        "requires": [],
+        "rewards": ["electronics/basic-circuit"]
+    },
+    "96": {
+        "requires": ["robotics/line-follower", "robotics/servo-control", "robotics/servo-gripper"],
+        "rewards": ["electronics/arduino-blink"]
+    },
+    "97": {
+        "requires": ["3dprinting/phone-stand"],
+        "rewards": ["robotics/line-follower", "robotics/servo-control"]
+    },
+    "98": {
+        "requires": ["electronics/potentiometer-dimmer"],
+        "rewards": []
+    },
+    "99": {
+        "requires": ["hydroponics/lettuce"],
+        "rewards": ["hydroponics/lettuce"]
+    },
+    "100": {
+        "requires": [],
+        "rewards": ["aquaria/walstad"]
+    },
+    "101": {
+        "requires": [],
+        "rewards": ["aquaria/shrimp"]
+    },
+    "102": {
+        "requires": [],
+        "rewards": ["aquaria/breeding"]
+    },
+    "103": {
+        "requires": ["hydroponics/nutrient-check"],
+        "rewards": []
+    },
+    "104": {
+        "requires": ["aquaria/floating-plants"],
+        "rewards": []
+    },
+    "105": {
+        "requires": [],
+        "rewards": ["aquaria/water-testing"]
+    },
+    "106": {
+        "requires": [],
+        "rewards": ["aquaria/position-tank", "aquaria/water-change"]
+    },
+    "107": {
+        "requires": [],
+        "rewards": ["aquaria/guppy"]
+    },
+    "109": {
+        "requires": ["woodworking/birdhouse", "woodworking/bookshelf", "woodworking/step-stool"],
+        "rewards": []
+    },
+    "110": {
+        "requires": [
+            "woodworking/birdhouse",
+            "woodworking/bookshelf",
+            "woodworking/step-stool",
+            "woodworking/workbench"
+        ],
+        "rewards": []
+    },
+    "111": {
+        "requires": ["woodworking/finish-sanding"],
+        "rewards": []
+    },
+    "112": {
+        "requires": [
+            "woodworking/birdhouse",
+            "woodworking/bookshelf",
+            "woodworking/step-stool",
+            "woodworking/workbench"
+        ],
+        "rewards": []
+    },
+    "116": {
+        "requires": [],
+        "rewards": ["aquaria/sponge-filter"]
+    },
+    "118": {
+        "requires": ["hydroponics/stevia"],
+        "rewards": []
+    },
+    "119": {
+        "requires": ["hydroponics/stevia"],
+        "rewards": []
+    },
+    "122": {
+        "requires": ["chemistry/stevia-extraction"],
+        "rewards": []
+    },
+    "123": {
+        "requires": ["devops/pi-cluster-hardware", "devops/prepare-first-node"],
+        "rewards": []
+    },
+    "124": {
+        "requires": ["devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "125": {
+        "requires": ["devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "126": {
+        "requires": ["devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "127": {
+        "requires": ["devops/docker-compose", "devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "128": {
+        "requires": ["devops/docker-compose", "devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "129": {
+        "requires": ["devops/pi-cluster-hardware"],
+        "rewards": []
+    },
+    "130": {
+        "requires": ["devops/prepare-first-node"],
+        "rewards": []
+    },
+    "131": {
+        "requires": ["devops/ssd-boot"],
+        "rewards": []
+    },
+    "132": {
+        "requires": ["devops/docker-compose", "devops/k3s-deploy", "devops/ssd-boot"],
+        "rewards": []
+    },
+    "133": {
+        "requires": ["devops/daily-backups", "devops/monitoring"],
+        "rewards": []
+    },
+    "134": {
+        "requires": [
+            "astronomy/basic-telescope",
+            "astronomy/constellations",
+            "astronomy/jupiter-moons",
+            "astronomy/lunar-eclipse",
+            "astronomy/meteor-shower"
+        ],
+        "rewards": []
+    },
+    "135": {
+        "requires": ["firstaid/assemble-kit", "firstaid/learn-cpr"],
+        "rewards": []
+    },
+    "136": {
+        "requires": ["chemistry/stevia-crystals"],
+        "rewards": []
+    }
+}

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -35,7 +35,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Item Management ✅
         -   [x] Item creation interface with ItemForm.svelte
     -   [x] Item validation schema
-        -   [x] Item dependency tracking
+        -   [x] Item dependency tracking 💯
     -   [x] Process System
         -   [x] Process creation UI with duration handling
         -   [x] Required/consumed/created items selection

--- a/frontend/src/pages/inventory/item/ItemPage.svelte
+++ b/frontend/src/pages/inventory/item/ItemPage.svelte
@@ -5,6 +5,7 @@
     import BuySell from '../../../components/svelte/BuySell.svelte';
     import { getProcessesForItem, ProcessItemTypes } from '../../../utils/gameState/processes.js';
     import { getItemCounts } from '../../../utils/gameState/inventory.js';
+    import { getQuestsForItem } from '../../../utils/itemDependencies.js';
     import items from '../json/items.json';
     import Process from '../../../components/svelte/Process.svelte';
     import CompactItemList from '../../../components/svelte/CompactItemList.svelte';
@@ -19,8 +20,10 @@
     const item = items.find((item) => item.id === itemId);
 
     const processes = getProcessesForItem(itemId);
+    const quests = getQuestsForItem(itemId);
 
     const hasProcesses = Object.values(processes).some((arr) => arr.length);
+    const hasQuests = quests.requires.length > 0 || quests.rewards.length > 0;
 
     onMount(() => {
         const itemCount = getItemCounts([{ id: itemId }])[itemId];
@@ -54,6 +57,25 @@
                 {#each processes[ProcessItemTypes.CREATE_ITEM] as processId}
                     <Process inverted={false} {processId} />
                 {/each}
+            {/if}
+            {#if hasQuests}
+                <p>Quests:</p>
+            {/if}
+            {#if quests.requires.length > 0}
+                <p>Required in:</p>
+                <ul>
+                    {#each quests.requires as qid}
+                        <li>{qid}</li>
+                    {/each}
+                </ul>
+            {/if}
+            {#if quests.rewards.length > 0}
+                <p>Rewards in:</p>
+                <ul>
+                    {#each quests.rewards as qid}
+                        <li>{qid}</li>
+                    {/each}
+                </ul>
             {/if}
         </div>
     </Chip>

--- a/frontend/src/utils/itemDependencies.js
+++ b/frontend/src/utils/itemDependencies.js
@@ -1,0 +1,12 @@
+import itemQuestMap from '../generated/itemQuestMap.json';
+
+export function getQuestsForItem(itemId) {
+    const entry = itemQuestMap[itemId];
+    if (!entry) {
+        return { requires: [], rewards: [] };
+    }
+    return {
+        requires: entry.requires || [],
+        rewards: entry.rewards || [],
+    };
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format": "cd frontend && npm run format",
     "type-check": "tsc --noEmit",
     "build": "cd frontend && npm run build",
-    "quest:count": "node scripts/compareQuestCount.js"
+    "quest:count": "node scripts/compareQuestCount.js",
+    "generate:item-map": "node scripts/generate-item-dependencies.js"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/scripts/generate-item-dependencies.js
+++ b/scripts/generate-item-dependencies.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const questsPattern = path.join(
+  __dirname,
+  '..',
+  'frontend',
+  'src',
+  'pages',
+  'quests',
+  'json',
+  '**',
+  '*.json'
+);
+const outFile = path.join(
+  __dirname,
+  '..',
+  'frontend',
+  'src',
+  'generated',
+  'itemQuestMap.json'
+);
+
+function collectItemDeps(obj, questId, map) {
+  if (Array.isArray(obj)) {
+    obj.forEach((v) => collectItemDeps(v, questId, map));
+    return;
+  }
+  if (obj && typeof obj === 'object') {
+    if (obj.requiresItems) {
+      obj.requiresItems.forEach((item) => {
+        map[item.id] = map[item.id] || { requires: [], rewards: [] };
+        if (!map[item.id].requires.includes(questId)) {
+          map[item.id].requires.push(questId);
+        }
+      });
+    }
+    if (obj.rewards) {
+      obj.rewards.forEach((item) => {
+        map[item.id] = map[item.id] || { requires: [], rewards: [] };
+        if (!map[item.id].rewards.includes(questId)) {
+          map[item.id].rewards.push(questId);
+        }
+      });
+    }
+    Object.values(obj).forEach((v) => collectItemDeps(v, questId, map));
+  }
+}
+
+function buildMap() {
+  const files = glob.sync(questsPattern);
+  const map = {};
+  files.forEach((file) => {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const questId = data.id;
+    collectItemDeps(data, questId, map);
+  });
+  return map;
+}
+
+function main() {
+  const map = buildMap();
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, JSON.stringify(map, null, 2));
+  console.log('Generated item quest map at', outFile);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildMap };


### PR DESCRIPTION
## Summary
- generate item-to-quest map
- expose `getQuestsForItem` utility
- display quest info on item pages
- document `generate:item-map` script
- mark item dependency tracking complete in changelog
- test new utility

## Testing
- `npm ci`
- `npm ci --prefix frontend`
- `npm run generate:item-map`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6889cfc471a8832f957460ec588dcf5f