### PR TITLE
🧪: run full test suite via npm test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Run checks locally before opening a pull request:
 
 ```bash
 # Full test suite including lint and unit tests
-SKIP_E2E=1 npm run test:pr
+SKIP_E2E=1 npm test
 ```
 
 - Install Playwright browsers with `npx playwright install chromium` when E2E tests require it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ Thank you for your interest in helping the project! Below is a quick overview of
   npm run check
   ```
 - The test suite verifies file formatting, so unformatted changes will fail CI.
-- The pre-commit hook runs `lint-staged`, `npm run check`, and then `SKIP_E2E=1 npm run test:pr` to make sure tests are green. You can run it manually with:
+- The pre-commit hook runs `lint-staged`, `npm run check`, and then `SKIP_E2E=1 npm test` to make sure tests are green. You can run it manually with:
   ```bash
-  SKIP_E2E=1 npm run test:pr
+  SKIP_E2E=1 npm test
   ```
 - If Playwright browsers are missing, install them with `npx playwright install chromium` or set `SKIP_E2E=1`.
 
@@ -31,7 +31,7 @@ Thank you for your interest in helping the project! Below is a quick overview of
 
 1. Run the full suite before submitting:
    ```bash
-   npm run test:pr
+   npm test
    ```
    Include `SKIP_E2E=1` if you cannot run the browsers.
 2. Update documentation when adding or changing features.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -117,7 +117,7 @@ We follow a feature branch workflow:
 
 1. Update documentation for any new features
 2. Add or update tests as necessary
-3. Ensure all tests pass with `npm run test:pr`
+3. Ensure all tests pass with `npm test`
 4. Get approval from at least one maintainer
 5. Squash and merge into the main branch
 
@@ -131,7 +131,7 @@ Before submitting a pull request, run the comprehensive cross-platform test suit
 
 ```bash
 # From project root
-npm run test:pr
+npm test
 ```
 
 This command:
@@ -169,7 +169,7 @@ npm run test:e2e
 npm run test:e2e:groups
 ```
 
-> **Important:** When using `npm run test:pr` or `npm run test:e2e:groups`, the
+> **Important:** When using `npm test` or `npm run test:e2e:groups`, the
 > development server is started automatically. Start the server yourself only if
 > you run Playwright commands directly.
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Before submitting a pull request, run the comprehensive test suite with:
 
 ```bash
 # Skip Playwright tests if browsers aren't installed
-SKIP_E2E=1 npm run test:pr
+SKIP_E2E=1 npm test
 ```
 
 If Playwright browsers are available, omit `SKIP_E2E=1` to run the full suite:
 
 ```bash
-npm run test:pr
+npm test
 ```
 
 If you encounter an error like `browserType.launch: Executable doesn't exist`,
@@ -71,7 +71,7 @@ This cross-platform script will:
 - Run all end-to-end tests in optimized groups
 - Provide helpful error messages if any tests fail
 
-The `test:pr` command handles everything automatically, including starting and stopping the development server for end-to-end tests.
+The `npm test` command (alias `npm run test:pr`) handles everything automatically, including starting and stopping the development server for end-to-end tests.
 
 ### Testing Information
 
@@ -116,7 +116,7 @@ npm run benchmark:db
 
 ### Continuous Integration
 
