### PR TITLE
feat: hook ItemForm to IndexedDB

### DIFF
--- a/frontend/__tests__/ItemForm.test.js
+++ b/frontend/__tests__/ItemForm.test.js
@@ -211,7 +211,7 @@ describe('ItemForm Component', () => {
 
         const file = new File(['mock content'], 'test.jpg', { type: 'image/jpeg' });
         await act(async () => {
-            fireEvent.change(getByLabelText(/attach an image/i), {
+            fireEvent.change(getByLabelText(/upload an image/i), {
                 target: { files: [file] },
             });
         });

--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -1,6 +1,7 @@
 <script>
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, onMount } from 'svelte';
     import ItemPreview from './ItemPreview.svelte';
+    import { addEntity, updateEntity } from '../../utils/indexeddb.js';
 
     export let name = '';
     export let description = '';
@@ -9,6 +10,8 @@
     export let price = '';
     export let unit = '';
     export let type = '';
+    export let isEdit = false;
+    export let itemData = null;
 
     const dispatch = createEventDispatcher();
     let validationErrors = {};
@@ -37,34 +40,60 @@
         if (!description.trim()) {
             errors.description = 'Description is required';
         }
-        if (!image) {
+        if (!image && !previewUrl) {
             errors.image = 'Image is required';
         }
         validationErrors = errors;
         return Object.keys(errors).length === 0;
     }
 
-    function handleSubmit(event) {
+    async function handleSubmit(event) {
         event.preventDefault();
         if (!validateForm()) {
             return;
         }
-        const formData = new FormData();
-        formData.append('name', name);
-        formData.append('description', description);
-        formData.append('image', image);
-        if (price) {
-            formData.append('price', price);
-        }
-        if (unit) {
-            formData.append('unit', unit);
-        }
-        if (type) {
-            formData.append('type', type);
+
+        let imageUrl = previewUrl;
+        if (image instanceof File) {
+            const uploadData = new FormData();
+            uploadData.append('image', image);
+            const response = await fetch('/api/upload', {
+                method: 'POST',
+                body: uploadData,
+            });
+            const data = await response.json();
+            imageUrl = data.url;
         }
 
-        dispatch('submit', formData);
+        const payload = {
+            name,
+            description,
+            image: imageUrl,
+            ...(price && { price }),
+            ...(unit && { unit }),
+            ...(type && { type }),
+        };
+
+        if (isEdit && itemData?.id) {
+            payload.id = itemData.id;
+            await updateEntity(payload);
+        } else {
+            await addEntity(payload);
+        }
+
+        dispatch('submit', payload);
     }
+
+    onMount(() => {
+        if (isEdit && itemData) {
+            name = itemData.name || '';
+            description = itemData.description || '';
+            price = itemData.price || '';
+            unit = itemData.unit || '';
+            type = itemData.type || '';
+            previewUrl = itemData.image || null;
+        }
+    });
 </script>
 
 <form on:submit={handleSubmit} enctype="multipart/form-data" class="item-form">
@@ -96,7 +125,7 @@
     </div>
 
     <div class="form-group">
-        <label for="image">Attach an Image*</label>
+        <label for="image">Upload an Image*</label>
         <input
             type="file"
             id="image"
@@ -130,7 +159,8 @@
     </div>
 
     <div class="form-submit">
-        <button type="submit" class="submit-button">Create Item</button>
+        <button type="submit" class="submit-button">{isEdit ? 'Update Item' : 'Create Item'}</button
+        >
     </div>
 </form>
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -38,7 +38,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] Custom Items and Processes (using the same system as quests)
 
     -   [x] Item Management ✅
-        -   [x] Item creation interface with `ItemForm.svelte`
+        -   [x] Item creation interface with `ItemForm.svelte` 💯
     -   [x] Item validation schema 💯
         -   [x] Item dependency tracking 💯
     -   [x] Process System

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -44,7 +44,7 @@ Every item requires the following basic properties:
 
 ### Implementation State
 
-Currently, the `ItemForm.svelte` component supports creating items with the properties listed above. The current implementation focuses on the fundamental aspects of items, with more advanced features planned for future updates.
+Currently, the `ItemForm.svelte` component supports creating and editing items with the properties listed above. It uploads images, persists data to IndexedDB, and focuses on the fundamental aspects of items, with more advanced features planned for future updates.
 
 As you fill out the form, an `ItemPreview` component displays a live preview so you can confirm the details before submitting. The layout automatically adjusts on small screens so form fields expand to the full width for easier touch input. You can safely experiment with different values before saving—no data is written until you click **Create Item**.
 


### PR DESCRIPTION
## Summary
- save new or edited items from ItemForm directly to IndexedDB
- document item editing and mark changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`
- `npx jest __tests__/ItemForm.test.js --runInBand --testPathIgnorePatterns=""` *(fails: Cannot find module '../build/Release/canvas.node')*

------
https://chatgpt.com/codex/tasks/task_e_68946a191bc8832fa20c718c2ae6d96a