### PR TITLE
🪴: add root rinse hydroponics quest

### DIFF
--- a/frontend/src/pages/quests/json/hydroponics/root-rinse.json
+++ b/frontend/src/pages/quests/json/hydroponics/root-rinse.json
@@ -1,0 +1,55 @@
+{
+    "id": "hydroponics/root-rinse",
+    "title": "Rinse the Roots",
+    "description": "Flush salts from the root zone with clean water.",
+    "image": "/assets/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Salt buildup can stress plants. Let's give those roots a quick rinse.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "rinse",
+                    "text": "Sounds good."
+                }
+            ]
+        },
+        {
+            "id": "rinse",
+            "text": "Fill a bucket with dechlorinated water and pour it through the grow media to wash away salts.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "bucket-water-dechlorinated",
+                    "text": "I'll prep the fresh water."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        {
+                            "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Roots rinsed and happy!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Clearing excess salts keeps nutrient uptake smooth.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Back to growing."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/filter-clean"]
+}


### PR DESCRIPTION
## Summary
- add root rinse quest to hydroponics

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `npm run test:ci` *(fails: Missing script "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_68943723267c832fba32e86652056971