### PR TITLE
🧪 : start frontend server before Playwright tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,19 @@ jobs:
       - name: Install Playwright browsers
         run: npx --prefix frontend playwright install --with-deps chromium
 
+      - name: Build frontend
+        run: pnpm --filter frontend build
+
+      - name: Start frontend server
+        run: |
+          pnpm --filter frontend run preview &
+        env:
+          NODE_ENV: test
+          PORT: 3002
+
+      - name: Wait for frontend server
+        run: npx wait-on http://localhost:3002/
+
       - name: Run test suite
         env:
           NODE_OPTIONS: --experimental-vm-modules


### PR DESCRIPTION
what: build and run frontend in CI tests so e2e can reach it.
why: playwright shop tests failed because server was missing.
how to test: npm run lint && npm run type-check && npm run build.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a55b2860832faf15b5e647847951