### PR TITLE
feat: refine dechlorinated water item

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -224,10 +224,18 @@
     },
     {
         "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50",
-        "name": "5 gallon bucket of tap water (dechlorinated)",
-        "description": "A 5 gallon bucket of water. This water is dechlorinated and can be used for hydroponics.",
+        "name": "5 gallon bucket of dechlorinated tap water",
+        "description": "A standard 19 L (5 gal) bucket filled with tap water that's been left for 48 hours so chlorine dissipates. Ready for hydroponic use.",
         "image": "/assets/bucket_water.jpg",
-        "priceExemptionReason": "BETA_PLACEHOLDER"
+        "price": "8.20 dUSD",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }
+            ]
+        }
     },
     {
         "id": "545aeb15-7e8b-489d-be4a-af2a59f447e1",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -82,7 +82,7 @@
     },
     {
         "id": "bucket-water-chlorinated",
-        "title": "fill a bucket with tap water",
+        "title": "fill a 5 gallon bucket with tap water",
         "requireItems": [
             {
                 "id": "799ace33-1336-46c0-904a-9f16778230f1",
@@ -173,7 +173,7 @@
     },
     {
         "id": "bucket-water-dechlorinated",
-        "title": "dechlorinate a bucket of water",
+        "title": "dechlorinate a 5 gallon bucket of tap water",
         "requireItems": [],
         "consumeItems": [
             {


### PR DESCRIPTION
## Summary
- clarify 5 gallon bucket of dechlorinated tap water with realistic units, price, and hardening record
- specify volume in water-related processes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run itemValidation itemQuality processQuality`

------
https://chatgpt.com/codex/tasks/task_e_68905ccb6c18832fb0f6da49b9fff244