### PR TITLE
Add new quests across categories

### DIFF
--- a/frontend/src/pages/quests/json/3dprinting/temperature-tower.json
+++ b/frontend/src/pages/quests/json/3dprinting/temperature-tower.json
@@ -1,0 +1,34 @@
+{
+    "id": "3dprinting/temperature-tower",
+    "title": "Print a Temperature Tower",
+    "description": "Find the ideal nozzle temperature by printing a simple calibration tower.",
+    "image": "/assets/quests/testprint.png",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's dial in your filament settings with a temperature tower.",
+            "options": [{ "type": "goto", "goto": "print", "text": "Great idea!" }]
+        },
+        {
+            "id": "print",
+            "text": "Slice the tower so each section prints a few degrees cooler than the last.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Tower complete",
+                    "requiresItems": [{ "id": "3", "count": 30 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Check which layer looks best and use that temp for future prints.",
+            "options": [{ "type": "finish", "text": "Got it, thanks!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinting/retraction-test"]
+}

--- a/frontend/src/pages/quests/json/chemistry/stevia-tasting.json
+++ b/frontend/src/pages/quests/json/chemistry/stevia-tasting.json
@@ -1,0 +1,34 @@
+{
+    "id": "chemistry/stevia-tasting",
+    "title": "Taste Test Stevia Crystals",
+    "description": "Evaluate the sweetness of your freshly made stevia crystals.",
+    "image": "/assets/dCarbon.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your extraction went well. Let's test the crystals to judge their flavor.",
+            "options": [{ "type": "goto", "goto": "mix", "text": "Sure!" }]
+        },
+        {
+            "id": "mix",
+            "text": "Dissolve a pinch in water and compare the sweetness to sugar.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Quite sweet!",
+                    "requiresItems": [{ "id": "136", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! We'll refine the process even further next time.",
+            "options": [{ "type": "finish", "text": "Looking forward to it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["chemistry/stevia-crystals"]
+}

--- a/frontend/src/pages/quests/json/electronics/data-logger.json
+++ b/frontend/src/pages/quests/json/electronics/data-logger.json
@@ -1,0 +1,42 @@
+{
+    "id": "electronics/data-logger",
+    "title": "Log Temperature Data",
+    "description": "Use a Raspberry Pi to record readings from your thermistor.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've got the sensor working. Let's connect a Pi to log temperatures automatically.",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Sounds good!" }]
+        },
+        {
+            "id": "setup",
+            "text": "Plug the Arduino into the Pi with a USB cable and install the serial libraries.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "script",
+                    "text": "Hardware ready",
+                    "requiresItems": [
+                        { "id": "95", "count": 1 },
+                        { "id": "123", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "script",
+            "text": "Write a short program to read the sensor and append values to a file every minute.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Logging!" }]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! With data over time you can spot trends and trigger alerts.",
+            "options": [{ "type": "finish", "text": "Thanks, Orion!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/thermistor-reading"]
+}

--- a/frontend/src/pages/quests/json/firstaid/splint-limb.json
+++ b/frontend/src/pages/quests/json/firstaid/splint-limb.json
@@ -1,0 +1,34 @@
+{
+    "id": "firstaid/splint-limb",
+    "title": "Splint a Minor Fracture",
+    "description": "Learn to immobilize an injured limb until help arrives.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Accidents happen. Let's practice applying a simple splint.",
+            "options": [{ "type": "goto", "goto": "wrap", "text": "Okay, walk me through it." }]
+        },
+        {
+            "id": "wrap",
+            "text": "Place padding around the injury and secure a rigid support with bandage wraps.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Splint secured",
+                    "requiresItems": [{ "id": "135", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Keep the limb immobilized and seek medical attention.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/wound-care"]
+}

--- a/frontend/src/pages/quests/json/rocketry/recovery-run.json
+++ b/frontend/src/pages/quests/json/rocketry/recovery-run.json
@@ -1,0 +1,57 @@
+{
+    "id": "rocketry/recovery-run",
+    "title": "Practice Rocket Recovery",
+    "description": "Launch with a parachute and retrieve the rocket intact.",
+    "image": "/assets/quests/parachute.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Our last flight was great. Let's practice recovering the rocket so we can reuse it.",
+            "options": [{ "type": "goto", "goto": "prep", "text": "I'm ready." }]
+        },
+        {
+            "id": "prep",
+            "text": "Pack the recovery wadding and fold the parachute carefully.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "launch",
+                    "text": "Parachute packed",
+                    "requiresItems": [
+                        { "id": "67", "count": 1 },
+                        { "id": "84", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "launch",
+            "text": "Set up the pad and controller, then send it skyward.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "launch-rocket-parachute",
+                    "text": "Launching!"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Rocket recovered!",
+                    "requiresItems": [
+                        { "id": "67", "count": 1 },
+                        { "id": "69", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent! Smooth recoveries mean we can iterate faster on designs.",
+            "options": [{ "type": "finish", "text": "Can't wait for the next launch!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["rocketry/parachute"]
+}


### PR DESCRIPTION
## Summary
- add `data-logger` to electronics quests
- add `recovery-run` to rocketry
- add `stevia-tasting` to chemistry
- add `splint-limb` to first aid
- add `temperature-tower` to 3D printing

All tests pass via `npm run test:pr` and build steps succeed.


------
https://chatgpt.com/codex/tasks/task_e_688a739a97b8832f90a2f027819e41ca