### PR TITLE
docs: align quest prompts with codex

### DIFF
--- a/frontend/src/pages/docs/md/new-quests-v3.md
+++ b/frontend/src/pages/docs/md/new-quests-v3.md
@@ -1,0 +1,126 @@
+---
+title: 'New Quests in v3'
+slug: 'new-quests-v3'
+---
+
+# Quests added in v3
+
+These quests exist in the `v3` branch but are not present on `main` yet. Use this list when upgrading quests or proposing follow-up content.
+
+### 3dprinting
+- 3dprinting/calibration-cube
+- 3dprinting/phone-stand
+- 3dprinting/retraction-test
+- 3dprinting/temperature-tower
+
+### aquaria
+- aquaria/breeding
+- aquaria/floating-plants
+- aquaria/guppy
+- aquaria/position-tank
+- aquaria/shrimp
+- aquaria/sponge-filter
+- aquaria/walstad
+- aquaria/water-change
+- aquaria/water-testing
+
+### astronomy
+- astronomy/basic-telescope
+- astronomy/comet-tracking
+- astronomy/constellations
+- astronomy/iss-flyover
+- astronomy/jupiter-moons
+- astronomy/lunar-eclipse
+- astronomy/meteor-shower
+- astronomy/observe-moon
+- astronomy/satellite-pass
+- astronomy/star-trails
+
+### chemistry
+- chemistry/ph-test
+- chemistry/safe-reaction
+- chemistry/stevia-crystals
+- chemistry/stevia-extraction
+- chemistry/stevia-tasting
+
+### completionist
+- completionist/reminder
+
+### devops
+- devops/auto-updates
+- devops/ci-pipeline
+- devops/daily-backups
+- devops/docker-compose
+- devops/enable-https
+- devops/k3s-deploy
+- devops/log-maintenance
+- devops/monitoring
+- devops/pi-cluster-hardware
+- devops/prepare-first-node
+- devops/ssd-boot
+
+### electronics
+- electronics/arduino-blink
+- electronics/basic-circuit
+- electronics/data-logger
+- electronics/potentiometer-dimmer
+- electronics/servo-sweep
+- electronics/thermistor-reading
+
+### energy
+- energy/battery-upgrade
+- energy/dWatt-1e8
+- energy/wind-turbine
+
+### firstaid
+- firstaid/assemble-kit
+- firstaid/learn-cpr
+- firstaid/restock-kit
+- firstaid/splint-limb
+- firstaid/wound-care
+
+### hydroponics
+- hydroponics/grow-light
+- hydroponics/lettuce
+- hydroponics/nutrient-check
+- hydroponics/ph-check
+- hydroponics/ph-test
+- hydroponics/regrow-stevia
+- hydroponics/stevia
+
+### programming
+- programming/graph-temp
+- programming/graph-temp-data
+- programming/hello-sensor
+- programming/temp-graph
+- programming/temp-logger
+- programming/web-server
+
+### robotics
+- robotics/line-follower
+- robotics/maze-navigation
+- robotics/obstacle-avoidance
+- robotics/servo-arm
+- robotics/servo-control
+- robotics/servo-gripper
+- robotics/wheel-encoders
+
+### rocketry
+- rocketry/recovery-run
+- rocketry/static-test
+
+### ubi
+- ubi/first-payment
+
+### welcome
+- welcome/connect-github
+- welcome/intro-inventory
+
+### woodworking
+- woodworking/birdhouse
+- woodworking/bookshelf
+- woodworking/finish-sanding
+- woodworking/planter-box
+- woodworking/step-stool
+- woodworking/tool-rack
+- woodworking/workbench

--- a/frontend/src/pages/docs/md/new-quests-v3.md
+++ b/frontend/src/pages/docs/md/new-quests-v3.md
@@ -5,15 +5,17 @@ slug: 'new-quests-v3'
 
 # Quests added in v3
 
-These quests exist in the `v3` branch but are not present on `main` yet. Use this list when upgrading quests or proposing follow-up content.
+These quests exist in the `v3` branch but are not yet on `main`. Use this list when upgrading quests or proposing follow-up content.
 
 ### 3dprinting
+
 - 3dprinting/calibration-cube
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
 
 ### aquaria
+
 - aquaria/breeding
 - aquaria/floating-plants
 - aquaria/guppy
@@ -25,6 +27,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - aquaria/water-testing
 
 ### astronomy
+
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -37,6 +40,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - astronomy/star-trails
 
 ### chemistry
+
 - chemistry/ph-test
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
@@ -44,9 +48,11 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - chemistry/stevia-tasting
 
 ### completionist
