### PR TITLE
fix: extend Prettier formatting test timeout

### DIFF
--- a/scripts/tests/prettierFormatting.test.ts
+++ b/scripts/tests/prettierFormatting.test.ts
@@ -3,11 +3,15 @@ import { execSync } from 'child_process';
 import path from 'path';
 
 describe('Prettier formatting', () => {
-  test('frontend sources are formatted', () => {
-    const frontendDir = path.join(__dirname, '../../frontend');
-    execSync('npx prettier --check "src/**/*.{md,json}"', {
-      cwd: frontendDir,
-      stdio: 'inherit',
-    });
-  });
+  test(
+    'frontend sources are formatted',
+    () => {
+      const frontendDir = path.join(__dirname, '../../frontend');
+      execSync('npx prettier --check "src/**/*.{md,json}"', {
+        cwd: frontendDir,
+        stdio: 'inherit',
+      });
+    },
+    20000,
+  );
 });


### PR DESCRIPTION
## Summary
- fix failing `pnpm run coverage` by extending the Prettier formatting test timeout

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6896dd96423c832faf482be1fb813ccf