### PR TITLE
Ignore query strings in image checks

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -75,3 +75,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-09 – Installing only Chromium left Firefox and WebKit missing; install all
     browsers with `playwright install --with-deps` and print the preview log on failure for
     easier debugging.
+-   2025-08-10 – `listMissingImages` treated URLs with query strings as missing files; strip
+    query and hash parts before checking so coverage tests don't flag valid assets.

--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+import { listMissingImages } from '../utils/fs-checks';
+
+describe('listMissingImages', () => {
+  test('ignores query and hash in image paths', () => {
+    const images = ['/assets/logo.png?v=1#hash'];
+    const missing = listMissingImages(images);
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -4,7 +4,9 @@ const path = require('path');
 function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '..', 'frontend', 'public')) {
     const missing = [];
     imagePaths.forEach((img) => {
-        const rel = img.startsWith('/') ? img.slice(1) : img;
+        // Strip query strings or hash fragments so existence checks aren't fooled
+        const base = img.split(/[?#]/)[0];
+        const rel = base.startsWith('/') ? base.slice(1) : base;
         const full = path.join(publicDir, rel);
         if (!fs.existsSync(full)) {
             missing.push(img);


### PR DESCRIPTION
## Summary
- handle query and hash fragments in `listMissingImages`
- cover cache-busted URLs with a unit test
- document the fix in the CI prompt guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_689917c087f8832f84af4cfbff5bc763