+
 - completionist/reminder
 
 ### devops
+
 - devops/auto-updates
 - devops/ci-pipeline
 - devops/daily-backups
@@ -60,6 +66,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - devops/ssd-boot
 
 ### electronics
+
 - electronics/arduino-blink
 - electronics/basic-circuit
 - electronics/data-logger
@@ -68,11 +75,13 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - electronics/thermistor-reading
 
 ### energy
+
 - energy/battery-upgrade
 - energy/dWatt-1e8
 - energy/wind-turbine
 
 ### firstaid
+
 - firstaid/assemble-kit
 - firstaid/learn-cpr
 - firstaid/restock-kit
@@ -80,6 +89,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - firstaid/wound-care
 
 ### hydroponics
+
 - hydroponics/grow-light
 - hydroponics/lettuce
 - hydroponics/nutrient-check
@@ -89,6 +99,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - hydroponics/stevia
 
 ### programming
+
 - programming/graph-temp
 - programming/graph-temp-data
 - programming/hello-sensor
@@ -97,6 +108,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - programming/web-server
 
 ### robotics
+
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
@@ -106,17 +118,21 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - robotics/wheel-encoders
 
 ### rocketry
+
 - rocketry/recovery-run
 - rocketry/static-test
 
 ### ubi
+
 - ubi/first-payment
 
 ### welcome
+
 - welcome/connect-github
 - welcome/intro-inventory
 
 ### woodworking
+
 - woodworking/birdhouse
 - woodworking/bookshelf
 - woodworking/finish-sanding

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -15,6 +15,7 @@ guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.
 
 > **TL;DR**
+>
 > 1. Scope changes to a single quest file.
 > 2. Say exactly what output you expect (diff, tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
@@ -24,11 +25,11 @@ which covers quests, items and processes in detail.
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case              | Codex Web (ChatGPT sidebar)                   | Codex CLI                                                     |
-| --------------------- | --------------------------------------------- | ------------------------------------------------------------- |
-| Add or update a quest | “Code” button, attach repo                    | `codex "add quest solar/led-basics"`                          |
-| Ask about quest files | “Ask” button                                 | `codex exec "explain frontend/src/pages/quests/json/*.json"` |
-| Run quest tests       | –                                            | `codex exec --full-auto "npm test -- questCanonical questQuality"` |
+| Use‑case              | Codex Web (ChatGPT sidebar) | Codex CLI                                                          |
+| --------------------- | --------------------------- | ------------------------------------------------------------------ |
+| Add or update a quest | “Code” button, attach repo  | `codex "add quest solar/led-basics"`                               |
+| Ask about quest files | “Ask” button                | `codex exec "explain frontend/src/pages/quests/json/*.json"`       |
+| Run quest tests       | –                           | `codex exec --full-auto "npm test -- questCanonical questQuality"` |
 
 See the upstream CLI reference for more flags.
 
@@ -36,12 +37,12 @@ See the upstream CLI reference for more flags.
 
 ## 2 Prompt ingredients
 
-| Ingredient           | Why it matters                                                     |
-| -------------------- | ------------------------------------------------------------------ |
-| **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”).|
-| **Files to touch**   | Limits search space → faster & cheaper.                            |
-| **Constraints**      | Coding style, a11y, quest schema rules.                            |
-| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.           |
+| Ingredient           | Why it matters                                                      |
+| -------------------- | ------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                             |
+| **Constraints**      | Coding style, a11y, quest schema rules.                             |
+| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.            |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -3,22 +3,140 @@ title: 'Quest Prompts'
 slug: 'prompts-quests'
 ---
 
-# AI-Assisted Content Development for DSPACE
+# Writing great quest prompts for the _dspace_ repo (v3)
 
-This guide provides structured prompts for using AI assistants like Claude, GPT-4, and others to help create content for DSPACE. These prompts serve as starting templates that you can customize for your specific content needs.
+Codex is a sandboxed engineering agent that can open this repository,
+run its own tests, and send you a ready‑made PR—but only if you give it a
+clear, file‑scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when working on quests. For the steps
+required to share quests with the community, see the
+[Quest Submission Guide](/docs/quest-submission). Comprehensive content
+guidelines live in our [Content Development Guide](/docs/content-development),
+which covers quests, items and processes in detail.
 
-For the steps required to share your quests with the community, see the [Quest Submission Guide](/docs/quest-submission).
+> **TL;DR**
+> 1. Scope changes to a single quest file.
+> 2. Say exactly what output you expect (diff, tests, docs).
+> 3. Stop when the spec is complete. Codex treats all remaining text as
+>    mandatory instructions.
 
