### PR TITLE
🧹 : remove obsolete npm config and doc proxy env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ SKIP_E2E=1 npm run test:pr
 - If dependencies are missing, run `npm ci` in the repo root and `npm ci --prefix frontend`.
 - Fix formatting issues with `npx prettier`.
 - Set `ESLINT_USE_FLAT_CONFIG=false` if running ESLint manually.
+- If a proxy is required, set `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables
+  instead of using `.npmrc` proxy settings.
 
 ## Quest Creation Guidelines
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,0 @@
-# Expose Astro dependencies for `pnpm` users
-shamefully-hoist=true

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -101,9 +101,9 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Create `pnpm‑workspace.yaml` at repo root
         -   [ ] Remove `frontend/package-lock.json`
         -   [ ] Add `.npmrc` with `packageManager=pnpm@latest`
-    -   [ ] **Remove obsolete npm configs & warnings**
-        -   [ ] Delete `http-proxy` and `shamefully-hoist` keys from `.npmrc`
-        -   [ ] Document proxy environment variables in `AGENTS.md`
+    -   [x] **Remove obsolete npm configs & warnings** 💯
+        -   [x] Delete `http-proxy` and `shamefully-hoist` keys from `.npmrc` 💯
+        -   [x] Document proxy environment variables in `AGENTS.md` 💯
     -   [ ] **Husky hardening for CI**
         -   [ ] Move `husky install` to a postinstall script gated by `.git` presence
         -   [ ] Add `ci:install` script that skips hook execution in CI


### PR DESCRIPTION
## Summary
- remove legacy `shamefully-hoist` npm setting
- document HTTP proxy env vars in `AGENTS.md`
- mark changelog item complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6892de6caa94832fa0aa7e4a5c8acc78