### PR TITLE
harden quest content validation

### DIFF
--- a/frontend/__tests__/customQuestValidation.test.js
+++ b/frontend/__tests__/customQuestValidation.test.js
@@ -81,6 +81,22 @@ describe('validateQuestData', () => {
         expect(result.valid).toBe(true);
     });
 
+    test('HTML tags are rejected', () => {
+        const result = validateQuestData({
+            title: 'Quest',
+            description: 'This <b>quest</b> uses HTML.',
+            image: 'https://example.com/img.png',
+        });
+        expect(result.valid).toBe(false);
+
+        const result2 = validateQuestData({
+            title: '<script>alert(1)</script>',
+            description: 'Valid description for quest.',
+            image: 'https://example.com/img.png',
+        });
+        expect(result2.valid).toBe(false);
+    });
+
     test('requiresQuests must be array of strings', () => {
         const result = validateQuestData({
             title: 'Bad Quest',

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -92,7 +92,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Test touch interactions ✅
         -   [x] Verify mobile layouts 💯
     -   [x] Security audit 💯
-        -   [x] Review content validation
+        -   [x] Review content validation 💯
         -   [x] Check data sanitization 💯
         -   [x] Audit authentication flow ✅
 

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -21,6 +21,7 @@ This guide describes how to submit your custom quests to become part of the offi
     npm test -- questValidation
     ```
     Ensure your quest file passes all schema checks. See the [Quest Schema Requirements](/docs/quest-schema) for field definitions.
+    Quest titles and descriptions must be plain text with no HTML tags.
 4. **Check quest quality** with:
     ```bash
     npm test -- questQuality

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -3,8 +3,8 @@ import Ajv from 'ajv';
 export const customQuestSchema = {
     type: 'object',
     properties: {
-        title: { type: 'string', minLength: 3 },
-        description: { type: 'string', minLength: 10 },
+        title: { type: 'string', minLength: 3, pattern: '^[^<>]*$' },
+        description: { type: 'string', minLength: 10, pattern: '^[^<>]*$' },
         image: {
             type: 'string',
             minLength: 1,


### PR DESCRIPTION
## Summary
- reject HTML tags in custom quest titles and descriptions
- document plain-text requirement for quest submissions
- mark "Review content validation" checklist item as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`
- `npm run audit:ci` *(axios high-severity advisory remains)*


------
https://chatgpt.com/codex/tasks/task_e_689436f926f4832fa78f360af69da774