### PR TITLE
feat: refine nosebleed quest safety steps

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/stop-nosebleed.json
+++ b/frontend/src/pages/quests/json/firstaid/stop-nosebleed.json
@@ -1,14 +1,14 @@
 {
     "id": "firstaid/stop-nosebleed",
     "title": "Stop a Nosebleed",
-    "description": "Lean forward and pinch your nose to control a minor bleed.",
+    "description": "Sit up straight, lean forward, and pinch the soft part of your nose with sterile gauze to control a minor bleed.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Nosebleed? Let's stop it before it drips everywhere.",
+            "text": "You're bleeding from the nose. Let's handle it safely before it drips everywhere.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "pressure",
-            "text": "Sit upright, lean slightly forward, and pinch the soft part of your nose for ten minutes. Gloves and gauze from your kit keep things clean.",
+            "text": "Sit upright and lean slightly forward so blood drains out. With nitrile gloves on, press a sterile gauze pad against the soft part of your nose and pinch for at least ten minutes.",
             "options": [
                 {
                     "type": "goto",
@@ -27,7 +27,11 @@
                     "text": "Holding pressure now.",
                     "requiresItems": [
                         {
-                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                            "id": "cc7d36e7-c66d-466f-9390-f7a365d857b9",
+                            "count": 1
+                        },
+                        {
+                            "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
                             "count": 1
                         }
                     ]
@@ -36,7 +40,7 @@
         },
         {
             "id": "finish",
-            "text": "If the bleeding hasn't stopped after 20 minutes, seek medical help. Otherwise, rest and avoid blowing your nose for a while.",
+            "text": "If bleeding hasn't stopped after 20 minutes, is heavy, or you feel faint, seek medical help. Otherwise rest and avoid blowing your nose for a while.",
             "options": [
                 {
                     "type": "finish",
@@ -46,5 +50,17 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["firstaid/assemble-kit"]
+    "requiresQuests": ["firstaid/assemble-kit"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-05",
+                "date": "2025-08-05",
+                "score": 60
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify nosebleed quest instructions with explicit sterile gauze and nitrile glove use
- record initial hardening pass and score for stop-nosebleed quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_6891b20c0bcc832fa6c082c871e3c17a