### PR TITLE
🧪 : – stabilize Prettier formatting test

### DIFF
--- a/scripts/tests/prettierFormatting.test.ts
+++ b/scripts/tests/prettierFormatting.test.ts
@@ -3,15 +3,11 @@ import { execSync } from 'child_process';
 import path from 'path';
 
 describe('Prettier formatting', () => {
-  test(
-    'frontend sources are formatted',
-    () => {
-      const frontendDir = path.join(__dirname, '../../frontend');
-      execSync('npx prettier --check "src/**/*.{md,json}"', {
-        cwd: frontendDir,
-        stdio: 'inherit',
-      });
-    },
-    20000,
-  );
+  test('frontend sources are formatted', () => {
+    const frontendDir = path.join(__dirname, '../../frontend');
+    execSync('npm run format:check', {
+      cwd: frontendDir,
+      stdio: 'inherit',
+    });
+  }, 20000);
 });


### PR DESCRIPTION
what: use npm run format:check in Prettier test to pin version and config
why: npx fetched mismatched Prettier, causing false formatting failures
how to test: npm run lint && npm run test:ci
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6899690153d4832f9379c89fb05e5992