### PR TITLE
📝 : – document rollback functionality and add test

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -529,8 +529,9 @@ For component state:
 - During development you can quickly wipe progress by calling
   `resetGameState()` from `frontend/src/utils/gameState/common.js`.
 - If something goes wrong, use `rollbackGameState()` to restore the last
-  saved state. The helper `validateGameState()` runs on load to keep the
-  structure intact.
+  saved state (see [Game State Rollback](/docs/rollback) for details).
+  The helper `validateGameState()` runs on load to keep the structure
+  intact.
 
 #### Rollback Use Cases
 

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -61,4 +61,19 @@ describe('gameState - common utilities', () => {
         const rolled = loadGameState();
         expect(rolled.inventory['1']).toBe(1);
     });
+
+    test('rollbackGameState does nothing when no backup exists', () => {
+        const state = loadGameState();
+        state.inventory['1'] = 3;
+        saveGameState(state);
+
+        const updated = loadGameState();
+        updated.inventory['1'] = 4;
+        saveGameState(updated);
+        localStorage.removeItem('gameStateBackup');
+
+        rollbackGameState();
+        const rolled = loadGameState();
+        expect(rolled.inventory['1']).toBe(4);
+    });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -58,7 +58,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Schema version tracking
         -   [x] Migration scripts for v2 to v3
         -   [x] Data integrity validation 💯
-        -   [x] Rollback functionality
+        -   [x] Rollback functionality 💯
 
 -   [x] AI Integration
 

--- a/frontend/src/pages/docs/md/rollback.md
+++ b/frontend/src/pages/docs/md/rollback.md
@@ -1,0 +1,18 @@
+---
+title: 'Game State Rollback'
+slug: 'rollback'
+---
+
+# Game State Rollback
+
+DSPACE keeps a backup of the previous game state before every save. If a change corrupts your data,
+you can revert to the last snapshot using `rollbackGameState()`.
+
+```ts
+import { rollbackGameState } from '../utils/gameState/common.js';
+
+rollbackGameState();
+```
+
+The helper restores the most recently saved snapshot from `localStorage`. If no backup exists,
+the call has no effect.


### PR DESCRIPTION
## Summary
- document game state rollback helper
- cover missing-backup scenario in rollback tests
- note rollback doc in developer guide and changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d27bb520832fb9f3b5eca8014324