### PR TITLE
refine aquaria shrimp quest with drip acclimation

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -732,6 +732,13 @@
         "price": "3 dUSD"
     },
     {
+        "id": "60e517b4-5807-4983-afb8-e2aad1566587",
+        "name": "Airline tubing",
+        "description": "Flexible tubing for aquarium air pumps and drip acclimation.",
+        "image": "/assets/aquarium_empty.jpg",
+        "price": "2 dUSD"
+    },
+    {
         "id": "3f1cc002-1f7a-4301-a1c6-343f65e7f21a",
         "name": "Guppy group",
         "description": "Three females and one male guppy ready to breed.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1547,5 +1547,22 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "5m"
+    },
+    {
+        "id": "drip-acclimate-shrimp",
+        "title": "Drip acclimate dwarf shrimp",
+        "requireItems": [
+            {
+                "id": "60e517b4-5807-4983-afb8-e2aad1566587",
+                "count": 1
+            },
+            {
+                "id": "0564d441-7367-412e-b709-dad770814a39",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1h"
     }
 ]

--- a/frontend/src/pages/quests/json/aquaria/shrimp.json
+++ b/frontend/src/pages/quests/json/aquaria/shrimp.json
@@ -1,14 +1,14 @@
 {
     "id": "aquaria/shrimp",
     "title": "Add dwarf shrimp",
-    "description": "Introduce hardy shrimp to help keep the tank clean.",
+    "description": "Introduce hardy shrimp to help keep the tank clean while maintaining good water quality.",
     "image": "/assets/quests/shrimp.svg",
     "npc": "/assets/npc/vega.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Your Walstad tank should be cycled now. A small colony of dwarf shrimp will keep algae in check.",
+            "text": "Your Walstad tank should be fully cycled now. A small colony of dwarf shrimp will graze on algae and highlight any water quality issues.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "acquire",
-            "text": "Pick up a few shrimp from the store and float the bag in your tank to equalize temperature.",
+            "text": "Pick up a few healthy shrimp from the store. Keep the bag sealed, verify ammonia and nitrite are zero, and float it in your tank for 15 minutes to equalize temperature.",
             "options": [
                 {
                     "type": "goto",
@@ -30,7 +30,33 @@
         },
         {
             "id": "acclimate",
-            "text": "Slowly drip tank water into the bag for about an hour. Then release the shrimp gently.",
+            "text": "Set up a drip acclimation using a clean bucket and airline tubing so tank water drips into the bag for about an hour.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "drip-acclimate-shrimp",
+                    "text": "Start drip acclimation",
+                    "requiresItems": [
+                        {
+                            "id": "60e517b4-5807-4983-afb8-e2aad1566587",
+                            "count": 1
+                        },
+                        {
+                            "id": "0564d441-7367-412e-b709-dad770814a39",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "goto",
+                    "goto": "release",
+                    "text": "Water is matched."
+                }
+            ]
+        },
+        {
+            "id": "release",
+            "text": "Use a net to move the shrimp into the tank. Discard the store water to avoid contamination.",
             "options": [
                 {
                     "type": "finish",
@@ -45,5 +71,17 @@
             "count": 3
         }
     ],
-    "requiresQuests": ["aquaria/walstad"]
+    "requiresQuests": ["aquaria/walstad"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-04",
+                "date": "2025-08-04",
+                "score": 60
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify aquaria/shrimp quest with safety notes and drip acclimation step
- add airline tubing inventory item and drip-acclimate-shrimp process
- document hardening metadata for shrimp quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run questCanonical questQuality itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_688ffbe76508832f9e0b018563f0708d