### PR TITLE
✨ Add resistor color check quest

### DIFF
--- a/frontend/src/pages/quests/json/electronics/resistor-color-check.json
+++ b/frontend/src/pages/quests/json/electronics/resistor-color-check.json
@@ -1,0 +1,68 @@
+{
+    "id": "electronics/resistor-color-check",
+    "title": "Verify resistor color bands",
+    "description": "Confirm a resistor's value by reading its color bands before using it in a circuit.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Need to confirm this resistor's value? Hold off on soldering until we read its stripes.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "check",
+                    "text": "Show me."
+                }
+            ]
+        },
+        {
+            "id": "check",
+            "text": "Orient the tolerance band to the right. Match the colors to the chart or run verify-resistor-color-code. Brown-black-red-gold equals 1 k\u03a9 \u00b15%.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Got 1 k\u03a9.",
+                    "process": "verify-resistor-color-code",
+                    "requiresItems": [
+                        {
+                            "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great. Label the resistor or store it for later use.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73",
+            "count": 1
+        }
+    ],
+    "requiresQuests": [],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-refine-2025-08-07",
+                "date": "2025-08-07",
+                "score": 60
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add electronics quest to verify resistor color bands

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a5b1e1c832fbfb20124b31488bf