### PR TITLE
📝 : refresh prompt docs for CLI and secret scan

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -27,7 +27,7 @@ invoking Codex on DSPACE and should evolve alongside the project.
 | Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
 | CI automation  | –                           | `codex exec --full-auto "run npm test"` |
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the upstream CLI reference for more flags.
 
 ---
 
@@ -120,5 +120,3 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
-
-[codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -35,7 +35,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
         codex exec "npm run itemValidation && npm run test:root -- itemQuality"
         ```
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the upstream CLI reference for more flags.
 
 ---
 
@@ -72,7 +72,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run itemValidation` and `npm run test:root -- itemQuality`, fixing any failures.
-7. Run `git diff --cached | ripsecrets` and ensure no secrets.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message.
 9. Update docs or processes if needed.
 
@@ -91,7 +91,7 @@ create items under `frontend/src/pages/inventory/json/items.json`. Ensure
 realistic details, required fields, and passing checks (`npm run lint`, `npm run
 type-check`, `npm run build`, `npm run itemValidation`, and `npm run test:root -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
-assets, and scan for secrets with `git diff --cached | ripsecrets` before
+assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
 committing.
 
 USER:
@@ -139,7 +139,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run itemValidation`,
    and `npm run test:root -- itemQuality`. Update docs if needed.
-6. Run `git diff --cached | ripsecrets` before committing.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -155,5 +155,3 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
-
-[codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -35,7 +35,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
         codex exec "npm run test:root -- processQuality"
         ```
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the upstream CLI reference for more flags.
 
 ---
 
@@ -71,7 +71,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run test:root -- processQuality` and fix any failures.
-7. Run `git diff --cached | ripsecrets` and ensure no secrets.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or items if needed.
 
 OUTPUT
@@ -90,7 +90,7 @@ steps, durations, item references, and passing checks (`npm run lint`,
 `npm run type-check`, `npm run build`, and `npm run test:root -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
-`git diff --cached | ripsecrets` before committing.
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Follow the steps above.
@@ -136,7 +136,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:root -- processQuality`. Update docs or items if needed.
-6. Run `git diff --cached | ripsecrets` before committing.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -152,5 +152,3 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
-
-[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
what: switch prompt docs to upstream CLI reference and scan-secrets script
why: remove obsolete codex-cli link and ripsecrets usage
how to test: npm run lint && npm run type-check && npm run build && SKIP_E2E=1 npm test

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893e23459b8832fb4efd5cd3f028bdd