### PR TITLE
docs: add Codex CI-failure fix prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -55,6 +55,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
+            <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -1,0 +1,46 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# OpenAI Codex CI-Failure Fix Prompt
+
+Use this drop-in snippet whenever a GitHub Actions run for **democratizedspace/dspace** fails.
+It guides Codex to diagnose the failure and return a pull request that keeps the main branch
+green.
+
+> **Human setup**
+>
+> 1. Open the failed job on GitHub Actions and copy its URL.
+> 2. Paste the URL on the first line of a new ChatGPT message.
+> 3. Hit <kbd>Enter</kbd> twice so two blank lines follow the URL.
+> 4. Copy the block below, paste it after the blanks, then send the message in **Code** mode.
+
+```text
+SYSTEM:
+You are an automated contributor for the democratizedspace/dspace repository.
+
+PURPOSE:
+Diagnose a failed CI run and make it pass.
+
+CONTEXT:
+- Given a link to a failed job, fetch the logs and identify the first real error.
+- Constraints:
+  * Keep existing behaviour intact.
+  * Follow `AGENTS.md` and project style.
+  * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test` locally.
+  * Add or update tests proving the fix.
+  * Update documentation when necessary.
+
+REQUEST:
+1. Explain in the pull-request body why the failure occurred.
+2. Commit the minimal changes needed to fix it.
+3. Push to a branch named `codex/ci-fix/<short-description>`.
+4. Open a pull request that leaves all CI checks green.
+
+OUTPUT:
+A GitHub pull request URL. Include a summary of the root cause and evidence that the
+commands above now succeed.
+```
+
+Copy this file forward whenever CI fails so future fixes stay consistent.


### PR DESCRIPTION
## Summary
- add Codex CI-failure fix prompt with copy-pasteable block
- link new prompt from docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896d9eef48c832f864f89b005b191f3