### PR TITLE
docs: add quest template examples

### DIFF
--- a/frontend/__tests__/questTemplateValidation.test.js
+++ b/frontend/__tests__/questTemplateValidation.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const schema = require('../src/pages/quests/jsonSchemas/quest.json');
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+
+function validateFile(filepath) {
+    const data = JSON.parse(fs.readFileSync(filepath));
+    return validate(data);
+}
+
+describe('quest template validation', () => {
+    test('templates conform to quest schema', () => {
+        const dir = path.join(__dirname, '../src/pages/quests/templates');
+        const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+        for (const file of files) {
+            const filepath = path.join(dir, file);
+            const valid = validateFile(filepath);
+            if (!valid) {
+                console.error(validate.errors);
+            }
+            expect(valid).toBe(true);
+        }
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -26,7 +26,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Quest submission process documentation
         -   [x] Write contribution guidelines
         -   [x] Document quest schema requirements
-        -   [x] Create example quest templates
+        -   [x] Create example quest templates 💯
 -   [x] 10x More Quests
     -   [x] Create new official quests using the custom quest system
     -   [x] Balance progression curve across all quests

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -14,7 +14,7 @@ This guide describes how to submit your custom quests to become part of the offi
 
 ## Steps
 
-1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. The command `npm run generate-quest` can scaffold a template for you.
+1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. Copy one of the examples from `frontend/src/pages/quests/templates` or run `npm run generate-quest` to scaffold a template.
 2. **Bundle related items and processes** using `scripts/create-content-bundle.js`. This script collects quests, items, and processes into a single JSON file under `submissions/bundles`.
 3. **Validate** the quest structure by running:
     ```bash

--- a/frontend/src/pages/quests/templates/basic.json
+++ b/frontend/src/pages/quests/templates/basic.json
@@ -1,15 +1,3 @@
----
-title: 'Quest Template Example'
-slug: 'quest-template'
----
-
-# Quest Template Example
-
-This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
-
-Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy `basic.json` for a linear quest or `branching.json` to experiment with multiple paths.
-
-```json
 {
     "id": "astronomy/constellations",
     "title": "Map the Constellations",
@@ -17,7 +5,7 @@ Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy 
     "hardening": {
         "passes": 0,
         "score": 0,
-        "emoji": "🛠️",
+        "emoji": "\ud83d\udd27",
         "history": []
     },
     "image": "/assets/quests/solar.jpg",
@@ -55,9 +43,3 @@ Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy 
     "rewards": [],
     "requiresQuests": ["astronomy/jupiter-moons"]
 }
-```
-
-Use this template as a baseline and expand it with additional dialogue nodes, processes, item requirements, and rewards. For more in-depth guidance, see the [Quest Development Guidelines](/docs/quest-guidelines).
-The optional `hardening` block tracks how many upgrade passes a quest has survived and stores a history of Codex tasks.
-Increment `passes`, update `score`, switch the status `emoji` (🛠️ → 🌀 → ✅ → 💯) and append an entry to `history` with the task ID, date and score each time you run the quest hardening loop described in the [quest prompt guide](/docs/prompts-quests).
-An automated Playwright example (`constellations-quest.spec.ts`) walks through creating this quest step by step if you prefer a hands-on reference.

--- a/frontend/src/pages/quests/templates/branching.json
+++ b/frontend/src/pages/quests/templates/branching.json
@@ -1,0 +1,53 @@
+{
+    "id": "template/branching-example",
+    "title": "Branching Quest Example",
+    "description": "Demonstrates branching dialogue options.",
+    "hardening": {
+        "passes": 0,
+        "score": 0,
+        "emoji": "\ud83d\udd27",
+        "history": []
+    },
+    "image": "/assets/quests/example.jpg",
+    "npc": "/assets/npc/placeholder.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Choose your path.",
+            "options": [
+                { "type": "goto", "goto": "study", "text": "Study the stars" },
+                {
+                    "type": "goto",
+                    "goto": "skip",
+                    "text": "Skip the lesson",
+                    "requiresItems": [{ "id": "134", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "study",
+            "text": "Learning is fun!",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "identify-constellations",
+                    "text": "Complete study"
+                },
+                { "type": "goto", "goto": "finish", "text": "Finish" }
+            ]
+        },
+        {
+            "id": "skip",
+            "text": "Skipping ahead!",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Continue" }]
+        },
+        {
+            "id": "finish",
+            "text": "You've completed the branching quest example.",
+            "options": [{ "type": "finish", "text": "Done", "requiresGitHub": false }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- add basic and branching quest JSON templates
- validate quest templates against schema
- document quest templates and link from submission guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_688ef0d5ae24832f95b0e76ee2f4e86a