### PR TITLE
feat: harden wound care quest

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1014,5 +1014,12 @@
         "description": "Alkaline solution used to raise nutrient solution pH.",
         "image": "/assets/quests/basic_circuit.svg",
         "price": "8 dUSD"
+    },
+    {
+        "id": "144",
+        "name": "liquid soap",
+        "description": "Mild hand soap for cleaning skin before treating a wound.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "3 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1191,6 +1191,19 @@
         "duration": "2m"
     },
     {
+        "id": "clean-minor-cut",
+        "title": "Clean and dress a minor cut",
+        "requireItems": [{ "id": "135", "count": 1 }],
+        "consumeItems": [
+            { "id": "140", "count": 1 },
+            { "id": "139", "count": 1 },
+            { "id": "137", "count": 1 },
+            { "id": "144", "count": 1 }
+        ],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "practice-cpr",
         "title": "Practice CPR on a dummy",
         "requireItems": [{ "id": "135", "count": 1 }],

--- a/frontend/src/pages/quests/json/firstaid/wound-care.json
+++ b/frontend/src/pages/quests/json/firstaid/wound-care.json
@@ -1,20 +1,25 @@
 {
     "id": "firstaid/wound-care",
     "title": "Practice Basic Wound Care",
-    "description": "Learn to clean and bandage minor cuts safely.",
+    "description": "Learn to clean and bandage a minor cut safely.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Minor scrapes happen. We'll practice cleaning and dressing them with your first aid kit. If it's deep or bleeding heavily, seek medical help instead.",
+            "text": "Minor scrapes happen. We'll practice cleaning and dressing them with your first aid kit. If the cut is deep, gaping, or bleeding heavily, stop and seek medical help instead.",
             "options": [{ "type": "goto", "goto": "clean", "text": "Sounds good." }]
         },
         {
             "id": "clean",
-            "text": "Wash your hands, put on gloves, gently rinse the wound with clean water, dab on antiseptic from the kit, then cover it with a sterile bandage.",
+            "text": "Wash your hands with liquid soap, put on nitrile gloves, gently rinse the wound with clean water, wipe with an antiseptic wipe, then cover it with an adhesive bandage.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "clean-minor-cut",
+                    "text": "Clean and dress the cut"
+                },
                 {
                     "type": "goto",
                     "goto": "finish",
@@ -30,5 +35,11 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["firstaid/learn-cpr"]
+    "requiresQuests": ["firstaid/learn-cpr"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [{ "task": "codex-upgrade-2025-08-02", "date": "2025-08-02", "score": 60 }]
+    }
 }


### PR DESCRIPTION
## Summary
- refine first-aid wound-care quest with safety notes, process step, and hardening block
- add liquid soap item and clean-minor-cut process to support wound care

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test run questCanonical questQuality itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_688e8ad50b00832fa313327be758dd1d