### PR TITLE
Add quest expansions

### DIFF
--- a/frontend/src/pages/docs/md/quest-trees.md
+++ b/frontend/src/pages/docs/md/quest-trees.md
@@ -12,16 +12,17 @@ DSPACE quests are organized into themed trees that build skills over time. This 
 -   **Welcome** – introductory tutorial showing how to accept and complete quests
 -   **3D Printing** – receive a printer, tackle small projects, fine-tune settings, and work up to larger print runs
 -   **Aquaria** – set up a Walstad tank, test the water, install a sponge filter, position the tank, add shrimp, introduce floating plants, keep guppies, perform water changes, breed them, and graduate to goldfish
--   **Hydroponics** – grow basil, expand to bucket systems, refresh nutrients, experiment with lettuce, and cultivate stevia for homemade sweetener
+-   **Hydroponics** – grow basil, expand to bucket systems, refresh nutrients, experiment with lettuce, cultivate stevia for homemade sweetener, and regrow it for repeat harvests
 -   **Electronics** – wire a basic circuit, program an Arduino, read sensors, and build a dimmer
 -   **Robotics** – assemble a line follower, build a servo gripper, and learn advanced control after completing electronics basics
 -   **Rocketry** – print and launch a model rocket with parachute recovery and perform a static engine test
--   **Energy** – harvest solar power, expand battery capacity, and accumulate dWatts toward higher milestones
+-   **Energy** – harvest solar power, expand battery capacity, harness wind with a turbine, and accumulate dWatts toward higher milestones
+-   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s, then add monitoring, nightly backups and automatic updates
 -   **UBI** – an optional quest explaining the metaguild's basic income concept with daily payouts
 -   **Completionist** – track progress toward finishing all available quests
--   **Woodworking** – build a sturdy workbench, sand projects smooth, then craft birdhouses, stools and shelves
+-   **Woodworking** – build a sturdy workbench, sand projects smooth, then craft birdhouses, stools, shelves, and planter boxes
 -   **First Aid** – assemble a kit and practice CPR so accidents don't derail progress
--   **Astronomy** – observe the Moon, build a telescope, track Jupiter's moons and map the constellations, and document a meteor shower
+-   **Astronomy** – observe the Moon, build a telescope, track Jupiter's moons and map the constellations, document a meteor shower, and monitor passing satellites
 
 ## Planned Quest Trees
 
@@ -29,7 +30,7 @@ The following quest lines are being drafted to help achieve the "10x More Quests
 
 -   **Chemistry** – safe experiments that introduce sustainable rocket fuel principles, extract stevia into a sweetener, and purify it into crystals
 -   **Programming** – simple scripts for automating sensors and data collection
--   **DevOps** – deploy DSPACE on a Raspberry Pi cluster using Docker and k3s, then add monitoring and nightly backups
+<!-- DevOps tree moved to existing section -->
 
 Check back as these new quests are fleshed out and integrated into the main progression.
 