-GitHub Actions automatically run `npm run test:pr` on every pull request and push to `v3`.
+GitHub Actions automatically run `npm test` on every pull request and push to `v3`.
 If the `CODECOV_TOKEN` secret is configured, coverage reports upload to Codecov and update the badge at the top of this README.
 You'll find the CI results under the **Checks** tab of your pull request.
 

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -18,7 +18,7 @@ To run the complete test suite:
 
 ```bash
 # From the project root
-SKIP_E2E=1 npm run test:pr  # omit SKIP_E2E=1 for full suite
+SKIP_E2E=1 npm test  # omit SKIP_E2E=1 for full suite
 
 # Or from the frontend directory
 npm run test:all
@@ -112,7 +112,7 @@ We have automated checks to ensure no test files are orphaned from the test work
     - Important Jest test files are properly configured
     - Your browser environment supports the capabilities needed for testing
 
-This test runs as part of the `test:pr` and `test:e2e:groups` commands.
+This test runs as part of the `npm test` (alias `test:pr`) and `test:e2e:groups` commands.
 
 ## Writing New Tests
 
@@ -188,7 +188,7 @@ In CI environments, tests run with special settings:
 -   Runs Chromium, Firefox, and WebKit to ensure cross-browser compatibility
 -   Parallel execution based on available CPU cores
 
-The `test:pr` command simulates this environment locally before you submit a PR.
+The `npm test` command (alias `test:pr`) simulates this environment locally before you submit a PR.
 
 ## Test Structure
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -118,7 +118,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add GitHub Dependabot (`npm`, weekly) 💯
         -   [ ] Create `npm run audit:ci` that blocks merges on high‑severity issues
     -   [ ] **Test harness improvements**
-        -   [ ] Make `npm test` run all suites by default
+        -   [x] Make `npm test` run all suites by default 💯
         -   [ ] Emit a warning if zero tests are detected
     -   [ ] **Quest tooling enhancements**
         -   [ ] Script to generate UUIDs & inject item/process refs

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -86,7 +86,7 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯. Implement it fully, completing any sub-tasks. Provide all code,
 tests and documentation required. Follow `AGENTS.md` and ensure `npm run lint`,
-`npm run type-check`, `npm run build`, and `SKIP_E2E=1 npm run test:pr` all pass
+`npm run type-check`, `npm run build`, and `SKIP_E2E=1 npm test` all pass
 before committing. If Playwright browsers are missing run `npx playwright
 install chromium`.
 

--- a/frontend/src/pages/docs/md/quest-contribution.md
+++ b/frontend/src/pages/docs/md/quest-contribution.md
@@ -39,6 +39,6 @@ These guidelines outline the process for contributing your custom quests to the 
 
 -   Keep dialogue concise and educational.
 -   Include safety notes where appropriate.
--   Run `SKIP_E2E=1 npm run test:pr` before opening a pull request.
+-   Run `SKIP_E2E=1 npm test` before opening a pull request.
 
 Happy quest building!

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Astro renders pages server-side and hydrates Svelte components on the client. Place interactive code in `onMount` and mark hydrated components with `data-hydrated="true"` so tests can wait for readiness.
 
-Run `SKIP_E2E=1 npm run test:pr` before submitting changes. Install Playwright browsers with `npx playwright install chromium` when needed. Use `npm run check` for lint and format verification.
+Run `SKIP_E2E=1 npm test` before submitting changes. Install Playwright browsers with `npx playwright install chromium` when needed. Use `npm run check` for lint and format verification.
 
 Quest files live in `frontend/src/pages/quests/json` and must follow the schema in `frontend/src/pages/quests/jsonSchemas`. Each quest requires start, middle and completion nodes plus a `finish` option and at least one inventory item or process.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "cd frontend && npm run dev",
-    "test": "vitest",
+    "test": "npm run test:pr",
+    "test:root": "vitest run --testTimeout 20000",
     "coverage": "vitest run --coverage",
     "test:watch": "cd frontend && npm run test:watch",
     "test:e2e": "cd frontend && npm run test:e2e",

--- a/run-tests.js
+++ b/run-tests.js
@@ -6,7 +6,6 @@
  */
 
 const { execSync } = require('child_process');
-const path = require('path');
 const os = require('os');
 
 // ANSI color codes for pretty output
@@ -24,10 +23,10 @@ const colors = {
 console.log(`${colors.bright}${colors.magenta}DSPACE Testing Suite${colors.reset}`);
 console.log(`${colors.cyan}Running comprehensive tests before PR submission...${colors.reset}\n`);
 
-// Get the frontend directory path
-const frontendDir = path.join(__dirname, 'frontend');
-
 try {
+    console.log(`${colors.yellow}Running root unit tests...${colors.reset}`);
+    execSync('npm run test:root', { stdio: 'inherit' });
+
     // Determine which script to run based on OS
     if (os.platform() === 'win32') {
         console.log(`${colors.yellow}Detected Windows OS, running PowerShell script...${colors.reset}`);

--- a/tests/npmTestRunsAllSuites.test.ts
+++ b/tests/npmTestRunsAllSuites.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('npm test', () => {
+  it('runs test:pr script', () => {
+    const pkgPath = join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    expect(pkg.scripts.test).toBe('npm run test:pr');
+  });
+});


### PR DESCRIPTION
## Summary
- alias `npm test` to the full `test:pr` workflow and run root unit tests first
- document the new `npm test` behavior across guides and mark changelog item
- add coverage test to ensure `npm test` stays linked to `test:pr`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ed157af0832f9eab4f50ad5ee37e