### PR TITLE
docs: link Codex CLI in prompt guides

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -35,7 +35,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
         codex exec "npm run itemValidation && npm run test:root -- itemQuality"
         ```
 
-See the upstream CLI reference for more flags.
+See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
@@ -155,3 +155,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -35,7 +35,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
         codex exec "npm run test:root -- processQuality"
         ```
 
-See the upstream CLI reference for more flags.
+See the [Codex CLI documentation][codex-cli] for more flags.
 
 ---
 
@@ -152,3 +152,5 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
+
+[codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- link Codex CLI docs in item and process prompt guides

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689436fda78c832faea78dbb76529473