### PR TITLE
📝 replace secret scanning script in prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -73,7 +73,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run itemValidation` and `npm test -- itemQuality`, fixing any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | detect-secrets scan --string` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : add price field`.
 9. Update docs or processes if needed.
 
@@ -93,7 +93,7 @@ appropriate category file. Ensure realistic details, required fields, and
 passing checks (`npm run lint`, `npm run type-check`, `npm run build`,
 `npm run itemValidation`, and `npm test -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
-assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+assets, and scan for secrets with `git diff --cached | detect-secrets scan --string` before
 committing.
 
 USER:
@@ -141,7 +141,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run itemValidation`,
    and `npm test -- itemQuality`. Update docs if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run `git diff --cached | detect-secrets scan --string` before committing.
 7. Use an emoji-prefixed commit message like `📝 : refine item details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -72,7 +72,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- processQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | detect-secrets scan --string` and ensure no secrets.
 8. Update docs or items if needed.
 
 OUTPUT
@@ -91,7 +91,7 @@ steps, durations, item references, and passing checks (`npm run lint`,
 `npm run type-check`, `npm run build`, and `npm test -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
-`git diff --cached | ./scripts/scan-secrets.py` before committing.
+`git diff --cached | detect-secrets scan --string` before committing.
 
 USER:
 1. Follow the steps above.
@@ -137,7 +137,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- processQuality`. Update docs or items if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run `git diff --cached | detect-secrets scan --string` before committing.
 7. Use an emoji-prefixed commit message like `📝 : refine process details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -76,7 +76,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- questCanonical questQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | detect-secrets scan --string` and ensure no secrets.
 8. Update docs or dialogue as needed.
 
 OUTPUT
@@ -96,7 +96,7 @@ completion nodes, at least one item or process reference, and passing checks
 `npm test -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
-for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+for secrets with `git diff --cached | detect-secrets scan --string` before
 committing.
 
 USER:
@@ -125,7 +125,7 @@ USER:
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- questCanonical questQuality`. Fix any failures.
-4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Scan for secrets with `git diff --cached | detect-secrets scan --string` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -173,7 +173,7 @@ USER:
    }
     6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
     `npm test -- questCanonical questQuality`. Update docs if needed.
-   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   7. Run `git diff --cached | detect-secrets scan --string` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
 OUTPUT:


### PR DESCRIPTION
## Summary
- point docs to `detect-secrets scan --string`
- remove references to removed `scripts/scan-secrets.py`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689a4f012404832f81a491c0c35b2f99