### PR TITLE
feat: add LED indicator module and harden soldering process

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -776,6 +776,13 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "6da4a788-b743-4682-8dbe-f23d71435aa4",
+        "name": "LED indicator module",
+        "description": "5 mm red LED pre-wired with a 220 Ω resistor and jumper leads for breadboard projects.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73",
         "name": "USB Cable",
         "description": "Connects the Arduino to your computer for programming.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1778,16 +1778,27 @@
     },
     {
         "id": "solder-led-resistor",
-        "title": "Solder a 5 mm LED to a 220 Ω resistor with jumper wires",
+        "title": "Solder a 5 mm LED to a 220 Ω resistor and attach two jumper wires",
         "requireItems": [
-            { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+            { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 }
+        ],
+        "consumeItems": [
             { "id": "48cf736e-184c-4bd1-b9b0-15b7e9721646", "count": 1 },
             { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
             { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 }
         ],
-        "consumeItems": [],
-        "createItems": [],
-        "duration": "20m"
+        "createItems": [
+            { "id": "6da4a788-b743-4682-8dbe-f23d71435aa4", "count": 1 }
+        ],
+        "duration": "15m",
+        "hardening": {
+            "passes": 1,
+            "score": 70,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-hardening-2025-08-05", "date": "2025-08-05", "score": 70 }
+            ]
+        }
     },
     {
         "id": "print-phone-stand",


### PR DESCRIPTION
## Summary
- refine `solder-led-resistor` process to consume parts, produce LED indicator module, and track hardening
- add `LED indicator module` item to inventory

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --run processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_6891b7f3cab8832f8d357f19d887ff01