### PR TITLE
feat: add aquarium light quest

### DIFF
--- a/frontend/src/pages/quests/json/aquaria/aquarium-light.json
+++ b/frontend/src/pages/quests/json/aquaria/aquarium-light.json
@@ -1,0 +1,39 @@
+{
+    "id": "aquaria/aquarium-light",
+    "title": "Install an aquarium light",
+    "description": "Add LED lighting to support plant growth and fish health.",
+    "image": "/assets/aquarium_light.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your Walstad tank is cycling, but plants need steady light. Ready to install the lamp?",
+            "options": [{ "type": "goto", "goto": "mount", "text": "Let's mount the light." }]
+        },
+        {
+            "id": "mount",
+            "text": "Clip the light to the rim and route the cable so it stays dry.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "schedule",
+                    "text": "Light secured.",
+                    "requiresItems": [{ "id": "57", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "schedule",
+            "text": "Plug it in and set a timer for eight hours of gentle daylight.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Timer set and lamp glowing." }]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your plants will thrive under consistent lighting.",
+            "options": [{ "type": "finish", "text": "Enjoy the glow." }]
+        }
+    ],
+    "rewards": [{ "id": "105", "count": 1 }],
+    "requiresQuests": ["aquaria/sponge-filter"]
+}


### PR DESCRIPTION
## Summary
- add aquarium light quest referencing aquarium light item

## Testing
- `npm test -- --run questCanonical questQuality`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dcf164204832fbec9ad8ba2b6f92d