### PR TITLE
⬆️ : replace deprecated glob dependency

### DIFF
--- a/frontend/__tests__/questCanonical.test.js
+++ b/frontend/__tests__/questCanonical.test.js
@@ -3,12 +3,12 @@
  */
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 const { questHasFinishPath } = require('../src/utils/simulateQuest.js');
 
 describe('Quest canonical structure', () => {
     const questDir = path.join(__dirname, '../src/pages/quests/json');
-    const files = glob.sync(path.join(questDir, '**/*.json'));
+    const files = globSync(path.join(questDir, '**/*.json'));
 
     files.forEach((file) => {
         const quest = JSON.parse(fs.readFileSync(file));

--- a/frontend/__tests__/questDependencies.test.js
+++ b/frontend/__tests__/questDependencies.test.js
@@ -3,12 +3,12 @@
  */
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 const { findQuestDependencyIssues } = require('../src/utils/questDependencies.js');
 
 describe('Quest dependency integrity', () => {
     const questDir = path.join(__dirname, '../src/pages/quests/json');
-    const files = glob.sync(path.join(questDir, '**/*.json'));
+    const files = globSync(path.join(questDir, '**/*.json'));
     const quests = new Map();
 
     files.forEach((file) => {

--- a/frontend/__tests__/questQuality.test.js
+++ b/frontend/__tests__/questQuality.test.js
@@ -3,7 +3,7 @@
  */
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 
 // Define paths
 const questDirectoryRelativePath = '../src/pages/quests/json/';
@@ -63,7 +63,7 @@ const CRITERIA = {
 // Load all quest files
 function loadAllQuests() {
     const directoryPath = path.join(__dirname, questDirectoryRelativePath);
-    const files = glob.sync(path.join(directoryPath, '**/*.json'));
+    const files = globSync(path.join(directoryPath, '**/*.json'));
 
     files.forEach((file) => {
         try {

--- a/frontend/__tests__/questSimulation.test.js
+++ b/frontend/__tests__/questSimulation.test.js
@@ -3,7 +3,7 @@
  */
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 const { questHasFinishPath } = require('../src/utils/simulateQuest.js');
 
 const questFile = path.join(__dirname, '../test-data/constellations-quest.json');
@@ -46,7 +46,7 @@ describe('Quest simulation', () => {
 
     test('all canonical quests have a path to finish', () => {
         const questDir = path.join(__dirname, '../src/pages/quests/json');
-        const files = glob.sync(path.join(questDir, '**/*.json'));
+        const files = globSync(path.join(questDir, '**/*.json'));
         files.forEach((file) => {
             const quest = JSON.parse(fs.readFileSync(file));
             expect(questHasFinishPath(quest)).toBe(true);

--- a/frontend/scripts/generate-quest.mjs
+++ b/frontend/scripts/generate-quest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { writeFileSync, mkdirSync, readdirSync, readFileSync, statSync } from 'fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import path from 'path';
 import readline from 'readline';
 
@@ -33,8 +33,7 @@ async function main() {
     const { categories, npcCounts } = gatherStats();
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const questRoot = path.join('frontend', 'src', 'pages', 'quests', 'json');
-    const existing = glob
-        .sync(path.join(questRoot, '**/*.json'))
+    const existing = globSync(path.join(questRoot, '**/*.json'))
         .map((f) => path.relative(questRoot, f).replace(/\.json$/, ''));
 
     const args = process.argv.slice(2);

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -110,7 +110,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Automate `pnpm approve-builds`** 💯
         -   [x] Add `pnpmfile.cjs` to pre‑approve native deps (`canvas`, `esbuild`, `@swc/core`) 💯
     -   [ ] **Dependency upgrades & cleanup**
-        -   [ ] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`)
+        -   [x] Replace deprecated packages (`rimraf ≥ 5`, `glob ≥ 10`) 💯
         -   [x] Remove `node-domexception` in favor of native API 💯
         -   [ ] Upgrade ESLint to current LTS and align plugins
         -   [ ] Introduce weekly `npm-check-updates` workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "chart.js": "^4.5.0",
         "chartjs-node-canvas": "^5.0.0",
         "fake-indexeddb": "^6.0.0",
-        "glob": "^7.2.3",
+        "glob": "^10.4.5",
         "jest": "^29.7.0",
         "jsdom": "^26.1.0",
         "prettier-plugin-svelte": "^3.4.0",
@@ -1485,6 +1485,28 @@
         }
       }
     },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2310,27 +2332,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
@@ -4055,22 +4056,47 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4704,6 +4730,28 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5195,6 +5243,28 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-snapshot": {
@@ -6945,6 +7015,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chart.js": "^4.5.0",
     "chartjs-node-canvas": "^5.0.0",
     "fake-indexeddb": "^6.0.0",
-    "glob": "^7.2.3",
+    "glob": "^10.4.5",
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "prettier-plugin-svelte": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.1
       glob:
-        specifier: ^7.2.3
-        version: 7.2.3
+        specifier: ^10.4.5
+        version: 10.4.5
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@24.1.0)

--- a/scripts/create-content-bundle.js
+++ b/scripts/create-content-bundle.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 
 function collect(patterns) {
-  const files = patterns.flatMap((p) => glob.sync(p));
+  const files = patterns.flatMap((p) => globSync(p));
   return files.map((f) => JSON.parse(fs.readFileSync(f, 'utf8')));
 }
 

--- a/scripts/generate-item-dependencies.js
+++ b/scripts/generate-item-dependencies.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('glob');
 
 const questsPattern = path.join(
   __dirname,
@@ -49,7 +49,7 @@ function collectItemDeps(obj, questId, map) {
 }
 
 function buildMap() {
-  const files = glob.sync(questsPattern);
+  const files = globSync(questsPattern);
   const map = {};
   files.forEach((file) => {
     const data = JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/scripts/tests/contentIntegrity.test.ts
+++ b/scripts/tests/contentIntegrity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import { globSync } from 'glob';
 
 const baselineFile = path.join(__dirname, '../baselines/contentCounts.json');
 const baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf8'));
@@ -11,7 +11,7 @@ const processesFile = path.join(__dirname, '../../frontend/src/pages/processes/p
 const npcDir = path.join(__dirname, '../../frontend/public/assets/npc');
 
 function getCounts() {
-    const quests = glob.sync(path.join(questDir, '**/*.json')).length;
+    const quests = globSync(path.join(questDir, '**/*.json')).length;
     const items = JSON.parse(fs.readFileSync(itemsFile, 'utf8')).length;
     const processes = JSON.parse(fs.readFileSync(processesFile, 'utf8')).length;
     const npcImages = fs.readdirSync(npcDir).filter(f => /\.(png|jpe?g|webp)$/.test(f)).length;

--- a/scripts/tests/imageReferences.test.ts
+++ b/scripts/tests/imageReferences.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { listMissingImages } from '../utils/fs-checks';
 
 const questsDir = path.join(__dirname, '../../frontend/src/pages/quests/json');
@@ -15,7 +15,7 @@ const npcFile = path.join(
 );
 
 function collectQuestImages() {
-  const files = glob.sync(path.join(questsDir, '**/*.json'));
+  const files = globSync(path.join(questsDir, '**/*.json'));
   const imgs = [];
   files.forEach((file) => {
     const data = JSON.parse(fs.readFileSync(file, 'utf8'));


### PR DESCRIPTION
what: upgrade glob to v10 and refactor scripts/tests
why: replace deprecated glob package
how to test: npm run lint && npm run type-check && npm run build && SKIP_E2E=1 npm run test:pr
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6892f84cca50832f89bcb456a266d870