### PR TITLE
feat: add water conditioning process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -275,6 +275,22 @@
         }
     },
     {
+        "id": "condition-bucket-water",
+        "title": "Neutralize chlorine in a 5 gal bucket using water conditioner",
+        "image": "/assets/bucket_water.jpg",
+        "requireItems": [
+            { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "16eb261b-9d93-4aff-ab31-40f6a78d04f1", "count": 0.05 },
+            { "id": "156d06b2-ff10-4265-9ae9-3b7753c0206e", "count": 1 }
+        ],
+        "createItems": [
+            { "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }
+        ],
+        "duration": "1m"
+    },
+    {
         "id": "rockwool-soak",
         "title": "Soak 11 hydroponic starter plugs in a 5 gallon bucket of dechlorinated tap water",
         "image": "/assets/rockwool_wet.jpg",

--- a/tests/processQuality.test.ts
+++ b/tests/processQuality.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import processes from '../frontend/src/pages/processes/processes.json';
+import items from '../frontend/src/pages/inventory/json/items';
+
+describe('process quality', () => {
+  it('references valid item ids', () => {
+    const itemIds = new Set((items as Array<any>).map((i) => i.id));
+    for (const proc of processes as Array<any>) {
+      for (const list of ['requireItems', 'consumeItems', 'createItems']) {
+        for (const entry of proc[list] || []) {
+          expect(itemIds.has(entry.id)).toBe(true);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add process to neutralize chlorine in a 5 gal bucket using water conditioner
- add test ensuring processes reference valid item ids

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- processQuality`
- `detect-secrets scan /tmp/diff.patch`


------
https://chatgpt.com/codex/tasks/task_e_68946a420398832fb9781a48492ad839