### PR TITLE
📝 docs: sync quest prompt security steps

### DIFF
--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -38,7 +38,7 @@ which covers quests, items and processes in detail.
         codex exec "npm test -- questCanonical questQuality"
         ```
 
-See the upstream CLI reference for more flags.
+See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
@@ -75,7 +75,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- questCanonical questQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | ripsecrets` and ensure no secrets.
 8. Update docs or dialogue as needed.
 
 OUTPUT
@@ -95,7 +95,7 @@ completion nodes, at least one item or process reference, and passing checks
 questCanonical questQuality`). Survey existing quests to pick a natural
 predecessor and update `requiresQuests` accordingly. Add missing items or
 processes to their registries, reuse existing image assets, and scan for secrets
-with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+with `git diff --cached | ripsecrets` before committing.
 
 USER:
 1. Follow the steps above.
@@ -123,7 +123,7 @@ USER:
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- questCanonical questQuality`. Fix any failures.
-4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Scan for secrets with `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -171,7 +171,7 @@ USER:
    }
    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
    questCanonical questQuality`. Update docs if needed.
-   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   7. Run `git diff --cached | ripsecrets` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -187,3 +187,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 - **Iterate on outputs** rather than expecting perfection on the first try.
 - **Fact-check technical information** since AI systems can generate plausible
   but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- reference Codex CLI docs in quest prompt guide
- switch secret-scanning instructions to ripsecrets

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e23459b8832fb4efd5cd3f028bdd