### PR TITLE
✅ add UI responsiveness metric test and docs

### DIFF
--- a/frontend/__tests__/UIResponsiveness.test.js
+++ b/frontend/__tests__/UIResponsiveness.test.js
@@ -1,8 +1,11 @@
 /** @jest-environment jsdom */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
 const fs = require('fs');
 const path = require('path');
 const svelte = require('svelte/compiler');
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import UIResponsiveness from '../src/components/svelte/UIResponsiveness.svelte';
 
 describe('UIResponsiveness Component', () => {
@@ -16,5 +19,13 @@ describe('UIResponsiveness Component', () => {
             'utf8'
         );
         expect(() => svelte.compile(source)).not.toThrow();
+    });
+
+    it('renders hydration time', async () => {
+        const spy = vi.spyOn(performance, 'now').mockReturnValue(150);
+        const { getByTestId } = render(UIResponsiveness, { startTime: 100 });
+        await tick();
+        expect(getByTestId('hydration-time')).toHaveTextContent('Hydration time: 50 ms');
+        spy.mockRestore();
     });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -82,7 +82,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Performance testing
         -   [x] Load testing custom content system
         -   [x] Database performance benchmarks
-        -   [x] UI responsiveness metrics ✅
+        -   [x] UI responsiveness metrics 💯
     -   [x] Cross‑browser compatibility
         -   [x] Test IndexedDB in all major browsers 💯
         -   [x] Verify UI components across browsers 💯

--- a/frontend/src/pages/docs/md/ui-lifecycle.md
+++ b/frontend/src/pages/docs/md/ui-lifecycle.md
@@ -39,10 +39,20 @@ To avoid hydration mismatches and make tests predictable, follow this pattern in
 -   Use `onMount` for any code that depends on the browser environment.
 -   Include a `data-hydrated="true"` attribute once the component is ready. Tests wait for this attribute before interacting with the component.
 
+## UI Responsiveness Metrics
+
+Before rendering a page, set `window.dspaceStart = performance.now()` to mark the start time. The
+`<UIResponsiveness>` component uses this value and `calculateHydrationTime` to report how long
+hydration takes.
+
 ## Debugging Tips
 
--   Check the browser console for hydration warnings. They usually mean a mismatch between the server-rendered HTML and the hydrated component.
+-   Check the browser console for hydration warnings. They usually mean a mismatch between the
+    server-rendered HTML and the hydrated component.
 -   When writing Playwright tests, wait for `[data-hydrated="true"]` before performing actions.
--   If a component behaves differently in tests versus the browser, ensure initialization logic is wrapped in `onMount`.
+-   If a component behaves differently in tests versus the browser, ensure initialization logic is
+    wrapped in `onMount`.
 
-For additional details on testing strategies, see [Testing Guide](../../../../TESTING.md) and the broader [Developer Guide](../../../../../DEVELOPER_GUIDE.md).
+For additional details on testing strategies, see
+[Testing Guide](../../../../TESTING.md) and the broader
+[Developer Guide](../../../../../DEVELOPER_GUIDE.md).


### PR DESCRIPTION
## Summary
- document hydration metric usage
- test UIResponsiveness component render

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ca2cdbb4832fb9079c028e8705c3