### PR TITLE
Add minor burn treatment quest

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/treat-burn.json
+++ b/frontend/src/pages/quests/json/firstaid/treat-burn.json
@@ -1,0 +1,34 @@
+{
+    "id": "firstaid/treat-burn",
+    "title": "Treat a Minor Burn",
+    "description": "Cool and dress a small burn so it heals cleanly.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Cooking mishap? Let's cool that burn before it blisters.",
+            "options": [{ "type": "goto", "goto": "cool", "text": "How?" }]
+        },
+        {
+            "id": "cool",
+            "text": "Hold the area under cool running water for several minutes, then gently pat it dry.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Cooled off and ready to cover",
+                    "requiresItems": [{ "id": "135", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Apply a sterile dressing from your kit and watch for signs of infection.",
+            "options": [{ "type": "finish", "text": "I'll keep an eye on it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}


### PR DESCRIPTION
## Summary
- add **Treat a Minor Burn** quest to first aid tree
- require first aid kit to cover the cooled burn

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_688dcf17df04832f90a7a069fa76fc2b