### PR TITLE
feat: add reusable preview toggle

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -42,7 +42,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Process validation and testing 💯
         -   [x] Process state management 💯
     -   [x] Preview and Testing
-        -   [x] Content preview functionality
+        -   [x] Content preview functionality 💯
         -   [x] Testing environment for custom content
         -   [x] Validation feedback system
 -   [x] Local-First Architecture

--- a/frontend/src/pages/inventory/svelte/ManageItems.svelte
+++ b/frontend/src/pages/inventory/svelte/ManageItems.svelte
@@ -3,6 +3,7 @@
     import ItemCard from '../../../components/svelte/ItemCard.svelte';
     import ItemPreview from '../../../components/svelte/ItemPreview.svelte';
     import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
+    import { togglePreviewId } from '../../../utils/preview.js';
 
     export let items = [];
     let customItems = [];
@@ -40,7 +41,7 @@
     }
 
     function togglePreview(id) {
-        previewItemId = previewItemId === id ? null : id;
+        previewItemId = togglePreviewId(previewItemId, id);
     }
 </script>
 

--- a/frontend/src/pages/processes/svelte/ManageProcesses.svelte
+++ b/frontend/src/pages/processes/svelte/ManageProcesses.svelte
@@ -3,6 +3,7 @@
     import Process from '../../../components/svelte/Process.svelte';
     import ProcessPreview from '../../../components/svelte/ProcessPreview.svelte';
     import { db, ENTITY_TYPES } from '../../../utils/customcontent.js';
+    import { togglePreviewId } from '../../../utils/preview.js';
 
     export let processes = [];
     let customProcesses = [];
@@ -37,7 +38,7 @@
     }
 
     function togglePreview(id) {
-        previewProcessId = previewProcessId === id ? null : id;
+        previewProcessId = togglePreviewId(previewProcessId, id);
     }
 </script>
 

--- a/frontend/src/utils/preview.js
+++ b/frontend/src/utils/preview.js
@@ -1,0 +1,3 @@
+export function togglePreviewId(currentId, newId) {
+    return currentId === newId ? null : newId;
+}

--- a/tests/togglePreviewId.test.ts
+++ b/tests/togglePreviewId.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { togglePreviewId } from '../frontend/src/utils/preview.js';
+
+describe('togglePreviewId', () => {
+  it('sets id when none is active', () => {
+    expect(togglePreviewId(null, 'a')).toBe('a');
+  });
+  it('clears id when same id provided', () => {
+    expect(togglePreviewId('a', 'a')).toBeNull();
+  });
+  it('switches to new id when different id provided', () => {
+    expect(togglePreviewId('a', 'b')).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize content preview toggling in a shared utility
- cover preview toggle logic with unit tests
- mark "Content preview functionality" complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: Not a valid object name origin/main)*
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68914a36f018832fa484fc682796c94e