### PR TITLE
Add token.place env override and docs

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -2,10 +2,11 @@ const { vi } = require('vitest');
 const jest = vi;
 
 jest.mock('../src/utils/gameState/common.js', () => ({
-    loadGameState: jest.fn(() => ({ tokenPlace: { url: 'http://token.place' } })),
+    loadGameState: jest.fn(),
 }));
 
 const { tokenPlaceChat } = require('../src/utils/tokenPlace.js');
+const { loadGameState } = require('../src/utils/gameState/common.js');
 
 describe('tokenPlaceChat', () => {
     beforeEach(() => {
@@ -19,11 +20,31 @@ describe('tokenPlaceChat', () => {
 
     afterEach(() => {
         jest.resetAllMocks();
+        delete process.env.VITE_TOKEN_PLACE_URL;
+    });
+
+    test('uses game state url when configured', async () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place' } });
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
+    });
+
+    test('falls back to env url when game state missing', async () => {
+        loadGameState.mockReturnValue({});
+        process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';
+        await tokenPlaceChat([]);
+        expect(fetch).toHaveBeenCalledWith('http://env.token/chat', expect.any(Object));
+    });
+
+    test('uses default url when none provided', async () => {
+        loadGameState.mockReturnValue({});
+        await tokenPlaceChat([]);
+        expect(fetch).toHaveBeenCalledWith('https://token.place/api/chat', expect.any(Object));
     });
 
     test('prepends system message and returns response', async () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place' } });
         const result = await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(fetch).toHaveBeenCalledTimes(1);
         const body = JSON.parse(fetch.mock.calls[0][1].body);
         expect(body.messages[0].role).toBe('system');
         expect(result).toBe('mocked reply');

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -62,7 +62,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
 -   [x] AI Integration
 
-    -   [x] token.place integration
+    -   [x] token.place integration 💯
 
 -   [x] Infrastructure
 

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -1,0 +1,18 @@
+---
+title: 'token.place Integration'
+slug: 'token-place'
+---
+
+DSPACE uses the [token.place](https://token.place) API for in-game AI features like chat.
+The `tokenPlaceChat` utility sends messages to the service and returns the model's reply.
+
+The API endpoint defaults to `https://token.place/api`. You can override it:
+
+-   **Game settings**: set a custom URL in your saved game state.
+-   **Environment variable**: set `VITE_TOKEN_PLACE_URL` when building or running tests.
+
+```bash
+VITE_TOKEN_PLACE_URL=https://my-token-place/api npm run dev
+```
+
+You can clear the saved URL by resetting your game state.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -2,8 +2,20 @@ import { loadGameState } from './gameState/common.js';
 
 const DEFAULT_URL = 'https://token.place/api';
 
+const getEnvUrl = () => {
+    // Prefer Vite-style environment variables but fall back to Node env for tests
+    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TOKEN_PLACE_URL) {
+        return import.meta.env.VITE_TOKEN_PLACE_URL;
+    }
+    if (typeof process !== 'undefined' && process.env?.VITE_TOKEN_PLACE_URL) {
+        return process.env.VITE_TOKEN_PLACE_URL;
+    }
+    return null;
+};
+
 export const tokenPlaceChat = async (messages) => {
-    const baseUrl = loadGameState().tokenPlace?.url || DEFAULT_URL;
+    const envUrl = getEnvUrl();
+    const baseUrl = loadGameState().tokenPlace?.url || envUrl || DEFAULT_URL;
 
     const systemMessage = {
         role: 'system',


### PR DESCRIPTION
## Summary
- allow overriding token.place API via `VITE_TOKEN_PLACE_URL`
- document token.place integration and reset instructions
- mark changelog item complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c0b6d22c832fa9574133e549bb75