### PR TITLE
refine aquaria water change quest

### DIFF
--- a/frontend/src/pages/quests/json/aquaria/water-change.json
+++ b/frontend/src/pages/quests/json/aquaria/water-change.json
@@ -8,17 +8,17 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Regular water changes keep your fish healthy. Let's remove about 25% of the water.",
+            "text": "Regular water changes keep fish healthy. Gather a siphon, bucket, and water conditioner, then remove about 25% of the water.",
             "options": [{ "type": "goto", "goto": "remove", "text": "Got it. How do I start?" }]
         },
         {
             "id": "remove",
-            "text": "Use a siphon to vacuum debris while draining into a bucket. Stop when you've removed about a quarter of the volume.",
+            "text": "Use a siphon or gravel vacuum to gently drain water into a clean bucket while lifting debris. Keep the intake away from fish and stop after roughly a quarter of the volume is gone.",
             "options": [{ "type": "goto", "goto": "refill", "text": "Water removed." }]
         },
         {
             "id": "refill",
-            "text": "Refill slowly with dechlorinated water that's close to the tank's temperature.",
+            "text": "Treat tap water with dechlorinator and match it to the tank's temperature before refilling. Pour slowly to avoid shocking fish.",
             "options": [{ "type": "finish", "text": "Tank refilled and fish are happy!" }]
         }
     ],


### PR DESCRIPTION
## Summary
- clarify instructions for partial water change
- add safety and item references for siphon, bucket, and dechlorinator

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_688dc51007a4832f9c8bb1cef7c94879