### PR TITLE
Warn on zero E2E tests in prepare-pr scripts

### DIFF
--- a/frontend/scripts/prepare-pr.ps1
+++ b/frontend/scripts/prepare-pr.ps1
@@ -38,11 +38,15 @@ try {
 
     # Step 3: Run grouped E2E tests
     Write-Host "`nStep 3/3: Running end-to-end tests (grouped)..."
-    npm run test:e2e:groups
+    $e2eOutput = npm run test:e2e:groups 2>&1
+    Write-Host $e2eOutput
     if ($LASTEXITCODE -ne 0) {
         Write-Host "❌ End-to-end tests failed. Please fix them before submitting your PR." -ForegroundColor Red
         Set-Location -Path $originalDir
         exit 1
+    }
+    if ($e2eOutput -match 'Test Files\s+0' -or $e2eOutput -match 'Tests\s+0' -or $e2eOutput -match 'No test files? found') {
+        Write-Warning "No end-to-end tests were run."
     }
     Write-Host "✅ End-to-end tests passed!" -ForegroundColor Green
 

--- a/frontend/scripts/prepare-pr.sh
+++ b/frontend/scripts/prepare-pr.sh
@@ -41,11 +41,16 @@ echo "✅ Unit tests passed!"
 # Step 3: Run grouped E2E tests (unless disabled)
 if [ -z "$SKIP_E2E" ]; then
   echo -e "\nStep 3/3: Running end-to-end tests (grouped)..."
-  npm run test:e2e:groups
-  if [ $? -ne 0 ]; then
+  E2E_OUTPUT=$(npm run test:e2e:groups 2>&1)
+  E2E_EXIT=$?
+  echo "$E2E_OUTPUT"
+  if [ $E2E_EXIT -ne 0 ]; then
     echo "❌ End-to-end tests failed. Please fix them before submitting your PR."
     cd "$ORIGINAL_DIR" || exit 1
     exit 1
+  fi
+  if echo "$E2E_OUTPUT" | grep -Eq "Test Files\\s+0|Tests\\s+0|No test files? found"; then
+    echo "⚠️  Warning: no end-to-end tests were run."
   fi
   echo "✅ End-to-end tests passed!"
 else

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -117,9 +117,9 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Security & audit pipeline** 💯
         -   [x] Add GitHub Dependabot (`npm`, weekly) 💯
         -   [x] Create `npm run audit:ci` that blocks merges on high‑severity issues 💯
-    -   [ ] **Test harness improvements**
+    -   [x] **Test harness improvements** 💯
         -   [x] Make `npm test` run all suites by default 💯
-        -   [x] Emit a warning if zero tests are detected 💯
+        -   [x] Emit a warning if zero tests are detected (unit & E2E) 💯
     -   [x] **Quest tooling enhancements** 💯
         -   [x] Script to generate UUIDs & inject item/process refs 💯
         -   [x] Pre‑commit hook to validate quests before push 💯


### PR DESCRIPTION
## Summary
- warn when grouped end-to-end tests execute zero cases
- mark test harness improvements complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896eb1fb6d0832f9fc8cfe4938963ea