### PR TITLE
docs: document custom content schema versioning

### DIFF
--- a/frontend/__tests__/schemaVersion.test.js
+++ b/frontend/__tests__/schemaVersion.test.js
@@ -15,4 +15,17 @@ describe('Custom content DB schema version', () => {
         const version = await getSchemaVersion();
         expect(version).toBe(CUSTOM_CONTENT_DB_VERSION);
     });
+
+    test('defaults to latest version when meta entry is missing', async () => {
+        const db = await openCustomContentDB();
+        const tx = db.transaction('meta', 'readwrite');
+        tx.objectStore('meta').delete('schemaVersion');
+        await new Promise((resolve, reject) => {
+            tx.oncomplete = resolve;
+            /* istanbul ignore next */
+            tx.onerror = (e) => reject(e.target.error);
+        });
+        const version = await getSchemaVersion();
+        expect(version).toBe(CUSTOM_CONTENT_DB_VERSION);
+    });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -55,7 +55,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] IndexedDB implementation
     -   [x] Data migration system
-        -   [x] Schema version tracking
+        -   [x] Schema version tracking 💯
         -   [x] Migration scripts for v2 to v3
         -   [x] Data integrity validation 💯
         -   [x] Rollback functionality 💯

--- a/frontend/src/pages/docs/md/schema-versioning.md
+++ b/frontend/src/pages/docs/md/schema-versioning.md
@@ -1,0 +1,23 @@
+---
+title: 'Custom Content Schema Versioning'
+slug: 'schema-versioning'
+---
+
+# Custom Content Schema Versioning
+
+DSPACE tracks the structure of the custom content database with a numeric schema version. The
+`schemaVersion` entry lives in the `meta` object store of the `CustomContent` IndexedDB database and
+is compared to the current `CUSTOM_CONTENT_DB_VERSION` on startup. If the stored version is older,
+migrations run automatically and the version is updated.
+
+Use `getSchemaVersion` to inspect the current value:
+
+```ts
+import { getSchemaVersion } from '../utils/indexeddb.js';
+
+const version = await getSchemaVersion();
+console.log(`Custom content schema version: ${version}`);
+```
+
+The helper ensures that a missing or outdated entry defaults to the latest schema version so the
+database stays in sync with the application.


### PR DESCRIPTION
## Summary
- document custom content schema versioning and default handling
- mark schema version tracking item complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689436f926f4832fa78f360af69da774