### PR TITLE
📝 : update quest prompt test instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -35,7 +35,7 @@ which covers quests, items and processes in detail.
     - Web: –
     - CLI:
         ```bash
-        codex exec "npm test -- questCanonical questQuality"
+        codex exec "npm run test:root -- questCanonical questQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
@@ -49,7 +49,7 @@ See the [Codex CLI documentation][codex-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
-| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.            |
+| **Acceptance check** | e.g. “`npm run test:root -- questCanonical questQuality` passes”.   |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -74,8 +74,8 @@ REQUIREMENTS
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
-6. Run `npm test -- questCanonical questQuality` and fix any failures.
-7. Run `git diff --cached | ripsecrets` and ensure no secrets.
+6. Run `npm run test:root -- questCanonical questQuality` and fix any failures.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or dialogue as needed.
 
 OUTPUT
@@ -91,11 +91,12 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
-(`npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
-questCanonical questQuality`). Survey existing quests to pick a natural
-predecessor and update `requiresQuests` accordingly. Add missing items or
-processes to their registries, reuse existing image assets, and scan for secrets
-with `git diff --cached | ripsecrets` before committing.
+(`npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:root -- questCanonical questQuality`). Survey existing quests to
+pick a natural predecessor and update `requiresQuests` accordingly. Add missing
+items or processes to their registries, reuse existing image assets, and scan
+for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+committing.
 
 USER:
 1. Follow the steps above.
@@ -122,8 +123,8 @@ USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm test -- questCanonical questQuality`. Fix any failures.
-4. Scan for secrets with `git diff --cached | ripsecrets` before committing.
+   `npm run test:root -- questCanonical questQuality`. Fix any failures.
+4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -169,9 +170,9 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-   6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test --
-   questCanonical questQuality`. Update docs if needed.
-   7. Run `git diff --cached | ripsecrets` and ensure no secrets.
+   6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:root -- questCanonical questQuality`. Update docs if needed.
+   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
 OUTPUT:


### PR DESCRIPTION
## What
- align quest prompt doc with current test and secret scan commands

## Why
- keep contributor guidance accurate

## How to Test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689436fda78c832faea78dbb76529473