### PR TITLE
feat: refine solder-led-resistor process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1778,7 +1778,7 @@
     },
     {
         "id": "solder-led-resistor",
-        "title": "Solder a 5 mm LED to a 220 Ω resistor with jumper wires",
+        "title": "Use a soldering iron kit to join a 5 mm LED and a 220 Ω resistor with two jumper wires",
         "requireItems": [
             { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
             { "id": "48cf736e-184c-4bd1-b9b0-15b7e9721646", "count": 1 },
@@ -1787,7 +1787,15 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "20m"
+        "duration": "15m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-hardening-2025-06-24", "date": "2025-06-24", "score": 65 }
+            ]
+        }
     },
     {
         "id": "print-phone-stand",


### PR DESCRIPTION
## Summary
- clarify solder-led-resistor process and tie to existing inventory items
- add initial hardening metadata with score and history

## Testing
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest -q`
- `npm test -- --coverage` *(fails: newQuestsList tests out of date)*
- `python -m flywheel.fit` *(fails: No module named 'flywheel')*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`

------
https://chatgpt.com/codex/tasks/task_e_6891b7f3cab8832f8d357f19d887ff01