### PR TITLE
Fix jest setup for Node 20

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,6 +1,6 @@
-// Import necessary modules
-const { TextEncoder, TextDecoder } = require('util');
-const crypto = require('crypto');
+// Import necessary modules using ESM syntax for Node 20
+import { TextEncoder, TextDecoder } from 'util';
+import crypto from 'crypto';
 
 if (typeof globalThis.crypto === 'undefined') {
     globalThis.crypto = crypto.webcrypto || {


### PR DESCRIPTION
## Summary
- ensure `frontend/jest.setup.js` uses ESM imports so Jest works under `--experimental-vm-modules`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr` *(fails to show full output in this environment but individual tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c611916c8832f92f0a42a977d130a