### PR TITLE
feat: refine lunar eclipse process

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1096,5 +1096,12 @@
         "description": "Adjustable three-legged stand for stabilizing cameras or small telescopes.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "a96ce9ed-b9e0-44e5-bd9f-c068643e6749",
+        "name": "digital camera",
+        "description": "Mirrorless camera capable of long-exposure astrophotography.",
+        "image": "/assets/quests/solar.jpg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1479,16 +1479,32 @@
     },
     {
         "id": "photograph-lunar-eclipse",
-        "title": "Photograph a lunar eclipse",
+        "title": "Photograph a lunar eclipse with a telescope",
         "requireItems": [
             {
                 "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
+                "count": 1
+            },
+            {
+                "id": "a96ce9ed-b9e0-44e5-bd9f-c068643e6749",
+                "count": 1
+            },
+            {
+                "id": "151",
                 "count": 1
             }
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "20m"
+        "duration": "45m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-process-2025-08-04", "date": "2025-08-04", "score": 60 }
+            ]
+        }
     },
     {
         "id": "arduino-servo-sweep",


### PR DESCRIPTION
## Summary
- require a digital camera and tripod for photographing lunar eclipses
- add digital camera item to inventory
- mark lunar eclipse process with first hardening pass

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68903f535d04832fb3a3931b5c0e34a1