### PR TITLE
Add Saturn rings quest

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1788,6 +1788,23 @@
         }
     },
     {
+        "id": "observe-saturn-rings",
+        "title": "Observe Saturn's rings through a basic telescope",
+        "requireItems": [
+            { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+            { "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [{ "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 65 }]
+        }
+    },
+    {
         "id": "identify-constellations",
         "title": "Identify constellations with a star chart",
         "requireItems": [
@@ -2155,9 +2172,7 @@
             { "id": "aa82b02f-2617-4474-a91b-29647e4a9780", "count": 1 }
         ],
         "consumeItems": [],
-        "createItems": [
-            { "id": "280ed361-ac70-4ab9-bcd9-aee481790faf", "count": 1 }
-        ],
+        "createItems": [{ "id": "280ed361-ac70-4ab9-bcd9-aee481790faf", "count": 1 }],
         "duration": "2m"
     },
     {
@@ -2200,9 +2215,7 @@
             { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 },
             { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 }
         ],
-        "consumeItems": [
-            { "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 }
-        ],
+        "consumeItems": [{ "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 }],
         "createItems": [],
         "duration": "10m",
         "hardening": {
@@ -2496,14 +2509,12 @@
         ],
         "createItems": [{ "id": "092fdddc-431a-40bd-a66c-f7ef878ae1f8", "count": 1 }],
         "duration": "2h"
-        },
+    },
     {
         "id": "start-compost-bin",
         "title": "Start a kitchen compost bucket",
         "image": "/assets/bucket.jpg",
-        "requireItems": [
-            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
-        ],
+        "requireItems": [{ "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }],
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"

--- a/frontend/src/pages/quests/json/astronomy/saturn-rings.json
+++ b/frontend/src/pages/quests/json/astronomy/saturn-rings.json
@@ -1,0 +1,55 @@
+{
+    "id": "astronomy/saturn-rings",
+    "title": "Spot Saturn's Rings",
+    "description": "Use your basic telescope to glimpse Saturn's rings when the planet is bright.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "With Jupiter's moons tracked, let's aim for Saturn. Assemble your telescope and tripod, avoid city lights, and never point near the Sun. Ready?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "observe",
+                    "text": "Let's find Saturn.",
+                    "requiresItems": [
+                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+                        { "id": "49fb255e-a4c3-48e4-bca7-4c3781fdb98b", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "observe",
+            "text": "Use a star chart or app to locate Saturn. Focus until the rings come into view, keeping gear stable and eyes dark adapted.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "observe-saturn-rings",
+                    "text": "Peering at the ringed giant."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I saw the rings!",
+                    "requiresItems": [{ "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Saturn's rings are unforgettable. Keep notes and revisit during opposition for the sharpest view.",
+            "options": [{ "type": "finish", "text": "I'll log the observation." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/jupiter-moons"],
+    "hardening": {
+        "passes": 1,
+        "score": 65,
+        "emoji": "🌀",
+        "history": [{ "task": "codex-quest-2025-08-04", "date": "2025-08-04", "score": 65 }]
+    }
+}


### PR DESCRIPTION
## Summary
- add "Spot Saturn's Rings" quest after tracking Jupiter's moons
- register observe-saturn-rings process with telescope and tripod requirements

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689a4f562594832faece9318f5ce2302