### PR TITLE
Add pause/resume support for processes

### DIFF
--- a/frontend/src/components/__tests__/Process.spec.ts
+++ b/frontend/src/components/__tests__/Process.spec.ts
@@ -1,0 +1,57 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import Process from '../svelte/Process.svelte';
+import { vi } from 'vitest';
+import { tick } from 'svelte';
+
+const ProcessStates = {
+    NOT_STARTED: 'not started',
+    IN_PROGRESS: 'in progress',
+    FINISHED: 'finished',
+    PAUSED: 'paused',
+};
+
+const stateInfo = { state: ProcessStates.IN_PROGRESS, progress: 0 };
+
+const pauseProcess = vi.fn(() => {
+    stateInfo.state = ProcessStates.PAUSED;
+});
+const resumeProcess = vi.fn(() => {
+    stateInfo.state = ProcessStates.IN_PROGRESS;
+});
+
+vi.mock('../../pages/processes/processes.json', () => ({
+    default: [
+        {
+            id: 'p1',
+            title: 'Test Process',
+            duration: '10s',
+            requireItems: [],
+            consumeItems: [],
+            createItems: [],
+        },
+    ],
+}));
+
+vi.mock('../../utils/gameState/processes.js', () => ({
+    startProcess: vi.fn(),
+    cancelProcess: vi.fn(),
+    finishProcess: vi.fn(),
+    getProcessState: vi.fn(() => stateInfo),
+    ProcessStates,
+    getProcessStartedAt: vi.fn(() => Date.now()),
+    pauseProcess,
+    resumeProcess,
+}));
+
+test('pauses and resumes a process', async () => {
+    const { getByText } = render(Process, { processId: 'p1' });
+
+    // pause the process
+    await fireEvent.click(getByText('Pause'));
+    expect(pauseProcess).toHaveBeenCalledWith('p1');
+    await tick();
+
+    // resume the process
+    await fireEvent.click(getByText('Resume'));
+    expect(resumeProcess).toHaveBeenCalledWith('p1');
+});

--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -5,6 +5,8 @@
         startProcess,
         cancelProcess,
         finishProcess,
+        pauseProcess,
+        resumeProcess,
         getProcessState,
         ProcessStates,
         getProcessStartedAt,
@@ -44,6 +46,18 @@
     const onProcessComplete = () => {
         clearInterval(intervalId);
         finishProcess(processId);
+        updateState();
+    };
+
+    const onProcessPause = () => {
+        clearInterval(intervalId);
+        pauseProcess(processId);
+        updateState();
+    };
+
+    const onProcessResume = () => {
+        resumeProcess(processId);
+        intervalId = setInterval(updateState, 100);
         updateState();
     };
 
@@ -89,6 +103,14 @@
                 <Chip text="Start" onClick={onProcessStart} inverted={true} />
             {:else if state === ProcessStates.IN_PROGRESS}
                 <Chip text="Cancel" onClick={onProcessCancel} inverted={true} />
+                <Chip text="Pause" onClick={onProcessPause} inverted={true} />
+                <ProgressBar
+                    startDate={processStartedAt}
+                    totalDurationSeconds={durationInSeconds(process.duration)}
+                />
+            {:else if state === ProcessStates.PAUSED}
+                <Chip text="Cancel" onClick={onProcessCancel} inverted={true} />
+                <Chip text="Resume" onClick={onProcessResume} inverted={true} />
                 <ProgressBar
                     startDate={processStartedAt}
                     totalDurationSeconds={durationInSeconds(process.duration)}

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -40,7 +40,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Process creation UI with duration handling
         -   [x] Required/consumed/created items selection
         -   [x] Process validation and testing 💯
-        -   [x] Process state management
+        -   [x] Process state management 💯
     -   [x] Preview and Testing
         -   [x] Content preview functionality
         -   [x] Testing environment for custom content

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -109,6 +109,10 @@ In this state, a process is waiting to be started. You can start a process by cl
 
 In this state, the process is active. You have the option to terminate an active process by clicking the Cancel button. If you cancel a process, your items will be returned to you. A countdown to the process's completion and a progress bar are also displayed in this state.
 
+### PAUSED
+
+In this state, the process is temporarily halted. The countdown stops until you choose to resume. You may resume the process later or cancel it to reclaim consumed items.
+
 ### FINISHED
 
 <img src="/assets/docs/process_finished.jpg">


### PR DESCRIPTION
## Summary
- allow pausing and resuming processes via new controls
- document paused process state
- mark Process state management as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68902814659c832fb5904e6478e48987