### PR TITLE
feat: harden launch controller item

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -362,9 +362,18 @@
     {
         "id": "ae343640-c7c0-4f7e-907b-17bd87574d9b",
         "name": "launch controller",
-        "description": "A controller for launching model rockets.",
+        "description": "Handheld 9 V-powered controller with removable safety key and 6 m (20 ft) leads for remote ignition of model rockets.",
         "image": "/assets/launch_controller.jpg",
-        "price": "20 dUSD"
+        "price": "25 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }
+            ]
+        }
     },
     {
         "id": "aaa5fbca-54a1-40a5-8461-24dc2ef81d4d",


### PR DESCRIPTION
## Summary
- clarify launch controller details with realistic power, cable length, and pricing
- mark launch controller as a tool and add first hardening record

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `npm test -- --coverage` *(fails: tests/newQuestsList.test.ts)*
- `python -m flywheel.fit` *(fails: ModuleNotFoundError: No module named 'flywheel')*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- itemValidation`
- `npm test -- itemQuality`
- `npm test -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_6891b1dcda40832f8628f160c34cab7a