### PR TITLE
🧪 : align Playwright webServer test with preview command

### DIFF
--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -202,7 +202,7 @@ test('verify playwright web server is properly configured', async ({ page }) => 
 
     // Check that the webServer config exists and is properly configured
     expect(configContent).toContain('webServer:');
-    expect(configContent).toContain("command: 'npm run dev'");
+    expect(configContent).toContain("command: 'npm run preview'");
     expect(configContent).toContain('url: baseURL');
 
     console.log('Playwright webServer is properly configured and running');


### PR DESCRIPTION
## What
- expect preview server command in Playwright test

## Why
- CI uses `npm run preview` to start web server

## How to test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx playwright test e2e/test-coverage.spec.ts --project=chromium`


------
https://chatgpt.com/codex/tasks/task_e_68996e1862b0832f89481f75fec74fbc