### PR TITLE
docs: expand prompt test instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -32,7 +32,8 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
     -   Web: –
     -   CLI:
         ```bash
-        codex exec "npm run itemValidation && npm run test:root -- itemQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run itemValidation && npm run test:root -- itemQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -32,7 +32,8 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
     -   Web: –
     -   CLI:
         ```bash
-        codex exec "npm run test:root -- processQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run test:root -- processQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -35,7 +35,8 @@ which covers quests, items and processes in detail.
     - Web: –
     - CLI:
         ```bash
-        codex exec "npm run test:root -- questCanonical questQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run test:root -- questCanonical questQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.


### PR DESCRIPTION
## Summary
- expand CLI test commands in item, process, and quest prompt docs to include lint, type-check, and build

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946a2008ec832f8103b34947863ed5