### PR TITLE
docs: update prompt check steps

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -28,11 +28,14 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 -   **Ask about item data**
     -   Web: use the “Ask” button.
     -   CLI: `codex exec "explain frontend/src/pages/inventory/json/items.json"`
--   **Run item tests**
+-   **Run item checks**
+
     -   Web: –
     -   CLI:
+
         ```bash
-        codex exec "npm run itemValidation && npm run test:root -- itemQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run itemValidation && npm run test:root -- itemQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -28,11 +28,14 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 -   **Ask about process data**
     -   Web: use the “Ask” button.
     -   CLI: `codex exec "explain frontend/src/pages/processes/processes.json"`
--   **Run process tests**
+-   **Run process checks**
+
     -   Web: –
     -   CLI:
+
         ```bash
-        codex exec "npm run test:root"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run test:root"
         ```
 
 See the upstream CLI reference for more flags.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -26,17 +26,19 @@ which covers quests, items and processes in detail.
 ## 1 Quick start (Web vs CLI)
 
 - **Add or update a quest**
-  - Web: use the “Code” button and attach the repo.
-  - CLI: `codex "add quest solar/led-basics"`
+    - Web: use the “Code” button and attach the repo.
+    - CLI: `codex "add quest solar/led-basics"`
 - **Ask about quest files**
-  - Web: use the “Ask” button.
-  - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
-  - Web: –
-  - CLI:
-    ```bash
-    codex exec "npm test -- questCanonical questQuality"
-    ```
+    - Web: use the “Ask” button.
+    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+- **Run quest checks**
+    - Web: –
+    - CLI:
+
+        ```bash
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm test -- questCanonical questQuality"
+        ```
 
 See the upstream CLI reference for more flags.
 


### PR DESCRIPTION
## Summary
- document full lint/type-check/build steps for item, process, and quest prompts
- format prompt guides with Prettier

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ca4306f8832f80b69622e9fcb7be