-> **Note:** For comprehensive content development guidelines, please refer to our [Content Development Guide](/docs/content-development), which includes specific documentation for [Quests](/docs/quest-guidelines), [Items](/docs/item-guidelines), and [Processes](/docs/process-guidelines).
+---
 
-## Getting Started with AI Assistance
+## 1 Quick start (Web vs CLI)
 
-Modern AI assistants can be powerful collaborators in content creation. Here are some tips for effective use:
+| Use‑case              | Codex Web (ChatGPT sidebar)                   | Codex CLI                                                     |
+| --------------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| Add or update a quest | “Code” button, attach repo                    | `codex "add quest solar/led-basics"`                          |
+| Ask about quest files | “Ask” button                                 | `codex exec "explain frontend/src/pages/quests/json/*.json"` |
+| Run quest tests       | –                                            | `codex exec --full-auto "npm test -- questCanonical questQuality"` |
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus
-- **Use system prompts** to guide the AI toward appropriate tone and technical accuracy
-- **Iterate on outputs** rather than expecting perfect results on the first try
-- **Fact-check technical information** since AI systems can sometimes generate plausible-sounding but incorrect details
+See the upstream CLI reference for more flags.
+
+---
+
+## 2 Prompt ingredients
+
+| Ingredient           | Why it matters                                                     |
+| -------------------- | ------------------------------------------------------------------ |
+| **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”).|
+| **Files to touch**   | Limits search space → faster & cheaper.                            |
+| **Constraints**      | Coding style, a11y, quest schema rules.                            |
+| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.           |
+
+Codex merges those instructions with any `AGENTS.md` files it finds, so keep
+prompt‑level rules short and concrete.
+
+---
+
+## 3 Reusable template
+
+```text
+You are working in democratizedspace/dspace (branch v3).
+
+GOAL: <one sentence quest addition or edit>.
+
+FILES OF INTEREST
+- frontend/src/pages/quests/json/<quest-id>.json   ← quest definition
+
+REQUIREMENTS
+1. Follow the quest schema.
+2. Reference at least one inventory item or process.
+3. Run `npm test -- questCanonical questQuality` and fix any failures.
+4. Update docs or dialogue as needed.
+
+OUTPUT
+Return **only** the patch (diff) needed.
+```
+
+## Implementation Prompt
+
+Use this when you want Codex to automatically create or upgrade a quest.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Edit or create
+quests under `frontend/src/pages/quests/json`. Ensure start, middle and
+completion nodes, at least one item or process reference, and passing
+`npm test -- questCanonical questQuality`.
+
+USER:
+1. Follow the steps above.
+2. Run the quest tests before committing.
+3. Summarize the new or updated quest in the PR description.
+
+OUTPUT:
+A pull request implementing the quest with all tests green.
+```
+
+## One-click random quest
+
+Spin up a brand‑new quest in a random quest tree with this drop‑in prompt. The
+hand‑crafted quests on `main` are good references for tone and structure.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository (branch v3). List
+the folders under `frontend/src/pages/quests/json` and pick one at random. Use
+existing quests in that tree as examples for tone and structure.
+
+USER:
+1. Create a new quest JSON in the chosen tree following the quest schema.
+2. Reference at least one inventory item or process.
+3. Run `npm test -- questCanonical questQuality` and fix any failures.
+
+OUTPUT:
+Return only the diff with the new quest.
+```
+
+## Upgrade prompt for new quests
+
+Focus on quests recently added on the `v3` branch — [see the list](/docs/new-quests-v3) —
+to keep quality high as the codebase grows.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository (branch v3).
+
+USER:
+1. Pick a quest ID from `frontend/src/pages/quests/json` that also appears in
+   `/docs/new-quests-v3`.
+2. Improve clarity, safety notes and item or process references.
+3. Run `npm test -- questCanonical questQuality` and update docs if needed.
+
+OUTPUT:
+A pull request with the refined quest and passing tests.
+```
+
+---
+
+## Additional tips for AI assistance
+
+Modern assistants can be powerful collaborators. Keep in mind:
+
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible but incorrect details.
 
 ## Quest Development Prompts
 


### PR DESCRIPTION
## Summary
- clarify how to write quest prompts for Codex, linking to submission and content guides
- add quick start table, prompt ingredients, and reusable template for quest changes
- include implementation prompt, one-click random quest creator, and upgrade prompt for new v3 quests
- track quests added on v3 in `docs/new-quests-v3`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dafec426c832fbf3b858b74329b68