### PR TITLE
🎨 : stack QuestForm buttons on mobile

### DIFF
--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -397,6 +397,12 @@
         margin-top: 10px;
     }
 
+    .form-submit {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+    }
+
     .submit-button {
         font-size: 16px;
         padding: 10px 20px;
@@ -444,6 +450,20 @@
         select {
             width: 100%;
             font-size: 14px;
+        }
+
+        .form-submit {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .preview-button {
+            margin-left: 0;
+            width: 100%;
+        }
+
+        .submit-button {
+            width: 100%;
         }
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -88,7 +88,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Verify UI components across browsers 💯
         -   [x] Check offline functionality 💯
     -   [x] Mobile responsiveness
-        -   [x] Adapt quest creation UI for mobile
+        -   [x] Adapt quest creation UI for mobile 💯
         -   [x] Test touch interactions ✅
         -   [x] Verify mobile layouts
     -   [x] Security audit 💯

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -126,7 +126,10 @@ Every quest JSON file must include:
 
 ### Current Implementation State
 
-> **Note:** The full quest editing interface is still under development. The current implementation in `QuestForm.svelte` supports basic quest properties (title, description, image) with more complete dialogue editing planned for future updates.
+> **Note:** The full quest editing interface is still under development. The current implementation in
+> `QuestForm.svelte` supports basic quest properties (title, description, image) with more complete
+> dialogue editing planned for future updates. The form is mobile‑responsive and stacks action buttons
+> on small screens.
 
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
 You can run `npm run generate-quest --template basic` (or `branching`) to scaffold a template JSON file with placeholder dialogue.

--- a/tests/quest-form-mobile.test.ts
+++ b/tests/quest-form-mobile.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const source = readFileSync(
+  'frontend/src/components/svelte/QuestForm.svelte',
+  'utf8'
+);
+
+describe('QuestForm mobile layout', () => {
+  it('stacks submit buttons on narrow screens', () => {
+    expect(source).toMatch(/\.form-submit\s*{[\s\S]*display: flex/);
+    expect(source).toMatch(
+      /@media \(max-width: 480px\)[\s\S]*\.form-submit\s*{[\s\S]*flex-direction: column/
+    );
+  });
+});
+


### PR DESCRIPTION
what: adapt quest creation form for narrow screens; document mobile support.
why: improve mobile usability of quest creation.
how to test: npm run lint && npm run type-check && npm run build && SKIP_E2E=1 npm test.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893c0b6d22c832fa9574133e549bb75