### PR TITLE
Add additional quests

### DIFF
--- a/frontend/src/pages/quests/json/astronomy/iss-pass.json
+++ b/frontend/src/pages/quests/json/astronomy/iss-pass.json
@@ -1,0 +1,34 @@
+{
+    "id": "astronomy/iss-pass",
+    "title": "Spot the Space Station",
+    "description": "Track the International Space Station as it passes overhead.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready for a quick observation challenge? Let's spot the ISS tonight.",
+            "options": [{ "type": "goto", "goto": "prepare", "text": "I'm ready!" }]
+        },
+        {
+            "id": "prepare",
+            "text": "Check an orbit tracker online and point your telescope to the expected path.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I see it zooming by!",
+                    "requiresItems": [{ "id": "134", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great catch! It's fast, but you'll recognize it more easily next time.",
+            "options": [{ "type": "finish", "text": "Space is awesome!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/observe-moon"]
+}

--- a/frontend/src/pages/quests/json/devops/add-node.json
+++ b/frontend/src/pages/quests/json/devops/add-node.json
@@ -1,0 +1,34 @@
+{
+    "id": "devops/add-node",
+    "title": "Add a Second Pi Node",
+    "description": "Expand your cluster by assembling another Pi with PoE.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your first node is humming along. Ready to grow the cluster?",
+            "options": [{ "type": "goto", "goto": "build", "text": "Yes, let's expand." }]
+        },
+        {
+            "id": "build",
+            "text": "Assemble the hardware just like before and join it to the k3s master.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Node online!",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! More nodes mean more power for your services.",
+            "options": [{ "type": "finish", "text": "Onward to scale!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/prepare-first-node"]
+}

--- a/frontend/src/pages/quests/json/electronics/energy-monitor.json
+++ b/frontend/src/pages/quests/json/electronics/energy-monitor.json
@@ -1,0 +1,34 @@
+{
+    "id": "electronics/energy-monitor",
+    "title": "Monitor Energy Usage",
+    "description": "Use a smart plug to track how much power your projects consume.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Want to see exactly how much electricity your printer draws? Let's set up a smart plug.",
+            "options": [{ "type": "goto", "goto": "plug", "text": "Sounds useful." }]
+        },
+        {
+            "id": "plug",
+            "text": "Plug the smart device into the outlet and connect it to the app.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Reading watts now.",
+                    "requiresItems": [{ "id": "29", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Monitoring usage helps optimize your energy costs.",
+            "options": [{ "type": "finish", "text": "I'll keep an eye on it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/arduino-blink"]
+}

--- a/frontend/src/pages/quests/json/energy/wind-turbine.json
+++ b/frontend/src/pages/quests/json/energy/wind-turbine.json
@@ -1,0 +1,34 @@
+{
+    "id": "energy/wind-turbine",
+    "title": "Install a Wind Turbine",
+    "description": "Add a 500W wind turbine to complement your solar setup.",
+    "image": "/assets/turbine.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Solar is great, but let's harvest the wind too. Ready to install a small turbine?",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Absolutely!" }]
+        },
+        {
+            "id": "setup",
+            "text": "Mount the turbine in a clear area and route the wiring to your charge controller.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Turbine is up and spinning!",
+                    "requiresItems": [{ "id": "7", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Every gust now charges your batteries.",
+            "options": [{ "type": "finish", "text": "Wind power engaged!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["energy/solar"]
+}

--- a/frontend/src/pages/quests/json/firstaid/bandage-cut.json
+++ b/frontend/src/pages/quests/json/firstaid/bandage-cut.json
@@ -1,0 +1,34 @@
+{
+    "id": "firstaid/bandage-cut",
+    "title": "Treat a Minor Cut",
+    "description": "Practice cleaning and bandaging a small wound.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Minor injuries happen. Let's go through bandaging a cut.",
+            "options": [{ "type": "goto", "goto": "clean", "text": "Okay" }]
+        },
+        {
+            "id": "clean",
+            "text": "Rinse the cut with clean water then apply antiseptic from your kit.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "All cleaned.",
+                    "requiresItems": [{ "id": "135", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Cover it with a sterile bandage and keep it dry.",
+            "options": [{ "type": "finish", "text": "All patched up." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}

--- a/frontend/src/pages/quests/json/hydroponics/grow-light.json
+++ b/frontend/src/pages/quests/json/hydroponics/grow-light.json
@@ -1,0 +1,34 @@
+{
+    "id": "hydroponics/grow-light",
+    "title": "Add a Grow Light",
+    "description": "Install lighting to keep your plants thriving indoors.",
+    "image": "/assets/hydroponic_lamp.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Some plants need more light than your window provides.",
+            "options": [{ "type": "goto", "goto": "install", "text": "Let's brighten things up." }]
+        },
+        {
+            "id": "install",
+            "text": "Hang the grow lamp above your tub and set a timer for 12 hours a day.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Lamp installed.",
+                    "requiresItems": [{ "id": "43", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! Consistent light will boost growth.",
+            "options": [{ "type": "finish", "text": "Thanks for the tip." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/basil"]
+}

--- a/frontend/src/pages/quests/json/robotics/servo-turret.json
+++ b/frontend/src/pages/quests/json/robotics/servo-turret.json
@@ -1,0 +1,34 @@
+{
+    "id": "robotics/servo-turret",
+    "title": "Build a Servo Turret",
+    "description": "Use two servos to pan and tilt a small camera.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's combine two servos so your camera can look around.",
+            "options": [{ "type": "goto", "goto": "assemble", "text": "Let's do it." }]
+        },
+        {
+            "id": "assemble",
+            "text": "Stack the servos at right angles so one controls pan and the other tilt.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "It moves smoothly.",
+                    "requiresItems": [{ "id": "96", "count": 2 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Now you can scan the room or track targets.",
+            "options": [{ "type": "finish", "text": "Turret ready!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["robotics/servo-gripper"]
+}

--- a/frontend/src/pages/quests/json/woodworking/picture-frame.json
+++ b/frontend/src/pages/quests/json/woodworking/picture-frame.json
@@ -1,0 +1,53 @@
+{
+    "id": "woodworking/picture-frame",
+    "title": "Craft a Picture Frame",
+    "description": "Practice precise cuts to build a small frame.",
+    "image": "/assets/workbench.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Want a quick project? Let's make a simple frame for your wall.",
+            "options": [{ "type": "goto", "goto": "cut", "text": "Sounds good!" }]
+        },
+        {
+            "id": "cut",
+            "text": "Measure your pine board and cut four pieces at 45° angles.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "text": "Pieces cut.",
+                    "requiresItems": [
+                        { "id": "108", "count": 1 },
+                        { "id": "109", "count": 1 },
+                        { "id": "112", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "Glue the corners together and clamp until dry. A little sanding will finish it off.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Looks sharp!",
+                    "requiresItems": [
+                        { "id": "110", "count": 1 },
+                        { "id": "111", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! Display your favorite photo with pride.",
+            "options": [{ "type": "finish", "text": "Can't wait!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/workbench"]
+}


### PR DESCRIPTION
## Summary
- expand the quest catalog with new content across multiple categories
  - wind turbine setup
  - energy usage monitoring
  - minor first aid practice
  - spot the ISS
  - servo turret build
  - add a second Pi node
  - woodworking picture frame
  - hydroponics grow light
- run lint/type-check/build to ensure validity

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889d17de4d0832f8ca675e76edf536e