### PR TITLE
docs: clarify image reuse in hardening prompts

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -107,9 +107,10 @@ USER:
 2. Improve clarity, realism and units. Ensure prices and descriptions match
    real-world expectations and that related processes reference the item
    correctly.
-3. Update or create the item's `hardening` block, incrementing `passes`,
-   refreshing the evaluator `score`, swapping the status `emoji` and appending a
-   history entry with the Codex task ID, date and score. Choose the emoji based
+3. When modifying the `image` field, reuse an existing image URL already in the repository; do not add new or external images.
+4. Update or create the item's `hardening` block, incrementing `passes`,
+    refreshing the evaluator `score`, swapping the status `emoji` and appending a
+    history entry with the Codex task ID, date and score. Choose the emoji based
    on:
    - 0 passes → score 0 → 🛠️ Draft
    - ≥1 pass & score ≥60 → 🌀 First polishing pass
@@ -124,7 +125,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- itemValidation itemQuality processQuality`. Update docs if
    needed.
 
@@ -136,9 +137,9 @@ A pull request with the refined item, updated hardening block and passing tests.
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible but incorrect details.
 
 [codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -105,9 +105,10 @@ USER:
    `hardening` block or has a low score.
 2. Improve clarity, realism and item references. Ensure durations are feasible
    and related items exist in `frontend/src/pages/inventory/json/items.json`.
-3. Update or create the process's `hardening` block, incrementing `passes`,
-   refreshing the evaluator `score`, swapping the status `emoji` and appending a
-   history entry with the Codex task ID, date and score. Choose the emoji based
+3. When updating the `image` field, reuse an existing image URL already in the repository; do not introduce new or external images.
+4. Update or create the process's `hardening` block, incrementing `passes`,
+    refreshing the evaluator `score`, swapping the status `emoji` and appending a
+    history entry with the Codex task ID, date and score. Choose the emoji based
    on:
    - 0 passes → score 0 → 🛠️ Draft
    - ≥1 pass & score ≥60 → 🌀 First polishing pass
@@ -122,7 +123,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- processQuality itemQuality`. Update docs or items if needed.
 
 OUTPUT:
@@ -133,7 +134,7 @@ A pull request with the refined process, updated hardening block and passing tes
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible but incorrect details.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -139,8 +139,9 @@ USER:
    `frontend/src/pages/inventory/json/items.json` or
    `frontend/src/pages/processes/processes.json`. Add missing items or
    processes so quests stay grounded in reality and are reproducible IRL.
-4. Update the quest's `hardening` block, incrementing `passes`, refreshing the
-   evaluator `score`, swapping the status `emoji` and appending a history entry
+4. If the quest includes an image, reuse an existing image URL already in the repository; do not add new or external images.
+5. Update the quest's `hardening` block, incrementing `passes`, refreshing the
+    evaluator `score`, swapping the status `emoji` and appending a history entry
    with the Codex task ID, date and score. Choose the emoji based on:
    - 0 passes → score 0 → 🛠️ Draft
    - ≥1 pass & score ≥60 → 🌀 First polishing pass
@@ -155,7 +156,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
+6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
    questCanonical questQuality itemQuality processQuality`. Update docs if
    needed.
 


### PR DESCRIPTION
## Summary
- note to reuse existing image URLs in quest hardening prompts
- note to reuse existing image URLs in item hardening prompts
- note to reuse existing image URLs in process hardening prompts

## Testing
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lxml')*
- `npm test -- --coverage`
- `python -m flywheel.fit` *(fails: No module named 'flywheel')*
- `SKIP_E2E=1 npm run test:pr` *(fails: Formatting or linting issues found)*
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68928ef7f1b0832f9c298a78a843959b