### PR TITLE
Fix jest global imports in frontend tests

### DIFF
--- a/frontend/__tests__/ProcessForm.test.js
+++ b/frontend/__tests__/ProcessForm.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import ProcessForm from '../src/components/svelte/ProcessForm.svelte';
 
 // Mock the items.json import

--- a/frontend/__tests__/QuestFormPage.test.js
+++ b/frontend/__tests__/QuestFormPage.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import QuestFormPage from '../src/components/svelte/QuestFormPage.svelte';
 
 jest.mock('../src/components/svelte/QuestForm.svelte', () => ({ default: {} }));

--- a/frontend/__tests__/cloudSync.test.js
+++ b/frontend/__tests__/cloudSync.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import 'fake-indexeddb/auto';
 import {
     uploadGameStateToGist,

--- a/frontend/__tests__/devLog.test.js
+++ b/frontend/__tests__/devLog.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { jest } from '@jest/globals';
 const { log } = require('../src/utils/devLog.js');
 
 describe('devLog', () => {

--- a/frontend/__tests__/jestSetup.test.js
+++ b/frontend/__tests__/jestSetup.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { jest } from '@jest/globals';
 
 const PATH = '../jest.setup.js';
 

--- a/frontend/__tests__/localStorage.test.js
+++ b/frontend/__tests__/localStorage.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import { getLocalStorage } from '../src/utils/localStorage.js';
 
 describe('getLocalStorage', () => {

--- a/frontend/__tests__/openCustomContentDB.test.js
+++ b/frontend/__tests__/openCustomContentDB.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import { openCustomContentDB } from '../src/utils/indexeddb.js';
 import * as migrations from '../src/utils/migrations.js';
 

--- a/frontend/__tests__/questImage.test.js
+++ b/frontend/__tests__/questImage.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 
 import { createQuest, getQuest, ENTITY_TYPES } from '../src/utils/customcontent.js';
 import * as indexedDb from '../src/utils/indexeddb.js';

--- a/frontend/__tests__/setupJest.test.js
+++ b/frontend/__tests__/setupJest.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { jest } from '@jest/globals';
 
 const PATH = '../setupJest.js';
 

--- a/frontend/__tests__/starry.test.js
+++ b/frontend/__tests__/starry.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import { createStarryNight } from '../src/scripts/starry.js';
 
 describe('createStarryNight', () => {

--- a/frontend/__tests__/submitQuestPR.test.js
+++ b/frontend/__tests__/submitQuestPR.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { jest } from '@jest/globals';
 import { submitQuestPR } from '../src/utils/submitQuestPR.js';
 
 describe('submitQuestPR', () => {

--- a/frontend/__tests__/utils.coverage.test.js
+++ b/frontend/__tests__/utils.coverage.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 const {
     parseCookie,
     getCookieValue,

--- a/frontend/__tests__/utils.extra.test.js
+++ b/frontend/__tests__/utils.extra.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 jest.mock('../src/utils/gameState.js', () => ({
     questFinished: jest.fn(),
     canStartQuest: jest.fn(),

--- a/frontend/__tests__/utils.more.test.js
+++ b/frontend/__tests__/utils.more.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 const {
     prettyPrintNumber,
     parseBool,

--- a/frontend/__tests__/utils.time.test.js
+++ b/frontend/__tests__/utils.time.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 const {
     msToTime,
     formatNumber,


### PR DESCRIPTION
## Summary
- import `jest` from `@jest/globals` in several frontend tests to avoid `ReferenceError`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_688c692c5b64832fac10c14e3bacdd41