### PR TITLE
feat: add nosebleed first aid quest

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/stop-nosebleed.json
+++ b/frontend/src/pages/quests/json/firstaid/stop-nosebleed.json
@@ -1,0 +1,50 @@
+{
+    "id": "firstaid/stop-nosebleed",
+    "title": "Stop a Nosebleed",
+    "description": "Lean forward and pinch your nose to control a minor bleed.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Nosebleed? Let's stop it before it drips everywhere.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "pressure",
+                    "text": "How do I stop it?"
+                }
+            ]
+        },
+        {
+            "id": "pressure",
+            "text": "Sit upright, lean slightly forward, and pinch the soft part of your nose for ten minutes. Gloves and gauze from your kit keep things clean.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Holding pressure now.",
+                    "requiresItems": [
+                        {
+                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "If the bleeding hasn't stopped after 20 minutes, seek medical help. Otherwise, rest and avoid blowing your nose for a while.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Will do."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}


### PR DESCRIPTION
## Summary
- add "stop nosebleed" quest to first aid tree

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`
- `npx jest __tests__/questCanonical.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68903e991534832f869b29961ebe6b97