### PR TITLE
Automate pnpm approve-builds via pnpmfile

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -107,8 +107,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Husky hardening for CI** 💯
         -   [x] Move `husky install` to a postinstall script gated by `.git` presence 💯
         -   [x] Add `ci:install` script that skips hook execution in CI 💯
-    -   [ ] **Automate `pnpm approve-builds`**
-        -   [ ] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`)
+    -   [x] **Automate `pnpm approve-builds`** 💯
+        -   [x] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`) 💯
     -   [ ] **Dependency upgrades & cleanup**
         -   [ ] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`)
         -   [ ] Remove `node-domexception` in favor of native API

--- a/pnpmfile.cjs
+++ b/pnpmfile.cjs
@@ -1,0 +1,16 @@
+/**
+ * Pre-approve build scripts for selected native dependencies.
+ * This allows CI to install without manual `pnpm approve-builds`.
+ */
+const APPROVED_DEPENDENCIES = ['canvas', 'esbuild', '@swc/core'];
+
+module.exports = {
+  hooks: {
+    afterAllResolved(lockfile, context) {
+      for (const name of APPROVED_DEPENDENCIES) {
+        context.resolutionBuilds.add(name);
+      }
+      return lockfile;
+    },
+  },
+};

--- a/tests/pnpmfile.test.ts
+++ b/tests/pnpmfile.test.ts
@@ -1,0 +1,11 @@
+import pnpmfile from '../pnpmfile.cjs';
+import { describe, it, expect } from 'vitest';
+
+describe('pnpmfile', () => {
+  it('pre-approves native build dependencies', () => {
+    const context = { resolutionBuilds: new Set<string>() };
+    const lockfile = {};
+    pnpmfile.hooks.afterAllResolved(lockfile, context as any);
+    expect([...context.resolutionBuilds]).toEqual(['canvas', 'esbuild', '@swc/core']);
+  });
+});


### PR DESCRIPTION
## Summary
- pre-approve native build dependencies through pnpmfile
- cover pnpmfile behavior with unit test
- mark changelog entry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npx --prefix frontend playwright install chromium`


------
https://chatgpt.com/codex/tasks/task_e_6892f5b7d50c832fbcf9c42c6d9f22c8