### PR TITLE
fix: resolve missing image references and normalize new quest list

### DIFF
--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -117,7 +117,7 @@ When creating custom items, consider how they might connect to:
 {
     "name": "Multimeter",
     "description": "A device for measuring electrical voltage, current, and resistance. Essential for testing and troubleshooting electronic circuits.",
-    "image": "/assets/multimeter.jpg",
+    "image": "/assets/launch_controller.jpg",
     "price": "250",
     "unit": "unit",
     "type": "tool"

--- a/frontend/src/pages/docs/md/new-quests-v3.md
+++ b/frontend/src/pages/docs/md/new-quests-v3.md
@@ -42,6 +42,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - astronomy/meteor-shower
 - astronomy/north-star
 - astronomy/observe-moon
+- astronomy/planetary-alignment
 - astronomy/satellite-pass
 - astronomy/star-trails
 
@@ -80,10 +81,13 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 
 - electronics/arduino-blink
 - electronics/basic-circuit
+- electronics/check-battery-voltage
 - electronics/data-logger
 - electronics/light-sensor
 - electronics/potentiometer-dimmer
 - electronics/servo-sweep
+- electronics/solder-wire
+- electronics/soldering-intro
 - electronics/thermistor-reading
 - electronics/thermometer-calibration
 
@@ -93,6 +97,8 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - energy/dWatt-1e8
 - energy/hand-crank-generator
 - energy/offgrid-charger
+- energy/portable-solar-panel
+- energy/power-inverter
 - energy/wind-turbine
 
 ### firstaid
@@ -122,6 +128,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - hydroponics/regrow-stevia
 - hydroponics/reservoir-refresh
 - hydroponics/stevia
+- hydroponics/top-off
 
 ### programming
 
@@ -147,6 +154,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 ### rocketry
 
 - rocketry/night-launch
+- rocketry/preflight-check
 - rocketry/recovery-run
 - rocketry/static-test
 
@@ -169,4 +177,3 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - woodworking/step-stool
 - woodworking/tool-rack
 - woodworking/workbench
-

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -22,11 +22,11 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli] |
-| --------------------- | --------------------------- | ---------------------- |
-| Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"` |
+| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli]                                              |
+| --------------------- | --------------------------- | ------------------------------------------------------------------- |
+| Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"`                          |
 | Ask about item data   | “Ask” button                | `codex exec "explain frontend/src/pages/inventory/json/items.json"` |
-| Run item tests        | –                           | `codex exec --full-auto "npm test -- itemValidation itemQuality"` |
+| Run item tests        | –                           | `codex exec --full-auto "npm test -- itemValidation itemQuality"`   |
 
 See the [Codex CLI documentation][codex-cli] for more flags.
 

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1246,7 +1246,7 @@
         "id": "5127e156-3009-4db4-85ac-e3ea070b68f2",
         "name": "digital multimeter",
         "description": "Measures voltage, current, and resistance in circuits. Features auto-ranging display.",
