### PR TITLE
chore: format processes JSON

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1513,9 +1513,7 @@
             "passes": 1,
             "score": 60,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-process-2025-08-04", "date": "2025-08-04", "score": 60 }
-            ]
+            "history": [{ "task": "codex-process-2025-08-04", "date": "2025-08-04", "score": 60 }]
         }
     },
     {


### PR DESCRIPTION
## Summary
- run Prettier over `processes.json` to satisfy repository formatting rules

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_689043d7754c832f84f6969439863376