### PR TITLE
docs: add quest contribution guidelines

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -24,7 +24,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add validation for quest dependencies 💯
         -   [x] Implement quest simulation testing 💯
     -   [x] Quest submission process documentation
-        -   [x] Write contribution guidelines
+        -   [x] Write contribution guidelines 💯
         -   [x] Document quest schema requirements 💯
         -   [x] Create example quest templates 💯
 -   [x] 10x More Quests

--- a/frontend/src/pages/docs/md/contribute.md
+++ b/frontend/src/pages/docs/md/contribute.md
@@ -19,7 +19,7 @@ There are several ways to contribute to the DSPACE project:
 
 DSPACE is designed as an extensible platform where community members can create and contribute various types of content:
 
--   **[Create Custom Quests](/docs/quest-guidelines)** - Design educational missions that teach space-related skills
+-   **[Create Custom Quests](/docs/quest-guidelines)** - Design educational missions that teach space-related skills. When you're ready to share your work, follow the [Quest Contribution Guidelines](/docs/quest-contribution) to submit it for review.
 -   **[Develop Custom Items](/docs/item-guidelines)** - Create virtual resources, tools, and components
 -   **[Design Custom Processes](/docs/process-guidelines)** - Build activities that transform or utilize items
 

--- a/frontend/src/pages/docs/md/quest-contribution.md
+++ b/frontend/src/pages/docs/md/quest-contribution.md
@@ -1,0 +1,44 @@
+---
+title: 'Quest Contribution Guidelines'
+slug: 'quest-contribution'
+---
+
+# Quest Contribution Guidelines
+
+These guidelines outline the process for contributing your custom quests to the official DSPACE repository.
+
+## Prerequisites
+
+-   [Quest Development Guidelines](/docs/quest-guidelines)
+-   Node.js environment with this repository cloned
+
+## Workflow
+
+1. **Generate a template**
+    ```bash
+    npm run generate-quest --template basic
+    ```
+    Use `branching` instead of `basic` for multi-path quests.
+2. **Build your quest** following the [Quest Schema](/docs/quest-schema). Include at least one item or process reference.
+3. **Run validations**
+    ```bash
+    npm test -- questValidation
+    npm test -- questQuality
+    npm test -- questSimulation
+    ```
+4. **Bundle related content**
+    ```bash
+    node scripts/create-content-bundle.js
+    ```
+    This creates a JSON bundle in `submissions/bundles`.
+5. **Submit via the in-game form** at `/quests/submit`.
+6. **Authorize GitHub** with a personal access token and create a pull request.
+7. **Respond to feedback** until the quest meets project standards.
+
+## Tips
+
+-   Keep dialogue concise and educational.
+-   Include safety notes where appropriate.
+-   Run `SKIP_E2E=1 npm run test:pr` before opening a pull request.
+
+Happy quest building!


### PR DESCRIPTION
## Summary
- document quest contribution workflow in new doc and link from the general Contribute page
- mark quest contribution guidelines item as verified in the September 2025 changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run check`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68902814659c832fb5904e6478e48987