### PR TITLE
fix: restore codecov reporting

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -15,4 +15,5 @@ jobs:
           grep -q 'scripts/checkPatchCoverage.cjs' .github/workflows/tests.yml
           grep -q 'codecov/codecov-action@' .github/workflows/tests.yml
           grep -q 'fetch-depth: 0' .github/workflows/tests.yml
+          grep -q 'CODECOV_TOKEN' .github/workflows/tests.yml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,5 @@ jobs:
         with:
           files: frontend/coverage/lcov.info
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary
- run coverage and upload results in tests workflow
- guard tests workflow with ci-sentinel to ensure coverage, Codecov and full git history for patch coverage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_688e7977c9ac832faaeb70ffba1aa1a3