### PR TITLE
📝 : clarify Codex prompt doc links

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -20,21 +20,21 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1 Quick start (web vs CLI)
 
--   **Add or update an item**
-    -   Web: use the “Code” button and attach the repo.
-    -   CLI: `codex "add item solar-cell-junction-box"`
--   **Ask about item data**
-    -   Web: use the “Ask” button.
-    -   CLI: `codex exec "explain frontend/src/pages/inventory/json/items"`
--   **Run item tests**
-    -   Web: not supported yet.
-    -   CLI:
-        ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run itemValidation && npm run test:root -- itemQuality"
-        ```
+- **Add or update an item**
+  - Web: use the "Code" button and attach the repo.
+  - CLI: `codex "add item solar-cell-junction-box"`
+- **Ask about item data**
+  - Web: use the "Ask" button.
+  - CLI: `codex exec "explain frontend/src/pages/inventory/json/items"`
+- **Run item tests**
+  - Web: not supported yet.
+  - CLI:
+    ```bash
+    codex exec "npm run lint && npm run type-check && npm run build && \
+    npm run itemValidation && npm run test:root -- itemQuality"
+    ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
 
@@ -152,10 +152,10 @@ A pull request with the refined item, updated hardening block and passing tests.
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible
-    but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible
+  but incorrect details.
 
-[codex-cli]: https://github.com/openai/codex-cli
+[codex-cli]: https://www.npmjs.com/package/codex-cli

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -20,21 +20,21 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1 Quick start (web vs CLI)
 
--   **Add or update a process**
-    -   Web: use the “Code” button and attach the repo.
-    -   CLI: `codex "add process 3dprinting/solar-mount"`
--   **Ask about process data**
-    -   Web: use the “Ask” button.
-    -   CLI: `codex exec "explain frontend/src/pages/processes/processes.json"`
--   **Run process tests**
-    -   Web: not supported yet.
-    -   CLI:
-        ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:root -- processQuality"
-        ```
+- **Add or update a process**
+  - Web: use the "Code" button and attach the repo.
+  - CLI: `codex "add process 3dprinting/solar-mount"`
+- **Ask about process data**
+  - Web: use the "Ask" button.
+  - CLI: `codex exec "explain frontend/src/pages/processes/processes.json"`
+- **Run process tests**
+  - Web: not supported yet.
+  - CLI:
+    ```bash
+    codex exec "npm run lint && npm run type-check && npm run build && \
+    npm run test:root -- processQuality"
+    ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
 
@@ -148,10 +148,10 @@ A pull request with the refined process, updated hardening block and passing tes
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible
-    but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible
+  but incorrect details.
 
 [codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- standardize Quick start list formatting in item and process prompt docs
- point Codex CLI reference to npm package

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: Missing script "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_6896eb402508832f8cc8783aef9ac2f0