### PR TITLE
📝 docs: update prompt quick start commands

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -28,11 +28,11 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 -   **Ask about item data**
     -   Web: use the “Ask” button.
     -   CLI: `codex exec "explain frontend/src/pages/inventory/json/items"`
--   **Run item tests**
+-   **Run item checks**
     -   Web: –
     -   CLI:
         ```bash
-        codex exec "npm run itemValidation && npm run test:root -- itemQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && npm run itemValidation && npm run test:root -- itemQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -28,11 +28,11 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 -   **Ask about process data**
     -   Web: use the “Ask” button.
     -   CLI: `codex exec "explain frontend/src/pages/processes/processes.json"`
--   **Run process tests**
+-   **Run process checks**
     -   Web: –
     -   CLI:
         ```bash
-        codex exec "npm run test:root -- processQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && npm run test:root -- processQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -31,11 +31,11 @@ which covers quests, items and processes in detail.
 - **Ask about quest files**
     - Web: use the “Ask” button.
     - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
+- **Run quest checks**
     - Web: –
     - CLI:
         ```bash
-        codex exec "npm run test:root -- questCanonical questQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && npm run test:root -- questCanonical questQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.


### PR DESCRIPTION
## Summary
- expand prompt quick-start commands to run lint, type-check, and build before tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test` *(fails: Prettier and new-quests checks; unrelated to doc changes)*

------
https://chatgpt.com/codex/tasks/task_e_68946a2008ec832f8103b34947863ed5