### PR TITLE
Remove node-domexception polyfill

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -14,11 +14,6 @@ export default defineConfig({
     server: {
       port: parseInt(process.env.PORT) || 3002, // Use PORT env var or default to 3000
       host: "0.0.0.0",
-    },
-    resolve: {
-      alias: {
-        "node-domexception": "/domexception-shim.js"
-      }
     }
   }
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -111,7 +111,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`)
     -   [ ] **Dependency upgrades & cleanup**
         -   [ ] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`)
-        -   [ ] Remove `node-domexception` in favor of native API
+        -   [x] Remove `node-domexception` in favor of native API 💯
         -   [ ] Upgrade ESLint to current LTS and align plugins
         -   [ ] Introduce weekly `npm-check-updates` workflow
     -   [ ] **Security & audit pipeline**

--- a/tests/domException.test.ts
+++ b/tests/domException.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+
+describe('DOMException', () => {
+  it('uses the built-in DOMException', () => {
+    const err = new DOMException('boom');
+    expect(err).toBeInstanceOf(DOMException);
+    expect(err.message).toBe('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- remove node-domexception alias and rely on built-in DOMException
- add DOMException unit test
- mark changelog entry complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run audit:ci` *(fails: axios vulnerability via openai)*

------
https://chatgpt.com/codex/tasks/task_e_6892f3313ef0832f89b57070126c8fd8