### PR TITLE
Add quest dependency validation test

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -33,7 +33,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] Create new official quests using the custom quest system 💯
     -   [x] Balance progression curve across all quests
-    -   [x] Test quest chains and dependencies
+    -   [x] Test quest chains and dependencies 💯
 
 -   [x] Custom Items and Processes (using the same system as quests)
 

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -121,7 +121,8 @@ Every quest JSON file must include:
         - `grantsItems`: Optional items given when selecting option
         - `requiresGitHub`: Set to `true` to disable the option until a GitHub token is saved
 - `rewards`: Items given upon quest completion
-- `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**)
+- `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**).
+  Automated tests ensure these dependencies reference existing quests and avoid cycles.
 
 ### Current Implementation State
 

--- a/scripts/tests/questDependencies.test.ts
+++ b/scripts/tests/questDependencies.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+const questsDir = path.join(__dirname, '../../frontend/src/pages/quests/json');
+
+function loadQuests() {
+  const files = globSync(path.join(questsDir, '**/*.json'));
+  const quests = {} as Record<string, any>;
+  for (const file of files) {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    quests[data.id] = data;
+  }
+  return quests;
+}
+
+describe('quest dependency graph', () => {
+  const quests = loadQuests();
+
+  it('references existing quests', () => {
+    const missing: string[] = [];
+    for (const quest of Object.values(quests)) {
+      const deps: string[] = quest.requiresQuests || [];
+      for (const dep of deps) {
+        if (!quests[dep]) {
+          missing.push(`${quest.id} -> ${dep}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('has no circular dependencies', () => {
+    const visited = new Set<string>();
+    const stack = new Set<string>();
+    const cycles: string[] = [];
+
+    function dfs(id: string) {
+      if (stack.has(id)) {
+        cycles.push(id);
+        return;
+      }
+      if (visited.has(id)) return;
+      visited.add(id);
+      stack.add(id);
+      const deps: string[] = quests[id]?.requiresQuests || [];
+      deps.forEach(dfs);
+      stack.delete(id);
+    }
+
+    Object.keys(quests).forEach(dfs);
+    expect(cycles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- verify quest chains via unit test
- document automated dependency checks
- mark changelog entry as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci` *(fails: axios high vulnerability)*
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_689303e8c0a0832f8d04418d72d6ddb6