### PR TITLE
docs: update item prompt test command

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -26,7 +26,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 | --------------------- | --------------------------- | ------------------------------------------------------------------- |
 | Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"`                          |
 | Ask about item data   | “Ask” button                | `codex exec "explain frontend/src/pages/inventory/json/items.json"` |
-| Run item tests        | –                           | `codex exec --full-auto "npm test -- itemValidation itemQuality"`   |
+| Run item tests        | –                           | `codex exec "npm test -- itemValidation itemQuality"`               |
 
 See the upstream CLI reference for more flags.
 


### PR DESCRIPTION
## Summary
- remove deprecated `--full-auto` flag from item prompt CLI example

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68905d1dbd1c832faf6a776e2e48b6f2