### PR TITLE
Fix jest setup to define document before window

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -45,29 +45,6 @@ if (typeof structuredClone === 'undefined') {
 global.__SSR__ = false;
 global.__BROWSER__ = true;
 
-// Setup JSDOM environment
-global.window = {
-    location: {
-        href: 'http://localhost:3000/',
-    },
-    navigator: {
-        userAgent: 'node.js',
-    },
-    dispatchEvent: jest.fn(),
-};
-
-// Define CustomEvent
-class MockCustomEvent {
-    constructor(type, options = {}) {
-        this.type = type;
-        this.detail = options.detail || null;
-    }
-}
-global.CustomEvent = MockCustomEvent;
-global.Event = function (type) {
-    this.type = type;
-};
-
 // Define a function to create realistic DOM elements
 const createDomElement = (tag) => {
     const element = {
@@ -211,8 +188,29 @@ global.document = {
     head: createDomElement('head'),
 };
 
-// Make document.body accessible on window
-window.document = global.document;
+// Setup JSDOM environment
+global.window = {
+    location: {
+        href: 'http://localhost:3000/',
+    },
+    navigator: {
+        userAgent: 'node.js',
+    },
+    dispatchEvent: jest.fn(),
+    document: global.document,
+};
+
+// Define CustomEvent
+class MockCustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || null;
+    }
+}
+global.CustomEvent = MockCustomEvent;
+global.Event = function (type) {
+    this.type = type;
+};
 
 // Define necessary HTML elements
 global.Element = function () {};


### PR DESCRIPTION
## Summary
- fix the order of DOM mocks in `frontend/jest.setup.js`
- move document creation before window setup and attach to `window`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688c5caeead0832fa223bbdecb4055e6