### PR TITLE
feat: validate items against schema in pre-commit

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -22,6 +22,10 @@ module.exports = {
   "frontend/src/pages/quests/json/**/*.json": (files) =>
     files.map((file) => `node scripts/validate-quest.js ${file}`),
 
+  // Validate item JSON files
+  "frontend/src/pages/inventory/json/**/*.json": (files) =>
+    files.map((file) => `node scripts/validate-item.js ${file}`),
+
   // Format JSON, markdown, and CSS files
   "frontend/**/*.{json,md,css,scss}": [
     "npm run format -- --quiet"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in helping the project! Below is a quick overview of
   npm run check
   ```
 - The test suite verifies file formatting, so unformatted changes will fail CI.
-- The pre-commit hook validates quest schemas, runs `lint-staged`, `npm run check`,
+- The pre-commit hook validates quest and item schemas, runs `lint-staged`, `npm run check`,
   and `SKIP_E2E=1 npm test`. Run it manually with:
     ```bash
     SKIP_E2E=1 npm test

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -39,7 +39,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] Item Management ✅
         -   [x] Item creation interface with `ItemForm.svelte`
-    -   [x] Item validation schema
+    -   [x] Item validation schema 💯
         -   [x] Item dependency tracking 💯
     -   [x] Process System
         -   [x] Process creation UI with duration handling

--- a/frontend/src/pages/inventory/jsonSchemas/item.json
+++ b/frontend/src/pages/inventory/jsonSchemas/item.json
@@ -14,6 +14,29 @@
             "type": "array",
             "items": { "type": "string" },
             "default": []
+        },
+        "hardening": {
+            "type": "object",
+            "properties": {
+                "passes": { "type": "integer" },
+                "score": { "type": "number" },
+                "emoji": { "type": "string" },
+                "history": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "task": { "type": "string" },
+                            "date": { "type": "string" },
+                            "score": { "type": "number" }
+                        },
+                        "required": ["task", "date", "score"],
+                        "additionalProperties": false
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": false
         }
     },
     "required": ["id", "name", "description", "image"],

--- a/scripts/tests/lintStagedItemValidation.test.ts
+++ b/scripts/tests/lintStagedItemValidation.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+
+const config = require('../../.lintstagedrc.js');
+
+describe('lint-staged item validation', () => {
+  it('runs item schema validation on staged item files', () => {
+    const rule = config['frontend/src/pages/inventory/json/**/*.json'];
+    expect(rule).toBeDefined();
+    const commands = typeof rule === 'function'
+      ? rule(['frontend/src/pages/inventory/json/foo.json'])
+      : rule;
+    const list = Array.isArray(commands) ? commands : [commands];
+    expect(list.some((cmd) => String(cmd).includes('scripts/validate-item.js'))).toBe(true);
+  });
+});

--- a/scripts/tests/validateItem.test.ts
+++ b/scripts/tests/validateItem.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+const validateItem = require('../validate-item');
+
+describe('validateItem script', () => {
+  it('returns true for a valid item file', () => {
+    const tempPath = path.join(__dirname, 'temp-item.json');
+    const item = { id: '1', name: 'test', description: 'ok item', image: 'foo.jpg' };
+    fs.writeFileSync(tempPath, JSON.stringify(item));
+    expect(validateItem(tempPath)).toBe(true);
+    fs.unlinkSync(tempPath);
+  });
+
+  it('returns false for an invalid item file', () => {
+    const tempPath = path.join(__dirname, 'temp-invalid-item.json');
+    fs.writeFileSync(tempPath, JSON.stringify({ name: 'bad' }));
+    const result = validateItem(tempPath);
+    fs.unlinkSync(tempPath);
+    expect(result).toBe(false);
+  });
+});

--- a/scripts/validate-item.js
+++ b/scripts/validate-item.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const schema = require('../frontend/src/pages/inventory/jsonSchemas/item.json');
+
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+
+function validateItem(filePath) {
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const items = Array.isArray(data) ? data : [data];
+  let valid = true;
+  for (const item of items) {
+    const ok = validate(item);
+    if (!ok) {
+      console.error(`Validation failed for ${filePath}`);
+      console.error(validate.errors);
+    }
+    valid = valid && ok;
+  }
+  return valid;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node scripts/validate-item.js <item.json>');
+    process.exit(1);
+  }
+  const isValid = validateItem(path.resolve(file));
+  process.exit(isValid ? 0 : 1);
+}
+
+module.exports = validateItem;


### PR DESCRIPTION
## Summary
- add Ajv-based validator and lint-staged hook for item JSON
- allow `hardening` block in item schema
- document pre-commit item validation and mark changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_689303e8c0a0832f8d04418d72d6ddb6