### PR TITLE
Fix tests workflow server startup and timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Start frontend server
         run: |
-          pnpm --filter frontend run dev --port 3002 &
-          npx wait-on http://localhost:3002/
+          pnpm --filter ./frontend run dev --port 3002 &
+          npx wait-on http://localhost:3002/ --timeout 60000
 
       - name: Run test suite
         env:

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -60,5 +60,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 
 > Agents: append a bullet after each successful fix.
 
-- 2025-03-?? – prompt no longer requires a failing job URL; agents must inspect
-  workflows and run local checks when none is provided.
+-   2025-03-?? – prompt no longer requires a failing job URL; agents must inspect
+    workflows and run local checks when none is provided.


### PR DESCRIPTION
## Summary
- ensure pnpm filter uses frontend path so dev server starts
- fail sooner by waiting only 60s for server response
- format CI-fix prompt doc for Prettier

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:pr`


------
https://chatgpt.com/codex/tasks/task_e_6896e6301a28832fa590ea3cbc056326