### PR TITLE
feat: validate custom processes

### DIFF
--- a/frontend/__tests__/ProcessForm.test.js
+++ b/frontend/__tests__/ProcessForm.test.js
@@ -95,6 +95,9 @@ describe('ProcessForm Component', () => {
         durationInput.value = '1h';
         durationInput.dispatchEvent(new Event('input'));
 
+        // Add minimal required item relationship
+        component.$$set({ requireItems: [{ id: 'item-1', count: 1 }] });
+
         // Submit form
         form.dispatchEvent(new Event('submit', { cancelable: true }));
 
@@ -103,9 +106,33 @@ describe('ProcessForm Component', () => {
         const formData = submittedData;
         expect(formData.get('title')).toBe('Test Process');
         expect(formData.get('duration')).toBe('1h');
-        expect(JSON.parse(formData.get('requireItems'))).toEqual([]);
+        expect(JSON.parse(formData.get('requireItems'))).toEqual([{ id: 'item-1', count: 1 }]);
         expect(JSON.parse(formData.get('consumeItems'))).toEqual([]);
         expect(JSON.parse(formData.get('createItems'))).toEqual([]);
+    });
+
+    test('should reject submission without item relationships', () => {
+        const component = new ProcessForm({
+            target: container,
+        });
+
+        const form = container.querySelector('form');
+        const titleInput = container.querySelector('input[type="text"]');
+        const durationInput = container.querySelector('input[placeholder="e.g. 1h 30m"]');
+
+        let submittedData = null;
+        component.$on('submit', (event) => {
+            submittedData = event.detail;
+        });
+
+        titleInput.value = 'Test Process';
+        titleInput.dispatchEvent(new Event('input'));
+        durationInput.value = '1h';
+        durationInput.dispatchEvent(new Event('input'));
+
+        form.dispatchEvent(new Event('submit', { cancelable: true }));
+
+        expect(submittedData).toBeFalsy();
     });
 
     test('should handle adding and removing items', () => {

--- a/frontend/__tests__/processValidation.test.js
+++ b/frontend/__tests__/processValidation.test.js
@@ -1,0 +1,54 @@
+import { validateProcessData } from '../src/utils/customProcessValidation.js';
+
+describe('validateProcessData', () => {
+    test('accepts valid process', () => {
+        const { valid, errors } = validateProcessData({
+            title: 'Test Process',
+            duration: '1h',
+            requireItems: [{ id: 'item1', count: 1 }],
+        });
+        expect(valid).toBe(true);
+        expect(errors).toBeNull();
+    });
+
+    test('rejects missing title', () => {
+        const { valid, errors } = validateProcessData({
+            duration: '1h',
+            requireItems: [{ id: 'item1', count: 1 }],
+        });
+        expect(valid).toBe(false);
+        expect(errors).toBeTruthy();
+    });
+
+    test('rejects invalid duration', () => {
+        const { valid, errors } = validateProcessData({
+            title: 'Bad Duration',
+            duration: 'abc',
+            requireItems: [{ id: 'item1', count: 1 }],
+        });
+        expect(valid).toBe(false);
+        expect(errors).toBeTruthy();
+    });
+
+    test('requires at least one item relationship', () => {
+        const { valid, errors } = validateProcessData({
+            title: 'No Items',
+            duration: '1h',
+            requireItems: [],
+            consumeItems: [],
+            createItems: [],
+        });
+        expect(valid).toBe(false);
+        expect(errors).toBeTruthy();
+    });
+
+    test('rejects negative item count', () => {
+        const { valid, errors } = validateProcessData({
+            title: 'Negative Count',
+            duration: '1h',
+            requireItems: [{ id: 'item1', count: -1 }],
+        });
+        expect(valid).toBe(false);
+        expect(errors).toBeTruthy();
+    });
+});

--- a/frontend/src/components/svelte/ProcessForm.svelte
+++ b/frontend/src/components/svelte/ProcessForm.svelte
@@ -4,6 +4,7 @@
     import ProcessPreview from './ProcessPreview.svelte';
     import items from '../../pages/inventory/json/items.json';
     import { durationInSeconds } from '../../utils.js';
+    import { validateProcessData } from '../../utils/customProcessValidation.js';
 
     export let title = '';
     export let duration = '';
@@ -86,6 +87,32 @@
 
         if (!validateItems()) {
             errors.items = 'Item counts must be positive';
+        }
+
+        const { valid, errors: schemaErrors } = validateProcessData({
+            title,
+            duration,
+            requireItems,
+            consumeItems,
+            createItems,
+        });
+
+        if (!valid && schemaErrors) {
+            schemaErrors.forEach((err) => {
+                if (err.keyword === 'anyOf') {
+                    errors.items = 'At least one item relationship is required';
+                } else if (err.instancePath === '/title') {
+                    errors.title = err.message || 'Invalid title';
+                } else if (err.instancePath === '/duration') {
+                    errors.duration = err.message || 'Invalid duration';
+                } else if (
+                    err.instancePath.startsWith('/requireItems') ||
+                    err.instancePath.startsWith('/consumeItems') ||
+                    err.instancePath.startsWith('/createItems')
+                ) {
+                    errors.items = err.message || 'Invalid items';
+                }
+            });
         }
 
         validationErrors = errors;

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -39,7 +39,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Process System
         -   [x] Process creation UI with duration handling
         -   [x] Required/consumed/created items selection
-        -   [x] Process validation and testing
+        -   [x] Process validation and testing 💯
         -   [x] Process state management
     -   [x] Preview and Testing
         -   [x] Content preview functionality

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -31,6 +31,17 @@ Every process requires the following properties:
 
 At least one of `requireItems`, `consumeItems`, or `createItems` must be specified for a process to be useful.
 
+### Validation
+
+Custom processes are validated against a JSON schema when created. The schema ensures:
+
+-   Titles have at least three characters
+-   Durations use the `h`, `m`, or `s` units (decimals allowed)
+-   Item relationships include positive counts
+-   At least one of `requireItems`, `consumeItems`, or `createItems` is present
+
+Processes that fail validation will not be saved and the form displays helpful error messages.
+
 ### Duration Format
 
 Duration must follow the pattern `(\d+h\s*)?(\d+m\s*)?(\d+s\s*)?`, for example:

--- a/frontend/src/utils/customProcessValidation.js
+++ b/frontend/src/utils/customProcessValidation.js
@@ -1,0 +1,45 @@
+import Ajv from 'ajv';
+
+export const customProcessSchema = {
+    type: 'object',
+    properties: {
+        title: { type: 'string', minLength: 3 },
+        duration: {
+            type: 'string',
+            minLength: 1,
+            pattern: '^(\\d+(?:\\.\\d+)?[dhms]\\s*)+$',
+        },
+        requireItems: { $ref: '#/definitions/items' },
+        consumeItems: { $ref: '#/definitions/items' },
+        createItems: { $ref: '#/definitions/items' },
+    },
+    required: ['title', 'duration'],
+    additionalProperties: false,
+    definitions: {
+        items: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', minLength: 1 },
+                    count: { type: 'number', minimum: 1 },
+                },
+                required: ['id', 'count'],
+                additionalProperties: false,
+            },
+        },
+    },
+    anyOf: [
+        { required: ['requireItems'], properties: { requireItems: { minItems: 1 } } },
+        { required: ['consumeItems'], properties: { consumeItems: { minItems: 1 } } },
+        { required: ['createItems'], properties: { createItems: { minItems: 1 } } },
+    ],
+};
+
+const ajv = new Ajv();
+const validate = ajv.compile(customProcessSchema);
+
+export function validateProcessData(data) {
+    const valid = validate(data);
+    return { valid, errors: validate.errors };
+}


### PR DESCRIPTION
## Summary
- add Ajv-based schema to validate custom processes
- enforce schema in ProcessForm and require at least one item relation
- document process validation rules and mark changelog as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_688ffbd3dc98832fb53d2ee5259ee744