### PR TITLE
clarify CPR quest and add mask item

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -64,9 +64,7 @@
             "passes": 1,
             "score": 65,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }]
         }
     },
     {
@@ -1009,6 +1007,13 @@
         "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
         "name": "first aid kit",
         "description": "Adhesive bandages, gauze and antiseptic packed for emergencies.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "a1c7f153-5b2e-443d-936a-47f396a7d191",
+        "name": "CPR pocket mask",
+        "description": "A reusable one-way valve mask for delivering rescue breaths safely.",
         "image": "/assets/quests/basic_circuit.svg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1424,6 +1424,14 @@
                 "count": 1
             },
             {
+                "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
+                "count": 1
+            },
+            {
+                "id": "a1c7f153-5b2e-443d-936a-47f396a7d191",
+                "count": 1
+            },
+            {
                 "id": "b397aa70-3503-4e40-b84a-4d5609578d2b",
                 "count": 1
             }
@@ -1458,9 +1466,7 @@
             "passes": 1,
             "score": 65,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }]
         }
     },
     {

--- a/frontend/src/pages/quests/json/firstaid/learn-cpr.json
+++ b/frontend/src/pages/quests/json/firstaid/learn-cpr.json
@@ -1,14 +1,14 @@
 {
     "id": "firstaid/learn-cpr",
     "title": "Practice Basic CPR",
-    "description": "Put on gloves, use a training manikin and a CPR mask from your first aid kit to rehearse chest compressions and rescue breaths. Always verify the scene is safe and call emergency services before starting.",
+    "description": "Put on nitrile gloves and use a CPR pocket mask with a training manikin to rehearse chest compressions and rescue breaths. Always verify the scene is safe and call emergency services before starting.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Slip on gloves, confirm the area is safe, call emergency services, and check the manikin's airway before you begin.",
+            "text": "Slip on nitrile gloves, make sure the area is safe, call emergency services, and check the manikin's airway before you begin.",
             "options": [
                 {
                     "type": "goto",
@@ -19,21 +19,27 @@
         },
         {
             "id": "steps",
-            "text": "Place the heel of one hand in the center of the chest and interlock your fingers. Keep your arms straight and press about 2 inches deep at 100–120 compressions per minute, letting the chest return fully. After 30 compressions, give two rescue breaths through the CPR mask if you're trained.",
+            "text": "Place the heel of one hand in the center of the chest and interlock your fingers. Keep your arms straight and press about 2 inches deep at 100–120 compressions per minute, letting the chest return fully. After 30 compressions, seal the CPR pocket mask over the manikin's mouth and give two rescue breaths if you're trained.",
             "options": [
                 {
                     "type": "process",
                     "process": "practice-cpr",
-                    "text": "Practicing now."
+                    "text": "Practicing now.",
+                    "requiresItems": [
+                        { "id": "09af703f-7054-4b33-a67d-4035d58bdfb7", "count": 1 },
+                        { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 },
+                        { "id": "a1c7f153-5b2e-443d-936a-47f396a7d191", "count": 1 },
+                        { "id": "b397aa70-3503-4e40-b84a-4d5609578d2b", "count": 1 }
+                    ]
                 },
                 {
                     "type": "goto",
                     "goto": "finish",
                     "requiresItems": [
-                        {
-                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
-                            "count": 1
-                        }
+                        { "id": "09af703f-7054-4b33-a67d-4035d58bdfb7", "count": 1 },
+                        { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 },
+                        { "id": "a1c7f153-5b2e-443d-936a-47f396a7d191", "count": 1 },
+                        { "id": "b397aa70-3503-4e40-b84a-4d5609578d2b", "count": 1 }
                     ],
                     "text": "I know the basics."
                 }
@@ -51,5 +57,11 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["firstaid/assemble-kit"]
+    "requiresQuests": ["firstaid/assemble-kit"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [{ "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 60 }]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify the first aid CPR quest with explicit nitrile gloves and CPR pocket mask steps
- add CPR pocket mask inventory item and require it for the practice-cpr process
- add first hardening pass metadata for the quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68904b5a955c832fb0bf80c33abbd051