### PR TITLE
🔒: ensure Message content sanitization – add unit test

### DIFF
--- a/frontend/__tests__/Message.test.js
+++ b/frontend/__tests__/Message.test.js
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import Message from '../src/pages/chat/svelte/Message.svelte';
+
+describe('Message component', () => {
+    it('sanitizes dangerous markdown', () => {
+        const { container } = render(Message, {
+            messageMarkdown:
+                '<img src=x onerror="window.hacked=1">' + '<script>window.hacked=2</script>',
+            className: 'user',
+            timestamp: Date.now(),
+        });
+        expect(container.querySelector('script')).toBeNull();
+        const img = container.querySelector('img');
+        expect(img).not.toHaveAttribute('onerror');
+        expect(window).not.toHaveProperty('hacked');
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -92,7 +92,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Test touch interactions ✅
         -   [x] Verify mobile layouts 💯
     -   [x] Security audit 💯
-        -   [x] Review content validation
+        -   [x] Review content validation 💯
         -   [x] Check data sanitization 💯
         -   [x] Audit authentication flow ✅
 


### PR DESCRIPTION
what: add Message component test to verify DOMPurify removes scripts
why: confirm content validation
how to test: npm run check && npm run lint && npm run type-check &&
  npm run build && SKIP_E2E=1 npm test &&
  SKIP_E2E=1 npm run coverage -- --testTimeout 20000
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689436f926f4832fa78f360af69da774