### PR TITLE
feat: add photoresistor measurement process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1562,6 +1562,19 @@
         "duration": "1m"
     },
     {
+        "id": "measure-photoresistor",
+        "title": "Measure photoresistor value with a multimeter",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 },
+            { "id": "6301ff22-49c9-468b-88aa-cafedfd5dcd3", "count": 1 },
+            { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "measure-ec-solution",
         "title": "Measure hydroponic nutrient solution EC with a handheld meter",
         "image": "/assets/aquarium_thermometer.jpg",

--- a/frontend/src/pages/quests/json/electronics/light-sensor.json
+++ b/frontend/src/pages/quests/json/electronics/light-sensor.json
@@ -40,8 +40,20 @@
         },
         {
             "id": "wire",
-            "text": "Disconnect the USB cable. Build a voltage divider by connecting one leg of the photoresistor to 5 V and the other to one side of the 10 kΩ resistor, then connect the resistor's far leg to GND. Use the multimeter to confirm roughly 10 kΩ, run a jumper from the junction to A0, keep your goggles on, and make sure no bare wires touch before powering up.",
-            "options": [{ "type": "goto", "goto": "code", "text": "Wired up!" }]
+            "text": "Disconnect the USB cable. Build a voltage divider by connecting one leg of the photoresistor to 5 V and the other to one side of the 10 kΩ resistor, then connect the resistor's far leg to GND. Measure the photoresistor's resistance in ambient light with the multimeter, run a jumper from the junction to A0, keep your goggles on, and make sure no bare wires touch before powering up.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "Wired up and measured.",
+                    "process": "measure-photoresistor",
+                    "requiresItems": [
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 },
+                        { "id": "6301ff22-49c9-468b-88aa-cafedfd5dcd3", "count": 1 },
+                        { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 }
+                    ]
+                }
+            ]
         },
         {
             "id": "code",


### PR DESCRIPTION
## Summary
- add `measure-photoresistor` process for checking a photoresistor with a multimeter
- integrate the new process into the light sensor quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- processQuality`
- `SKIP_E2E=1 pnpm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_689917fa78f4832f8bf14f2d61a90ec1