### PR TITLE
✨ feat: add quest id injection script

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -121,7 +121,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Make `npm test` run all suites by default 💯
         -   [x] Emit a warning if zero tests are detected 💯
     -   [ ] **Quest tooling enhancements**
-        -   [ ] Script to generate UUIDs & inject item/process refs
+        -   [x] Script to generate UUIDs & inject item/process refs 💯
         -   [x] Pre‑commit hook to validate quests before push 💯
     -   [ ] **Hardening metadata refactor**
         -   [ ] Extract `hardening` blocks to `/hardening/*.json`

--- a/scripts/inject-ids.cjs
+++ b/scripts/inject-ids.cjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { randomUUID } = require('crypto');
+
+function slugify(str) {
+    return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function processQuest(quest) {
+    if (!quest.id) {
+        quest.id = randomUUID();
+    }
+    if (Array.isArray(quest.dialogue)) {
+        quest.dialogue.forEach((node) => {
+            if (!node.id) {
+                node.id = randomUUID();
+            }
+            if (Array.isArray(node.options)) {
+                node.options.forEach((opt) => {
+                    if (Array.isArray(opt.requiresItems)) {
+                        opt.requiresItems.forEach((item) => {
+                            if (!item.id && item.name) {
+                                item.id = slugify(item.name);
+                            }
+                        });
+                    }
+                    if (Array.isArray(opt.grantsItems)) {
+                        opt.grantsItems.forEach((item) => {
+                            if (!item.id && item.name) {
+                                item.id = slugify(item.name);
+                            }
+                        });
+                    }
+                    if (opt.processName && !opt.process) {
+                        opt.process = slugify(opt.processName);
+                        delete opt.processName;
+                    }
+                });
+            }
+        });
+    }
+    return quest;
+}
+
+function main() {
+    const files = process.argv.slice(2);
+    if (files.length === 0) {
+        console.error('Usage: node scripts/inject-ids.cjs <quest.json> [...]');
+        process.exit(1);
+    }
+    files.forEach((file) => {
+        const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+        const updated = processQuest(data);
+        fs.writeFileSync(file, JSON.stringify(updated, null, 4));
+        console.log(`Updated ${file}`);
+    });
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { processQuest, slugify };

--- a/tests/inject-ids.test.ts
+++ b/tests/inject-ids.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { processQuest } from '../scripts/inject-ids.cjs';
+
+describe('inject-ids script', () => {
+    it('adds uuids and injects item/process refs', () => {
+        const quest = {
+            dialogue: [
+                {
+                    text: 'Start',
+                    options: [
+                        {
+                            requiresItems: [{ name: 'Space Suit', count: 1 }],
+                            grantsItems: [{ name: 'Wrench', count: 2 }],
+                            processName: 'build rocket'
+                        }
+                    ]
+                }
+            ]
+        } as any;
+        const updated = processQuest(quest);
+        expect(updated.id).toMatch(/[0-9a-f\-]{36}/);
+        const node = updated.dialogue[0];
+        expect(node.id).toMatch(/[0-9a-f\-]{36}/);
+        const opt = node.options[0];
+        expect(opt.requiresItems[0].id).toBe('space-suit');
+        expect(opt.grantsItems[0].id).toBe('wrench');
+        expect(opt.process).toBe('build-rocket');
+        expect(opt.processName).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- add script to generate UUIDs and inject quest item/process refs
- test script behaviour
- document quest tooling enhancement

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`
- `npm run audit:ci` *(fails: Axios Cross-Site Request Forgery Vulnerability, axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL)*

------
https://chatgpt.com/codex/tasks/task_e_689303e8c0a0832f8d04418d72d6ddb6