### PR TITLE
Fix tests workflow Node version and Jest setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,8 @@
 name: tests
 on:
   push:
-    branches: [main]
+    branches: [v3]
   pull_request:
-    branches: [main]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the [docs](https://democratized.space/docs)!
 
 Clone and set up the project:
 
-Make sure you have **Node.js 18 or 20 LTS** installed.
+Make sure you have **Node.js 18 or 20 LTS** installed. The CI runs on Node.js 20.
 
 ```bash
 git clone https://github.com/democratizedspace/dspace.git

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,6 +1,6 @@
 // Import necessary modules
-import { TextEncoder, TextDecoder } from 'util';
-import crypto from 'crypto';
+const { TextEncoder, TextDecoder } = require('util');
+const crypto = require('crypto');
 
 // Add polyfills for TextEncoder and TextDecoder if they're not defined
 if (typeof TextEncoder === 'undefined') {


### PR DESCRIPTION
## Summary
- run test workflow for v3 pushes and all PRs
- note Node.js 20 in README
- use CommonJS imports in Jest setup file

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688c52cffab4832fb21768ea456c3358