--- a/frontend/src/pages/quests/json/astronomy/satellite-pass.json
+++ b/frontend/src/pages/quests/json/astronomy/satellite-pass.json
@@ -1,0 +1,39 @@
+{
+    "id": "astronomy/satellite-pass",
+    "title": "Track a Satellite Pass",
+    "description": "Nova helps you follow an overhead satellite using your telescope.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A bright satellite is passing tonight. Let's try to track it across the sky.",
+            "options": [{ "type": "goto", "goto": "observe", "text": "I'll set up." }]
+        },
+        {
+            "id": "observe",
+            "text": "Point your telescope at the predicted path and use slow movements to keep it in view.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "identify-constellations",
+                    "text": "Following now"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I kept it in sight",
+                    "requiresItems": [{ "id": "134", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great tracking! Recording the time and path helps refine its orbit.",
+            "options": [{ "type": "finish", "text": "That was fun!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/meteor-shower"]
+}

--- a/frontend/src/pages/quests/json/devops/auto-updates.json
+++ b/frontend/src/pages/quests/json/devops/auto-updates.json
@@ -1,0 +1,34 @@
+{
+    "id": "devops/auto-updates",
+    "title": "Enable Automatic Updates",
+    "description": "Keep your Pi cluster secure with unattended upgrades.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Software gets old fast. Let's configure unattended-upgrades on each node.",
+            "options": [{ "type": "goto", "goto": "configure", "text": "Let's do it." }]
+        },
+        {
+            "id": "configure",
+            "text": "Edit the configuration file to enable security updates and schedule a weekly reboot.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Updates enabled",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your cluster will stay patched without manual work.",
+            "options": [{ "type": "finish", "text": "Thanks, Orion." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/monitoring"]
+}

--- a/frontend/src/pages/quests/json/energy/wind-turbine.json
+++ b/frontend/src/pages/quests/json/energy/wind-turbine.json
@@ -1,0 +1,39 @@
+{
+    "id": "energy/wind-turbine",
+    "title": "Install a Wind Turbine",
+    "description": "Supplement your solar setup with power from the breeze.",
+    "image": "/assets/quests/solar_200Wh.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your solar rig is humming. Let's capture wind energy too by mounting this 500W turbine.",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Sounds great!" }]
+        },
+        {
+            "id": "setup",
+            "text": "Secure the turbine on a tall pole and wire it to your charge controller.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "7", "count": 1 }],
+                    "text": "Take the turbine"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "All wired up",
+                    "requiresItems": [{ "id": "7", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! When the wind picks up you'll store power even faster.",
+            "options": [{ "type": "finish", "text": "Can't wait!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["energy/solar-1kWh"]
+}

--- a/frontend/src/pages/quests/json/hydroponics/regrow-stevia.json
+++ b/frontend/src/pages/quests/json/hydroponics/regrow-stevia.json
@@ -1,0 +1,35 @@
+{
+    "id": "hydroponics/regrow-stevia",
+    "title": "Regrow Your Stevia",
+    "description": "Hydro shows you how to coax another harvest from trimmed plants.",
+    "image": "/assets/quests/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Those stevia stalks you clipped will grow back if we treat them right. Ready to try?",
+            "options": [{ "type": "goto", "goto": "regrow", "text": "Absolutely!" }]
+        },
+        {
+            "id": "regrow",
+            "text": "Place the harvested plants under strong light and keep the tub topped off. We'll trigger the regrow process now.",
+            "options": [
+                { "type": "process", "process": "regrow-stevia", "text": "Starting regrowth." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "New leaves sprouting!",
+                    "requiresItems": [{ "id": "119", "count": 11 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Keep them fed and you'll have another bundle of sweet leaves soon.",
+            "options": [{ "type": "finish", "text": "Thanks, Hydro!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/stevia"]
+}

--- a/frontend/src/pages/quests/json/woodworking/planter-box.json
+++ b/frontend/src/pages/quests/json/woodworking/planter-box.json
@@ -1,0 +1,50 @@
+{
+    "id": "woodworking/planter-box",
+    "title": "Build a Planter Box",
+    "description": "Cedar guides you through crafting a simple planter for herbs.",
+    "image": "/assets/workbench.jpg",
+    "npc": "/assets/npc/cedar.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready for another project? Let's make a wooden planter box for your hydroponic experiments.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "Sure thing!" }]
+        },
+        {
+            "id": "gather",
+            "text": "You'll need a few pine boards and some wood glue. I'll supply what you don't have.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 }
+                    ],
+                    "text": "Gather materials"
+                },
+                {
+                    "type": "goto",
+                    "goto": "build",
+                    "text": "Materials ready",
+                    "requiresItems": [
+                        { "id": "112", "count": 4 },
+                        { "id": "110", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "build",
+            "text": "Cut the boards to length, glue them into a rectangle, and let everything dry overnight.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Box assembled" }]
+        },
+        {
+            "id": "finish",
+            "text": "Great job! This planter will hold soil or even a small hydroponic tub.",
+            "options": [{ "type": "finish", "text": "Looks sturdy!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/workbench"]
+}


### PR DESCRIPTION
## Summary
- expand docs for existing quest trees
- add hydroponics/regrow-stevia quest
- add energy/wind-turbine quest
- add devops/auto-updates quest
- add woodworking/planter-box quest
- add astronomy/satellite-pass quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_6889e5e25b1c832fb0e408267ee3a9f0