### PR TITLE
📝 : – silence language text build warnings

### DIFF
--- a/frontend/__tests__/astro-config.test.ts
+++ b/frontend/__tests__/astro-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import config from '../astro.config.mjs';
+import textToPlain from '../scripts/remark-text-to-plain.js';
+
+describe('astro markdown config', () => {
+    it('maps text code fences to plaintext', () => {
+        expect(config.markdown?.remarkPlugins).toContain(textToPlain);
+    });
+});

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import node from '@astrojs/node';
 import svelte from '@astrojs/svelte';
+import textToPlain from './scripts/remark-text-to-plain.js';
 
 // https://astro.build/config
 export default defineConfig({
@@ -9,6 +10,9 @@ export default defineConfig({
     integrations: [svelte()],
     style: {
         postcss: {},
+    },
+    markdown: {
+        remarkPlugins: [textToPlain],
     },
     vite: {
         server: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
         "svelte-switch-case": "^2.0.0",
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.2.6",
-        "typescript": "~5.1.6"
+        "typescript": "~5.1.6",
+        "unist-util-visit": "^5.0.0"
     },
     "dependencies": {
         "@algolia/client-search": "^4.13.1",

--- a/frontend/scripts/remark-text-to-plain.js
+++ b/frontend/scripts/remark-text-to-plain.js
@@ -1,0 +1,11 @@
+import { visit } from 'unist-util-visit';
+
+export default function textToPlain() {
+    return (tree) => {
+        visit(tree, 'code', (node) => {
+            if (node.lang === 'text') {
+                node.lang = undefined;
+            }
+        });
+    };
+}

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -128,7 +128,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Build‑time script to re‑inject metadata
     -   [ ] **Docs & build noise**
         -   [ ] Rename orphan `/docs/new-quests-v3` folder to match actual path
-        -   [ ] Add Prism plaintext mapping to silence “language text” warnings
+        -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
     -   [ ] **CI speed & log cleanliness**
         -   [ ] Silence non‑critical build messages
         -   [ ] Consolidate install logs for readability


### PR DESCRIPTION
what: map markdown `text` fences to plain via remark plugin.
why: avoid noisy "language text" warnings in Astro build.
how to test: npm run lint && npm run type-check && npm run build && npm run audit:ci && SKIP_E2E=1 npm run test:pr.


------
https://chatgpt.com/codex/tasks/task_e_689306b51c58832f8c5d39c14794dc56