### PR TITLE
feat: refine CPR training quest

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1048,5 +1048,19 @@
         "description": "A battery pack or USB adapter that provides a stable 5V DC output.",
         "image": "/assets/quests/basic_circuit.svg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "148",
+        "name": "CPR training manikin",
+        "description": "A torso manikin for practicing chest compressions and rescue breaths.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "35 dUSD"
+    },
+    {
+        "id": "149",
+        "name": "CPR mask",
+        "description": "A one-way valve mask that protects you when giving rescue breaths.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "5 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1205,8 +1205,13 @@
     },
     {
         "id": "practice-cpr",
-        "title": "Practice CPR on a dummy",
-        "requireItems": [{ "id": "135", "count": 1 }],
+        "title": "Practice CPR on a manikin",
+        "requireItems": [
+            { "id": "135", "count": 1 },
+            { "id": "140", "count": 1 },
+            { "id": "148", "count": 1 },
+            { "id": "149", "count": 1 }
+        ],
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"

--- a/frontend/src/pages/quests/json/firstaid/learn-cpr.json
+++ b/frontend/src/pages/quests/json/firstaid/learn-cpr.json
@@ -1,19 +1,19 @@
 {
     "id": "firstaid/learn-cpr",
     "title": "Practice Basic CPR",
-    "description": "Put on gloves, use a training manikin and a CPR mask from your first aid kit to rehearse chest compressions and rescue breaths. Always verify the scene is safe and call emergency services before starting.",
+    "description": "Slide on nitrile gloves, set a CPR manikin on a firm surface and fit a CPR mask to rehearse 30 chest compressions and two rescue breaths. Practice only on the manikin and ensure emergency services are contacted before any real attempt.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Slip on gloves, confirm the area is safe, call emergency services, and check the manikin's airway before you begin.",
+            "text": "Wear nitrile gloves, make sure the area is safe, and have someone call emergency services. Position the manikin on its back and tilt the head to open the airway.",
             "options": [{ "type": "goto", "goto": "steps", "text": "I'm ready." }]
         },
         {
             "id": "steps",
-            "text": "Place the heel of one hand in the center of the chest and interlock your fingers. Keep your arms straight and press about 2 inches deep at 100–120 compressions per minute, letting the chest return fully. After 30 compressions, give two rescue breaths through the CPR mask if you're trained.",
+            "text": "With the CPR mask sealed over the mouth, place the heel of one hand at the center of the chest and interlock your fingers. Keep your arms straight and press about 2 inches deep at 100–120 compressions per minute, letting the chest return fully. After 30 compressions, give two slow rescue breaths through the mask, watching for chest rise.",
             "options": [
                 { "type": "process", "process": "practice-cpr", "text": "Practicing now." },
                 {
@@ -26,10 +26,18 @@
         },
         {
             "id": "finish",
-            "text": "Great job! Regular practice with a manikin, gloves, and mask helps you respond calmly and safely. Remember, real emergencies should be handled by certified professionals whenever possible.",
+            "text": "Great job! Regular practice with a manikin, gloves, and mask builds muscle memory. Never practice on a real person, and in an actual emergency let certified professionals take over when they arrive.",
             "options": [{ "type": "finish", "text": "I'll keep practicing." }]
         }
     ],
     "rewards": [],
-    "requiresQuests": ["firstaid/assemble-kit"]
+    "requiresQuests": ["firstaid/assemble-kit"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            { "task": "codex-upgrade-2025-08-03", "date": "2025-08-03", "score": 60 }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify first-aid CPR quest text and emphasize safety
- add CPR manikin and mask items and require them for practice-cpr process
- record initial hardening pass for learn-cpr quest

## Testing
- `npm test -- questCanonical questQuality itemQuality processQuality`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f095ed16c832f903e0f6d0728bc85