### PR TITLE
📝 : update prompt docs to use npm test

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -33,7 +33,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run itemValidation && npm run test:root -- itemQuality"
+        npm run itemValidation && npm test -- itemQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
@@ -42,12 +42,12 @@ See the [Codex CLI documentation][codex-cli] for more flags.
 
 ## 2 Prompt ingredients
 
-| Ingredient           | Why it matters                                                           |
-| -------------------- | ------------------------------------------------------------------------ |
-| **Goal sentence**    | Gives the agent a north star (“Add price to `white PLA filament`”).      |
-| **Files to touch**   | Limits search space → faster & cheaper.                                  |
-| **Constraints**      | Coding style, a11y, item schema rules.                                   |
-| **Acceptance check** | `npm run itemValidation` and<br>`npm run test:root -- itemQuality` pass. |
+| Ingredient           | Why it matters                                                      |
+| -------------------- | ------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add price to `white PLA filament`”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                             |
+| **Constraints**      | Coding style, a11y, item schema rules.                              |
+| **Acceptance check** | `npm run itemValidation` and<br>`npm test -- itemQuality` pass.     |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt-level rules short and concrete.
@@ -72,7 +72,7 @@ REQUIREMENTS
    files and create missing processes as needed.
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
-6. Run `npm run itemValidation` and `npm run test:root -- itemQuality`, fixing any failures.
+6. Run `npm run itemValidation` and `npm test -- itemQuality`, fixing any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : add price field`.
 9. Update docs or processes if needed.
@@ -91,7 +91,7 @@ You are an automated contributor for the DSPACE repository. Edit or
 create items under `frontend/src/pages/inventory/json/items`, choosing the
 appropriate category file. Ensure realistic details, required fields, and
 passing checks (`npm run lint`, `npm run type-check`, `npm run build`,
-`npm run itemValidation`, and `npm run test:root -- itemQuality`).
+`npm run itemValidation`, and `npm test -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
 assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
 committing.
@@ -140,7 +140,7 @@ USER:
      ]
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run itemValidation`,
-   and `npm run test:root -- itemQuality`. Update docs if needed.
+   and `npm test -- itemQuality`. Update docs if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : refine item details`.
 

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -33,7 +33,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:root -- processQuality"
+        npm test -- processQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
@@ -47,7 +47,7 @@ See the [Codex CLI documentation][codex-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add lettuce seed input to hydroponics”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                                 |
 | **Constraints**      | Coding style, a11y, process schema rules.                               |
-| **Acceptance check** | e.g. “`npm run test:root -- processQuality` passes”.                    |
+| **Acceptance check** | e.g. “`npm test -- processQuality` passes”.                             |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -71,7 +71,7 @@ REQUIREMENTS
    missing items or quest hooks as needed.
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
-6. Run `npm run test:root -- processQuality` and fix any failures.
+6. Run `npm test -- processQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or items if needed.
 
@@ -88,7 +88,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/processes.json`. Ensure realistic
 steps, durations, item references, and passing checks (`npm run lint`,
-`npm run type-check`, `npm run build`, and `npm run test:root -- processQuality`).
+`npm run type-check`, `npm run build`, and `npm test -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -136,7 +136,7 @@ USER:
      ]
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:root -- processQuality`. Update docs or items if needed.
+   `npm test -- processQuality`. Update docs or items if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : refine process details`.
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -25,18 +25,18 @@ which covers quests, items and processes in detail.
 
 ## 1 Quick start (Web vs CLI)
 
-- **Add or update a quest**
-    - Web: use the “Code” button and attach the repo.
-    - CLI: `codex "add quest solar/led-basics"`
-- **Ask about quest files**
-    - Web: use the “Ask” button.
-    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
-    - Web: not supported yet.
-    - CLI:
+-   **Add or update a quest**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "add quest solar/led-basics"`
+-   **Ask about quest files**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+-   **Run quest tests**
+    -   Web: not supported yet.
+    -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:root -- questCanonical questQuality"
+        npm test -- questCanonical questQuality"
         ```
 
 See the [Codex CLI documentation][codex-cli] for more flags.
@@ -50,7 +50,7 @@ See the [Codex CLI documentation][codex-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
-| **Acceptance check** | e.g. “`npm run test:root -- questCanonical questQuality` passes”.   |
+| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.            |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -75,7 +75,7 @@ REQUIREMENTS
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
-6. Run `npm run test:root -- questCanonical questQuality` and fix any failures.
+6. Run `npm test -- questCanonical questQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or dialogue as needed.
 
@@ -93,7 +93,7 @@ You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
 (`npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:root -- questCanonical questQuality`). Survey existing quests to
+`npm test -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
 for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
@@ -124,7 +124,7 @@ USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:root -- questCanonical questQuality`. Fix any failures.
+   `npm test -- questCanonical questQuality`. Fix any failures.
 4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 5. Use an emoji-prefixed commit message.
 
@@ -171,8 +171,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-   6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:root -- questCanonical questQuality`. Update docs if needed.
+    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+    `npm test -- questCanonical questQuality`. Update docs if needed.
    7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
@@ -184,10 +184,10 @@ A pull request with the refined quest, updated hardening block and passing tests
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus.
-- **Use system prompts** to guide tone and technical accuracy.
-- **Iterate on outputs** rather than expecting perfection on the first try.
-- **Fact-check technical information** since AI systems can generate plausible
-  but incorrect details.
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://www.npmjs.com/package/codex-cli


### PR DESCRIPTION
## Summary
- sync item/process/quest prompt guides to use `npm test` for quality checks
## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689917d849bc832f9c4e0d33c1f4cf8e