### PR TITLE
feat: harden practice CPR process

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -972,6 +972,13 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "b397aa70-3503-4e40-b84a-4d5609578d2b",
+        "name": "CPR training manikin",
+        "description": "Life-size torso manikin for practicing chest compressions and rescue breaths.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "e1714868-aa17-4f04-ac09-13ac4d7ecea0",
         "name": "stevia crystals",
         "description": "Highly concentrated sweetener purified from stevia extract.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1417,16 +1417,26 @@
     },
     {
         "id": "practice-cpr",
-        "title": "Practice CPR on a dummy",
+        "title": "Practice CPR on a training manikin",
         "requireItems": [
             {
                 "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                "count": 1
+            },
+            {
+                "id": "b397aa70-3503-4e40-b84a-4d5609578d2b",
                 "count": 1
             }
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "1m"
+        "duration": "15m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [{ "task": "codex-hardening-2025-08-03", "date": "2025-08-03", "score": 60 }]
+        }
     },
     {
         "id": "observe-jupiter-moons",


### PR DESCRIPTION
## Summary
- add CPR training manikin inventory item
- clarify and harden "practice CPR" process with realistic duration and hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_688fdeaaf0d0832f9a15449c90cdd58c