### PR TITLE
Add mission log entry process

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1085,5 +1085,12 @@
                 }
             ]
         }
+    },
+    {
+        "id": "280ed361-ac70-4ab9-bcd9-aee481790faf",
+        "name": "mission log entry",
+        "description": "One handwritten entry recording a mission event in the logbook.",
+        "image": "/assets/paperwork.jpg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -2160,6 +2160,18 @@
         }
     },
     {
+        "id": "write-mission-log-entry",
+        "title": "Record a mission log entry with a quill pen",
+        "image": "/assets/paperwork.jpg",
+        "requireItems": [
+            { "id": "70bb8d86-2c4e-4330-9705-371891934686", "count": 1 },
+            { "id": "aa82b02f-2617-4474-a91b-29647e4a9780", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [{ "id": "280ed361-ac70-4ab9-bcd9-aee481790faf", "count": 1 }],
+        "duration": "5m"
+    },
+    {
         "id": "measure-aquarium-ph",
         "title": "Test the pH of a 150 L freshwater aquarium using a disposable strip",
         "image": "/assets/pH_strip.jpg",


### PR DESCRIPTION
## Summary
- add mission log entry item
- record mission log entries with quill and logbook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- --passWithNoTests processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a420398832fb9781a48492ad839