### PR TITLE
🛠️ fix Playwright install path in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx --prefix frontend playwright install --with-deps chromium
 
       - name: Run test suite
         env:


### PR DESCRIPTION
what: install Playwright browsers from frontend workspace in tests workflow
why: root npx couldn't find Playwright, causing CI install step to fail
how to test: npm run lint; npm run type-check; npm run build; SKIP_E2E=1 npm test (fails at coverage)
Refs: #000

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68959ef794c0832fbd1816320e2c6d3d