### PR TITLE
🔧 fix: guard server from IndexedDB

### DIFF
--- a/frontend/__tests__/indexeddb.server.test.js
+++ b/frontend/__tests__/indexeddb.server.test.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { vi } from 'vitest';
+
+test('getItems returns empty array when IndexedDB unsupported', async () => {
+    const original = globalThis.indexedDB;
+    delete globalThis.indexedDB;
+    vi.resetModules();
+    const { getItems } = await import('../src/utils/indexeddb.js');
+    const items = await getItems();
+    expect(items).toEqual([]);
+    globalThis.indexedDB = original;
+});

--- a/frontend/src/utils/indexeddb.js
+++ b/frontend/src/utils/indexeddb.js
@@ -13,6 +13,8 @@ function getIndexedDB() {
     return g.indexedDB || g.webkitIndexedDB || g.mozIndexedDB || g.msIndexedDB || null;
 }
 
+const hasIndexedDB = typeof globalThis !== 'undefined' && 'indexedDB' in globalThis;
+
 function openDB() {
     return new Promise((resolve, reject) => {
         if (dbInstance) {
@@ -50,6 +52,9 @@ function openDB() {
 }
 
 function getTransaction(storeName, mode) {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     return openCustomContentDB().then((db) => {
         const transaction = db.transaction([storeName], mode);
         return transaction.objectStore(storeName);
@@ -57,6 +62,9 @@ function getTransaction(storeName, mode) {
 }
 
 export function addEntity(entity) {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     const storeName = getStoreForEntityType(entity.type);
     return getTransaction(storeName, 'readwrite').then((store) => {
         return new Promise((resolve, reject) => {
@@ -72,6 +80,9 @@ export function addEntity(entity) {
 }
 
 export function getEntity(id, entityType) {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     const storeName = getStoreForEntityType(entityType);
     return getTransaction(storeName, 'readonly').then((store) => {
         return new Promise((resolve, reject) => {
@@ -87,6 +98,9 @@ export function getEntity(id, entityType) {
 }
 
 export async function updateEntity(updatedEntity) {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     const storeName = getStoreForEntityType(updatedEntity.type);
     return getTransaction(storeName, 'readwrite').then((store) => {
         return new Promise((resolve, reject) => {
@@ -120,6 +134,9 @@ export async function updateEntity(updatedEntity) {
 }
 
 export function deleteEntity(id, entityType) {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     const storeName = getStoreForEntityType(entityType);
     return getTransaction(storeName, 'readwrite').then((store) => {
         return new Promise((resolve, reject) => {
@@ -205,6 +222,9 @@ export const openCustomContentDB = () => {
 };
 
 export const getSchemaVersion = async () => {
+    if (!hasIndexedDB) {
+        return CUSTOM_CONTENT_DB_VERSION;
+    }
     const db = await openCustomContentDB();
     const tx = db.transaction('meta', 'readonly');
     const store = tx.objectStore('meta');
@@ -223,6 +243,9 @@ export const getSchemaVersion = async () => {
 
 // DB Transaction
 export const saveItem = async (item) => {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('items', 'readwrite');
@@ -247,6 +270,9 @@ export const saveItem = async (item) => {
 
 // Get all items
 export const getItems = async () => {
+    if (!hasIndexedDB) {
+        return [];
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('items', 'readonly');
@@ -271,6 +297,9 @@ export const getItems = async () => {
 
 // Get an item by id
 export const getItem = async (id) => {
+    if (!hasIndexedDB) {
+        return null;
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('items', 'readonly');
@@ -281,9 +310,6 @@ export const getItem = async (id) => {
                 resolve(request.result);
                 db.close();
             };
-            /* istanbul ignore next */
-            /* istanbul ignore next */
-            /* istanbul ignore next */
             /* istanbul ignore next */
             request.onerror = (event) => {
                 reject(event.target.error);
@@ -298,6 +324,9 @@ export const getItem = async (id) => {
 
 // DB Transaction
 export const saveProcess = async (process) => {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('processes', 'readwrite');
@@ -322,6 +351,9 @@ export const saveProcess = async (process) => {
 
 // Get all processes
 export const getProcesses = async () => {
+    if (!hasIndexedDB) {
+        return [];
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('processes', 'readonly');
@@ -346,6 +378,9 @@ export const getProcesses = async () => {
 
 // Get a process by id
 export const getProcess = async (id) => {
+    if (!hasIndexedDB) {
+        return null;
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('processes', 'readonly');
@@ -370,6 +405,9 @@ export const getProcess = async (id) => {
 
 // Delete processes by id
 export const deleteProcess = async (id) => {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('processes', 'readwrite');
@@ -394,6 +432,9 @@ export const deleteProcess = async (id) => {
 
 // DB Transaction
 export const saveQuest = async (quest) => {
+    if (!hasIndexedDB) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('quests', 'readwrite');
@@ -418,6 +459,9 @@ export const saveQuest = async (quest) => {
 
 // Get all quests
 export const getQuests = async () => {
+    if (!hasIndexedDB) {
+        return [];
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('quests', 'readonly');
@@ -442,6 +486,9 @@ export const getQuests = async () => {
 
 // Get a quest by id
 export const getQuest = async (id) => {
+    if (!hasIndexedDB) {
+        return null;
+    }
     try {
         const db = await openCustomContentDB();
         const tx = db.transaction('quests', 'readonly');

--- a/frontend/src/utils/indexeddb.js
+++ b/frontend/src/utils/indexeddb.js
@@ -13,7 +13,9 @@ function getIndexedDB() {
     return g.indexedDB || g.webkitIndexedDB || g.mozIndexedDB || g.msIndexedDB || null;
 }
 
-const hasIndexedDB = typeof globalThis !== 'undefined' && 'indexedDB' in globalThis;
+function hasIndexedDB() {
+    return !!getIndexedDB();
+}
 
 function openDB() {
     return new Promise((resolve, reject) => {
@@ -52,7 +54,7 @@ function openDB() {
 }
 
 function getTransaction(storeName, mode) {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     return openCustomContentDB().then((db) => {
@@ -62,7 +64,7 @@ function getTransaction(storeName, mode) {
 }
 
 export function addEntity(entity) {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     const storeName = getStoreForEntityType(entity.type);
@@ -80,7 +82,7 @@ export function addEntity(entity) {
 }
 
 export function getEntity(id, entityType) {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     const storeName = getStoreForEntityType(entityType);
@@ -98,7 +100,7 @@ export function getEntity(id, entityType) {
 }
 
 export async function updateEntity(updatedEntity) {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     const storeName = getStoreForEntityType(updatedEntity.type);
@@ -134,7 +136,7 @@ export async function updateEntity(updatedEntity) {
 }
 
 export function deleteEntity(id, entityType) {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     const storeName = getStoreForEntityType(entityType);
@@ -222,7 +224,7 @@ export const openCustomContentDB = () => {
 };
 
 export const getSchemaVersion = async () => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return CUSTOM_CONTENT_DB_VERSION;
     }
     const db = await openCustomContentDB();
@@ -243,7 +245,7 @@ export const getSchemaVersion = async () => {
 
 // DB Transaction
 export const saveItem = async (item) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     try {
@@ -270,7 +272,7 @@ export const saveItem = async (item) => {
 
 // Get all items
 export const getItems = async () => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return [];
     }
     try {
@@ -297,7 +299,7 @@ export const getItems = async () => {
 
 // Get an item by id
 export const getItem = async (id) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return null;
     }
     try {
@@ -324,7 +326,7 @@ export const getItem = async (id) => {
 
 // DB Transaction
 export const saveProcess = async (process) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     try {
@@ -351,7 +353,7 @@ export const saveProcess = async (process) => {
 
 // Get all processes
 export const getProcesses = async () => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return [];
     }
     try {
@@ -378,7 +380,7 @@ export const getProcesses = async () => {
 
 // Get a process by id
 export const getProcess = async (id) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return null;
     }
     try {
@@ -405,7 +407,7 @@ export const getProcess = async (id) => {
 
 // Delete processes by id
 export const deleteProcess = async (id) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     try {
@@ -432,7 +434,7 @@ export const deleteProcess = async (id) => {
 
 // DB Transaction
 export const saveQuest = async (quest) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return Promise.reject(new Error('IndexedDB is not supported'));
     }
     try {
@@ -459,7 +461,7 @@ export const saveQuest = async (quest) => {
 
 // Get all quests
 export const getQuests = async () => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return [];
     }
     try {
@@ -486,7 +488,7 @@ export const getQuests = async () => {
 
 // Get a quest by id
 export const getQuest = async (id) => {
-    if (!hasIndexedDB) {
+    if (!hasIndexedDB()) {
         return null;
     }
     try {

--- a/tests/indexeddb.server.test.ts
+++ b/tests/indexeddb.server.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment node
+ * @vitest-environment node
  */
 import { vi } from 'vitest';
 
@@ -7,8 +7,12 @@ test('getItems returns empty array when IndexedDB unsupported', async () => {
     const original = globalThis.indexedDB;
     delete globalThis.indexedDB;
     vi.resetModules();
-    const { getItems } = await import('../src/utils/indexeddb.js');
+    const { getItems } = await import('../frontend/src/utils/indexeddb.js');
     const items = await getItems();
     expect(items).toEqual([]);
-    globalThis.indexedDB = original;
+    if (original) {
+        globalThis.indexedDB = original;
+    } else {
+        delete globalThis.indexedDB;
+    }
 });


### PR DESCRIPTION
## Summary
- guard server from unsupported IndexedDB usage
- add Node test for IndexedDB absence

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`


------
https://chatgpt.com/codex/tasks/task_e_689849b583ec832f89f1d3772541b4f1