### PR TITLE
refine 5 gallon bucket item and related processes

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -138,9 +138,21 @@
     {
         "id": "0564d441-7367-412e-b709-dad770814a39",
         "name": "5 gallon bucket",
-        "description": "A 5 gallon bucket that can be used to store water or other liquids.",
+        "description": "19 L (5 gal) high-density polyethylene bucket with metal handle for carrying liquids.",
         "image": "/assets/bucket.jpg",
-        "price": "8 dUSD"
+        "price": "8 dUSD",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-07",
+                    "date": "2025-08-07",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "d88ef09c-9191-4c18-8628-a888bb9f926d",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -139,7 +139,7 @@
     },
     {
         "id": "bucket-water-chlorinated",
-        "title": "Use a sink to fill a 5 gallon bucket with tap water",
+        "title": "Use a sink to fill a 19 L (5 gal) bucket with tap water",
         "requireItems": [
             {
                 "id": "799ace33-1336-46c0-904a-9f16778230f1",
@@ -1938,7 +1938,7 @@
     },
     {
         "id": "partial-water-change",
-        "title": "Use a gravel vacuum with 2 m hose and bucket to change 5% of water in a 150 L aquarium",
+        "title": "Use gravel vacuum with 2 m hose and 19 L (5 gal) bucket to change 5% of water in 150 L aquarium",
         "requireItems": [
             { "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a", "count": 1 },
             { "id": "97317bc3-507a-4e2c-912b-507d586cee87", "count": 1 },


### PR DESCRIPTION
## Summary
- clarify 5 gallon bucket description with metric units and add hardening block
- update process titles to mention 19 L bucket

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`
- `git diff --cached | ./scripts/scan-secrets.py` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68943708d2a8832fb2a223c446393b12