### PR TITLE
feat: harden print-phone-stand process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1829,11 +1829,29 @@
     },
     {
         "id": "print-phone-stand",
-        "title": "3D print a smartphone stand",
-        "requireItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }],
-        "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 20 }],
-        "createItems": [{ "id": "9018feac-7213-4eef-9654-b06dbd9404ea", "count": 1 }],
-        "duration": "2h"
+        "title": "3D print a smartphone stand on Real Printer 1 using 20 g of white PLA",
+        "requireItems": [
+            { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 20 }
+        ],
+        "createItems": [
+            { "id": "9018feac-7213-4eef-9654-b06dbd9404ea", "count": 1 }
+        ],
+        "duration": "2h",
+        "hardening": {
+            "passes": 1,
+            "score": 70,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-05",
+                    "date": "2025-08-05",
+                    "score": 70
+                }
+            ]
+        }
     },
     {
         "id": "check-iss-pass",


### PR DESCRIPTION
## Summary
- clarify print-phone-stand with explicit printer and filament references
- add initial hardening pass and history entry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_6891bd47ffa8832f84bf13b62e02c08a