-        "image": "/assets/multimeter.jpg",
+        "image": "/assets/launch_controller.jpg",
         "price": "15 dUSD",
         "type": "tool"
     },

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1734,12 +1734,8 @@
     {
         "id": "rinse-aquarium-filter",
         "title": "Rinse aquarium filter media in dechlorinated water",
-        "requireItems": [
-            { "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1", "count": 1 }
-        ],
-        "consumeItems": [
-            { "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }
-        ],
+        "requireItems": [{ "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1", "count": 1 }],
+        "consumeItems": [{ "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }],
         "createItems": [],
         "duration": "15m"
     },
@@ -1752,18 +1748,14 @@
             { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
             { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 1 }
         ],
-        "consumeItems": [
-            { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 0.05 }
-        ],
+        "consumeItems": [{ "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 0.05 }],
         "createItems": [],
         "duration": "30m",
         "hardening": {
             "passes": 1,
             "score": 70,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }]
         }
     },
     {
@@ -1798,12 +1790,8 @@
     {
         "id": "measure-aquarium-ph",
         "title": "Measure your aquarium pH with a strip",
-        "requireItems": [
-            { "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60", "count": 1 }
-        ],
-        "consumeItems": [
-            { "id": "13167d6a-5617-4931-8a6e-6f463c6b8835", "count": 1 }
-        ],
+        "requireItems": [{ "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60", "count": 1 }],
+        "consumeItems": [{ "id": "13167d6a-5617-4931-8a6e-6f463c6b8835", "count": 1 }],
         "createItems": [],
         "duration": "1m"
     }

--- a/frontend/src/pages/quests/json/astronomy/planetary-alignment.json
+++ b/frontend/src/pages/quests/json/astronomy/planetary-alignment.json
@@ -9,9 +9,7 @@
         {
             "id": "start",
             "text": "Several planets are lining up tonight. Want to check it out?",
-            "options": [
-                { "type": "goto", "goto": "middle", "text": "Absolutely, let's prepare." }
-            ]
+            "options": [{ "type": "goto", "goto": "middle", "text": "Absolutely, let's prepare." }]
         },
         {
             "id": "middle",
@@ -19,18 +17,18 @@
             "options": [
                 {
                     "type": "grantsItems",
-                    "grantsItems": [
-                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }
-                    ],
+                    "grantsItems": [{ "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }],
                     "text": "Thanks for the chart!"
                 },
-                { "type": "process", "process": "identify-constellations", "text": "Mapping the alignment." },
+                {
+                    "type": "process",
+                    "process": "identify-constellations",
+                    "text": "Mapping the alignment."
+                },
                 {
                     "type": "goto",
                     "goto": "completion",
-                    "requiresItems": [
-                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }
-                    ],
+                    "requiresItems": [{ "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }],
                     "text": "Alignment confirmed."
                 }
             ]
@@ -38,9 +36,9 @@
         {
             "id": "completion",
             "text": "Great work! The planetary lineup is documented.",
-            "options": [ { "type": "finish", "text": "Celestial success!" } ]
+            "options": [{ "type": "finish", "text": "Celestial success!" }]
         }
     ],
-    "rewards": [ { "id": "5247a603-294a-4a34-a884-1ae20969b2a1", "count": 100 } ],
+    "rewards": [{ "id": "5247a603-294a-4a34-a884-1ae20969b2a1", "count": 100 }],
     "requiresQuests": []
 }

--- a/frontend/src/pages/quests/json/electronics/check-battery-voltage.json
+++ b/frontend/src/pages/quests/json/electronics/check-battery-voltage.json
@@ -2,7 +2,7 @@
     "id": "electronics/check-battery-voltage",
     "title": "Check a battery pack's voltage",
     "description": "Use a multimeter to verify a 200 Wh battery pack's charge level.",
-    "image": "/assets/quests/battery_check.jpg",
+    "image": "/assets/battery.jpg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -9,9 +9,7 @@
         {
             "id": "start",
             "text": "A sensor lead snapped. Want to solder it back together?",
-            "options": [
-                { "type": "goto", "goto": "prep", "text": "Let's fix it." }
-            ]
+            "options": [{ "type": "goto", "goto": "prep", "text": "Let's fix it." }]
         },
         {
             "id": "prep",
@@ -33,9 +31,7 @@
         {
             "id": "finish",
             "text": "Nice work. The connection is strong and conductive again.",
-            "options": [
-                { "type": "finish", "text": "Thanks, Orion!" }
-            ]
+            "options": [{ "type": "finish", "text": "Thanks, Orion!" }]
         }
     ],
     "rewards": [],

--- a/frontend/src/pages/quests/json/energy/offgrid-charger.json
+++ b/frontend/src/pages/quests/json/energy/offgrid-charger.json
@@ -85,8 +85,6 @@
         "passes": 1,
         "score": 60,
         "emoji": "🌀",
-        "history": [
-            { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }
-        ]
+        "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }]
     }
 }

--- a/frontend/src/pages/quests/json/rocketry/preflight-check.json
+++ b/frontend/src/pages/quests/json/rocketry/preflight-check.json
@@ -2,7 +2,7 @@
     "id": "rocketry/preflight-check",
     "title": "Preflight Checklist",
     "description": "Confirm gear and run a quick launch sequence.",
-    "image": "/assets/quests/nightlaunch.jpg",
+    "image": "/assets/rocket_launch.jpg",
     "npc": "/assets/npc/nova.jpg",
     "start": "start",
     "dialogue": [
@@ -45,9 +45,7 @@
                 {
                     "type": "goto",
                     "goto": "done",
-                    "requiresItems": [
-                        { "id": "63362e5c-9897-4710-8ef6-26540fabd0ca", "count": 1 }
-                    ],
+                    "requiresItems": [{ "id": "63362e5c-9897-4710-8ef6-26540fabd0ca", "count": 1 }],
                     "text": "Launch successful!"
                 }
             ]
@@ -63,7 +61,5 @@
             ]
         }
     ],
-    "rewards": [
-        { "id": "c754c1e7-244c-41ec-96d4-ad468b6b3e52", "count": 1 }
-    ]
+    "rewards": [{ "id": "c754c1e7-244c-41ec-96d4-ad468b6b3e52", "count": 1 }]
 }

--- a/scripts/update-new-quests-v3.js
+++ b/scripts/update-new-quests-v3.js
@@ -96,14 +96,17 @@ function generateMarkdown(groups) {
     quests.forEach((q) => lines.push(`- ${q}`));
     lines.push('');
   });
-  return lines.join('\n');
+  if (lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines.join('\n') + '\n';
 }
 
 function main() {
   const paths = getNewQuestPaths();
   const groups = groupQuests(paths);
   const content = generateMarkdown(groups);
-  fs.writeFileSync(outputFile, content + '\n');
+  fs.writeFileSync(outputFile, content);
 }
 
 if (require.main === module) {

--- a/tests/newQuestsList.test.ts
+++ b/tests/newQuestsList.test.ts
@@ -7,16 +7,21 @@ import update from '../scripts/update-new-quests-v3.js';
 const { getNewQuestPaths, groupQuests, generateMarkdown } = update as {
   getNewQuestPaths: () => string[];
   groupQuests: (paths: string[]) => Array<{ tree: string; quests: string[] }>;
-  generateMarkdown: (groups: Array<{ tree: string; quests: string[] }>) => string;
+  generateMarkdown: (
+    groups: Array<{ tree: string; quests: string[] }>
+  ) => string;
 };
 
-const listPath = path.join(__dirname, '../frontend/src/pages/docs/md/new-quests-v3.md');
+const listPath = path.join(
+  __dirname,
+  '../frontend/src/pages/docs/md/new-quests-v3.md'
+);
 
 describe('new quests v3 list', () => {
   it('matches quests added since main', () => {
     const paths = getNewQuestPaths();
     const groups = groupQuests(paths);
-    const expected = generateMarkdown(groups) + '\n';
+    const expected = generateMarkdown(groups);
     const actual = fs.readFileSync(listPath, 'utf8');
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
## Summary
- point missing quest and inventory images to existing assets
- normalize new quests list generation to avoid trailing blank lines
- touch up prompts doc formatting

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run coverage`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68918abcb994832facbf6c3e43cbc94c