### PR TITLE
docs: add item and process prompt guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,16 @@ everything consistent.
 > dialogue. Token.place itself doesn't host quests, but you can reuse the same
 > prompts to create content across your projects.
 
-### AI-Assisted Quest Creation
+### AI-Assisted Content Creation
 
-For faster quest development, consult our [Quest Prompts](docs/prompts-quests)
-guide. It includes ready-made prompt templates for tools like GPT-4 or Claude to
-help you generate dialogue and structure quickly. Combine these with the
-[Quest Development Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template), and the [Quest Submission Guide](docs/quest-submission) to streamline content creation and sharing.
+For faster content development, consult our prompt guides for
+[quests](docs/prompts-quests), [items](docs/prompts-items), and
+[processes](docs/prompts-processes). Each includes ready-made templates for
+tools like GPT-4 or Claude. Combine these with the [Quest Development
+Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template),
+the [Item Development Guidelines](docs/item-guidelines), the [Process Development
+Guidelines](docs/process-guidelines), and the [Quest Submission
+Guide](docs/quest-submission) to streamline content creation and sharing.
 
 ## Authentication
 

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -49,6 +49,8 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prs">Pull Requests</a>
             <a href="/docs/bounties">Bounties</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
+            <a href="/docs/prompts-items">Item prompts</a>
+            <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
         </nav>

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -60,8 +60,9 @@ Instructions for creating processes that transform or utilize items. Topics incl
 
 ## AI Assistance for Content Creation
 
-For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex#implementation-prompt). It walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. This guide includes:
-For general repository maintenance, the [Codex Upgrade Prompt](/docs/prompts-codex#upgrade-prompt) instructs Codex to scan the project for improvements and implement them automatically.
+For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests), [Item Prompts](/docs/prompts-items) and [Process Prompts](/docs/prompts-processes) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex#implementation-prompt); it walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. For general repository maintenance, the [Codex Upgrade Prompt](/docs/prompts-codex#upgrade-prompt) instructs Codex to scan the project for improvements and implement them automatically.
+
+These guides include:
 
 -   Effective prompt templates for different content types
 -   Best practices for working with AI assistants
@@ -108,3 +109,4 @@ For more advanced contributors interested in extending core game functionality:
 -   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTORS.md): General contribution guidelines
 
 By following these guidelines, you'll create high-quality content that enhances the DSPACE experience while contributing to our mission of democratizing space exploration through practical, hands-on education.
+Remember to run `npm run check` to verify formatting and linting before submitting.

--- a/frontend/src/pages/docs/md/contribute.md
+++ b/frontend/src/pages/docs/md/contribute.md
@@ -23,7 +23,7 @@ DSPACE is designed as an extensible platform where community members can create 
 -   **[Develop Custom Items](/docs/item-guidelines)** - Create virtual resources, tools, and components
 -   **[Design Custom Processes](/docs/process-guidelines)** - Build activities that transform or utilize items
 
