### PR TITLE
🐛 : add Prism Svelte language to fix build

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import node from '@astrojs/node';
 import svelte from '@astrojs/svelte';
+import 'prism-svelte';
 
 // https://astro.build/config
 export default defineConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.6",
         "@types/node": "^24.1.0",
+        "@types/prismjs": "^1.26.5",
         "@vitest/coverage-v8": "^3.2.4",
         "ajv": "^8.12.0",
         "chart.js": "^4.5.0",
@@ -27,6 +28,8 @@
         "jest": "^29.7.0",
         "jsdom": "^26.1.0",
         "prettier-plugin-svelte": "^3.4.0",
+        "prism-svelte": "^0.5.0",
+        "prismjs": "^1.30.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
@@ -2255,6 +2258,13 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -6326,6 +6336,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prism-svelte": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.5.0.tgz",
+      "integrity": "sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prompts": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.6",
     "@types/node": "^24.1.0",
+    "@types/prismjs": "^1.26.5",
     "@vitest/coverage-v8": "^3.2.4",
     "ajv": "^8.12.0",
     "chart.js": "^4.5.0",
@@ -46,6 +47,8 @@
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "prettier-plugin-svelte": "^3.4.0",
+    "prism-svelte": "^0.5.0",
+    "prismjs": "^1.30.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^24.1.0
         version: 24.1.0
+      '@types/prismjs':
+        specifier: ^1.26.5
+        version: 1.26.5
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jsdom@26.1.0(canvas@3.1.2))(yaml@2.8.1))
@@ -57,6 +60,12 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.4.0
         version: 3.4.0(prettier@3.6.2)(svelte@5.37.0)
+      prism-svelte:
+        specifier: ^0.5.0
+        version: 0.5.0
+      prismjs:
+        specifier: ^1.30.0
+        version: 1.30.0
       ts-jest:
         specifier: ^29.1.1
         version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.1.0))(typescript@5.8.3)
@@ -1827,6 +1836,9 @@ packages:
 
   '@types/parse5@6.0.3':
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+
+  '@types/prismjs@1.26.5':
+    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -4329,6 +4341,9 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  prism-svelte@0.5.0:
+    resolution: {integrity: sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -7103,6 +7118,8 @@ snapshots:
       undici-types: 7.8.0
 
   '@types/parse5@6.0.3': {}
+
+  '@types/prismjs@1.26.5': {}
 
   '@types/resolve@1.20.6': {}
 
@@ -10303,6 +10320,8 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  prism-svelte@0.5.0: {}
 
   prismjs@1.30.0: {}
 

--- a/tests/prismSvelte.test.ts
+++ b/tests/prismSvelte.test.ts
@@ -1,0 +1,9 @@
+import Prism from 'prismjs';
+import 'prism-svelte';
+
+describe('Prism Svelte language', () => {
+  it('highlights Svelte code without throwing', () => {
+    const code = `<script>let count = 0;</script>`;
+    expect(() => Prism.highlight(code, Prism.languages.svelte, 'svelte')).not.toThrow();
+  });
+});


### PR DESCRIPTION
what: load prism-svelte and add test for svelte highlighting
why: build failed with "Language does not exist: svelte"
how to test: npm run lint && npm run type-check && npm run build && npm test
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896dd96423c832faf482be1fb813ccf