### PR TITLE
docs: add backup guide and mark redundancy complete

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -23,3 +23,5 @@ test-videos/
 src/pages/docs/md/prompts-quests.md
 src/pages/docs/md/quest-guidelines.md
 src/pages/docs/md/new-quests-v3.md
+src/generated/itemQuestMap.json
+src/pages/docs/md/new-quests.md

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -34,6 +34,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/realtime">Everything is real-time</a>
             <a href="/docs/inventory">Inventory</a>
             <a href="/docs/cloud-sync">Cloud Sync</a>
+            <a href="/docs/backups">Backups</a>
             <a href="/docs/authentication">Authentication</a>
             <a href="/docs/achievements">Achievements</a>
             <a href="/docs/titles">Titles</a>

--- a/frontend/src/pages/docs/md/backups.md
+++ b/frontend/src/pages/docs/md/backups.md
@@ -1,0 +1,22 @@
+---
+title: 'Backups'
+---
+
+DSPACE offers manual backup options for both your overall game state and any
+custom content you create.
+
+## Game saves
+
+Visit the [Import/export gamesaves](/gamesaves) page to copy a snapshot of your
+entire progress. Click **Copy** to place the backup string on your clipboard or
+paste a previously saved string and click **Import** to restore it on another
+device.
+
+## Custom content
+
+If you only need to back up user‑created items, quests or processes, open the
+[Custom Content Backup](/contentbackup) page. It provides the same copy and
+import controls but limited to custom creations.
+
+These backups are stored locally until you manually save them elsewhere. For
+automatic cloud backups see [Cloud Sync](/docs/cloud-sync).

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -70,7 +70,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Docker deployment 💯
     -   [x] Redundancy implementation
         -   [x] Load balancer setup 💯
-        -   [x] Backup system ✅
+        -   [x] Backup system 💯
         -   [x] Failover procedures 💯
         -   [x] Monitoring setup 💯
     -   [x] Migration from Netlify

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -10,8 +10,8 @@ slug: 'new-quests'
 These quests exist in the `v3` branch but are not present on `main` yet. Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 144
-New quests in this release: 122
+Current quest count: 152
+New quests in this release: 130
 
 ### 3dprinting
 
@@ -25,6 +25,7 @@ New quests in this release: 122
 
 -   aquaria/aquarium-light
 -   aquaria/breeding
+-   aquaria/filter-rinse
 -   aquaria/floating-plants
 -   aquaria/guppy
 -   aquaria/position-tank
@@ -47,6 +48,7 @@ New quests in this release: 122
 -   astronomy/meteor-shower
 -   astronomy/north-star
 -   astronomy/observe-moon
+-   astronomy/orion-nebula
 -   astronomy/planetary-alignment
 -   astronomy/satellite-pass
 -   astronomy/star-trails
@@ -89,6 +91,7 @@ New quests in this release: 122
 -   electronics/basic-circuit
 -   electronics/check-battery-voltage
 -   electronics/data-logger
+-   electronics/led-polarity
 -   electronics/light-sensor
 -   electronics/potentiometer-dimmer
 -   electronics/servo-sweep
@@ -119,6 +122,8 @@ New quests in this release: 122
 
 ### geothermal
 
+-   geothermal/calibrate-ground-sensor
+-   geothermal/compare-seasonal-ground-temps
 -   geothermal/log-ground-temperature
 -   geothermal/monitor-heat-pump-energy
 -   geothermal/survey-ground-temperature
@@ -131,9 +136,11 @@ New quests in this release: 122
 -   hydroponics/nutrient-check
 -   hydroponics/ph-check
 -   hydroponics/ph-test
+-   hydroponics/plug-soak
 -   hydroponics/pump-install
 -   hydroponics/regrow-stevia
 -   hydroponics/reservoir-refresh
+-   hydroponics/root-rinse
 -   hydroponics/stevia
 -   hydroponics/top-off
 
@@ -143,6 +150,7 @@ New quests in this release: 122
 -   programming/graph-temp
 -   programming/graph-temp-data
 -   programming/hello-sensor
+-   programming/temp-alert
 -   programming/temp-graph
 -   programming/temp-logger
 -   programming/web-server


### PR DESCRIPTION
## Summary
- document game save and custom content backups
- expose backups page in docs navigation
- mark redundancy backup system as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946a191bc8832fa20c718c2ae6d96a