### PR TITLE
docs: add load balancer failover testing

### DIFF
--- a/docs/cloudflare_load_balancing.md
+++ b/docs/cloudflare_load_balancing.md
@@ -4,7 +4,9 @@ This guide explains how to load balance multiple DSPACE instances using Cloudfla
 
 ## Overview
 
-Instead of running an Nginx reverse proxy, each DSPACE instance exposes port **3002** through its own Cloudflare Tunnel. Cloudflare's load balancer distributes incoming traffic across these tunnels, providing high availability without additional infrastructure.
+Instead of running an Nginx reverse proxy, each DSPACE instance exposes port **3002** through its
+own Cloudflare Tunnel. Cloudflare's load balancer distributes incoming traffic across these
+tunnels, providing high availability without additional infrastructure.
 
 ## Steps
 
@@ -22,9 +24,24 @@ Instead of running an Nginx reverse proxy, each DSPACE instance exposes port **3
    - Optionally configure session affinity or geographic routing.
 
 3. **Update DNS**
-   Cloudflare manages the DNS records automatically for each tunnel. Once the load balancer is active, users are directed to a healthy instance.
+   Cloudflare manages the DNS records automatically for each tunnel. Once the load balancer is
+   active, users are directed to a healthy instance.
+
+## Testing
+
+After configuring the load balancer, verify that traffic fails over when an instance goes offline.
+
+1. Stop one DSPACE node so its tunnel reports unhealthy.
+2. Run:
+   ```bash
+   curl -I https://dspace.example.com
+   ```
+   The request should still return `200`, showing Cloudflare routed to a healthy node.
+3. Start the stopped node and repeat to confirm it re-enters rotation.
 
 ## Related Guides
 
-- [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md) – shows how to run DSPACE on a k3s cluster with Cloudflare Tunnel.
-- [Monitoring Setup](./monitoring_setup.md) – add Prometheus and Grafana to watch the health of each instance.
+- [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md) – shows how to run DSPACE on a k3s
+  cluster with Cloudflare Tunnel.
+- [Monitoring Setup](./monitoring_setup.md) – add Prometheus and Grafana to watch the health of
+  each instance.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -58,7 +58,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Self-hosted setup documentation 💯
     -   [x] Docker deployment 💯
     -   [x] Redundancy implementation
-        -   [x] Load balancer setup
+        -   [x] Load balancer setup 💯
         -   [x] Backup system ✅
         -   [x] Failover procedures 💯
         -   [x] Monitoring setup 💯

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1746,9 +1746,7 @@
             "passes": 1,
             "score": 70,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }]
         }
     },
     {

--- a/frontend/src/pages/quests/json/astronomy/iss-flyover.json
+++ b/frontend/src/pages/quests/json/astronomy/iss-flyover.json
@@ -6,9 +6,7 @@
         "passes": 1,
         "score": 60,
         "emoji": "🌀",
-        "history": [
-            { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }
-        ]
+        "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }]
     },
     "image": "/assets/quests/solar.jpg",
     "npc": "/assets/npc/nova.jpg",
@@ -61,4 +59,3 @@
     "rewards": [],
     "requiresQuests": ["astronomy/observe-moon"]
 }
-


### PR DESCRIPTION
## Summary
- document how to verify Cloudflare load balancer failover
- mark load balancer setup as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6891b1d3caf0832fb3fc0be20529a49b