### PR TITLE
feat: add aquarium filter rinsing process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1720,6 +1720,18 @@
         }
     },
     {
+        "id": "rinse-aquarium-filter",
+        "title": "Rinse aquarium filter media in dechlorinated water",
+        "requireItems": [
+            { "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }
+        ],
+        "createItems": [],
+        "duration": "15m"
+    },
+    {
         "id": "partial-water-change",
         "title": "Perform a partial aquarium water change",
         "requireItems": [


### PR DESCRIPTION
## Summary
- add `rinse-aquarium-filter` process that rinses filter media using dechlorinated water

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: Not a valid object name origin/main)*

------
https://chatgpt.com/codex/tasks/task_e_68914a54570c832f915f560232513fac