### PR TITLE
Remove hardcoded shop item id

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -129,6 +129,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Docs & build noise** 💯
         -   [x] Rename orphan `/docs/new-quests-v3` folder to match actual path 💯
         -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
+        -   [x] Remove hardcoded numeric item ID from shop index 💯
     -   [ ] **CI speed & log cleanliness**
         -   [x] Silence non‑critical build messages 💯
         -   [x] Consolidate install logs for readability 💯

--- a/frontend/src/pages/shop/index.astro
+++ b/frontend/src/pages/shop/index.astro
@@ -4,7 +4,7 @@ import CompactCard from '../../components/CompactCard.astro';
 import { getWalletBalance } from '../../utils';
 import items from '../inventory/json/items';
 
-const item = items.find((item) => item.id === "1");
+const item = items[0];
 ---
 
 <Page title="Shop" columns="1">

--- a/tests/shopIndex.test.ts
+++ b/tests/shopIndex.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('shop index page', () => {
+  it('does not hardcode numeric item id', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, '../frontend/src/pages/shop/index.astro'),
+      'utf8'
+    );
+    expect(source).not.toMatch(/item\.id\s*===\s*['"]\d+['"]/);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid numeric item lookup on shop index
- test and document shop item id handling

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`


------
https://chatgpt.com/codex/tasks/task_e_6896d3b94114832fa050558174b52233