### PR TITLE
docs: add Cloudflare load balancer setup guide

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -41,3 +41,9 @@ docker compose up --build -d
 ```
 
 Stop the containers with `docker compose down`.
+
+## High Availability
+
+For redundancy across multiple hosts, use [Cloudflare Load Balancing](../cloudflare_load_balancing.md)
+to distribute traffic among instances. Each host exposes port **3002** through its own Cloudflare
+Tunnel, and the load balancer handles health checks automatically.

--- a/docs/failover_procedures.md
+++ b/docs/failover_procedures.md
@@ -4,7 +4,8 @@ This guide outlines how to handle downtime when running multiple DSPACE instance
 
 ## Overview
 
-If an instance becomes unreachable, Cloudflare automatically routes traffic to a healthy node. However, you should still investigate the failed instance and restore it as soon as possible.
+If an instance becomes unreachable, Cloudflare automatically routes traffic to a healthy node.
+However, you should still investigate the failed instance and restore it as soon as possible.
 
 ## Steps
 
@@ -20,11 +21,14 @@ If an instance becomes unreachable, Cloudflare automatically routes traffic to a
    - Wait a few seconds and verify that `curl http://localhost:3002/health` returns `{ "status": "ok" }`.
 
 3. **Check Prometheus metrics**
-   - Navigate to your Grafana dashboard (default `http://localhost:3001`) and ensure the `up` metric shows `1` for all instances.
+    - Navigate to your Grafana dashboard (default `http://localhost:3001`) and ensure the
+      `up` metric shows `1` for all instances.
 
 4. **Fallback option**
-   - If a node is corrupted or unreachable, spin up a new instance using the same deployment steps from [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md).
-   - Once the new node is running, add it to your Cloudflare load balancer as an origin.
+    - If a node is corrupted or unreachable, spin up a new instance using the same deployment steps from
+      [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md).
+    - Once the new node is running, add it to your [Cloudflare load balancer](./cloudflare_load_balancing.md)
+      as an origin.
 
 Cloudflare will automatically bring the restored instance back into rotation once it reports healthy.
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -58,7 +58,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Self-hosted setup documentation 💯
     -   [x] Docker deployment 💯
     -   [x] Redundancy implementation
-        -   [x] Load balancer setup
+        -   [x] Load balancer setup 💯
         -   [x] Backup system ✅
         -   [x] Failover procedures 💯
         -   [x] Monitoring setup 💯

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1746,9 +1746,7 @@
             "passes": 1,
             "score": 70,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }]
         }
     },
     {

--- a/frontend/src/pages/quests/json/astronomy/iss-flyover.json
+++ b/frontend/src/pages/quests/json/astronomy/iss-flyover.json
@@ -6,9 +6,7 @@
         "passes": 1,
         "score": 60,
         "emoji": "🌀",
-        "history": [
-            { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }
-        ]
+        "history": [{ "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }]
     },
     "image": "/assets/quests/solar.jpg",
     "npc": "/assets/npc/nova.jpg",
@@ -61,4 +59,3 @@
     "rewards": [],
     "requiresQuests": ["astronomy/observe-moon"]
 }
-


### PR DESCRIPTION
## Summary
- document Cloudflare load balancing setup for Docker deployments and failover procedures
- mark load balancer setup as complete in changelog
- format quest and process history arrays

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6891b1d3caf0832fb3fc0be20529a49b