### PR TITLE
test: run CI on quest json and enforce quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ on:
   push:
     branches: [v3]
   pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.json'
+      - '**/*.svelte'
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.github/workflows/**'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,15 @@ on:
   push:
     branches: [v3]
   pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.json'
+      - '**/*.svelte'
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.github/workflows/**'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -213,8 +213,8 @@ We have specialized tests to ensure content quality:
 
 1. **Quest Quality Tests** (`questQuality.test.js`):
 
-    - Validates NPC dialogue style consistency
-    - Checks for ethical considerations in aquarium quests
+    - Validates NPC dialogue style consistency and fails on mismatches
+    - Checks for ethical considerations in aquarium quests and fails on violations
     - Verifies proper quest progression and dependencies. Failures now occur if any quest chain issues are detected.
     - Identifies dialogue that doesn't match NPC personalities
     - Uses simple heuristics for now; integration with the OpenAI API is planned
@@ -238,7 +238,7 @@ We have specialized tests to ensure content quality:
     - Ensures quest chains reference existing quests
     - Detects circular dependencies that could block progress
 
-These tests are designed to produce warnings rather than failures, allowing for ongoing development while still identifying quality issues to address.
+Most of these tests produce warnings rather than failures, but quest quality issues now cause the test suite to error, ensuring regressions are caught early.
 
 To run these tests specifically:
 

--- a/frontend/__tests__/questQuality.test.js
+++ b/frontend/__tests__/questQuality.test.js
@@ -475,15 +475,11 @@ describe('Quest Quality Validation', () => {
         }
 
         if (allIssues.length > 0) {
-            console.warn('Dialogue Style Issues:');
-            allIssues.forEach((issue) => console.warn(`- ${issue}`));
+            console.error('Dialogue Style Issues:');
+            allIssues.forEach((issue) => console.error(`- ${issue}`));
         }
 
-        // Fail the test if we have critical issues (uncomment to enforce)
-        // expect(allIssues.length).toBe(0);
-
-        // For now, just output warnings but don't fail tests
-        expect(true).toBe(true);
+        expect(allIssues.length).toBe(0);
     });
 
     test('Aquarium quests follow ethical care guidelines', () => {
@@ -497,12 +493,11 @@ describe('Quest Quality Validation', () => {
         }
 
         if (allIssues.length > 0) {
-            console.warn('Aquarium Ethics Issues:');
-            allIssues.forEach((issue) => console.warn(`- ${issue}`));
+            console.error('Aquarium Ethics Issues:');
+            allIssues.forEach((issue) => console.error(`- ${issue}`));
         }
 
-        // For now, just output warnings but don't fail tests
-        expect(true).toBe(true);
+        expect(allIssues.length).toBe(0);
     });
 
     test('Quest dependencies form a logical progression', () => {

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -25,7 +25,7 @@ This guide describes how to submit your custom quests to become part of the offi
     ```bash
     npm test -- questQuality
     ```
-    Review any warnings and make improvements where necessary.
+    Fix any reported errors until the test passes.
 5. **Open the Quest Submission form** at `/quests/submit`.
 6. **Authorize GitHub** by entering a personal access token with `repo` scope. The token is only used client-side to push your quest.
 7. **Create the pull request** directly from the form. This uploads your quest to a new branch and opens a draft PR.


### PR DESCRIPTION
## Summary
- ensure CI runs when PRs touch quest JSON
- make quest quality checks fail instead of warn
- document stricter quest quality requirements

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688f0b2d6044832f8395f2dd9466fb73