### PR TITLE
Add JSON API programming quest

### DIFF
--- a/frontend/src/pages/quests/json/programming/json-api.json
+++ b/frontend/src/pages/quests/json/programming/json-api.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/json-api",
+    "title": "Serve JSON Data",
+    "description": "Extend your server to respond with structured JSON.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your web server prints text. Let's make it return JSON.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "Show me how"
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Add an endpoint like /data that replies with `{ message: 'Hello' }`.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "JSON endpoint works!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Clients can now consume your structured data.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "API online"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/web-server"]
+}


### PR DESCRIPTION
## Summary
- introduce "Serve JSON Data" quest after web-server
- requires Raspberry Pi board to demonstrate JSON endpoint

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68946a58a044832fbdeeb34c2bae83a8