### PR TITLE
Draft: docs: encourage running E2E tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --reporter=append-only
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
       - name: Run test suite
         env:
           NODE_OPTIONS: --experimental-vm-modules
-          SKIP_E2E: '1'
         run: npm run test:pr
 
       - name: Generate coverage report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,10 @@
 Run checks locally before opening a pull request:
 
 ```bash
-# Full test suite including lint and unit tests
+# Full test suite including lint, unit, and E2E tests
+npm test
+
+# Skip E2E tests only if browsers are unavailable
 SKIP_E2E=1 npm test
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ npm test
 SKIP_E2E=1 npm test
 ```
 
+- The CI workflow always runs E2E tests and will fail pull requests when they fail.
 - Install Playwright browsers with `npx playwright install chromium` when E2E tests require it.
 - Use `npm run check` to verify formatting and linting.
 - Use `npm run audit:ci` to fail on high-severity dependency vulnerabilities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Thank you for your interest in helping the project! Below is a quick overview of
    npm test
    ```
    Include `SKIP_E2E=1` only if you cannot run the browsers.
+   The CI workflow runs E2E tests and will fail your PR if any of them fail.
 2. Update documentation when adding or changing features.
 3. Open a PR using the provided template and describe your changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,11 @@ Thank you for your interest in helping the project! Below is a quick overview of
   ```
 - The test suite verifies file formatting, so unformatted changes will fail CI.
 - The pre-commit hook validates quest and item schemas, runs `lint-staged`, `npm run check`,
-  and `SKIP_E2E=1 npm test`. Run it manually with:
+  and `npm test`. Run it manually with:
     ```bash
-    SKIP_E2E=1 npm test
+    npm test
     ```
-- If Playwright browsers are missing, install them with `npx playwright install chromium` or set `SKIP_E2E=1`.
+- If Playwright browsers are missing, install them with `npx playwright install chromium` or run `SKIP_E2E=1 npm test`.
 
 ## Opening a Pull Request
 
@@ -32,7 +32,7 @@ Thank you for your interest in helping the project! Below is a quick overview of
    ```bash
    npm test
    ```
-   Include `SKIP_E2E=1` if you cannot run the browsers.
+   Include `SKIP_E2E=1` only if you cannot run the browsers.
 2. Update documentation when adding or changing features.
 3. Open a PR using the provided template and describe your changes.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If Playwright browsers aren't installed, you may skip E2E tests:
 SKIP_E2E=1 npm test
 ```
 
+GitHub Actions runs the E2E tests and fails pull requests when they do not pass.
 If you encounter an error like `browserType.launch: Executable doesn't exist`,
 download the browsers with:
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,16 @@ DSPACE uses a comprehensive testing suite to ensure code quality and prevent reg
 
 ### Pre-PR Testing
 
-Before submitting a pull request, run the comprehensive test suite with:
-
-```bash
-# Skip Playwright tests if browsers aren't installed
-SKIP_E2E=1 npm test
-```
-
-If Playwright browsers are available, omit `SKIP_E2E=1` to run the full suite:
+Before submitting a pull request, run the comprehensive test suite:
 
 ```bash
 npm test
+```
+
+If Playwright browsers aren't installed, you may skip E2E tests:
+
+```bash
+SKIP_E2E=1 npm test
 ```
 
 If you encounter an error like `browserType.launch: Executable doesn't exist`,

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -18,7 +18,10 @@ To run the complete test suite:
 
 ```bash
 # From the project root
-SKIP_E2E=1 npm test  # omit SKIP_E2E=1 for full suite
+npm test
+
+# Skip E2E tests if browsers are missing
+SKIP_E2E=1 npm test
 
 # Or from the frontend directory
 npm run test:all

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -27,6 +27,8 @@ SKIP_E2E=1 npm test
 npm run test:all
 ```
 
+CI runs the E2E suite and blocks pull requests when any E2E test fails.
+
 ### Preventing Playwright Artifact Errors
 
 When running Playwright tests or developing with a recent test history, you might encounter ENOENT errors related to missing trace or network files. We've added tools to prevent these errors:

--- a/frontend/scripts/prepare-pr.sh
+++ b/frontend/scripts/prepare-pr.sh
@@ -50,6 +50,7 @@ if [ -z "$SKIP_E2E" ]; then
   echo "✅ End-to-end tests passed!"
 else
   echo -e "\nStep 3/3: SKIP_E2E is set, skipping end-to-end tests..."
+  echo "⚠️ Remember to run them locally before submitting your PR."
 fi
 
 # All done!

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -86,9 +86,9 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯. Implement it fully, completing any sub-tasks. Provide all code,
 tests and documentation required. Follow `AGENTS.md` and ensure `npm run lint`,
-`npm run type-check`, `npm run build`, and `SKIP_E2E=1 npm test` all pass
-before committing. If Playwright browsers are missing run `npx playwright
-install chromium`.
+`npm run type-check`, `npm run build`, and `npm test` all pass before
+committing. If Playwright browsers are missing run `npx playwright install
+chromium` or use `SKIP_E2E=1 npm test`.
 
 USER:
 1. Follow the steps above.

--- a/frontend/src/pages/docs/md/quest-contribution.md
+++ b/frontend/src/pages/docs/md/quest-contribution.md
@@ -39,6 +39,6 @@ These guidelines outline the process for contributing your custom quests to the 
 
 -   Keep dialogue concise and educational.
 -   Include safety notes where appropriate.
--   Run `SKIP_E2E=1 npm test` before opening a pull request.
+-   Run `npm test` before opening a pull request (use `SKIP_E2E=1 npm test` only if browsers are unavailable).
 
 Happy quest building!

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Astro renders pages server-side and hydrates Svelte components on the client. Place interactive code in `onMount` and mark hydrated components with `data-hydrated="true"` so tests can wait for readiness.
 
-Run `SKIP_E2E=1 npm test` before submitting changes. Install Playwright browsers with `npx playwright install chromium` when needed. Use `npm run check` for lint and format verification.
+Run `npm test` before submitting changes. Install Playwright browsers with `npx playwright install chromium` when needed or use `SKIP_E2E=1 npm test` to skip. Use `npm run check` for lint and format verification.
 
 Quest files live in `frontend/src/pages/quests/json` and must follow the schema in `frontend/src/pages/quests/jsonSchemas`. Each quest requires start, middle and completion nodes plus a `finish` option and at least one inventory item or process.
 


### PR DESCRIPTION
## Summary
- emphasize running `npm test` with E2E by default across docs and scripts
- warn when `SKIP_E2E` skips grouped tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: browser has necessary capabilities for tests)*

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_6894087f6e70832f854de0081ced9afd