### PR TITLE
feat(quests): add firewall rules quest

### DIFF
--- a/frontend/src/pages/quests/json/devops/firewall-rules.json
+++ b/frontend/src/pages/quests/json/devops/firewall-rules.json
@@ -1,0 +1,34 @@
+{
+    "id": "devops/firewall-rules",
+    "title": "Configure Firewall Rules",
+    "description": "Lock down network ports to only what you need.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Open ports invite trouble. Let's add a firewall to your node.",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Show me." }]
+        },
+        {
+            "id": "setup",
+            "text": "Install UFW and allow SSH and HTTPS. Deny everything else by default.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Rules applied.",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Your node now exposes only the ports it needs.",
+            "options": [{ "type": "finish", "text": "System secured." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/auto-updates"]
+}


### PR DESCRIPTION
## Summary
- add DevOps quest for configuring firewall rules

## Testing
- `npm test -- questCanonical questQuality`
- `npx jest __tests__/questCanonical.test.js --runTestsByPath -t firewall-rules`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dcf141738832f9d18c027be0aad9b