### PR TITLE
docs: refine prompts and enforce process duration realism

### DIFF
--- a/frontend/__tests__/processQuality.test.js
+++ b/frontend/__tests__/processQuality.test.js
@@ -90,4 +90,26 @@ describe('Process Quality Validation', () => {
         expect(checkProcess(shortProc)).toContain('duration under 30s');
         expect(checkProcess(longProc)).not.toContain('duration longer than 72h');
     });
+
+    test('semantic duration expectations', () => {
+        const hints = [
+            { pattern: /^(grow|regrow)/i, min: 7 * 24 * 3600 },
+            { pattern: /^charge/i, min: 3600 },
+        ];
+        const issues = [];
+        processes.forEach((proc) => {
+            const seconds = durationInSeconds(proc.duration);
+            const title = proc.title.toLowerCase();
+            hints.forEach(({ pattern, min }) => {
+                if (pattern.test(title) && seconds < min) {
+                    issues.push(`${proc.id} duration ${proc.duration} unrealistically short`);
+                }
+            });
+        });
+        if (issues.length > 0) {
+            console.warn('Semantic Duration Issues:');
+            issues.forEach((i) => console.warn(`- ${i}`));
+        }
+        expect(issues.length).toBe(0);
+    });
 });

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -60,9 +60,12 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Follow the item schema.
 2. Reflect real-world materials or devices.
-3. Run `npm run lint`, `npm run type-check` and `npm run build`.
-4. Run `npm test -- itemValidation itemQuality` and fix any failures.
-5. Update docs or processes if needed.
+3. Ensure the item is referenced by at least one quest or process; update those
+   files and create missing processes as needed.
+4. Use only existing image assets; do not add new image files.
+5. Run `npm run lint`, `npm run type-check` and `npm run build`.
+6. Run `npm test -- itemValidation itemQuality` and fix any failures.
+7. Update docs or processes if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -76,8 +79,10 @@ Use this when you want Codex to automatically create or upgrade an item.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 items under `frontend/src/pages/inventory/json/items.json`. Ensure realistic
-details, required fields, and passing checks (`npm run lint`, `npm run type-check`,
-`npm run build`, and `npm test -- itemValidation itemQuality`).
+details, required fields, and passing checks (`npm run lint`, `npm run
+type-check`, `npm run build`, and `npm test -- itemValidation itemQuality`).
+Verify the item appears in at least one quest or process, creating those links
+if missing, and reuse existing image assets.
 
 USER:
 1. Follow the steps above.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -58,10 +58,13 @@ FILES OF INTEREST
 
 REQUIREMENTS
 1. Follow the process schema.
-2. Use realistic durations and item relationships.
-3. Run `npm run lint`, `npm run type-check` and `npm run build`.
-4. Run `npm test -- processQuality itemQuality` and fix any failures.
-5. Update docs or items if needed.
+2. Use realistic durations and item relationships grounded in real-world timing.
+3. Ensure the process is referenced by at least one quest or item; create
+   missing items or quest hooks as needed.
+4. Use only existing image assets; do not add new image files.
+5. Run `npm run lint`, `npm run type-check` and `npm run build`.
+6. Run `npm test -- processQuality itemQuality` and fix any failures.
+7. Update docs or items if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -77,6 +80,8 @@ You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/processes.json`. Ensure realistic
 steps, durations, item references, and passing checks (`npm run lint`, `npm run
 type-check`, `npm run build`, and `npm test -- processQuality itemQuality`).
+Verify the process links to existing quests or items, add missing registry
+entries if needed, and reuse existing image assets.
 
 USER:
 1. Follow the steps above.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -61,10 +61,14 @@ FILES OF INTEREST
 
 REQUIREMENTS
 1. Follow the quest schema.
-2. Reference at least one inventory item or process.
-3. Run `npm run lint`, `npm run type-check` and `npm run build`.
-4. Run `npm test -- questCanonical questQuality` and fix any failures.
-5. Update docs or dialogue as needed.
+2. Reference at least one inventory item or process. Create missing items or
+   processes in their registries and link them in the quest.
+3. Find the most natural predecessor quest and update the `requiresQuests`
+   chain so progression flows logically.
+4. Use only existing image assets; do not add new image files.
+5. Run `npm run lint`, `npm run type-check` and `npm run build`.
+6. Run `npm test -- questCanonical questQuality` and fix any failures.
+7. Update docs or dialogue as needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -80,7 +84,9 @@ You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
 (`npm run lint`, `npm run type-check`, `npm run build`, and
-`npm test -- questCanonical questQuality`).
+`npm test -- questCanonical questQuality`). Survey existing quests to pick a
+natural predecessor and update `requiresQuests` accordingly. Add missing items
+or processes to their registries and reuse existing image assets.
 
 USER:
 1. Follow the steps above.

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1021,7 +1021,7 @@
                 "count": 1
             }
         ],
-        "duration": "30m"
+        "duration": "2h"
     },
     {
         "id": "add-goldfish",
@@ -1203,7 +1203,7 @@
                 "count": 1
             }
         ],
-        "duration": "30m"
+        "duration": "2h"
     },
     {
         "id": "flash-sd-card",


### PR DESCRIPTION
## Summary
- strengthen quest, item, and process prompt docs to link content, update dependencies, and reuse existing images
- add semantic duration checks for processes and extend hypercar charging time

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_68919548cec4832fb3fbf9af82a64034