### PR TITLE
✨: map text code blocks to Prism plaintext

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ DSPACE is a free and open source web-based space exploration idle game where pla
 -   **Framework**: [Astro](https://astro.build/) with [Svelte](https://svelte.dev/) components
 -   **Styling**: PostCSS with SCSS
 -   **Testing**: Jest with Testing Library
--   **Documentation**: Markdown with Remarkable
+-   **Documentation**: Markdown with Remarkable and Prism code highlighting (maps `text` to `plaintext`)
 -   **API Integration**: token.place
 -   **Code Quality**: ESLint, Prettier
 

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -10,6 +10,12 @@ export default defineConfig({
     style: {
         postcss: {},
     },
+    markdown: {
+        syntaxHighlight: 'prism',
+        prism: {
+            map: { text: 'plaintext' },
+        },
+    },
     vite: {
         server: {
             port: parseInt(process.env.PORT) || 3002, // Use PORT env var or default to 3000

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -128,7 +128,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Build‑time script to re‑inject metadata
     -   [ ] **Docs & build noise**
         -   [ ] Rename orphan `/docs/new-quests-v3` folder to match actual path
-        -   [ ] Add Prism plaintext mapping to silence “language text” warnings
+        -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
     -   [ ] **CI speed & log cleanliness**
         -   [ ] Silence non‑critical build messages
         -   [ ] Consolidate install logs for readability


### PR DESCRIPTION
## Summary
- configure Astro markdown to map `text` fences to Prism `plaintext`
- note Prism highlighting in frontend docs
- mark changelog task as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_689303e8c0a0832f8d04418d72d6ddb6