### PR TITLE
Add custom content load test utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ frontend/coverage/lcov-report/index.html
 
 # Run IndexedDB performance benchmark
 npm run benchmark:db
+
+# Run custom content load test
+npm run loadtest:custom-content
 ```
 
 > **Important:** End-to-end (E2E) tests use Playwright, which automatically starts and stops the development server when needed. You should not manually start a server when running these tests, as this could lead to port conflicts or unexpected behavior.

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -272,6 +272,14 @@ npm run benchmark:db
 
 This script adds and reads a batch of sample records and prints timing metrics so you can track performance regressions.
 
+To stress test the custom content database with concurrent writes, run:
+
+```bash
+npm run loadtest:custom-content
+```
+
+It inserts many items, processes, and quests in parallel and reports how long the operations take.
+
 ### End-to-End Tests
 
 -   E2E test files are in the `e2e/` directory

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
         "generate-quest": "node scripts/generate-quest.mjs",
         "seed:custom": "node scripts/seed-custom-content.js",
         "benchmark:db": "node scripts/db-benchmark.js",
+        "loadtest:custom-content": "node scripts/custom-content-load-test.js",
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js"

--- a/frontend/scripts/custom-content-load-test.js
+++ b/frontend/scripts/custom-content-load-test.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/* istanbul ignore file */
+import 'fake-indexeddb/auto';
+import { runCustomContentLoadTest } from '../src/utils/customContentLoadTest.js';
+
+async function main() {
+    if (!global.window) {
+        global.window = {};
+    }
+    global.window.indexedDB = indexedDB;
+    const result = await runCustomContentLoadTest();
+    console.log(JSON.stringify(result, null, 2));
+}
+
+if (
+    import.meta.url === `file://${process.argv[1]}` ||
+    process.argv[1].endsWith('custom-content-load-test.js')
+) {
+    main().catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
+}
+
+export { main };

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -80,7 +80,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] Testing & QA
 
     -   [x] Performance testing
-        -   [x] Load testing custom content system
+        -   [x] Load testing custom content system 💯
         -   [x] Database performance benchmarks
         -   [x] UI responsiveness metrics 💯
     -   [x] Cross‑browser compatibility

--- a/frontend/src/utils/customContentLoadTest.js
+++ b/frontend/src/utils/customContentLoadTest.js
@@ -1,0 +1,59 @@
+import {
+    saveItem,
+    saveProcess,
+    saveQuest,
+    getItems,
+    getProcesses,
+    getQuests,
+    openCustomContentDB,
+} from './indexeddb.js';
+
+export const DEFAULT_LOAD_TEST_COUNT = 100;
+
+/**
+ * Run a concurrent load test against the custom content database.
+ * Inserts multiple records for each entity type in parallel and reports timing metrics.
+ * @param {object} [options]
+ * @param {number} [options.count=100] Number of records for each entity type
+ * @returns {Promise<{insertMs:number, readMs:number, itemCount:number, processCount:number, questCount:number}>}
+ */
+export async function runCustomContentLoadTest({ count = DEFAULT_LOAD_TEST_COUNT } = {}) {
+    await openCustomContentDB();
+
+    const startInsert = performance.now();
+    const ops = [];
+    for (let i = 0; i < count; i++) {
+        const itemId = `lt-item-${i}`;
+        ops.push(saveItem({ id: itemId, name: `Item ${i}`, description: `Item ${i} description` }));
+        ops.push(
+            saveProcess({
+                id: `lt-proc-${i}`,
+                title: `Process ${i}`,
+                duration: '1s',
+                createItems: [{ id: itemId, count: 1 }],
+            })
+        );
+        ops.push(
+            saveQuest({
+                id: `lt-quest-${i}`,
+                title: `Quest ${i}`,
+                description: `Quest ${i} description`,
+                image: '/assets/quests/default.jpg',
+            })
+        );
+    }
+    await Promise.all(ops);
+    const insertMs = performance.now() - startInsert;
+
+    const startRead = performance.now();
+    const [items, processes, quests] = await Promise.all([getItems(), getProcesses(), getQuests()]);
+    const readMs = performance.now() - startRead;
+
+    return {
+        insertMs,
+        readMs,
+        itemCount: items.length,
+        processCount: processes.length,
+        questCount: quests.length,
+    };
+}

--- a/tests/customContentLoadTest.test.ts
+++ b/tests/customContentLoadTest.test.ts
@@ -1,0 +1,37 @@
+import 'fake-indexeddb/auto';
+import { describe, expect, test, beforeEach } from 'vitest';
+import {
+  runCustomContentLoadTest,
+  DEFAULT_LOAD_TEST_COUNT,
+} from '../frontend/src/utils/customContentLoadTest.js';
+
+function resetDB() {
+  return new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase('CustomContent');
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
+
+describe('runCustomContentLoadTest', () => {
+  beforeEach(async () => {
+    await resetDB();
+  });
+
+  test('returns counts and timing metrics', async () => {
+    const result = await runCustomContentLoadTest({ count: 5 });
+    expect(result.itemCount).toBe(5);
+    expect(result.processCount).toBe(5);
+    expect(result.questCount).toBe(5);
+    expect(result.insertMs).toBeGreaterThan(0);
+    expect(result.readMs).toBeGreaterThan(0);
+  });
+
+  test('uses default count when omitted', async () => {
+    const result = await runCustomContentLoadTest();
+    expect(result.itemCount).toBe(DEFAULT_LOAD_TEST_COUNT);
+    expect(result.processCount).toBe(DEFAULT_LOAD_TEST_COUNT);
+    expect(result.questCount).toBe(DEFAULT_LOAD_TEST_COUNT);
+  });
+});


### PR DESCRIPTION
## Summary
- add concurrent custom content load test script and helper
- document and expose `npm run loadtest:custom-content`
- record completion in 20250901 changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689917c925a4832f8bf62933ef3b51b3