### PR TITLE
docs: tighten prompt instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -7,7 +7,9 @@ slug: 'prompts-codex'
 
 Codex (Web + CLI) is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR — but only if you give it a clear,
-file‑scoped prompt. :contentReference[oaicite:0]{index=0}
+file‑scoped prompt. This document stores the baseline instructions used when
+invoking Codex on DSPACE and should evolve alongside the project.
+ :contentReference[oaicite:0]{index=0}
 
 > **TL;DR**  
 > 1. Scope the task to one or two files.  
@@ -69,9 +71,9 @@ Use this template when you want Codex to automatically clear items from the
 [September&nbsp;1,&nbsp;2025 changelog](/docs/changelog/20250901). Tasks are
 tracked with Markdown checkboxes and an emoji status:
 
--   `- [ ]` – work not started
--   `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
--   `- [x] 💯` – thoroughly tested and reviewed
+- `- [ ]` – work not started
+- `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
+- `- [x] 💯` – thoroughly tested and reviewed
 
 Codex should pick a single entry that is either unchecked or checked without a
 💯 and implement it completely. After all tests pass, update that row so the line
@@ -83,9 +85,10 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯. Implement it fully, completing any sub-tasks. Provide all code,
-tests and documentation required. Always run `npm run test:pr` before
-committing. If Playwright browsers are missing run `npx playwright install
-chromium` or prefix commands with `SKIP_E2E=1`.
+tests and documentation required. Follow `AGENTS.md` and ensure `npm run lint`,
+`npm run type-check`, `npm run build`, and `SKIP_E2E=1 npm run test:pr` all pass
+before committing. If Playwright browsers are missing run `npx playwright
+install chromium`.
 
 USER:
 1. Follow the steps above.
@@ -96,4 +99,24 @@ USER:
 OUTPUT:
 A pull request implementing the chosen item with all tests green. Summarize the
 completed task and test results in the PR body.
+```
+
+## Upgrade Prompt
+
+Use this prompt to refine DSPACE's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check` and `npm run build`
+pass before committing.
+
+USER:
+1. Pick one prompt doc under `frontend/src/pages/docs/md/` (for example,
+   `prompts-items.md`).
+2. Fix outdated instructions, links or formatting.
+3. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
 ```

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -60,8 +60,9 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Follow the item schema.
 2. Reflect real-world materials or devices.
-3. Run `npm test -- itemValidation itemQuality` and fix any failures.
-4. Update docs or processes if needed.
+3. Run `npm run lint`, `npm run type-check` and `npm run build`.
+4. Run `npm test -- itemValidation itemQuality` and fix any failures.
+5. Update docs or processes if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -75,11 +76,12 @@ Use this when you want Codex to automatically create or upgrade an item.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 items under `frontend/src/pages/inventory/json/items.json`. Ensure realistic
-details, required fields, and passing `npm test -- itemValidation itemQuality`.
+details, required fields, and passing checks (`npm run lint`, `npm run type-check`,
+`npm run build`, and `npm test -- itemValidation itemQuality`).
 
 USER:
 1. Follow the steps above.
-2. Run the item tests before committing.
+2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated item in the PR description.
 
 OUTPUT:
@@ -117,7 +119,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-4. Run `npm test -- itemValidation itemQuality processQuality` and update docs if
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm test -- itemValidation itemQuality processQuality`. Update docs if
    needed.
 
 OUTPUT:
@@ -128,7 +131,7 @@ A pull request with the refined item, updated hardening block and passing tests.
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible but incorrect details.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -59,8 +59,9 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Follow the process schema.
 2. Use realistic durations and item relationships.
-3. Run `npm test -- processQuality itemQuality` and fix any failures.
-4. Update docs or items if needed.
+3. Run `npm run lint`, `npm run type-check` and `npm run build`.
+4. Run `npm test -- processQuality itemQuality` and fix any failures.
+5. Update docs or items if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -74,11 +75,12 @@ Use this when you want Codex to automatically create or upgrade a process.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/processes.json`. Ensure realistic
-steps, durations, item references, and passing `npm test -- processQuality itemQuality`.
+steps, durations, item references, and passing checks (`npm run lint`, `npm run
+type-check`, `npm run build`, and `npm test -- processQuality itemQuality`).
 
 USER:
 1. Follow the steps above.
-2. Run the process tests before committing.
+2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated process in the PR description.
 
 OUTPUT:
@@ -115,7 +117,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-4. Run `npm test -- processQuality itemQuality` and update docs or items if needed.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm test -- processQuality itemQuality`. Update docs or items if needed.
 
 OUTPUT:
 A pull request with the refined process, updated hardening block and passing tests.
@@ -125,7 +128,7 @@ A pull request with the refined process, updated hardening block and passing tes
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible but incorrect details.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -62,8 +62,9 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Follow the quest schema.
 2. Reference at least one inventory item or process.
-3. Run `npm test -- questCanonical questQuality` and fix any failures.
-4. Update docs or dialogue as needed.
+3. Run `npm run lint`, `npm run type-check` and `npm run build`.
+4. Run `npm test -- questCanonical questQuality` and fix any failures.
+5. Update docs or dialogue as needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -77,12 +78,13 @@ Use this when you want Codex to automatically create or upgrade a quest.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
-completion nodes, at least one item or process reference, and passing
-`npm test -- questCanonical questQuality`.
+completion nodes, at least one item or process reference, and passing checks
+(`npm run lint`, `npm run type-check`, `npm run build`, and
+`npm test -- questCanonical questQuality`).
 
 USER:
 1. Follow the steps above.
-2. Run the quest tests before committing.
+2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated quest in the PR description.
 
 OUTPUT:
@@ -103,7 +105,8 @@ existing quests in that tree as examples for tone and structure.
 USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
-3. Run `npm test -- questCanonical questQuality` and fix any failures.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm test -- questCanonical questQuality`. Fix any failures.
 
 OUTPUT:
 Return only the diff with the new quest.
@@ -146,8 +149,9 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm test -- questCanonical questQuality itemQuality processQuality` and
-   update docs if needed.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
+   questCanonical questQuality itemQuality processQuality`. Update docs if
+   needed.
 
 OUTPUT:
 A pull request with the refined quest, updated hardening block and passing tests.


### PR DESCRIPTION
## Summary
- clarify that `prompts-codex.md` is the baseline reference and add a reusable upgrade prompt
- require `npm run lint`, `npm run type-check` and `npm run build` in item, process and quest prompt templates

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689043231c34832f810bf68ed0ca9e86