### PR TITLE
Add schema v3 migration for updatedAt timestamp

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -54,9 +54,9 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] Local‑First Architecture
 
     -   [x] IndexedDB implementation
-    -   [x] Data migration system
+    -   [x] Data migration system 💯
         -   [x] Schema version tracking 💯
-        -   [x] Migration scripts for v2 to v3
+        -   [x] Migration scripts for v2 to v3 💯
         -   [x] Data integrity validation 💯
         -   [x] Rollback functionality 💯
 

--- a/frontend/src/pages/docs/md/schema-versioning.md
+++ b/frontend/src/pages/docs/md/schema-versioning.md
@@ -21,3 +21,8 @@ console.log(`Custom content schema version: ${version}`);
 
 The helper ensures that a missing or outdated entry defaults to the latest schema version so the
 database stays in sync with the application.
+
+## Migration History
+
+-   **v2** – adds a `createdAt` timestamp to items, processes and quests.
+-   **v3** – adds an `updatedAt` timestamp to all records.

--- a/frontend/src/utils/indexeddb.js
+++ b/frontend/src/utils/indexeddb.js
@@ -153,7 +153,7 @@ export function getStoreForEntityType(entityType) {
     }
 }
 
-export const CUSTOM_CONTENT_DB_VERSION = 2;
+export const CUSTOM_CONTENT_DB_VERSION = 3;
 
 export const openCustomContentDB = () => {
     return new Promise((resolve, reject) => {

--- a/frontend/src/utils/migrations.js
+++ b/frontend/src/utils/migrations.js
@@ -25,6 +25,28 @@ export const MIGRATIONS = {
             });
         }
     },
+    3: async (db) => {
+        const stores = ['items', 'processes', 'quests'];
+        for (const storeName of stores) {
+            const tx = db.transaction(storeName, 'readwrite');
+            const store = tx.objectStore(storeName);
+            const req = store.getAll();
+            const records = await new Promise((resolve, reject) => {
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = (e) => reject(e.target.error);
+            });
+            for (const record of records) {
+                if (!record.updatedAt) {
+                    record.updatedAt = record.createdAt || new Date().toISOString();
+                    store.put(record);
+                }
+            }
+            await new Promise((resolve, reject) => {
+                tx.oncomplete = resolve;
+                tx.onerror = (e) => reject(e.target.error);
+            });
+        }
+    },
 };
 
 export async function getCurrentSchemaVersion(db) {

--- a/tests/migrationIntegrity.test.ts
+++ b/tests/migrationIntegrity.test.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
 });
 
 describe('data migration system', () => {
-  test('adds createdAt field and bumps version', async () => {
+  test('adds createdAt and updatedAt fields and bumps version', async () => {
     const db = await openCustomContentDB();
     await saveQuest({
       id: 'q1',
@@ -30,6 +30,7 @@ describe('data migration system', () => {
     await runMigrations(db, CUSTOM_CONTENT_DB_VERSION);
     const quest = await getQuest('q1');
     expect(quest.createdAt).toBeDefined();
+    expect(quest.updatedAt).toBeDefined();
     const version = await getSchemaVersion();
     expect(version).toBe(CUSTOM_CONTENT_DB_VERSION);
     const errors = await validateDataIntegrity(db);


### PR DESCRIPTION
## Summary
- add v3 migration that backfills `updatedAt`
- bump custom content DB version to 3
- document schema migration history

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896eb1fb6d0832f9fc8cfe4938963ea