-Our [Content Development Guide](/docs/content-development) provides a comprehensive overview of all content creation options, workflows, and best practices. We also offer [Quest Prompts](/docs/prompts-quests) for those looking to leverage AI tools in their content creation process.
+Our [Content Development Guide](/docs/content-development) provides a comprehensive overview of all content creation options, workflows, and best practices. We also offer [Quest Prompts](/docs/prompts-quests), [Item Prompts](/docs/prompts-items), and [Process Prompts](/docs/prompts-processes) for those looking to leverage AI tools in their content creation process.
 
 ## Code Contributions
 

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -1,0 +1,134 @@
+---
+title: 'Item Prompts'
+slug: 'prompts-items'
+---
+
+# Writing great item prompts for the _dspace_ repo (v3)
+
+Codex is a sandboxed engineering agent that can open this repository,
+run its own tests, and send you a ready‑made PR—but only if you give it a
+clear, file‑scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when working on items. For general
+content rules see the [Item Development Guidelines](/docs/item-guidelines).
+
+> **TL;DR**
+>
+> 1. Scope changes to a single item entry.
+> 2. Say exactly what output you expect (diff, tests, docs).
+> 3. Stop when the spec is complete. Codex treats all remaining text as
+>    mandatory instructions.
+
+---
+
+## 1 Quick start (Web vs CLI)
+
+| Use‑case              | Codex Web (ChatGPT sidebar) | Codex CLI                                                           |
+| --------------------- | --------------------------- | ------------------------------------------------------------------- |
+| Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"`                          |
+| Ask about item data   | “Ask” button                | `codex exec "explain frontend/src/pages/inventory/json/items.json"` |
+| Run item tests        | –                           | `codex exec --full-auto "npm test -- itemValidation itemQuality"`   |
+
+See the upstream CLI reference for more flags.
+
+---
+
+## 2 Prompt ingredients
+
+| Ingredient           | Why it matters                                                      |
+| -------------------- | ------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add price to `white PLA filament`”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                             |
+| **Constraints**      | Coding style, a11y, item schema rules.                              |
+| **Acceptance check** | e.g. “`npm test -- itemValidation itemQuality` passes”.             |
+
+Codex merges those instructions with any `AGENTS.md` files it finds, so keep
+prompt‑level rules short and concrete.
+
+---
+
+## 3 Reusable template
+
+```text
+You are working in democratizedspace/dspace (branch v3).
+
+GOAL: <one sentence item addition or edit>.
+
+FILES OF INTEREST
+- frontend/src/pages/inventory/json/items.json   ← item registry
+- frontend/src/pages/inventory/jsonSchemas/item.json   ← schema
+
+REQUIREMENTS
+1. Follow the item schema.
+2. Reflect real-world materials or devices.
+3. Run `npm test -- itemValidation itemQuality` and fix any failures.
+4. Update docs or processes if needed.
+
+OUTPUT
+Return **only** the patch (diff) needed.
+```
+
+## Implementation Prompt
+
+Use this when you want Codex to automatically create or upgrade an item.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Edit or create
+items under `frontend/src/pages/inventory/json/items.json`. Ensure realistic
+details, required fields, and passing `npm test -- itemValidation itemQuality`.
+
+USER:
+1. Follow the steps above.
+2. Run the item tests before committing.
+3. Summarize the new or updated item in the PR description.
+
+OUTPUT:
+A pull request implementing the item with all tests green.
+```
+
+## Upgrade prompt for existing items
+
+Apply this prompt to refine items and track quality over time.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository (branch v3).
+
+USER:
+1. Pick an item from `frontend/src/pages/inventory/json/items.json` that lacks a
+   `hardening` block or has a low score.
+2. Improve clarity, realism and units. Ensure prices and descriptions match
+   real-world expectations and that related processes reference the item
+   correctly.
+3. Update or create the item's `hardening` block, incrementing `passes`,
+   refreshing the evaluator `score`, swapping the status `emoji` and appending a
+   history entry with the Codex task ID, date and score. Choose the emoji based
+   on:
+   - 0 passes → score 0 → 🛠️ Draft
+   - ≥1 pass & score ≥60 → 🌀 First polishing pass
+   - ≥2 passes & score ≥75 → ✅ Meets internal quality bar
+   - ≥3 passes & score ≥90 → 💯 Hardened – locked until spec change
+   Example:
+   "hardening": {
+     "passes": 1,
+     "score": 60,
+     "emoji": "🌀",
+     "history": [
+       { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
+     ]
+   }
+4. Run `npm test -- itemValidation itemQuality processQuality` and update docs if
+   needed.
+
+OUTPUT:
+A pull request with the refined item, updated hardening block and passing tests.
+```
+
+## Additional tips for AI assistance
+
+Modern assistants can be powerful collaborators. Keep in mind:
+
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible but incorrect details.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -1,0 +1,131 @@
+---
+title: 'Process Prompts'
+slug: 'prompts-processes'
+---
+
+# Writing great process prompts for the _dspace_ repo (v3)
+
+Codex is a sandboxed engineering agent that can open this repository,
+run its own tests, and send you a ready‑made PR—but only if you give it a
+clear, file‑scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when working on processes. For
+fundamental design tips see the [Process Development Guidelines](/docs/process-guidelines).
+
+> **TL;DR**
+>
+> 1. Scope changes to a single process entry.
+> 2. Say exactly what output you expect (diff, tests, docs).
+> 3. Stop when the spec is complete. Codex treats all remaining text as
+>    mandatory instructions.
+
+---
+
+## 1 Quick start (Web vs CLI)
+
+| Use‑case                | Codex Web (ChatGPT sidebar) | Codex CLI                                                          |
+| ----------------------- | --------------------------- | ------------------------------------------------------------------ |
+| Add or update a process | “Code” button, attach repo  | `codex "add process 3dprinting/solar-mount"`                       |
+| Ask about process data  | “Ask” button                | `codex exec "explain frontend/src/pages/processes/processes.json"` |
+| Run process tests       | –                           | `codex exec --full-auto "npm test -- processQuality itemQuality"`  |
+
+See the upstream CLI reference for more flags.
+
+---
+
+## 2 Prompt ingredients
+
+| Ingredient           | Why it matters                                                          |
+| -------------------- | ----------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add lettuce seed input to hydroponics”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                                 |
+| **Constraints**      | Coding style, a11y, process schema rules.                               |
+| **Acceptance check** | e.g. “`npm test -- processQuality itemQuality` passes”.                 |
+
+Codex merges those instructions with any `AGENTS.md` files it finds, so keep
+prompt‑level rules short and concrete.
+
+---
+
+## 3 Reusable template
+
+```text
+You are working in democratizedspace/dspace (branch v3).
+
+GOAL: <one sentence process addition or edit>.
+
+FILES OF INTEREST
+- frontend/src/pages/processes/processes.json   ← process registry
+
+REQUIREMENTS
+1. Follow the process schema.
+2. Use realistic durations and item relationships.
+3. Run `npm test -- processQuality itemQuality` and fix any failures.
+4. Update docs or items if needed.
+
+OUTPUT
+Return **only** the patch (diff) needed.
+```
+
+## Implementation Prompt
+
+Use this when you want Codex to automatically create or upgrade a process.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Edit or create
+processes under `frontend/src/pages/processes/processes.json`. Ensure realistic
+steps, durations, item references, and passing `npm test -- processQuality itemQuality`.
+
+USER:
+1. Follow the steps above.
+2. Run the process tests before committing.
+3. Summarize the new or updated process in the PR description.
+
+OUTPUT:
+A pull request implementing the process with all tests green.
+```
+
+## Upgrade prompt for existing processes
+
+Use this prompt to refine processes and track quality as the game evolves.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository (branch v3).
+
+USER:
+1. Pick a process from `frontend/src/pages/processes/processes.json` that lacks a
+   `hardening` block or has a low score.
+2. Improve clarity, realism and item references. Ensure durations are feasible
+   and related items exist in `frontend/src/pages/inventory/json/items.json`.
+3. Update or create the process's `hardening` block, incrementing `passes`,
+   refreshing the evaluator `score`, swapping the status `emoji` and appending a
+   history entry with the Codex task ID, date and score. Choose the emoji based
+   on:
+   - 0 passes → score 0 → 🛠️ Draft
+   - ≥1 pass & score ≥60 → 🌀 First polishing pass
+   - ≥2 passes & score ≥75 → ✅ Meets internal quality bar
+   - ≥3 passes & score ≥90 → 💯 Hardened – locked until spec change
+   Example:
+   "hardening": {
+     "passes": 1,
+     "score": 60,
+     "emoji": "🌀",
+     "history": [
+       { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
+     ]
+   }
+4. Run `npm test -- processQuality itemQuality` and update docs or items if needed.
+
+OUTPUT:
+A pull request with the refined process, updated hardening block and passing tests.
+```
+
+## Additional tips for AI assistance
+
+Modern assistants can be powerful collaborators. Keep in mind:
+
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible but incorrect details.


### PR DESCRIPTION
## Summary
- add dedicated prompt guides for items and processes using quest-style hardening blocks
- link new guides from docs index, README, and contributor docs
- clarify content-development AI assistance section and format prompt guides
- remind contributors to run `npm run check` before submitting

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688ef6d222a4832f87bc68302736ac65