### PR TITLE
🧪 fix: add test:ci alias

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -75,3 +75,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-09 – Installing only Chromium left Firefox and WebKit missing; install all
     browsers with `playwright install --with-deps` and print the preview log on failure for
     easier debugging.
+-   2025-08-10 – Missing `test:ci` script broke local CI diagnostics; alias it to `test:pr` so
+    prompts run the complete test suite.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e:groups": "cd frontend && npm run test:e2e:groups",
     "test:e2e:custom": "cd frontend && npm run test:e2e:custom",
     "test:quick": "cd frontend && npm run test:quick",
+    "test:ci": "npm run test:pr",
     "test:pr": "node run-tests.js",
     "check": "cd frontend && npm run check",
     "itemValidation": "cd frontend && npm run itemValidation",

--- a/tests/testCiScript.test.ts
+++ b/tests/testCiScript.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('test:ci script', () => {
+  it('aliases to test:pr', () => {
+    const pkgPath = join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    expect(pkg.scripts['test:ci']).toBe('npm run test:pr');
+  });
+});


### PR DESCRIPTION
what: expose test:ci script and unit test; note lesson.
why: docs and prompts expect test:ci; missing script caused npm error.
how to test: npm run lint && npm run type-check && npm run build && SKIP_E2E=1 npm run test:ci.

------
https://chatgpt.com/codex/tasks/task_e_68990dbe07ec832fa97be1e063e8b6d9