### PR TITLE
🔧 : pre-approve native builds with pnpmfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ node --version # ensure Node.js 18 or 20 is in use
 pnpm install
 ```
 
+The repo includes a `pnpmfile.cjs` that pre-approves native builds for `canvas`,
+`esbuild`, and `@swc/core`, so `pnpm install` runs without interactive prompts.
+
 Start the development server:
 
 ```bash

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -107,8 +107,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Husky hardening for CI** 💯
         -   [x] Move `husky install` to a postinstall script gated by `.git` presence 💯
         -   [x] Add `ci:install` script that skips hook execution in CI 💯
-    -   [ ] **Automate `pnpm approve-builds`**
-        -   [ ] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`)
+    -   [x] **Automate `pnpm approve-builds`** 💯
+        -   [x] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`) 💯
     -   [ ] **Dependency upgrades & cleanup**
         -   [ ] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`)
         -   [ ] Remove `node-domexception` in favor of native API

--- a/pnpmfile.cjs
+++ b/pnpmfile.cjs
@@ -1,0 +1,9 @@
+/**
+ * Pre-approve native deps so installs can run non-interactively.
+ * See https://pnpm.io/security#pre-approving-builds
+ */
+module.exports = {
+  config: {
+    allowedBuiltDependencies: ['canvas', 'esbuild', '@swc/core']
+  }
+};

--- a/tests/pnpmfile.test.ts
+++ b/tests/pnpmfile.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('pnpmfile.cjs', () => {
+  it('pre-approves native builds', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pnpmfile = require('../pnpmfile.cjs');
+    expect(pnpmfile?.config?.allowedBuiltDependencies).toEqual([
+      'canvas',
+      'esbuild',
+      '@swc/core'
+    ]);
+  });
+});


### PR DESCRIPTION
what: pre-approve builds for canvas, esbuild, @swc/core
why: allow pnpm install without manual approve-builds step
how to test: npm run lint && npm run type-check && npm run build &&
  SKIP_E2E=1 npm run test:pr


------
https://chatgpt.com/codex/tasks/task_e_6892f3052ad8832f85c6e2337c6cb4e8