### PR TITLE
feat(quest): polish completionist trophy

### DIFF
--- a/frontend/src/pages/quests/json/completionist/polish.json
+++ b/frontend/src/pages/quests/json/completionist/polish.json
@@ -1,0 +1,50 @@
+{
+    "id": "completionist/polish",
+    "title": "Polish Your Trophy",
+    "description": "Keep your Completionist Award shiny and proud.",
+    "image": "/assets/quests/completionist.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "That award is looking a bit dusty. Want to give it a quick shine?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "polish",
+                    "text": "Absolutely, let's polish it"
+                }
+            ]
+        },
+        {
+            "id": "polish",
+            "text": "A soft cloth and some elbow grease will do the trick. Show me when it sparkles!",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Here it is, sparkling",
+                    "requiresItems": [
+                        {
+                            "id": "c01676ec-27e5-4a53-9a47-24bf6c5a56a9",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Brilliant! A clean trophy reflects a dedicated adventurer.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, dChat!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["completionist/v2"]
+}


### PR DESCRIPTION
## Summary
- add "Polish Your Trophy" quest to the completionist tree, requiring the Completionist Award to finish

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`
- `npm test -- validateQuest questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68901303a9e4832f85e1b4b06753843a