### PR TITLE
Fix jest undefined in vitest tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: [],
+    setupFiles: ['./vitest.setup.js'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,5 @@
+import { vi } from 'vitest';
+import './frontend/jest.setup.js';
+
+// Alias the Vitest global as "jest" for legacy tests
+globalThis.jest = vi;


### PR DESCRIPTION
## Summary
- expose a `jest` global pointing to Vitest in new `vitest.setup.js`
- include the setup file in `vitest.config.ts`

## Testing
- `SKIP_E2E=1 npm run test:pr`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c692c5b64832fac10c14e3bacdd41