### PR TITLE
feat: ground aquaria water testing quest

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1137,5 +1137,26 @@
         "description": "Mirrorless camera capable of long-exposure astrophotography.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2",
+        "name": "Aquarium liquid test kit",
+        "description": "Reagent-based kit for measuring ammonia, nitrite and nitrate levels in aquarium water.",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "price": "25 dUSD"
+    },
+    {
+        "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1",
+        "name": "Water conditioner",
+        "description": "Detoxifying drops that remove chlorine and chloramine from tap water before aquarium use.",
+        "image": "/assets/aquarium_filled.jpg",
+        "price": "5 dUSD"
+    },
+    {
+        "id": "97317bc3-507a-4e2c-912b-507d586cee87",
+        "name": "Gravel vacuum",
+        "description": "Siphon tube for cleaning substrate and removing aquarium water.",
+        "image": "/assets/aquarium_empty.jpg",
+        "price": "10 dUSD"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1614,5 +1614,19 @@
             "emoji": "🌀",
             "history": [{ "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 70 }]
         }
+    },
+    {
+        "id": "partial-water-change",
+        "title": "Perform a partial aquarium water change",
+        "requireItems": [
+            { "id": "97317bc3-507a-4e2c-912b-507d586cee87", "count": 1 },
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
+            { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 1 }
+        ],
+        "createItems": [],
+        "duration": "30m"
     }
 ]

--- a/frontend/src/pages/quests/json/aquaria/water-testing.json
+++ b/frontend/src/pages/quests/json/aquaria/water-testing.json
@@ -1,7 +1,7 @@
 {
     "id": "aquaria/water-testing",
     "title": "Test water parameters",
-    "description": "Use a liquid test kit to check for ammonia, nitrite and nitrate before adding shrimp.",
+    "description": "Use a liquid test kit to check ammonia, nitrite and nitrate before adding shrimp. Wear gloves and follow kit instructions.",
     "image": "/assets/quests/walstad.jpg",
     "npc": "/assets/npc/vega.jpg",
     "start": "start",
@@ -19,19 +19,34 @@
         },
         {
             "id": "explain",
-            "text": "Use a liquid test kit. Check ammonia and nitrite first—they should read zero. Nitrate should stay under 40 ppm.",
+            "text": "Use a liquid test kit. Wear nitrile gloves and avoid splashing the reagents. Check ammonia and nitrite first—they should read zero. Nitrate should stay under 40 ppm.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "results",
-                    "text": "Okay, I'll test now."
+                    "text": "Okay, I'll test now.",
+                    "requiresItems": [
+                        {
+                            "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2",
+                            "count": 1
+                        },
+                        {
+                            "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
         {
             "id": "results",
-            "text": "If you see ammonia or nitrite, give the tank more time. If nitrate is high, perform a partial water change.",
+            "text": "If you see ammonia or nitrite, give the tank more time. If nitrate is high, start a partial water change to dilute it.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "partial-water-change",
+                    "text": "Nitrate is high—start a partial water change."
+                },
                 {
                     "type": "finish",
                     "text": "All clear! Levels look good."
@@ -45,5 +60,13 @@
             "count": 1
         }
     ],
-    "requiresQuests": ["aquaria/walstad"]
+    "requiresQuests": ["aquaria/walstad"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            { "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 60 }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify aquaria water testing with safety gear and partial water change guidance
- add real-world items and a partial water change process to inventory and processes
- record first hardening pass for the quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality itemQuality processQuality`

------
https://chatgpt.com/codex/tasks/task_e_68904bb87718832fb63ab7d769fccfa3