### PR TITLE
Add new quests across categories

### DIFF
--- a/frontend/src/pages/quests/json/astronomy/star-trails.json
+++ b/frontend/src/pages/quests/json/astronomy/star-trails.json
@@ -1,0 +1,34 @@
+{
+    "id": "astronomy/star-trails",
+    "title": "Capture Star Trails",
+    "description": "Use long-exposure photography to show the Earth's rotation.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've mapped constellations; now let's photograph their motion across the sky.",
+            "options": [ { "type": "goto", "goto": "expose", "text": "I'm excited!" } ]
+        },
+        {
+            "id": "expose",
+            "text": "Point your camera north and take a multi-minute exposure to capture circular star trails.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Exposure complete",
+                    "requiresItems": [ { "id": "134", "count": 1 } ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Beautiful! Those trails reveal our planet's steady spin.",
+            "options": [ { "type": "finish", "text": "Stunning!" } ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/constellations"]
+}

--- a/frontend/src/pages/quests/json/devops/enable-https.json
+++ b/frontend/src/pages/quests/json/devops/enable-https.json
@@ -1,0 +1,34 @@
+{
+    "id": "devops/enable-https",
+    "title": "Secure the Cluster with HTTPS",
+    "description": "Use Let's Encrypt to add TLS encryption to your services.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your services are running well. Let's protect them with HTTPS certificates.",
+            "options": [ { "type": "goto", "goto": "setup", "text": "I'm ready." } ]
+        },
+        {
+            "id": "setup",
+            "text": "Install certbot and configure automatic renewal for your domain.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Certificates installed",
+                    "requiresItems": [ { "id": "132", "count": 1 } ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! Traffic to your cluster is now encrypted.",
+            "options": [ { "type": "finish", "text": "All set" } ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/daily-backups"]
+}

--- a/frontend/src/pages/quests/json/energy/dWatt-1e8.json
+++ b/frontend/src/pages/quests/json/energy/dWatt-1e8.json
@@ -1,0 +1,42 @@
+{
+    "id": "energy/dWatt-1e8",
+    "title": "Store a Colossal 100,000,000 dWatt",
+    "description": "Prove your dedication by collecting a staggering 100,000,000 dWatt.",
+    "image": "/assets/quests/dWatt_1e7.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your energy generation is off the charts! Think you can hit one hundred million dWatt?",
+            "options": [
+                { "type": "goto", "goto": "progress", "text": "Watch me." }
+            ]
+        },
+        {
+            "id": "progress",
+            "text": "Keep producing power until you reach the goal!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Goal reached!",
+                    "requiresItems": [
+                        { "id": "22", "count": 100000000 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Incredible! Few can claim such output. Take a well-deserved break before the next challenge.",
+            "options": [
+                { "type": "finish", "text": "Thanks, Orion!" }
+            ]
+        }
+    ],
+    "rewards": [
+        { "id": "5", "count": 50 }
+    ],
+    "requiresQuests": ["energy/dWatt-1e7"]
+}

--- a/frontend/src/pages/quests/json/firstaid/wound-care.json
+++ b/frontend/src/pages/quests/json/firstaid/wound-care.json
@@ -1,0 +1,34 @@
+{
+    "id": "firstaid/wound-care",
+    "title": "Practice Basic Wound Care",
+    "description": "Learn to clean and bandage minor cuts the right way.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A well stocked kit is great, but let's practice using it. We'll cover simple wound cleaning and bandaging.",
+            "options": [ { "type": "goto", "goto": "clean", "text": "Let's go." } ]
+        },
+        {
+            "id": "clean",
+            "text": "Rinse the cut with clean water and apply antiseptic before placing a bandage.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Bandage applied",
+                    "requiresItems": [ { "id": "135", "count": 1 } ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nicely done! Keeping wounds clean prevents infection so you can keep building without delay.",
+            "options": [ { "type": "finish", "text": "Got it!" } ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/learn-cpr"]
+}

--- a/frontend/src/pages/quests/json/programming/graph-temp-data.json
+++ b/frontend/src/pages/quests/json/programming/graph-temp-data.json
@@ -1,0 +1,36 @@
+{
+    "id": "programming/graph-temp-data",
+    "title": "Graph Your Temperature Logs",
+    "description": "Use a short script to plot the readings you've been recording.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Nice work gathering data! Let's visualize it with a simple chart.",
+            "options": [
+                { "type": "goto", "goto": "script", "text": "Show me how." }
+            ]
+        },
+        {
+            "id": "script",
+            "text": "Install matplotlib and plot your log file to see trends over time.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Graph generated!",
+                    "requiresItems": [ { "id": "90", "count": 1 } ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Visuals make patterns easy to spot. Keep logging and graphing for deeper insight.",
+            "options": [ { "type": "finish", "text": "Will do!" } ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-logger"]
+}

--- a/frontend/src/pages/quests/json/robotics/wheel-encoders.json
+++ b/frontend/src/pages/quests/json/robotics/wheel-encoders.json
@@ -1,0 +1,34 @@
+{
+    "id": "robotics/wheel-encoders",
+    "title": "Add Wheel Encoders",
+    "description": "Improve your robot's navigation by measuring wheel rotation.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's give your bot some feedback. A pair of encoders will track how far it travels.",
+            "options": [ { "type": "goto", "goto": "mount", "text": "Sounds good." } ]
+        },
+        {
+            "id": "mount",
+            "text": "Attach one encoder to each wheel and wire them to your controller.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Installed and reading values!",
+                    "requiresItems": [ { "id": "96", "count": 2 } ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Now you can precisely measure distance and adjust your code for straighter paths.",
+            "options": [ { "type": "finish", "text": "Awesome!" } ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["robotics/servo-gripper"]
+}


### PR DESCRIPTION
## Summary
- create several new quests to expand existing quest trees
- include energy, programming, robotics, first aid, devops and astronomy additions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889d17de4d0832f8ca675e76edf536e