### PR TITLE
refactor: refine basil seeds item

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -85,9 +85,22 @@
     {
         "id": "affa2f80-28f1-422e-a0c8-49e51ce65a1e",
         "name": "basil seeds",
-        "description": "A packet of basil seeds.",
+        "description": "Packet of ~50 Genovese basil seeds for hydroponic germination.",
         "image": "/assets/basil_seeds.jpg",
-        "price": "5 dUSD"
+        "price": "2 dUSD",
+        "unit": "packet",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-04",
+                    "date": "2025-08-04",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "5322b85e-b47d-4ea4-b515-318f91abc7df",


### PR DESCRIPTION
## Summary
- clarify basil seeds description and adjust price to match realistic packet size
- add hardening metadata for basil seeds

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `CI=1 npm test -- itemValidation itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68903f8410b4832f964b417e3530ce8e