### PR TITLE
📝 : harden item prompt doc

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -3,11 +3,11 @@ title: 'Item Prompts'
 slug: 'prompts-items'
 ---
 
-# Writing great item prompts for the _dspace_ repo (v3)
+# Writing great item prompts for the _dspace_ repo (v3)
 
 Codex is a sandboxed engineering agent that can open this repository,
-run its own tests, and send you a ready‑made PR—but only if you give it a
-clear, file‑scoped prompt. Use this guide alongside
+run its own tests, and send you a ready-made PR—but only if you give it a
+clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. For general
 content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
@@ -20,9 +20,9 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1 Quick start (Web vs CLI)
 
-| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli]                                              |
+| Use-case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli]                                              |
 | --------------------- | --------------------------- | ------------------------------------------------------------------- |
 | Add or update an item | “Code” button, attach repo  | `codex "add item solar-cell-junction-box"`                          |
 | Ask about item data   | “Ask” button                | `codex exec "explain frontend/src/pages/inventory/json/items.json"` |
@@ -32,21 +32,21 @@ See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
-## 2 Prompt ingredients
+## 2 Prompt ingredients
 
 | Ingredient           | Why it matters                                                      |
 | -------------------- | ------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add price to `white PLA filament`”). |
+| **Goal sentence**    | Gives the agent a north star (“Add price to `white PLA filament`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, item schema rules.                              |
 | **Acceptance check** | e.g. “`npm test -- itemValidation itemQuality` passes”.             |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
-prompt‑level rules short and concrete.
+prompt-level rules short and concrete.
 
 ---
 
-## 3 Reusable template
+## 3 Reusable template
 
 ```text
 You are working in democratizedspace/dspace (branch v3).
@@ -65,7 +65,9 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- itemValidation itemQuality` and fix any failures.
-7. Update docs or processes if needed.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+8. Use an emoji-prefixed commit message.
+9. Update docs or processes if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -77,17 +79,19 @@ Use this when you want Codex to automatically create or upgrade an item.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. Edit or create
-items under `frontend/src/pages/inventory/json/items.json`. Ensure realistic
-details, required fields, and passing checks (`npm run lint`, `npm run
+You are an automated contributor for the DSPACE repository (branch v3). Edit or
+create items under `frontend/src/pages/inventory/json/items.json`. Ensure
+realistic details, required fields, and passing checks (`npm run lint`, `npm run
 type-check`, `npm run build`, and `npm test -- itemValidation itemQuality`).
-Verify the item appears in at least one quest or process, creating those links
-if missing, and reuse existing image assets.
+Verify the item appears in at least one quest or process, reuse existing image
+assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+before committing.
 
 USER:
 1. Follow the steps above.
 2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated item in the PR description.
+4. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request implementing the item with all tests green.
@@ -107,15 +111,16 @@ USER:
 2. Improve clarity, realism and units. Ensure prices and descriptions match
    real-world expectations and that related processes reference the item
    correctly.
-3. When modifying the `image` field, reuse an existing image URL already in the repository; do not add new or external images.
+3. When modifying the `image` field, reuse an existing image URL already in the
+   repository; do not add new or external images.
 4. Update or create the item's `hardening` block, incrementing `passes`,
     refreshing the evaluator `score`, swapping the status `emoji` and appending a
     history entry with the Codex task ID, date and score. Choose the emoji based
    on:
-   - 0 passes → score 0 → 🛠️ Draft
-   - ≥1 pass & score ≥60 → 🌀 First polishing pass
-   - ≥2 passes & score ≥75 → ✅ Meets internal quality bar
-   - ≥3 passes & score ≥90 → 💯 Hardened – locked until spec change
+   - 0 passes → score 0 → 🛠️ Draft
+   - ≥1 pass & score ≥60 → 🌀 First polishing pass
+   - ≥2 passes & score ≥75 → ✅ Meets internal quality bar
+   - ≥3 passes & score ≥90 → 💯 Hardened – locked until spec change
    Example:
    "hardening": {
      "passes": 1,
@@ -128,6 +133,8 @@ USER:
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- itemValidation itemQuality processQuality`. Update docs if
    needed.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the refined item, updated hardening block and passing tests.
@@ -140,6 +147,7 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Provide clear context** about DSPACE's educational mission and sustainability focus.
 -   **Use system prompts** to guide tone and technical accuracy.
 -   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- restore v3 refs and expand template with secret scan and commit hints
- stress secret scans and emoji commits in implementation & upgrade prompts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` (missing script)
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6892de79c264832f8a13cb7a36a37ccc