### PR TITLE
feat(quest): add ssh hardening quest

### DIFF
--- a/frontend/src/pages/quests/json/devops/ssh-hardening.json
+++ b/frontend/src/pages/quests/json/devops/ssh-hardening.json
@@ -1,0 +1,45 @@
+{
+    "id": "devops/ssh-hardening",
+    "title": "Harden SSH Access",
+    "description": "Use key-based authentication and disable password logins.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Let's secure your node's SSH service.",
+            "options": [{ "type": "goto", "goto": "keys", "text": "Ready." }]
+        },
+        {
+            "id": "keys",
+            "text": "Generate an SSH key pair and copy the public key into ~/.ssh/authorized_keys on the node.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "config",
+                    "text": "Key installed.",
+                    "requiresItems": [{ "id": "132", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "config",
+            "text": "Edit /etc/ssh/sshd_config to disable password authentication and root login, then restart the service.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Service restarted."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "SSH is now locked down to your key. Nice work.",
+            "options": [{ "type": "finish", "text": "Security first." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["devops/firewall-rules"]
+}


### PR DESCRIPTION
## Summary
- add SSH hardening quest in devops track

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- run validateQuest questQuality`


------
https://chatgpt.com/codex/tasks/task_e_688eec6a2f5c832fa080f2f6da0600b8