### PR TITLE
feat: refine constellations process

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1006,6 +1006,13 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "98f6252e-95c2-468a-b110-69d47604df2c",
+        "name": "planisphere star chart",
+        "description": "A rotating sky map for matching constellations to the current date and time.",
+        "image": "/assets/quests/start.png",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
         "name": "first aid kit",
         "description": "Adhesive bandages, gauze and antiseptic packed for emergencies.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1465,16 +1465,22 @@
     },
     {
         "id": "identify-constellations",
-        "title": "Identify constellations",
+        "title": "Identify constellations with a star chart",
         "requireItems": [
-            {
-                "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
-                "count": 1
-            }
+            { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+            { "id": "98f6252e-95c2-468a-b110-69d47604df2c", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "15m"
+        "duration": "30m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-process-2025-08-04", "date": "2025-08-04", "score": 65 }
+            ]
+        }
     },
     {
         "id": "observe-meteor-shower",


### PR DESCRIPTION
## Summary
- add planisphere star chart inventory item
- require star chart for constellations process and record first hardening pass

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68903f535d04832fb3a3931b5c0e34a1