### PR TITLE
feat: add phone stand printing process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1675,5 +1675,21 @@
         ],
         "createItems": [],
         "duration": "30m"
+    },
+    {
+        "id": "3dprint-phone-stand",
+        "title": "3D print a phone stand",
+        "requireItems": [],
+        "consumeItems": [
+            { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+            { "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 20 },
+            { "id": "061fd221-404a-4bd1-9432-3e25b0f17a2c", "count": 150 }
+        ],
+        "createItems": [
+            { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+            { "id": "9018feac-7213-4eef-9654-b06dbd9404ea", "count": 1 },
+            { "id": "071ba424-3940-4c80-a782-5d7ea4d829ff", "count": 20 }
+        ],
+        "duration": "1h"
     }
 ]


### PR DESCRIPTION
## Summary
- add 3D print phone stand process consuming printer, filament, and energy

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68905ccdd41c832f95629bbc6b1c0bf1