### PR TITLE
feat: refine nutrient check quest

### DIFF
--- a/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
@@ -1,14 +1,14 @@
 {
     "id": "hydroponics/nutrient-check",
     "title": "Refresh Nutrient Solution",
-    "description": "Top off your tub with fresh hydroponic nutrients for healthy growth.",
+    "description": "Top off your hydroponic tub with fresh nutrients while keeping yourself and the plants safe.",
     "image": "/assets/hydroponics_nutrients.jpg",
     "npc": "/assets/npc/hydro.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Plants quickly deplete minerals in recirculating systems. We'll top off the reservoir so your basil stays strong and avoid nutrient deficiencies.",
+            "text": "Plants quickly deplete minerals in recirculating systems. We'll top off the reservoir so your basil stays strong and avoids nutrient deficiencies.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "add",
-            "text": "Put on nitrile gloves and safety goggles. Measure nutrients according to the label, dilute in clean water, then pour into the reservoir. Keep the submersible water pump running so the solution circulates and avoid splashes.",
+            "text": "Slip on nitrile gloves and safety goggles. Measure the manufacturer-recommended dose of hydroponics nutrients, dissolve it in a bucket of clean water, then slowly pour it into the reservoir. Keep the submersible water pump running so the solution mixes evenly and wipe up any splashes immediately.",
             "options": [
                 {
                     "type": "process",
@@ -28,6 +28,18 @@
                     "requiresItems": [
                         {
                             "id": "ef5a843f-0a9d-41e2-b2bc-81fc9f99a150",
+                            "count": 1
+                        },
+                        {
+                            "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
+                            "count": 1
+                        },
+                        {
+                            "id": "c9b51052-4594-42d7-a723-82b815ab8cc2",
+                            "count": 1
+                        },
+                        {
+                            "id": "584ca717-4ce1-4ca1-bcd3-38272a52768a",
                             "count": 1
                         }
                     ]
@@ -47,7 +59,7 @@
         },
         {
             "id": "finish",
-            "text": "Great! Monitor the water level every few days, rinse your measuring tools, wash your hands after mixing, and store nutrients safely away from kids and pets.",
+            "text": "Great! Mark today's date on the tub, monitor the water level every few days, rinse your measuring tools, wash your hands after mixing, and store nutrients safely away from kids and pets.",
             "options": [
                 {
                     "type": "finish",
@@ -59,9 +71,9 @@
     "rewards": [],
     "requiresQuests": ["hydroponics/basil"],
     "hardening": {
-        "passes": 2,
-        "score": 80,
-        "emoji": "✅",
+        "passes": 3,
+        "score": 90,
+        "emoji": "💯",
         "history": [
             {
                 "task": "codex-hardening-2025-08-04",
@@ -72,6 +84,11 @@
                 "task": "codex-hardening-2025-08-05",
                 "date": "2025-08-05",
                 "score": 80
+            },
+            {
+                "task": "codex-refine-2025-08-05",
+                "date": "2025-08-05",
+                "score": 90
             }
         ]
     }


### PR DESCRIPTION
## Summary
- improve hydroponics nutrient-check quest with clearer instructions and safety gear references
- update quest hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `CI=1 npm test -- questCanonical questQuality itemQuality processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68928e1d96f8832f897c0c0eacbdea78