### PR TITLE
docs: document monitoring setup

### DIFF
--- a/docs/monitoring_setup.md
+++ b/docs/monitoring_setup.md
@@ -20,7 +20,23 @@ This guide explains how to run Prometheus and Grafana to monitor your self-hoste
 
 3. Add Prometheus as a data source in Grafana using the URL `http://prometheus:9090`.
 
-You can now create dashboards to track container resource usage and any custom metrics you expose.
+Prometheus is preconfigured to scrape the DSPACE metrics endpoint at
+`http://host.docker.internal:3002/metrics`. If you run DSPACE on a different
+port or host, update `monitoring/prometheus/prometheus.yml` accordingly.
+
+You can now create dashboards to track container resource usage and the metrics
+exposed by your DSPACE instance.
+
+## Security Considerations
+
+- The bundled `docker-compose.yml` binds Prometheus and Grafana to `127.0.0.1`
+  so they are not reachable from other machines. If you need remote access,
+  change the port mappings but ensure a firewall protects these services.
+- Set custom Grafana credentials by exporting
+  `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD` before running
+  `docker compose up`.
+- The DSPACE metrics endpoint may expose operational details. Restrict access
+  to trusted networks or add authentication if exposing it beyond localhost.
 
 ## Configuration
 
@@ -29,4 +45,5 @@ The `docker-compose.yml` file defines two services:
 - **prometheus** – stores metrics using the configuration in `prometheus/prometheus.yml`.
 - **grafana** – visualizes data from Prometheus and persists settings in the `grafana-data` volume.
 
-Feel free to modify `prometheus/prometheus.yml` to scrape additional targets such as node exporters.
+Feel free to modify `prometheus/prometheus.yml` to scrape additional targets
+such as node exporters or remote DSPACE instances.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -61,7 +61,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Load balancer setup
         -   [x] Backup system ✅
         -   [x] Failover procedures 💯
-        -   [x] Monitoring setup
+        -   [x] Monitoring setup 💯
     -   [x] Migration from Netlify
 -   [x] License Migration
 -   [x] Testing & QA

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -6,14 +6,17 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
     depends_on:
       - prometheus
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
     volumes:
       - grafana-data:/var/lib/grafana
 volumes:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -5,3 +5,6 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+  - job_name: 'dspace'
+    static_configs:
+      - targets: ['host.docker.internal:3002']


### PR DESCRIPTION
## Summary
- document that Prometheus scrapes DSPACE metrics
- add DSPACE to monitoring/prometheus.yml
- bind monitoring services to localhost and allow custom Grafana credentials
- document security considerations for the monitoring stack
- mark monitoring setup as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688ef7412b34832f8e46ea22e1391f11