### PR TITLE
🩹 Clarify wound-care quest instructions

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/wound-care.json
+++ b/frontend/src/pages/quests/json/firstaid/wound-care.json
@@ -1,14 +1,14 @@
 {
     "id": "firstaid/wound-care",
     "title": "Practice Basic Wound Care",
-    "description": "Practice cleaning a minor cut with soap, gloves, antiseptic wipe and bandage.",
-    "image": "/assets/quests/basic_circuit.svg",
+    "description": "Practice cleaning a minor cut using liquid soap, nitrile gloves, an antiseptic wipe and an adhesive bandage.",
+    "image": "/assets/rescue.jpg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Minor scrapes happen. We'll practice cleaning and dressing one with your first aid kit. Only treat small, superficial cuts; if the wound is deep, gaping, or bleeding heavily, stop and seek medical help instead.",
+            "text": "Minor scrapes happen. We'll clean and dress a small cut with supplies from a first aid kit. Only treat shallow wounds; if it's deep, gaping or bleeding heavily, stop and seek medical care.",
             "options": [
                 {
                     "type": "goto",
@@ -19,12 +19,18 @@
         },
         {
             "id": "clean",
-            "text": "Wash your hands with liquid soap, put on nitrile gloves, gently rinse the cut with clean water, wipe around it with an antiseptic wipe, let it air dry, then cover it with an adhesive bandage. Dispose of used materials properly and stop if pain worsens.",
+            "text": "Scrub your hands with liquid soap under running water for 20 seconds, slip on nitrile gloves, rinse the cut with clean water, wipe around it with a fresh antiseptic wipe, let it air dry, then cover it with an adhesive bandage. Toss used supplies in the trash and stop if pain worsens or numbness appears.",
             "options": [
                 {
                     "type": "process",
                     "process": "clean-minor-cut",
-                    "text": "Clean and dress the cut"
+                    "text": "Clean and dress the cut",
+                    "requiresItems": [
+                        { "id": "55ace400-79ee-4b24-b7da-0b0435ab7d72", "count": 1 },
+                        { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 },
+                        { "id": "b0f10930-53aa-4d45-8bb7-9c7b17f14a5a", "count": 1 },
+                        { "id": "1b1030bf-9767-4b16-9ff6-a8e7de28b689", "count": 1 }
+                    ]
                 },
                 {
                     "type": "goto",
@@ -41,7 +47,7 @@
         },
         {
             "id": "finish",
-            "text": "Great job! Keep the wound clean and dry, change the dressing daily, and seek medical care if redness, swelling, or fever develops.",
+            "text": "Great job! Keep the wound clean and dry, change the bandage daily, and seek medical care if redness, swelling, pus or fever develops.",
             "options": [
                 {
                     "type": "finish",
@@ -53,9 +59,9 @@
     "rewards": [],
     "requiresQuests": ["firstaid/learn-cpr"],
     "hardening": {
-        "passes": 2,
-        "score": 80,
-        "emoji": "✅",
+        "passes": 3,
+        "score": 90,
+        "emoji": "💯",
         "history": [
             {
                 "task": "codex-upgrade-2025-08-02",
@@ -66,6 +72,11 @@
                 "task": "codex-upgrade-2025-08-04",
                 "date": "2025-08-04",
                 "score": 80
+            },
+            {
+                "task": "codex-upgrade-2025-08-06",
+                "date": "2025-08-06",
+                "score": 90
             }
         ]
     }


### PR DESCRIPTION
## What
- refine wound-care quest wording and safety guidance
- add explicit item requirements and update hardening metadata

## Why
- improves clarity and reproducibility for real-world practice

## How to test
- npm run lint
- npm run type-check
- npm run build
- SKIP_E2E=1 npm test -- questCanonical questQuality


------
https://chatgpt.com/codex/tasks/task_e_6893e27040bc832f828bfbe3bc250526