### PR TITLE
🐟: harden aquarium item details

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
         "test:e2e:integration": "npm run setup-test-env && playwright test -g \"integrate custom items, processes, and quests\"",
         "test:e2e:fast": "npm run setup-test-env && playwright test --workers=2 page-structure.spec.ts custom-content.spec.ts",
         "coverage": "npm run setup-test-env && vitest run -c ../vitest.config.ts --coverage",
-        "itemValidation": "npm run setup-test-env && vitest run -c ../vitest.config.ts itemValidation.test.js",
+        "itemValidation": "npm run setup-test-env && vitest run --root .. -c vitest.config.ts tests/itemValidation.test.ts",
         "lint": "ESLINT_USE_FLAT_CONFIG=false npx eslint . --max-warnings=0",
         "lint:fix": "ESLINT_USE_FLAT_CONFIG=false npx eslint . --fix",
         "format": "prettier --write \"**/*.{js,ts,svelte,json,md}\"",

--- a/frontend/src/pages/inventory/json/items.json
+++ b/frontend/src/pages/inventory/json/items.json
@@ -537,9 +537,17 @@
     {
         "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a",
         "name": "aquarium (150 L)",
-        "description": "A glass tank for housing fish.",
+        "description": "90×45×45 cm (150 L/40 gal) glass aquarium with 6 mm tempered panels; shipped empty without lid.",
         "image": "/assets/aquarium_empty.jpg",
-        "price": "60 dUSD"
+        "price": "120 dUSD",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-08-06", "date": "2025-08-06", "score": 60 }
+            ]
+        }
     },
     {
         "id": "76307a8e-4e0e-4dfa-abc2-7917d384d82c",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1078,7 +1078,7 @@
     },
     {
         "id": "prepare-aquarium",
-        "title": "Prepare your aquarium",
+        "title": "Prepare a 150 L aquarium",
         "requireItems": [],
         "consumeItems": [
             {

--- a/tests/itemValidation.test.ts
+++ b/tests/itemValidation.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { expect, test } from 'vitest';
+import Ajv from 'ajv';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const schema = JSON.parse(
+  readFileSync(
+    join(__dirname, '../frontend/src/pages/inventory/jsonSchemas/item.json'),
+    'utf8'
+  )
+);
+const items = JSON.parse(
+  readFileSync(
+    join(__dirname, '../frontend/src/pages/inventory/json/items.json'),
+    'utf8'
+  )
+);
+
+test('items conform to schema', () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+  for (const item of items) {
+    const valid = validate(item);
+    if (!valid) {
+      console.error(validate.errors);
+    }
+    expect(valid).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- refine 150 L aquarium item with realistic specs, price, and hardening
- align aquarium preparation process title
- wire up schema validation test for inventory items

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`
- `npm run test:ci` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6893d83f04a8832fac2dc18847879915