### PR TITLE
🛡️ : configure Dependabot for weekly npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    labels:
+      - dependencies
   - package-ecosystem: 'npm'
     directory: '/frontend'
     schedule:
       interval: 'weekly'
+    labels:
+      - dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ SKIP_E2E=1 npm run test:pr
 - Fix formatting issues with `npx prettier`.
 - Set `ESLINT_USE_FLAT_CONFIG=false` if running ESLint manually.
 
+## Dependency Management
+
+- GitHub Dependabot automatically opens weekly PRs for npm updates (see `.github/dependabot.yml`).
+
 ## Quest Creation Guidelines
 
 - Quest JSON lives in `frontend/src/pages/quests/json` and must follow the schema in `frontend/src/pages/quests/jsonSchemas`.

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -115,7 +115,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Upgrade ESLint to current LTS and align plugins
         -   [ ] Introduce weekly `npm-check-updates` workflow
     -   [ ] **Security & audit pipeline**
-        -   [ ] Add GitHub Dependabot (`npm`, weekly)
+        -   [x] Add GitHub Dependabot (`npm`, weekly) 💯
         -   [ ] Create `npm run audit:ci` that blocks merges on high‑severity issues
     -   [ ] **Test harness improvements**
         -   [ ] Make `npm test` run all suites by default


### PR DESCRIPTION
## Summary
- document weekly Dependabot runs for npm packages
- label Dependabot PRs as `dependencies`
- mark changelog entry complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6892de6caa94832fa0aa7e4a5c8acc78