### PR TITLE
docs: note supported Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Check out the [docs](https://democratized.space/docs)!
 
 Clone and set up the project:
 
+Make sure you have **Node.js 18 or 20 LTS** installed.
+
 ```bash
 git clone https://github.com/democratizedspace/dspace.git
 cd dspace
+npm --version # ensure Node.js 18 or 20 is in use
 npm ci
 # Install frontend dependencies
 cd frontend && npm ci

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "dspace",
   "version": "3.0.0",
+  "engines": {
+    "node": ">=18 <22"
+  },
   "main": "index.js",
   "scripts": {
     "dev": "cd frontend && npm run dev",


### PR DESCRIPTION
## Summary
- document Node.js 18/20 requirement in README
- enforce engines field in `package.json`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688c4d916b80832fad27b5a217da06df