### PR TITLE
🔧 : consolidate CI install logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v2
         with: { version: 9 }
-      - run: pnpm install --frozen-lockfile
-      - run: cd frontend && pnpm install --no-frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=append-only
       - name: Run tests with coverage
         run: pnpm run coverage
       - name: Upload coverage to Codecov

--- a/.github/workflows/quest-chart.yml
+++ b/.github/workflows/quest-chart.yml
@@ -15,7 +15,8 @@ jobs:
             - uses: pnpm/action-setup@v2
               with:
                   version: 9
-            - run: pnpm install --frozen-lockfile
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile --reporter=append-only
             - run: node scripts/generate-quest-chart.js
             - name: Upload chart image
               uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           version: 9
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Run test suite
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ SKIP_E2E=1 npm test
 - Use `npm run check` to verify formatting and linting.
 - Use `npm run audit:ci` to fail on high-severity dependency vulnerabilities.
 - Quest JSON files are validated via a pre-commit hook (`scripts/validate-staged-quests.js`).
-- If dependencies are missing, run `npm ci` in the repo root and `npm ci --prefix frontend`. In
-  CI environments, use `npm run ci:install` to skip Husky hooks.
+- Install dependencies with `pnpm install` in the repo root; this covers the `frontend` workspace.
+  In CI environments, run `pnpm install --frozen-lockfile --reporter=append-only` or use
+  `npm run ci:install` to skip Husky hooks.
 - Fix formatting issues with `npx prettier`.
 - Set `ESLINT_USE_FLAT_CONFIG=false` if running ESLint manually.
 - If a proxy is required, set `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -131,7 +131,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
     -   [ ] **CI speed & log cleanliness**
         -   [x] Silence non‑critical build messages 💯
-        -   [ ] Consolidate install logs for readability
+        -   [x] Consolidate install logs for readability 💯
 
 Authentication for the quest submission form was audited. Tokens are now saved in `localStorage` so you don't need to re‑enter them, and you can clear them at any time. See the updated [Authentication Flow](/docs/authentication) documentation for details.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "generate:item-map": "node scripts/generate-item-dependencies.js",
     "new-quests:update": "node scripts/update-new-quests.js",
     "audit:ci": "npm audit --audit-level=high && npm --prefix frontend audit --audit-level=high",
-    "ci:install": "HUSKY=0 npm ci && HUSKY=0 npm ci --prefix frontend"
+    "ci:install": "HUSKY=0 pnpm install --frozen-lockfile --reporter=append-only"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",


### PR DESCRIPTION
## Summary
- consolidate pnpm installs in workflows
- add append-only reporter for cleaner CI logs
- document workspace install in AGENTS and update ci:install script

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_6893e23108ec832f983cb6779bd2bb8f