### PR TITLE
docs: add secret scan steps to prompt guides

### DIFF
--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -22,7 +22,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case                | Codex Web (ChatGPT sidebar) | Codex CLI                                                          |
+| Use‑case                | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli]                                             |
 | ----------------------- | --------------------------- | ------------------------------------------------------------------ |
 | Add or update a process | “Code” button, attach repo  | `codex "add process 3dprinting/solar-mount"`                       |
 | Ask about process data  | “Ask” button                | `codex exec "explain frontend/src/pages/processes/processes.json"` |
@@ -64,7 +64,8 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run test:root` and fix any failures.
-7. Update docs or items if needed.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+8. Update docs or items if needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -78,15 +79,17 @@ Use this when you want Codex to automatically create or upgrade a process.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/processes.json`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run lint`, `npm run
-type-check`, `npm run build`, and `npm run test:root`).
-Verify the process links to existing quests or items, add missing registry
-entries if needed, and reuse existing image assets.
+steps, durations, item references, and passing checks (`npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:root`). Verify the
+process links to existing quests or items, add missing registry entries if
+needed, reuse existing image assets, and scan for secrets with `git diff
+--cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Follow the steps above.
 2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated process in the PR description.
+4. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request implementing the process with all tests green.
@@ -125,6 +128,8 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:root`. Update docs or items if needed.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the refined process, updated hardening block and passing tests.
@@ -138,3 +143,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Use system prompts** to guide tone and technical accuracy.
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -25,7 +25,7 @@ which covers quests, items and processes in detail.
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case              | Codex Web (ChatGPT sidebar) | Codex CLI                                                          |
+| Use‑case              | Codex Web (ChatGPT sidebar) | [Codex CLI][codex-cli]                                              |
 | --------------------- | --------------------------- | ------------------------------------------------------------------ |
 | Add or update a quest | “Code” button, attach repo  | `codex "add quest solar/led-basics"`                               |
 | Ask about quest files | “Ask” button                | `codex exec "explain frontend/src/pages/quests/json/*.json"`       |
@@ -68,7 +68,8 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- questCanonical questQuality` and fix any failures.
-7. Update docs or dialogue as needed.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+8. Update docs or dialogue as needed.
 
 OUTPUT
 Return **only** the patch (diff) needed.
@@ -83,15 +84,17 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
-(`npm run lint`, `npm run type-check`, `npm run build`, and
-`npm test -- questCanonical questQuality`). Survey existing quests to pick a
-natural predecessor and update `requiresQuests` accordingly. Add missing items
-or processes to their registries and reuse existing image assets.
+(`npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
+questCanonical questQuality`). Survey existing quests to pick a natural
+predecessor and update `requiresQuests` accordingly. Add missing items or
+processes to their registries, reuse existing image assets, and scan for secrets
+with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Follow the steps above.
 2. Run the commands listed in the system prompt before committing.
 3. Summarize the new or updated quest in the PR description.
+4. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request implementing the quest with all tests green.
@@ -113,6 +116,8 @@ USER:
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- questCanonical questQuality`. Fix any failures.
+4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 Return only the diff with the new quest.
@@ -156,8 +161,10 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
+   6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
    questCanonical questQuality`. Update docs if needed.
+   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   8. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the refined quest, updated hardening block and passing tests.
@@ -171,3 +178,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 - **Use system prompts** to guide tone and technical accuracy.
 - **Iterate on outputs** rather than expecting perfection on the first try.
 - **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- document git diff secret scanning for process and quest prompts
- link Codex CLI from prompt tables

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c0c422b0832fa19a40e9c47bca88