### PR TITLE
Add EC meter process for nutrient monitoring

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1549,6 +1549,18 @@
         "duration": "1m"
     },
     {
+        "id": "measure-ec-solution",
+        "title": "Measure hydroponic nutrient solution EC with a handheld meter",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            { "id": "71655665-4a59-41f4-9084-dad4d976df91", "count": 1 },
+            { "id": "fc2bb989-f192-4891-8bde-78ae631dae78", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "adjust-ph",
         "title": "Adjust solution pH",
         "requireItems": [

--- a/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
@@ -49,6 +49,15 @@
                     ]
                 },
                 {
+                    "type": "process",
+                    "process": "measure-ec-solution",
+                    "text": "Check EC levels.",
+                    "requiresItems": [
+                        { "id": "71655665-4a59-41f4-9084-dad4d976df91", "count": 1 },
+                        { "id": "fc2bb989-f192-4891-8bde-78ae631dae78", "count": 1 }
+                    ]
+                },
+                {
                     "type": "goto",
                     "goto": "finish",
                     "text": "Reservoir topped off!",


### PR DESCRIPTION
## Summary
- add process to measure hydroponic nutrient solution EC
- allow nutrient check quest to track EC readings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_6896ebcfeb68832f8e848778d0be5147