### PR TITLE
fix Playwright server command check

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -87,7 +87,7 @@ The automated server is configured in `playwright.config.ts`:
 
 ```typescript
 webServer: {
-  command: 'npm run dev',
+  command: 'npm run preview',
   url: 'http://localhost:3002',
   reuseExistingServer: !process.env.CI,
   stdout: 'ignore',
@@ -97,7 +97,7 @@ webServer: {
 
 This configuration:
 
-1. Starts a server using `npm run dev` before tests begin
+1. Starts a server using `npm run preview` before tests begin
 2. Waits for the server to be available at `http://localhost:3002`
 3. Runs tests against this server
 4. Shuts down the server when tests finish
@@ -582,7 +582,7 @@ if ((await chatButton.count()) > 0) {
 
 Remember that E2E tests require a running development server:
 
--   Server must be running on port 3002 (`npm run dev`)
+-   Server must be running on port 3002 (`npm run preview`)
 -   Run your server in a separate terminal before starting tests
 -   If tests show connection errors, check that your server is running
 

--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -202,7 +202,7 @@ test('verify playwright web server is properly configured', async ({ page }) => 
 
     // Check that the webServer config exists and is properly configured
     expect(configContent).toContain('webServer:');
-    expect(configContent).toContain("command: 'npm run dev'");
+    expect(configContent).toContain("command: 'npm run preview'");
     expect(configContent).toContain('url: baseURL');
 
     console.log('Playwright webServer is properly configured and running');


### PR DESCRIPTION
## Summary
- align test with preview server command
- update E2E testing docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: Shop Functionality group)*
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996e1862b0832f89481f75fec74fbc