### PR TITLE
fix: restore codecov reporting

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -11,5 +11,7 @@ jobs:
       - run: |
           test -f .github/workflows/tests.yml
           test -f .github/workflows/ci.yml
-          grep -q 'codecov/codecov-action@' .github/workflows/ci.yml
+          grep -q 'npm run coverage' .github/workflows/tests.yml
+          grep -q 'scripts/checkPatchCoverage.cjs' .github/workflows/tests.yml
+          grep -q 'codecov/codecov-action@' .github/workflows/tests.yml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,17 @@ jobs:
           SKIP_E2E: '1'
         run: npm run test:pr
 
+      - name: Generate coverage report
+        env:
+          NODE_OPTIONS: --experimental-vm-modules
+        run: npm run coverage
+
+      - name: Check patch coverage
+        run: node scripts/checkPatchCoverage.cjs
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: frontend/coverage/lcov.info
+          fail_ci_if_error: true
+


### PR DESCRIPTION
## Summary
- run coverage and upload results in tests workflow
- guard tests workflow with ci-sentinel to ensure coverage & Codecov steps remain

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: "fatal: Not a valid object name origin/main")*


------
https://chatgpt.com/codex/tasks/task_e_688e7977c9ac832faaeb70ffba1aa1a3