### PR TITLE
🩹 fix test coverage check for image references

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -225,7 +225,7 @@ We have specialized tests to ensure content quality:
     - Identifies dialogue that doesn't match NPC personalities
     - Uses simple heuristics for now; integration with the OpenAI API is planned
 
-2. **Image Reference Tests** (`imageReferences.test.js`):
+2. **Image Reference Tests** (`scripts/tests/imageReferences.test.ts`):
     - Scans all quest JSON files for image references
     - Verifies that referenced images exist in the public directory
     - Checks for proper image naming conventions
@@ -722,7 +722,8 @@ Unit tests focus on testing individual components, functions, or modules in isol
 
 ### Image Reference Tests
 
-The `imageReferences.test.js` file performs comprehensive validation of all images referenced in quest files:
+The `scripts/tests/imageReferences.test.ts` file performs comprehensive validation of all images
+referenced in quest files:
 
 1. **Existence Verification**: Checks that all referenced images exist in the public directory
 2. **Size Validation**: Warns if images exceed recommended file size limits (150KB)

--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -101,10 +101,10 @@ test('verify Jest test files are included in package.json test configuration', a
 
     scanDirectory(testsDir);
 
-    // Check that our specific files exist
-    const importantTestFiles = ['questQuality.test.js', 'imageReferences.test.js'];
+    // Check that our important Jest test files exist
+    const importantJestTestFiles = ['questQuality.test.js'];
 
-    for (const file of importantTestFiles) {
+    for (const file of importantJestTestFiles) {
         const exists = allJestTestFiles.some(
             (testFile) => testFile === file || testFile.endsWith(`/${file}`)
         );
@@ -116,6 +116,18 @@ test('verify Jest test files are included in package.json test configuration', a
 
         expect(exists).toBeTruthy();
     }
+
+    // Ensure critical vitest file exists in scripts/tests
+    const imageReferencesTestPath = path.resolve(
+        __dirname,
+        '../../scripts/tests/imageReferences.test.ts'
+    );
+    const imageReferencesExists = fs.existsSync(imageReferencesTestPath);
+    if (!imageReferencesExists) {
+        console.error(`Important test file not found: ${imageReferencesTestPath}`);
+        test.fail(true, `Important test file not found: ${imageReferencesTestPath}`);
+    }
+    expect(imageReferencesExists).toBeTruthy();
 
     // Check that Jest config in package.json includes our test pattern
     let jestConfigCapturesAllFiles = false;


### PR DESCRIPTION
## Summary
- point coverage test to scripts/tests/imageReferences.test.ts
- update testing guide for relocated image reference test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896dd96423c832faf482be1fb813ccf