### PR TITLE
docs: clarify item prompt CLI usage

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -22,13 +22,13 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI](https://www.npmjs.com/package/codex-cli)                |
-| --------------------- | --------------------------- | ------------------------------------------------------------------- |
-| Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"`                          |
+| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli] |
+| --------------------- | --------------------------- | ---------------------- |
+| Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"` |
 | Ask about item data   | “Ask” button                | `codex exec "explain frontend/src/pages/inventory/json/items.json"` |
-| Run item tests        | –                           | `codex exec "npm test -- itemValidation itemQuality"`               |
+| Run item tests        | –                           | `codex exec --full-auto "npm test -- itemValidation itemQuality"` |
 
-See the [Codex CLI documentation](https://www.npmjs.com/package/codex-cli) for more flags.
+See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
@@ -135,3 +135,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Use system prompts** to guide tone and technical accuracy.
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- clarify how to run item tests via Codex CLI with `--full-auto`
- convert Codex CLI link to reference style for easier maintenance

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68914a4560e4832fb5ee71c937e6944c