### PR TITLE
🔧 : gate husky install on repository presence

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,8 +38,7 @@
         "benchmark:db": "node scripts/db-benchmark.js",
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
-        "postinstall": "npm run sync",
-        "prepare": "husky"
+        "postinstall": "npm run sync && node ./scripts/husky-install.js"
     },
     "devDependencies": {
         "@astrojs/svelte": "^2.1.0",

--- a/frontend/scripts/husky-install.js
+++ b/frontend/scripts/husky-install.js
@@ -1,0 +1,11 @@
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+if (existsSync(path.join(repoRoot, '.git'))) {
+    execSync('husky install', { cwd: repoRoot, stdio: 'inherit' });
+}

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -105,7 +105,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Delete `http-proxy` and `shamefully-hoist` keys from `.npmrc` 💯
         -   [x] Document proxy environment variables in `AGENTS.md` 💯
     -   [ ] **Husky hardening for CI**
-        -   [ ] Move `husky install` to a postinstall script gated by `.git` presence
+        -   [x] Move `husky install` to a postinstall script gated by `.git` presence 💯
         -   [ ] Add `ci:install` script that skips hook execution in CI
     -   [ ] **Automate `pnpm approve-builds`**
         -   [ ] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`)


### PR DESCRIPTION
## Summary
- move Husky setup into a postinstall script that runs only when .git exists
- document Husky change in the September 1, 2025 changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6892ed194e7c832f87c6b278efb36989