### PR TITLE
🧼: refine gravel vacuum item

### DIFF
--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -1311,15 +1311,16 @@
     {
         "id": "97317bc3-507a-4e2c-912b-507d586cee87",
         "name": "gravel vacuum",
-        "description": "Manual siphon with 2 m (6.5 ft) flexible tubing and 4 cm intake for cleaning aquarium substrate and removing water.",
-        "image": "/assets/aquarium_empty.jpg",
+        "description": "Self-priming siphon with 2 m (6.5 ft) hose and 4 cm (1.6 in) tube; moves ~3 L/min to clear debris.",
+        "image": "/assets/gravel.jpg",
         "price": "10 dUSD",
         "hardening": {
-            "passes": 1,
-            "score": 60,
-            "emoji": "🌀",
+            "passes": 2,
+            "score": 80,
+            "emoji": "✅",
             "history": [
-                { "task": "codex-item-hardening-2025-08-05", "date": "2025-08-05", "score": 60 }
+                { "task": "codex-item-hardening-2025-08-05", "date": "2025-08-05", "score": 60 },
+                { "task": "codex-item-hardening-2025-08-06", "date": "2025-08-06", "score": 80 }
             ]
         }
     },


### PR DESCRIPTION
## What
- clarify gravel vacuum description, units and image
- raise hardening to score 80 with history

## Why
- improve realism and process alignment

## How to test
- npm run lint
- npm run type-check
- npm run build
- npm run itemValidation (no tests found)
- npm run test:root -- itemQuality

------
https://chatgpt.com/codex/tasks/task_e_6893c0cbd5cc832fb2038bc5618194cb