### PR TITLE
📝 : – clean Codex prompt doc formatting

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -5,52 +5,52 @@ slug: 'prompts-codex'
 
 # Writing great Codex prompts for the _dspace_ repo
 
-Codex (Web + CLI) is a sandboxed engineering agent that can open this repository,
-run its own tests, and send you a ready‑made PR — but only if you give it a clear,
+Codex (Web + CLI) is a sandboxed engineering agent that can open this repository,
+run its own tests, and send you a ready‑made PR — but only if you give it a clear,
 file‑scoped prompt. This document stores the baseline instructions used when
 invoking Codex on DSPACE and should evolve alongside the project.
- :contentReference[oaicite:0]{index=0}
 
-> **TL;DR**  
-> 1. Scope the task to one or two files.  
-> 2. Say **exactly** what output you expect (diff, test, docs, etc.).  
-> 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
-> mandatory instructions. :contentReference[oaicite:1]{index=1}
+> **TL;DR**
+>
+> 1. Scope the task to one or two files.
+> 2. Say **exactly** what output you expect (diff, test, docs, etc.).
+> 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
+>    mandatory instructions.
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1 Quick start (Web vs CLI)
 
-| Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
+| Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
 | -------------- | --------------------------- | --------------------------------------- |
 | Ad‑hoc feature | “Code” button, attach repo  | `codex "add buy‑button to ProcessView"` |
 | Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
 | CI automation  | –                           | `codex exec --full-auto "run npm test"` |
 
-See the upstream CLI reference for more flags. :contentReference[oaicite:2]{index=2}
+See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
-## 2 Prompt ingredients
+## 2 Prompt ingredients
 
 | Ingredient           | Why it matters                                                     |
 | -------------------- | ------------------------------------------------------------------ |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).   |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).   |
 | **Files to touch**   | Limits search space → faster & cheaper.                            |
 | **Constraints**      | Coding style, a11y, perf, etc.                                     |
-| **Acceptance check** | e.g. “All `npm test` suites pass” or “Return a unified diff only”. |
+| **Acceptance check** | e.g. “All `npm test` suites pass” or “Return a unified diff only”. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
-prompt‑level rules short and concrete. :contentReference[oaicite:3]{index=3}
+prompt‑level rules short and concrete.
 
 ---
 
-## 3 Reusable template
+## 3 Reusable template
 
 ```text
 You are working in democratizedspace/dspace.
 
-GOAL: <one sentence>.
+GOAL: <one sentence>.
 
 FILES OF INTEREST
 - <path/to/File1>   ← brief hint
@@ -71,14 +71,14 @@ Use this template when you want Codex to automatically clear items from the
 [September&nbsp;1,&nbsp;2025 changelog](/docs/changelog/20250901). Tasks are
 tracked with Markdown checkboxes and an emoji status:
 
--   `- [ ]` – work not started
--   `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
--   `- [x] 💯` – thoroughly tested and reviewed
+-   `- [ ]` – work not started
+-   `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
+-   `- [x] 💯` – thoroughly tested and reviewed
 
 Codex should pick a single entry that is either unchecked or checked without a
 💯 and implement it completely. After all tests pass, update that row so the line
 ends with `💯`. When possible, also promote any previously completed rows lacking
-the 💯 emoji.
+the 💯 emoji.
 
 ```text
 SYSTEM:
@@ -120,3 +120,5 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- drop stray citation tags and normalize spaces in Codex prompt guide
- link to Codex CLI docs for additional flags

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: Missing script: "test:ci")*
- `SKIP_E2E=1 npm test`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893ca4306f8832f80b69622e9fcb7be