### PR TITLE
🔇 : silence non-critical build messages

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
         },
     },
     vite: {
+        logLevel: 'error',
         server: {
             port: parseInt(process.env.PORT) || 3002, // Use PORT env var or default to 3000
             host: '0.0.0.0',

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -130,7 +130,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [ ] Rename orphan `/docs/new-quests-v3` folder to match actual path
         -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
     -   [ ] **CI speed & log cleanliness**
-        -   [ ] Silence non‑critical build messages
+        -   [x] Silence non‑critical build messages 💯
         -   [ ] Consolidate install logs for readability
 
 Authentication for the quest submission form was audited. Tokens are now saved in `localStorage` so you don't need to re‑enter them, and you can clear them at any time. See the updated [Authentication Flow](/docs/authentication) documentation for details.

--- a/tests/astroConfigLogLevel.test.ts
+++ b/tests/astroConfigLogLevel.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+describe('Astro Vite log level', () => {
+  it('silences non-critical build messages', () => {
+    const content = readFileSync('frontend/astro.config.mjs', 'utf8');
+    expect(content).toContain("logLevel: 'error'");
+  });
+});


### PR DESCRIPTION
## Summary
- reduce build log noise by setting Vite `logLevel` to `error`
- track change in changelog and verify via unit test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d27bb520832fb9f3b5eca8014324