### PR TITLE
Remove node-domexception shim for native DOMException

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,24 +1,19 @@
 import { defineConfig } from 'astro/config';
 import node from '@astrojs/node';
-import svelte from "@astrojs/svelte";
+import svelte from '@astrojs/svelte';
 
 // https://astro.build/config
 export default defineConfig({
-  output: 'server',
-  adapter: node({ mode: 'standalone' }),
-  integrations: [svelte()],
-  style: {
-    postcss: {}
-  },
-  vite: {
-    server: {
-      port: parseInt(process.env.PORT) || 3002, // Use PORT env var or default to 3000
-      host: "0.0.0.0",
+    output: 'server',
+    adapter: node({ mode: 'standalone' }),
+    integrations: [svelte()],
+    style: {
+        postcss: {},
     },
-    resolve: {
-      alias: {
-        "node-domexception": "/domexception-shim.js"
-      }
-    }
-  }
+    vite: {
+        server: {
+            port: parseInt(process.env.PORT) || 3002, // Use PORT env var or default to 3000
+            host: '0.0.0.0',
+        },
+    },
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -111,7 +111,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`)
     -   [ ] **Dependency upgrades & cleanup**
         -   [ ] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`)
-        -   [ ] Remove `node-domexception` in favor of native API
+        -   [x] Remove `node-domexception` in favor of native API 💯
         -   [ ] Upgrade ESLint to current LTS and align plugins
         -   [ ] Introduce weekly `npm-check-updates` workflow
     -   [ ] **Security & audit pipeline**

--- a/tests/domexception.test.ts
+++ b/tests/domexception.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+
+describe('DOMException', () => {
+  it('is available globally', () => {
+    const DOMExceptionCtor = (globalThis as any).DOMException;
+    expect(typeof DOMExceptionCtor).toBe('function');
+    expect(DOMExceptionCtor.name).toBe('DOMException');
+    const err = new DOMExceptionCtor('boom');
+    expect(err).toBeInstanceOf(DOMExceptionCtor);
+  });
+});


### PR DESCRIPTION
## Summary
- remove node-domexception alias in Astro config
- add test for native DOMException
- mark changelog for dependency cleanup

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6892f5b7d50c832fbcf9c42c6d9f22c8