### PR TITLE
Add pnpm cache to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
       - uses: pnpm/action-setup@v2
         with: { version: 9 }
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
       - uses: pnpm/action-setup@v2
         with:
           version: 9

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -130,9 +130,10 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Rename orphan `/docs/new-quests-v3` folder to match actual path 💯
         -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
         -   [x] Remove hardcoded numeric item ID from shop index 💯
-    -   [ ] **CI speed & log cleanliness**
+    -   [x] **CI speed & log cleanliness** 💯
         -   [x] Silence non‑critical build messages 💯
         -   [x] Consolidate install logs for readability 💯
+        -   [x] Cache pnpm store in CI 💯
 
 Authentication for the quest submission form was audited. Tokens are now saved in `localStorage` so you don't need to re‑enter them, and you can clear them at any time. See the updated [Authentication Flow](/docs/authentication) documentation for details.
 


### PR DESCRIPTION
## Summary
- cache pnpm dependencies in CI workflows
- note CI caching in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 node run-tests.js`


------
https://chatgpt.com/codex/tasks/task_e_6896eb1fb6d0832f9fc8cfe4938963ea