### PR TITLE
feat: flesh out first aid kit process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1185,10 +1185,26 @@
     {
         "id": "pack-first-aid-kit",
         "title": "Pack a basic first aid kit",
-        "requireItems": [],
-        "consumeItems": [],
+        "requireItems": [
+            { "id": "137", "count": 5 },
+            { "id": "138", "count": 3 },
+            { "id": "139", "count": 3 },
+            { "id": "140", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "137", "count": 5 },
+            { "id": "138", "count": 3 },
+            { "id": "139", "count": 3 },
+            { "id": "140", "count": 1 }
+        ],
         "createItems": [{ "id": "135", "count": 1 }],
-        "duration": "2m"
+        "duration": "5m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [{ "task": "codex-upgrade-2025-08-03", "date": "2025-08-03", "score": 60 }]
+        }
     },
     {
         "id": "clean-minor-cut",


### PR DESCRIPTION
## Summary
- expand `pack-first-aid-kit` to consume bandages, gauze, antiseptic wipes, and gloves
- add hardening metadata for first pass review

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_688f0425a914832fa578dc4b07b18142