### PR TITLE
test: cover quest requirement editing

### DIFF
--- a/frontend/__tests__/QuestForm.test.js
+++ b/frontend/__tests__/QuestForm.test.js
@@ -413,6 +413,7 @@ describe('QuestForm Component', () => {
             title: 'Existing Quest',
             description: 'Existing quest description',
             image: 'existing-image-url',
+            requiresQuests: ['q1'],
         };
 
         // Mock for edit mode
@@ -432,6 +433,8 @@ describe('QuestForm Component', () => {
         // Check if form is pre-filled with existing data
         expect(container.querySelector('#title').value).toBe(existingQuest.title);
         expect(container.querySelector('#description').value).toBe(existingQuest.description);
+        const reqSelect = container.querySelector('#requires');
+        expect(reqSelect.options[0].selected).toBe(true);
 
         // Submit form without changes
         await act(async () => {
@@ -445,7 +448,7 @@ describe('QuestForm Component', () => {
                 title: existingQuest.title,
                 description: existingQuest.description,
                 image: 'mocked-image-url',
-                requiresQuests: [],
+                requiresQuests: ['q1'],
             })
         );
     });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -14,7 +14,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Implement QuestForm component with image upload
         -   [x] Add quest validation against JSON schema
         -   [x] Create quest preview functionality 💯
-        -   [x] Add quest requirements selection
+        -   [x] Add quest requirements selection 💯
     -   [x] Quest contribution workflow ✅
         -   [x] Implement quest PR submission form
         -   [x] Add quest review interface 💯

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -121,7 +121,7 @@ Every quest JSON file must include:
         - `grantsItems`: Optional items given when selecting option
         - `requiresGitHub`: Set to `true` to disable the option until a GitHub token is saved
 - `rewards`: Items given upon quest completion
-- `requiresQuests`: Array of quest IDs that must be completed first
+- `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**)
 
 ### Current Implementation State
 


### PR DESCRIPTION
## Summary
- ensure quest requirement selections persist when editing existing quests
- document selecting prerequisite quests in the quest form
- mark quest requirement selection as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68902814659c832fb5904e6478e48987