### PR TITLE
🧹: ignore processes list JSON in Prettier checks

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -25,3 +25,6 @@ src/pages/docs/md/quest-guidelines.md
 src/pages/docs/md/new-quests-v3.md
 src/generated/itemQuestMap.json
 src/pages/docs/md/new-quests.md
+
+# Large process list; skip Prettier
+src/pages/processes/processes.json


### PR DESCRIPTION
what: add src/pages/processes/processes.json to prettierignore
why: large generated file triggered Prettier failures in tests
how to test: npm run lint && npm run type-check && npm run build &&
npm run coverage
Refs: #869

------
https://chatgpt.com/codex/tasks/task_e_6899690153d4832f9379c89fb05e5992