### PR TITLE
feat: stack ProcessForm buttons on mobile

### DIFF
--- a/frontend/src/components/svelte/ProcessForm.svelte
+++ b/frontend/src/components/svelte/ProcessForm.svelte
@@ -433,7 +433,9 @@
     }
 
     .form-submit {
-        text-align: center;
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
         margin-top: 20px;
     }
 
@@ -450,6 +452,17 @@
         .item-row {
             flex-direction: column;
             align-items: flex-start;
+        }
+
+        .form-submit {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .submit-button,
+        .preview-button {
+            width: 100%;
+            margin-left: 0;
         }
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -90,7 +90,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Mobile responsiveness
         -   [x] Adapt quest creation UI for mobile 💯
         -   [x] Test touch interactions ✅
-        -   [x] Verify mobile layouts
+        -   [x] Verify mobile layouts 💯
     -   [x] Security audit 💯
         -   [x] Review content validation
         -   [x] Check data sanitization 💯

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -55,7 +55,7 @@ Fractional values are allowed, so `0.5h` will be interpreted as thirty minutes.
 
 ### Implementation State
 
-The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation now accepts seconds and fractional durations in addition to hours and minutes. The form is also mobile-friendly with controls stacked vertically on small screens. You can toggle **Preview** to test your settings before committing them. End-to-end tests now confirm the preview renders correctly after valid input.
+The current `ProcessForm.svelte` component supports creating processes with all the properties listed above. It includes item selection interfaces for each of the three item relationship types. A built-in preview shows how the process will appear once created, and form validation now accepts seconds and fractional durations in addition to hours and minutes. The form is also mobile-friendly with controls and submit buttons stacked vertically on small screens. You can toggle **Preview** to test your settings before committing them. End-to-end tests now confirm the preview renders correctly after valid input.
 
 ## Process Categories
 

--- a/tests/process-form-mobile.test.ts
+++ b/tests/process-form-mobile.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const source = readFileSync(
+  'frontend/src/components/svelte/ProcessForm.svelte',
+  'utf8'
+);
+
+describe('ProcessForm mobile layout', () => {
+  it('stacks submit buttons on narrow screens', () => {
+    expect(source).toMatch(/\.form-submit\s*{[\s\S]*display:\s*flex/);
+    expect(source).toMatch(
+      /@media \(max-width: 480px\)[\s\S]*\.form-submit\s*{[\s\S]*flex-direction:\s*column/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure ProcessForm buttons use flex layout and stack on narrow screens
- document mobile ProcessForm layout
- test ProcessForm mobile layout and mark changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ca2cdbb4832fb9079c028e8705c3