### PR TITLE
Add composting starter quest

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -2431,5 +2431,16 @@
         ],
         "createItems": [{ "id": "092fdddc-431a-40bd-a66c-f7ef878ae1f8", "count": 1 }],
         "duration": "2h"
+        },
+    {
+        "id": "start-compost-bin",
+        "title": "Start a kitchen compost bucket",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
     }
 ]

--- a/frontend/src/pages/quests/json/composting/start.json
+++ b/frontend/src/pages/quests/json/composting/start.json
@@ -1,0 +1,62 @@
+{
+    "id": "composting/start",
+    "title": "Start a Compost Bucket",
+    "description": "Begin recycling kitchen scraps into soil.",
+    "image": "/assets/bucket.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Waste not, friend! Let's turn scraps into nutrient-rich compost.",
+            "options": [
+                { "type": "goto", "goto": "bucket", "text": "Sounds good!" }
+            ]
+        },
+        {
+            "id": "bucket",
+            "text": "First grab a sturdy bucket to hold your scraps.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ],
+                    "text": "I'll take the bucket."
+                },
+                {
+                    "type": "goto",
+                    "goto": "fill",
+                    "requiresItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ],
+                    "text": "Bucket ready!"
+                }
+            ]
+        },
+        {
+            "id": "fill",
+            "text": "Add plant trimmings and kitchen scraps, then cover with dry leaves.",
+            "options": [
+                { "type": "process", "process": "start-compost-bin", "text": "Adding scraps." },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ],
+                    "text": "The mix looks good!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Keep layering greens and browns, and soon you'll have rich compost.",
+            "options": [
+                { "type": "finish", "text": "Can't wait to see it turn." }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/reservoir-refresh"]
+}


### PR DESCRIPTION
## Summary
- guide players through starting a compost bucket
- register the `start-compost-bin` process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689918074a50832f8a7f4179c8b7993a