### PR TITLE
docs: clarify quest upgrade and hardening guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -122,7 +122,12 @@ USER:
 1. Pick a quest ID from `frontend/src/pages/quests/json` that also appears in
    `/docs/new-quests-v3`.
 2. Improve clarity, safety notes and item or process references.
-3. Run `npm test -- questCanonical questQuality` and update docs if needed.
+3. Check that every technology mentioned has a granular, real‑world entry in
+   `frontend/src/pages/inventory/json/items.json` or
+   `frontend/src/pages/processes/processes.json`. Add missing items or
+   processes so quests stay grounded in reality and are reproducible IRL.
+4. Run `npm test -- questCanonical questQuality itemQuality processQuality` and
+   update docs if needed.
 
 OUTPUT:
 A pull request with the refined quest and passing tests.
@@ -132,8 +137,9 @@ A pull request with the refined quest and passing tests.
 
 To measure how many refinement passes a quest has endured, add a `hardening`
 block to each quest's JSON. Every run of the upgrade prompt should increment
-`passes`, update the evaluator `score` and swap the status `emoji` according to
-these thresholds:
+`passes`, update the evaluator `score`, swap the status `emoji` and append an
+entry to `hardening.history` noting the Codex task ID, date and score. Use these
+thresholds when choosing the emoji:
 
 | Passes | Score ≥ | Emoji | Meaning |
 | -----: | ------: | :---: | ------- |
@@ -144,6 +150,19 @@ these thresholds:
 
 This mirrors the 100‑emoji loop used in the [September 1, 2025 changelog](/docs/changelog/20250901)
 and described in the [Codex implementation prompt](/docs/prompts-codex#implementation-prompt).
+
+Example `hardening` block with history entries:
+
+```json
+"hardening": {
+  "passes": 1,
+  "score": 60,
+  "emoji": "🌀",
+  "history": [
+    { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
+  ]
+}
+```
 
 
 ---

--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -15,7 +15,8 @@ This page provides a minimal quest JSON structure that you can use as a starting
     "hardening": {
         "passes": 0,
         "score": 0,
-        "emoji": "\uD83D\uDEE0\uFE0F"
+        "emoji": "🛠️",
+        "history": []
     },
     "image": "/assets/quests/solar.jpg",
     "npc": "/assets/npc/nova.jpg",
@@ -55,7 +56,6 @@ This page provides a minimal quest JSON structure that you can use as a starting
 ```
 
 Use this template as a baseline and expand it with additional dialogue nodes, processes, item requirements, and rewards. For more in-depth guidance, see the [Quest Development Guidelines](/docs/quest-guidelines).
-The optional `hardening` block tracks how many upgrade passes a quest has survived.
-Increment `passes`, update `score` and switch the status `emoji` (🛠️ → 🌀 → ✅ → 💯)
-each time you run the quest hardening loop described in the [quest prompt guide](/docs/prompts-quests).
+The optional `hardening` block tracks how many upgrade passes a quest has survived and stores a history of Codex tasks.
+Increment `passes`, update `score`, switch the status `emoji` (🛠️ → 🌀 → ✅ → 💯) and append an entry to `history` with the task ID, date and score each time you run the quest hardening loop described in the [quest prompt guide](/docs/prompts-quests).
 An automated Playwright example (`constellations-quest.spec.ts`) walks through creating this quest step by step if you prefer a hands-on reference.


### PR DESCRIPTION
## Summary
- expand quest upgrade prompt to validate real-world tech via items.json and processes.json and run broader quality tests
- document hardening history tracking with Codex task entries and sample block
- extend quest template to show `hardening.history` and explain logging of Codex tasks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e83129088832faed1b277f67fa938