### PR TITLE
🪵 : add coffee table woodworking quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -26,7 +26,8 @@
             "woodworking/step-stool",
             "woodworking/planter-box",
             "woodworking/bookshelf",
-            "woodworking/birdhouse"
+            "woodworking/birdhouse",
+            "woodworking/coffee-table"
         ],
         "rewards": []
     },
@@ -36,7 +37,8 @@
             "woodworking/step-stool",
             "woodworking/planter-box",
             "woodworking/bookshelf",
-            "woodworking/birdhouse"
+            "woodworking/birdhouse",
+            "woodworking/coffee-table"
         ],
         "rewards": []
     },
@@ -45,7 +47,8 @@
             "woodworking/tool-rack",
             "woodworking/step-stool",
             "woodworking/bookshelf",
-            "woodworking/birdhouse"
+            "woodworking/birdhouse",
+            "woodworking/coffee-table"
         ],
         "rewards": []
     },

--- a/frontend/src/pages/quests/json/woodworking/coffee-table.json
+++ b/frontend/src/pages/quests/json/woodworking/coffee-table.json
@@ -1,0 +1,69 @@
+{
+    "id": "woodworking/coffee-table",
+    "title": "Build a coffee table",
+    "description": "Craft a low table to anchor your living space.",
+    "image": "/assets/door.jpg",
+    "npc": "/assets/npc/atlas.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your bookshelf looks great! Ready for something that ties the room together?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "gather",
+                    "text": "Let's build a coffee table."
+                }
+            ]
+        },
+        {
+            "id": "gather",
+            "text": "We'll need pine boards, wood glue, and your trusty handsaw. Lay everything out before we begin.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "6c075116-ebd1-4147-8666-ec6338ca251e", "count": 6 },
+                        { "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399", "count": 1 },
+                        { "id": "ac6d5ef4-a7ec-4651-8f0c-db4c0ede865e", "count": 1 }
+                    ],
+                    "text": "Gather materials"
+                },
+                {
+                    "type": "goto",
+                    "goto": "assemble",
+                    "requiresItems": [
+                        { "id": "6c075116-ebd1-4147-8666-ec6338ca251e", "count": 6 },
+                        { "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399", "count": 1 },
+                        { "id": "ac6d5ef4-a7ec-4651-8f0c-db4c0ede865e", "count": 1 }
+                    ],
+                    "text": "Materials ready"
+                }
+            ]
+        },
+        {
+            "id": "assemble",
+            "text": "Cut the boards to size, glue a rectangular frame, and add a top. Clamp it tight and let it cure.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Table assembled"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Excellent work! This coffee table will be the centerpiece of many conversations.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Enjoy the new table"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/bookshelf"]
+}


### PR DESCRIPTION
what: add woodworking coffee table quest requiring bookshelf
why: extend woodworking chain with another furniture build
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:root -- questCanonical questQuality
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896eb99892c832f93847547988c8645