### PR TITLE
feat: add roll of coins item and quest reward

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1148,6 +1148,25 @@
         }
     },
     {
+        "id": "50ada74c-686d-4818-9421-e02d98444579",
+        "name": "roll of coins",
+        "description": "Paper-wrapped roll of twenty 0.5 dUSD coins for arcade machines and small purchases.",
+        "image": "/assets/coins.jpg",
+        "price": "10 dUSD",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-11",
+                    "date": "2025-08-11",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "280ed361-ac70-4ab9-bcd9-aee481790faf",
         "name": "mission log entry",
         "description": "One handwritten entry recording a mission event in the logbook.",

--- a/frontend/src/pages/quests/json/welcome/run-tests.json
+++ b/frontend/src/pages/quests/json/welcome/run-tests.json
@@ -13,12 +13,15 @@
         },
         {
             "id": "finish",
-            "text": "Great job! Running the test suite provides useful information and ensures your contributions are solid.",
+            "text": "Great job! Running the test suite keeps DSPACE reliable. Enjoy a roll of coins as a bonus!",
             "options": [
                 {
                     "type": "finish",
                     "text": "All tests passed",
-                    "grantsItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }]
+                    "grantsItems": [
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "50ada74c-686d-4818-9421-e02d98444579", "count": 1 }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Summary
- add roll of coins item to misc inventory
- reward roll of coins in run-tests quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `SKIP_E2E=1 npm test -- itemQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689a4f36dc50832fbac72af71903658a