### PR TITLE
docs: include private registry in new quests list

### DIFF
--- a/frontend/src/pages/docs/md/new-quests-v3.md
+++ b/frontend/src/pages/docs/md/new-quests-v3.md
@@ -74,6 +74,7 @@ These quests exist in the `v3` branch but are not present on `main` yet. Use thi
 - devops/monitoring
 - devops/pi-cluster-hardware
 - devops/prepare-first-node
+- devops/private-registry
 - devops/ssd-boot
 - devops/ssh-hardening
 


### PR DESCRIPTION
## Summary
- add `devops/private-registry` to new quests v3 markdown list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6891aea9785c832f8160f2d3da655ff7