### PR TITLE
Enable quest scaffolding from templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ SKIP_E2E=1 npm run test:pr
 - Each quest needs start, middle and completion nodes with at least one option per node and a final `finish` option.
 - Reference at least one inventory item or process in every quest or the `questQuality` test will fail.
 - Consult `frontend/src/pages/docs/md/npcs.md` for character voice and keep it updated.
-- Use `npm run generate-quest` to scaffold dialogue quickly.
+- Use `npm run generate-quest [--template <name>]` to scaffold dialogue quickly; templates live in `frontend/src/pages/quests/templates`.
 - Archive deprecated quests under `frontend/src/pages/quests/archive`.
 
 ## UI Guidelines

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ steps, run the dedicated test:
 
 ```bash
 [Quest Development Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template), and the [Quest Submission Guide](docs/quest-submission) to streamline content creation and sharing.
-Use `npm run generate-quest` to scaffold a new quest with placeholder dialogue.
+Use `npm run generate-quest [--template <name>]` to scaffold a new quest with placeholder dialogue.
 ```
 
 Custom quests often rely on new items or processes. Use [`scripts/create-content-bundle.js`](./scripts/create-content-bundle.js) to package these together. See the [Custom Content Bundles](docs/custom-bundles) guide for details.

--- a/frontend/scripts/generate-quest.mjs
+++ b/frontend/scripts/generate-quest.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { writeFileSync, mkdirSync, readdirSync, readFileSync, statSync } from 'fs';
 import glob from 'glob';
-import { fileURLToPath } from 'url';
 import path from 'path';
 import readline from 'readline';
 
@@ -34,10 +33,25 @@ async function main() {
     const { categories, npcCounts } = gatherStats();
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const questRoot = path.join('frontend', 'src', 'pages', 'quests', 'json');
-    const existing = glob.sync(path.join(questRoot, '**/*.json')).map((f) => path.relative(questRoot, f).replace(/\.json$/, ''));
+    const existing = glob
+        .sync(path.join(questRoot, '**/*.json'))
+        .map((f) => path.relative(questRoot, f).replace(/\.json$/, ''));
 
-    const noLlm = process.argv.includes('--no-llm');
-    let questId = process.argv[2] && !process.argv[2].startsWith('--') ? process.argv[2] : null;
+    const args = process.argv.slice(2);
+    let questId = null;
+    let noLlm = false;
+    let templateName = null;
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === '--no-llm') {
+            noLlm = true;
+        } else if (arg === '--template' && i + 1 < args.length) {
+            templateName = args[i + 1];
+            i++;
+        } else if (!questId && !arg.startsWith('--')) {
+            questId = arg;
+        }
+    }
     if (!questId) {
         console.log('Available categories:', categories.join(', '));
         const category = (await ask('Choose a category or type a new one: ', rl)).trim();
@@ -69,23 +83,59 @@ async function main() {
     const npcName = npcs[parseInt(npcChoice, 10) - 1] || 'vega';
     rl.close();
 
-    const quest = {
-        id: questId,
-        title,
-        description: 'Describe the quest objectives here.',
-        image: '/assets/quests/howtodoquests.jpg',
-        npc: `/assets/npc/${npcName}.jpg`,
-        start: 'start',
-        dialogue: [
-            {
-                id: 'start',
-                text: 'Generating...',
-                options: [{ type: 'finish', text: 'Finish' }],
-            },
-        ],
-        rewards: [],
-        requiresQuests: [],
-    };
+    let quest;
+    if (templateName) {
+        const templatePath = path.join(
+            'frontend',
+            'src',
+            'pages',
+            'quests',
+            'templates',
+            `${templateName}.json`
+        );
+        try {
+            quest = JSON.parse(readFileSync(templatePath, 'utf8'));
+        } catch (e) {
+            console.error(`Template ${templateName} not found.`);
+            process.exit(1);
+        }
+        quest.id = questId;
+        quest.title = title;
+        quest.description = 'Describe the quest objectives here.';
+        quest.npc = `/assets/npc/${npcName}.jpg`;
+        quest.rewards = [];
+        quest.requiresQuests = [];
+        if (quest.dialogue && quest.dialogue.length) {
+            quest.dialogue[0].text = 'Generating...';
+        } else {
+            quest.start = 'start';
+            quest.dialogue = [
+                {
+                    id: 'start',
+                    text: 'Generating...',
+                    options: [{ type: 'finish', text: 'Finish' }],
+                },
+            ];
+        }
+    } else {
+        quest = {
+            id: questId,
+            title,
+            description: 'Describe the quest objectives here.',
+            image: '/assets/quests/howtodoquests.jpg',
+            npc: `/assets/npc/${npcName}.jpg`,
+            start: 'start',
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'Generating...',
+                    options: [{ type: 'finish', text: 'Finish' }],
+                },
+            ],
+            rewards: [],
+            requiresQuests: [],
+        };
+    }
 
     if (!noLlm) {
         const { scoreQuest } = await import('../../scripts/utils/llm.js');

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -128,7 +128,7 @@ Every quest JSON file must include:
 > **Note:** The full quest editing interface is still under development. The current implementation in `QuestForm.svelte` supports basic quest properties (title, description, image) with more complete dialogue editing planned for future updates.
 
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
-You can run `npm run generate-quest` to scaffold a template JSON file with placeholder dialogue.
+You can run `npm run generate-quest --template basic` (or `branching`) to scaffold a template JSON file with placeholder dialogue.
 
 - Dialogue node creation and editing
 - Process and item requirement selection
@@ -147,7 +147,7 @@ Before submitting a quest, verify:
 
 ## Contribution Workflow
 
-1. Develop your quest locally following these guidelines (start with `npm run generate-quest` for a ready-made template)
+1. Develop your quest locally following these guidelines (start with `npm run generate-quest --template basic` for a ready-made template)
 2. Test thoroughly in your local environment
 3. Submit a [pull request](https://github.com/democratizedspace/dspace/pulls) with your quest JSON file
 4. Respond to feedback during code review

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -14,7 +14,7 @@ This guide describes how to submit your custom quests to become part of the offi
 
 ## Steps
 
-1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. Copy one of the examples from `frontend/src/pages/quests/templates` or run `npm run generate-quest` to scaffold a template.
+1. **Create your quest** using the in-game editor or by editing a JSON file under `frontend/src/pages/quests/json`. Copy one of the examples from `frontend/src/pages/quests/templates` or run `npm run generate-quest --template basic` (use `branching` for multiple paths) to scaffold a template.
 2. **Bundle related items and processes** using `scripts/create-content-bundle.js`. This script collects quests, items, and processes into a single JSON file under `submissions/bundles`.
 3. **Validate** the quest structure by running:
     ```bash

--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -7,7 +7,7 @@ slug: 'quest-template'
 
 This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
 
-Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy `basic.json` for a linear quest or `branching.json` to experiment with multiple paths.
+Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy `basic.json` for a linear quest or `branching.json` to experiment with multiple paths. You can also run `npm run generate-quest --template basic` (or `branching`) to copy one automatically.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- allow `npm run generate-quest` to scaffold quests from JSON templates via a new `--template` flag
- document template-based quest creation in AGENTS, README, and quest guides

## Testing
- `npm run lint`
- `npm run check`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688ef378f1d8832f9ada5d5340c17a25