### PR TITLE
feat: add aquarium pH measurement process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1738,5 +1738,17 @@
         "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 15 }],
         "createItems": [{ "id": "7892ffc6-c651-445f-946b-7edc998cf389", "count": 1 }],
         "duration": "1h 30m"
+    },
+    {
+        "id": "measure-aquarium-ph",
+        "title": "Measure your aquarium pH with a strip",
+        "requireItems": [
+            { "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "13167d6a-5617-4931-8a6e-6f463c6b8835", "count": 1 }
+        ],
+        "createItems": [],
+        "duration": "1m"
     }
 ]


### PR DESCRIPTION
## Summary
- add process to measure aquarium pH with a disposable strip

## Testing
- `pre-commit run --all-files` *(command not found)*
- `pytest -q`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`
- `npm test -- --coverage`
- `python -m flywheel.fit` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68914a54570c832f915f560232513fac