### PR TITLE
feat: add smartphone stand printing process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1738,5 +1738,13 @@
         "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 15 }],
         "createItems": [{ "id": "7892ffc6-c651-445f-946b-7edc998cf389", "count": 1 }],
         "duration": "1h 30m"
+    },
+    {
+        "id": "print-phone-stand",
+        "title": "3D print a smartphone stand",
+        "requireItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }],
+        "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 20 }],
+        "createItems": [{ "id": "9018feac-7213-4eef-9654-b06dbd9404ea", "count": 1 }],
+        "duration": "2h"
     }
 ]


### PR DESCRIPTION
## Summary
- add `print-phone-stand` process that uses a printer and PLA filament to create a 3D printed phone stand

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68914a54570c832f915f560232513fac