### PR TITLE
docs: add Docker deployment guide

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -1,0 +1,43 @@
+# Docker Deployment
+
+This guide explains how to run DSPACE using Docker.
+
+## Prerequisites
+
+- Docker 24 or newer
+- The `docker compose` plugin
+
+## Build and Run
+
+Clone the repository and start the stack:
+
+```bash
+docker compose up --build -d
+```
+
+The application listens on port **3002**. Visit <http://localhost:3002> to confirm it is running.
+
+## Environment Variables
+
+The container reads these environment variables:
+
+- `PORT` (default: `3002`)
+- `HOST` (default: `0.0.0.0`)
+- `METRICS_TOKEN` for the `/metrics` endpoint (optional)
+
+To override them, create a `docker-compose.override.yml` file or pass them at runtime.
+
+## Health Checks and Metrics
+
+The Docker Compose file defines a health check against `GET /health` and exposes Prometheus metrics at `GET /metrics`.
+
+## Updating
+
+Pull the latest changes and rebuild:
+
+```bash
+git pull
+docker compose up --build -d
+```
+
+Stop the containers with `docker compose down`.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -56,7 +56,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] token.place integration
 -   [x] Infrastructure
     -   [x] Self-hosted setup documentation 💯
-    -   [x] Docker deployment
+    -   [x] Docker deployment 💯
     -   [x] Redundancy implementation
         -   [x] Load balancer setup
         -   [x] Backup system ✅


### PR DESCRIPTION
## Summary
- document running DSPACE in Docker
- mark Docker deployment as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`

------
https://chatgpt.com/codex/tasks/task_e_68914a36f018832fa484fc682796c94e