### PR TITLE
🩹 Harden clean minor cut process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1563,10 +1563,15 @@
     },
     {
         "id": "clean-minor-cut",
-        "title": "Clean and dress a minor cut",
+        "title": "Wash and bandage a minor cut",
+        "image": "/assets/rescue.jpg",
         "requireItems": [
             {
                 "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                "count": 1
+            },
+            {
+                "id": "799ace33-1336-46c0-904a-9f16778230f1",
                 "count": 1
             }
         ],
@@ -1589,7 +1594,19 @@
             }
         ],
         "createItems": [],
-        "duration": "5m"
+        "duration": "5m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-06",
+                    "date": "2025-08-06",
+                    "score": 65
+                }
+            ]
+        }
     },
     {
         "id": "practice-cpr",


### PR DESCRIPTION
## Summary
- clarify minor cut cleaning with sink requirement and rescue image
- add initial hardening metadata for this process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- processQuality` *(no test files)*
- `npm run test:root`
- `git diff --cached | ripsecrets` *(flagged existing test token)*

Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6893e2585520832fb37185916f9aeb21