### PR TITLE
🌱 : add pH test strips for nutrient refresh

### DIFF
--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -249,5 +249,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "092dae11-237a-43cc-b342-246aabbba258",
+        "name": "pH test strip pack",
+        "description": "50 litmus strips for checking hydroponic nutrient solution between pH 4 and 9.",
+        "image": "/assets/pH_strip.jpg",
+        "price": "5 dUSD",
+        "unit": "pack",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-08",
+                    "date": "2025-08-08",
+                    "score": 65
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "add",
-            "text": "Slip on nitrile gloves and safety goggles. Measure the manufacturer-recommended dose of hydroponic nutrient solution, dissolve it in a bucket of clean water, then slowly pour it into the reservoir. Keep the submersible water pump running so the solution mixes evenly and wipe up any splashes immediately.",
+            "text": "Slip on nitrile gloves and safety goggles. Measure the manufacturer-recommended dose of hydroponic nutrient solution, dissolve it in a bucket of clean water, then slowly pour it into the reservoir. Keep the submersible water pump running so the solution mixes evenly, wipe up any splashes immediately, and dip a pH strip to confirm the solution is between 5.5 and 6.5.",
             "options": [
                 {
                     "type": "process",
@@ -40,6 +40,10 @@
                         },
                         {
                             "id": "584ca717-4ce1-4ca1-bcd3-38272a52768a",
+                            "count": 1
+                        },
+                        {
+                            "id": "092dae11-237a-43cc-b342-246aabbba258",
                             "count": 1
                         }
                     ]


### PR DESCRIPTION
## Summary
- add pH test strip pack inventory item
- require strips during nutrient-check quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a326a54832fb7be8e4dd9a6ae77