### PR TITLE
feat: harden Benchy print process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1770,11 +1770,19 @@
     },
     {
         "id": "print-benchy",
-        "title": "3D print a Benchy test model",
+        "title": "3D print a Benchy calibration boat on Real Printer 1 using 15 g of white PLA",
         "requireItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }],
         "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 15 }],
         "createItems": [{ "id": "7892ffc6-c651-445f-946b-7edc998cf389", "count": 1 }],
-        "duration": "1h 30m"
+        "duration": "1h 30m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 65 }
+            ]
+        }
     },
     {
         "id": "solder-led-resistor",


### PR DESCRIPTION
## Summary
- refine Benchy print process with clearer item references
- add hardening block with first pass and score

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_6891b7f3cab8832f8d357f19d887ff01