### PR TITLE
Add wind turbine charging process

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -386,6 +386,13 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "d0758cf9-b5a6-46c7-b4b2-dc24c7d9df67",
+        "name": "dWind",
+        "description": "a token that represents 1 Watt of energy generated using a wind turbine.",
+        "image": "/assets/turbine.jpg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "80a83ecc-bcd2-400e-a469-8488a6453bb8",
         "name": "parachute",
         "description": "A parachute for model rockets.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -2250,5 +2250,20 @@
             { "id": "b02ecff5-1f7d-4247-a09d-7d6cd6bb218a", "count": 200 }
         ],
         "duration": "1h"
+    },
+    {
+        "id": "charge-battery-pack-wind",
+        "title": "Charge a 200 Wh battery pack using a 500 W wind turbine",
+        "image": "/assets/turbine.jpg",
+        "requireItems": [
+            { "id": "743681a7-d2e7-465c-af07-43665079bf4d", "count": 1 },
+            { "id": "cfe87611-623a-45b0-9243-422cd8a73a16", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [
+            { "id": "061fd221-404a-4bd1-9432-3e25b0f17a2c", "count": 200 },
+            { "id": "d0758cf9-b5a6-46c7-b4b2-dc24c7d9df67", "count": 200 }
+        ],
+        "duration": "1h"
     }
 ]


### PR DESCRIPTION
## Summary
- add dWind token to inventory
- add wind turbine charging process generating 200 dWatt and dWind

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- -t processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a420398832fb9781a48492ad839