### PR TITLE
📝 refine resistor color check quest

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -595,6 +595,13 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "bf3d2784-d48d-4b12-b12a-75f563b5dc88",
+        "name": "resistor color chart",
+        "description": "Printed reference sheet for decoding resistor color bands.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "6da4a788-b743-4682-8dbe-f23d71435aa4",
         "name": "LED indicator module",
         "description": "5 mm red LED pre-wired with a 220 Ω resistor and jumper leads for breadboard projects.",

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -2155,9 +2155,7 @@
             { "id": "aa82b02f-2617-4474-a91b-29647e4a9780", "count": 1 }
         ],
         "consumeItems": [],
-        "createItems": [
-            { "id": "280ed361-ac70-4ab9-bcd9-aee481790faf", "count": 1 }
-        ],
+        "createItems": [{ "id": "280ed361-ac70-4ab9-bcd9-aee481790faf", "count": 1 }],
         "duration": "2m"
     },
     {
@@ -2200,9 +2198,7 @@
             { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 },
             { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 }
         ],
-        "consumeItems": [
-            { "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 }
-        ],
+        "consumeItems": [{ "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 }],
         "createItems": [],
         "duration": "10m",
         "hardening": {
@@ -2215,7 +2211,10 @@
     {
         "id": "verify-resistor-color-code",
         "title": "Check resistor value using color bands",
-        "requireItems": [{ "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 }],
+        "requireItems": [
+            { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
+            { "id": "bf3d2784-d48d-4b12-b12a-75f563b5dc88", "count": 1 }
+        ],
         "consumeItems": [],
         "createItems": [],
         "duration": "2m",
@@ -2496,14 +2495,12 @@
         ],
         "createItems": [{ "id": "092fdddc-431a-40bd-a66c-f7ef878ae1f8", "count": 1 }],
         "duration": "2h"
-        },
+    },
     {
         "id": "start-compost-bin",
         "title": "Start a kitchen compost bucket",
         "image": "/assets/bucket.jpg",
-        "requireItems": [
-            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
-        ],
+        "requireItems": [{ "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }],
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"

--- a/frontend/src/pages/quests/json/electronics/resistor-color-check.json
+++ b/frontend/src/pages/quests/json/electronics/resistor-color-check.json
@@ -1,14 +1,14 @@
 {
     "id": "electronics/resistor-color-check",
     "title": "Verify resistor color bands",
-    "description": "Confirm a resistor's value by reading its color bands before using it in a circuit.",
+    "description": "Confirm a resistor's value by decoding its color bands before installing it in a circuit.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Need to confirm this resistor's value? Hold off on soldering until we read its stripes.",
+            "text": "Need to confirm this resistor's value? Power down the circuit and hold off on soldering until we read its stripes.",
             "options": [
                 {
                     "type": "goto",
@@ -19,16 +19,20 @@
         },
         {
             "id": "check",
-            "text": "Orient the tolerance band to the right. Match the colors to the chart or run verify-resistor-color-code. Brown-black-red-gold equals 1 k\u03a9 \u00b15%.",
+            "text": "Orient the gold tolerance band to the right. Compare the remaining stripes against a resistor color chart or run verify-resistor-color-code. Red-red-brown-gold equals 220 \u03a9 \u00b15%.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "finish",
-                    "text": "Got 1 k\u03a9.",
+                    "text": "Confirmed 220 \u03a9.",
                     "process": "verify-resistor-color-code",
                     "requiresItems": [
                         {
                             "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                            "count": 1
+                        },
+                        {
+                            "id": "bf3d2784-d48d-4b12-b12a-75f563b5dc88",
                             "count": 1
                         }
                     ]
@@ -54,14 +58,19 @@
     ],
     "requiresQuests": [],
     "hardening": {
-        "passes": 1,
-        "score": 60,
-        "emoji": "🌀",
+        "passes": 2,
+        "score": 78,
+        "emoji": "✅",
         "history": [
             {
                 "task": "codex-refine-2025-08-07",
                 "date": "2025-08-07",
                 "score": 60
+            },
+            {
+                "task": "codex-refine-2025-08-11",
+                "date": "2025-08-11",
+                "score": 78
             }
         ]
     }


### PR DESCRIPTION
## Summary
- clarify resistor color check quest with safety note and 220 Ω example
- add resistor color chart item and require it in verification process
- bump hardening to second pass with refreshed score

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689a4f630128832f8f8a09564f573d15