### PR TITLE
✨ Add UBI reminder quest

### DIFF
--- a/frontend/src/pages/quests/json/ubi/reminder.json
+++ b/frontend/src/pages/quests/json/ubi/reminder.json
@@ -1,0 +1,49 @@
+{
+    "id": "ubi/reminder",
+    "title": "Set a UBI Reminder",
+    "description": "Schedule a daily reminder so you never miss your dUSD payout.",
+    "image": "/assets/quests/basicincome.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Want help remembering to claim your basic income each day? I can set up a reminder for you.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "setup",
+                    "text": "Yes, please set a reminder."
+                }
+            ]
+        },
+        {
+            "id": "setup",
+            "text": "Great! This will ping you when it's time to claim tomorrow's payment.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "basic-income",
+                    "text": "Schedule the reminder."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "All set!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "You're good to go. Come back each day when the reminder fires to keep the dUSD flowing.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks for the tip!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["ubi/first-payment"]
+}


### PR DESCRIPTION
## Summary
- add quest for scheduling daily basic-income reminder【F:frontend/src/pages/quests/json/ubi/reminder.json†L2-L4】
- trigger basic-income process as part of setup【F:frontend/src/pages/quests/json/ubi/reminder.json†L21-L28】

## Testing
- `npm run lint`【27b313†L3-L8】
- `npm run type-check`【3f0852†L3-L4】
- `npm run build`【2f018b†L2-L21】
- `npm run test:root -- questCanonical questQuality`【c998ba†L3-L15】
- `git diff --cached | ./scripts/scan-secrets.py` (script missing)【15a24e†L1-L3】

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68946a5b1e1c832fbfb20124b31488bf