### PR TITLE
docs: document quest hardening loop

### DIFF
--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -128,6 +128,24 @@ OUTPUT:
 A pull request with the refined quest and passing tests.
 ```
 
+## Quest hardening feedback loop
+
+To measure how many refinement passes a quest has endured, add a `hardening`
+block to each quest's JSON. Every run of the upgrade prompt should increment
+`passes`, update the evaluator `score` and swap the status `emoji` according to
+these thresholds:
+
+| Passes | Score ≥ | Emoji | Meaning |
+| -----: | ------: | :---: | ------- |
+| 0      | 0       | 🛠️    | Draft |
+| ≥1     | 60      | 🌀    | First polishing pass |
+| ≥2     | 75      | ✅    | Meets internal quality bar |
+| ≥3     | 90      | 💯    | Hardened – locked until spec change |
+
+This mirrors the 100‑emoji loop used in the [September 1, 2025 changelog](/docs/changelog/20250901)
+and described in the [Codex implementation prompt](/docs/prompts-codex#implementation-prompt).
+
+
 ---
 
 ## Additional tips for AI assistance

--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -12,6 +12,11 @@ This page provides a minimal quest JSON structure that you can use as a starting
     "id": "astronomy/constellations",
     "title": "Map the Constellations",
     "description": "Identify key star patterns to aid celestial navigation.",
+    "hardening": {
+        "passes": 0,
+        "score": 0,
+        "emoji": "\uD83D\uDEE0\uFE0F"
+    },
     "image": "/assets/quests/solar.jpg",
     "npc": "/assets/npc/nova.jpg",
     "start": "start",
@@ -50,4 +55,7 @@ This page provides a minimal quest JSON structure that you can use as a starting
 ```
 
 Use this template as a baseline and expand it with additional dialogue nodes, processes, item requirements, and rewards. For more in-depth guidance, see the [Quest Development Guidelines](/docs/quest-guidelines).
+The optional `hardening` block tracks how many upgrade passes a quest has survived.
+Increment `passes`, update `score` and switch the status `emoji` (🛠️ → 🌀 → ✅ → 💯)
+each time you run the quest hardening loop described in the [quest prompt guide](/docs/prompts-quests).
 An automated Playwright example (`constellations-quest.spec.ts`) walks through creating this quest step by step if you prefer a hands-on reference.


### PR DESCRIPTION
## Summary
- document quest hardening feedback loop and emoji thresholds
- extend quest template with `hardening` block

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dc1d75f14832f92b2283270998246