### PR TITLE
📝 : update Codex CLI links in prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -36,7 +36,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
         npm run itemValidation && npm test -- itemQuality"
         ```
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the [Codex CLI repository][codex-cli] for more flags.
 
 ---
 
@@ -158,4 +158,4 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
 
-[codex-cli]: https://www.npmjs.com/package/codex-cli
+[codex-cli]: https://github.com/microsoft/Codex-CLI

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -36,7 +36,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
         npm test -- processQuality"
         ```
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the [Codex CLI repository][codex-cli] for more flags.
 
 ---
 
@@ -154,4 +154,4 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
 
-[codex-cli]: https://www.npmjs.com/package/codex-cli
+[codex-cli]: https://github.com/microsoft/Codex-CLI

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -39,7 +39,7 @@ which covers quests, items and processes in detail.
         npm test -- questCanonical questQuality"
         ```
 
-See the [Codex CLI documentation][codex-cli] for more flags.
+See the [Codex CLI repository][codex-cli] for more flags.
 
 ---
 
@@ -190,4 +190,4 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Fact-check technical information** since AI systems can generate plausible
     but incorrect details.
 
-[codex-cli]: https://www.npmjs.com/package/codex-cli
+[codex-cli]: https://github.com/microsoft/Codex-CLI


### PR DESCRIPTION
## Summary
- replace deprecated NPM link with Codex CLI repository in item, process, and quest prompt docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4f012404832f81a491c0c35b2f99