### PR TITLE
Add wire stripper tool and update solder quest

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -105,5 +105,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "6a3772b6-2550-434f-89f9-2eb53d5b139f",
+        "name": "wire stripper",
+        "description": "Self-adjusting tool for stripping 24-10 AWG insulation cleanly.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "15 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-08",
+                    "date": "2025-08-08",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -1,7 +1,7 @@
 {
     "id": "electronics/solder-wire",
     "title": "Solder a Wire Connection",
-    "description": "Join wires with a soldering iron kit and goggles to restore a circuit.",
+    "description": "Strip and join wires with a wire stripper, soldering iron kit and goggles to restore a circuit.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
@@ -13,7 +13,7 @@
         },
         {
             "id": "prep",
-            "text": "Kit and wires ready. Goggles on, heat the iron on its stand, keep area clear.",
+            "text": "Strip 5 mm of insulation with a wire stripper, heat the iron on its stand, keep the area clear.",
             "options": [
                 {
                     "type": "process",
@@ -26,7 +26,8 @@
                     "text": "Wire joined and cool",
                     "requiresItems": [
                         { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 },
-                        { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 }
+                        { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+                        { "id": "6a3772b6-2550-434f-89f9-2eb53d5b139f", "count": 1 }
                     ]
                 }
             ]


### PR DESCRIPTION
## Summary
- add wire stripper inventory tool with pricing and hardening data
- require wire stripper in solder-wire quest instructions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a326a54832fb7be8e4dd9a6ae77