### PR TITLE
Add claw hammer item and quest requirement

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -105,5 +105,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "5fbabfcf-27d0-48f5-a89e-7aba8ca4b913",
+        "name": "claw hammer",
+        "description": "450 g (16 oz) steel claw hammer with fiberglass handle for driving and removing nails.",
+        "image": "/assets/door.jpg",
+        "price": "10 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-06",
+                    "date": "2025-08-06",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/woodworking/planter-box.json
+++ b/frontend/src/pages/quests/json/woodworking/planter-box.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "gather",
-            "text": "You'll need a few pine boards and some wood glue. I'll supply what you don't have.",
+            "text": "You'll need a few pine boards, some wood glue, and a claw hammer. I'll supply what you don't have.",
             "options": [
                 {
                     "type": "grantsItems",
@@ -30,6 +30,10 @@
                         },
                         {
                             "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399",
+                            "count": 1
+                        },
+                        {
+                            "id": "5fbabfcf-27d0-48f5-a89e-7aba8ca4b913",
                             "count": 1
                         }
                     ],
@@ -47,6 +51,10 @@
                         {
                             "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399",
                             "count": 1
+                        },
+                        {
+                            "id": "5fbabfcf-27d0-48f5-a89e-7aba8ca4b913",
+                            "count": 1
                         }
                     ]
                 }
@@ -54,7 +62,7 @@
         },
         {
             "id": "build",
-            "text": "Cut the boards to length, glue them into a rectangle, and let everything dry overnight.",
+            "text": "Cut the boards to length, use the hammer and glue to assemble the box, and let everything dry overnight.",
             "options": [
                 {
                     "type": "goto",


### PR DESCRIPTION
## Summary
- add a claw hammer tool for woodworking tasks
- require the hammer when building a planter box

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a326a54832fb7be8e4dd9a6ae77