### PR TITLE
docs: add self-hosting guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -48,6 +48,7 @@ import Page from '../../components/Page.astro';
         <nav>
             <a href="/docs/prs">Pull Requests</a>
             <a href="/docs/bounties">Bounties</a>
+            <a href="/docs/self-hosting">Self-hosting</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -55,7 +55,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] AI Integration
     -   [x] token.place integration
 -   [x] Infrastructure
-    -   [x] Self-hosted setup documentation
+    -   [x] Self-hosted setup documentation 💯
     -   [x] Docker deployment
     -   [x] Redundancy implementation
         -   [x] Load balancer setup

--- a/frontend/src/pages/docs/md/self-hosting.md
+++ b/frontend/src/pages/docs/md/self-hosting.md
@@ -1,0 +1,49 @@
+---
+title: 'Self-hosting DSPACE'
+slug: 'self-hosting'
+---
+
+# Self-hosting DSPACE
+
+Run your own DSPACE instance on your hardware. Docker Compose builds the site and
+serves it locally.
+
+## Requirements
+
+-   Git
+-   Docker and Docker Compose
+
+## Quick start
+
+1. Clone this repository and enter the directory:
+    ```bash
+    git clone https://github.com/democratizedspace/dspace.git
+    cd dspace
+    ```
+2. Build and launch the production container:
+    ```bash
+    docker compose up -d
+    ```
+    The site will be available at `http://localhost:3002`.
+3. Stop the container at any time with:
+    ```bash
+    docker compose down
+    ```
+
+## Helper script
+
+The repository includes a convenience script that proxies common Docker
+commands. Use it from the repository root:
+
+```bash
+./run-dspace.sh start   # start the app
+./run-dspace.sh stop    # stop containers
+```
+
+## Advanced guides
+
+These additional documents cover more complex deployments:
+
+-   [Raspberry Pi k3s Deployment](https://github.com/democratizedspace/dspace/blob/v3/docs/deploy/raspi.md)
+-   [Failover Procedures](https://github.com/democratizedspace/dspace/blob/v3/docs/failover_procedures.md)
+-   [Monitoring Setup](https://github.com/democratizedspace/dspace/blob/v3/docs/monitoring_setup.md)


### PR DESCRIPTION
## Summary
- document how to run DSPACE locally with Docker
- link self-hosting guide from Docs index
- mark self-hosted setup documentation as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688f04600f28832facdc65105a5f6dd1