### PR TITLE
🛠 : – replace numeric telescope item ids with uuids

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1003,35 +1003,35 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
-        "id": "148",
+        "id": "0254a829-9002-4a75-8af2-03cd961601da",
         "name": "50 mm magnifying lens",
         "description": "Glass lens with ~50 mm focal length used as a telescope objective.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
-        "id": "149",
+        "id": "7aafe032-86e2-449e-8e25-8148f8c58c17",
         "name": "20 mm magnifying lens",
         "description": "Small lens with ~20 mm focal length for use as a telescope eyepiece.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
-        "id": "150",
+        "id": "2794503d-fbe7-4031-a63e-deac531f9784",
         "name": "cardboard mailing tube",
         "description": "Sturdy cardboard tube about 40 cm long to hold telescope optics.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
-        "id": "151",
+        "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b",
         "name": "camera tripod",
         "description": "Adjustable three-legged stand for stabilizing cameras or small telescopes.",
         "image": "/assets/quests/solar.jpg",
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
-        "id": "152",
+        "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed",
         "name": "masking tape",
         "description": "Low-tack paper tape for temporarily securing lenses during assembly.",
         "image": "/assets/quests/solar.jpg",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1494,11 +1494,11 @@
         "id": "assemble-basic-telescope",
         "title": "Assemble a basic telescope",
         "requireItems": [
-            { "id": "148", "count": 1 },
-            { "id": "149", "count": 1 },
-            { "id": "150", "count": 1 },
-            { "id": "151", "count": 1 },
-            { "id": "152", "count": 1 }
+            { "id": "0254a829-9002-4a75-8af2-03cd961601da", "count": 1 },
+            { "id": "7aafe032-86e2-449e-8e25-8148f8c58c17", "count": 1 },
+            { "id": "2794503d-fbe7-4031-a63e-deac531f9784", "count": 1 },
+            { "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b", "count": 1 },
+            { "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [
@@ -1713,7 +1713,7 @@
                 "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
                 "count": 1
             },
-            { "id": "151", "count": 1 }
+            { "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [],
@@ -1774,7 +1774,7 @@
                 "count": 1
             },
             {
-                "id": "151",
+                "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b",
                 "count": 1
             }
         ],

--- a/frontend/src/pages/quests/json/astronomy/basic-telescope.json
+++ b/frontend/src/pages/quests/json/astronomy/basic-telescope.json
@@ -15,11 +15,11 @@
                     "goto": "build",
                     "text": "I'm ready.",
                     "requiresItems": [
-                        { "id": "148", "count": 1 },
-                        { "id": "149", "count": 1 },
-                        { "id": "150", "count": 1 },
-                        { "id": "151", "count": 1 },
-                        { "id": "152", "count": 1 }
+                        { "id": "0254a829-9002-4a75-8af2-03cd961601da", "count": 1 },
+                        { "id": "7aafe032-86e2-449e-8e25-8148f8c58c17", "count": 1 },
+                        { "id": "2794503d-fbe7-4031-a63e-deac531f9784", "count": 1 },
+                        { "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b", "count": 1 },
+                        { "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed", "count": 1 }
                     ]
                 }
             ]


### PR DESCRIPTION
## What
- migrate leftover numeric item ids in telescope quest to UUIDs

## Why
- ensure item references align with UUID-based id system

## How to Test
- `npm run lint`
- `npm --prefix frontend run format:check`
- `npm run type-check`
- `SKIP_E2E=1 npm run test:pr`
- `npm run build` *(fails: Language does not exist: svelte)*

------
https://chatgpt.com/codex/tasks/task_e_6896d3b94114832fa050558174b52233