### PR TITLE
📝 refine solder-wire quest with safety gear

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1988,6 +1988,23 @@
         }
     },
     {
+        "id": "solder-wire-connection",
+        "title": "Join two wires with a soldering iron kit and safety goggles",
+        "requireItems": [
+            { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+            { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [{ "task": "codex-refine-2025-08-07", "date": "2025-08-07", "score": 60 }]
+        }
+    },
+    {
         "id": "verify-resistor-color-code",
         "title": "Check resistor value using color bands",
         "requireItems": [{ "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 }],

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -1,39 +1,48 @@
 {
     "id": "electronics/solder-wire",
     "title": "Solder a Wire Connection",
-    "description": "Use a soldering iron to join two wires and restore a circuit.",
+    "description": "Join wires with a soldering iron kit and goggles to restore a circuit.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "A sensor lead snapped. Want to solder it back together?",
-            "options": [{ "type": "goto", "goto": "prep", "text": "Let's fix it." }]
+            "text": "Lead snapped. Repair it? Ventilate, wear goggles, keep iron on stand.",
+            "options": [{ "type": "goto", "goto": "prep", "text": "What gear do I need?" }]
         },
         {
             "id": "prep",
-            "text": "Strip a little insulation, twist the ends, then heat the joint with your iron while feeding solder until it flows.",
+            "text": "Kit and wires ready. Goggles on, heat the iron on its stand, keep area clear.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "solder-wire-connection",
+                    "text": "Review soldering steps"
+                },
                 {
                     "type": "goto",
                     "goto": "finish",
-                    "text": "Joint looks solid.",
+                    "text": "Wire joined and cool",
                     "requiresItems": [
-                        {
-                            "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff",
-                            "count": 1
-                        }
+                        { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 },
+                        { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 }
                     ]
                 }
             ]
         },
         {
             "id": "finish",
-            "text": "Nice work. The connection is strong and conductive again.",
+            "text": "Nice work! Unplug the iron, let it cool, then store the kit and goggles.",
             "options": [{ "type": "finish", "text": "Thanks, Orion!" }]
         }
     ],
     "rewards": [],
-    "requiresQuests": []
+    "requiresQuests": [],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [{ "task": "codex-refine-2025-08-07", "date": "2025-08-07", "score": 60 }]
+    }
 }


### PR DESCRIPTION
## Summary
- add safety gear and process link to solder-wire quest
- document solder-wire-connection process with hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_6894372863c0832f8e19935c4b81afe9