### PR TITLE
Add wire cutters tool to inventory

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -132,5 +132,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+        "name": "wire cutters",
+        "description": "Angled-cutting pliers for trimming component leads and wires cleanly.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "12 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-09-17",
+                    "date": "2025-09-17",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -2312,7 +2312,8 @@
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 },
-            { "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73", "count": 1 }
+            { "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73", "count": 1 },
+            { "id": "ce92a1a9-c817-40f0-92b1-24aff053903d", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [],


### PR DESCRIPTION
## Summary
- add wire cutters tool item priced at 12 dUSD
- require wire cutters in test-cable-continuity process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:root -- itemQuality`
- `npm run test:ci` *(fails: Missing script "test:ci")*


------
https://chatgpt.com/codex/tasks/task_e_6896eb47a830832fb12cc0d0f4972e63