### PR TITLE
docs: clarify tech realism in quest upgrades

### DIFF
--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -112,7 +112,10 @@ Return only the diff with the new quest.
 ## Upgrade prompt for new quests
 
 Focus on quests recently added on the `v3` branch — [see the list](/docs/new-quests-v3) —
-to keep quality high as the codebase grows.
+to keep quality high as the codebase grows. This prompt uses the quest
+quality tests to ensure that every technological step is represented in
+the inventory (`items.json`) and process (`processes.json`) registries and
+grounded in reality with components that can be replicated in real life.
 
 ```text
 SYSTEM:
@@ -121,8 +124,12 @@ You are an automated contributor for the DSPACE repository (branch v3).
 USER:
 1. Pick a quest ID from `frontend/src/pages/quests/json` that also appears in
    `/docs/new-quests-v3`.
-2. Improve clarity, safety notes and item or process references.
-3. Run `npm test -- questCanonical questQuality` and update docs if needed.
+2. Verify every technology mentioned has a granular, real-world entry in
+   `frontend/src/pages/inventory/json/items.json` or
+   `frontend/src/pages/processes/processes.json`; add or refine entries as
+   needed and remove speculative tech.
+3. Improve clarity, safety notes and item or process references.
+4. Run `npm test -- questCanonical questQuality` and update docs if needed.
 
 OUTPUT:
 A pull request with the refined quest and passing tests.


### PR DESCRIPTION
## Summary
- emphasize quest-quality checks when refining recently added quests
- require each tech reference to map to real items and processes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688e82cf3a34832f90a087d02b6db0df