### PR TITLE
feat: add Andromeda galaxy observation quest

### DIFF
--- a/frontend/src/pages/quests/json/astronomy/andromeda.json
+++ b/frontend/src/pages/quests/json/astronomy/andromeda.json
@@ -1,0 +1,55 @@
+{
+    "id": "astronomy/andromeda",
+    "title": "Locate the Andromeda Galaxy",
+    "description": "Use constellation patterns to find our neighboring galaxy in the night sky.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Tonight we hunt for the Andromeda Galaxy. Ready to chart the stars?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "search",
+                    "text": "Absolutely."
+                }
+            ]
+        },
+        {
+            "id": "search",
+            "text": "First find the distinctive W of Cassiopeia and follow it to a faint smudge.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "identify-constellations",
+                    "text": "Spotting Cassiopeia."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        {
+                            "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
+                            "count": 1
+                        }
+                    ],
+                    "text": "I see Andromeda."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Observing Andromeda gets easier every season.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Amazing view."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- add Andromeda quest guiding players to spot the nearby galaxy
- link quest to `identify-constellations` process with item check for completion

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical`
- `npm test -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68905c8da548832fa7c714b8b5edbdf4