### PR TITLE
Audit authentication flow token persistence

### DIFF
--- a/frontend/__tests__/QuestPRFormComponent.test.js
+++ b/frontend/__tests__/QuestPRFormComponent.test.js
@@ -1,10 +1,48 @@
 /**
  * @jest-environment jsdom
  */
+import '@testing-library/jest-dom';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import QuestPRForm from '../src/components/svelte/QuestPRForm.svelte';
+import { submitQuestPR } from '../src/utils/submitQuestPR.js';
 
-describe('QuestPRForm component', () => {
-    it('exports a valid Svelte component', () => {
-        expect(typeof QuestPRForm).toBe('function');
+jest.mock('../src/utils/submitQuestPR.js');
+
+describe('QuestPRForm token handling', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        submitQuestPR.mockReset();
+    });
+
+    test('loads token from localStorage on mount', () => {
+        localStorage.setItem('gameState', JSON.stringify({ github: { token: 'abc123' } }));
+        const { getByLabelText } = render(QuestPRForm);
+        expect(getByLabelText('GitHub Token*').value).toBe('abc123');
+    });
+
+    test('clears token from component and storage', async () => {
+        localStorage.setItem('gameState', JSON.stringify({ github: { token: 'tok123' } }));
+        const { getByLabelText, getByTestId } = render(QuestPRForm);
+        expect(getByLabelText('GitHub Token*').value).toBe('tok123');
+        await fireEvent.click(getByTestId('clear-token'));
+        expect(getByLabelText('GitHub Token*').value).toBe('');
+        const state = JSON.parse(localStorage.getItem('gameState'));
+        expect(state.github.token).toBe('');
+    });
+
+    test('saves token after successful submission', async () => {
+        submitQuestPR.mockResolvedValue('https://example.com/pr');
+        const { getByLabelText, getByText } = render(QuestPRForm);
+        const token = 'ghp_123456789012345678901234567890123456';
+        await fireEvent.input(getByLabelText('GitHub Token*'), {
+            target: { value: token },
+        });
+        await fireEvent.input(getByLabelText('Quest JSON*'), {
+            target: { value: '{"id":"q1"}' },
+        });
+        await fireEvent.click(getByText('Create Pull Request'));
+        await waitFor(() => expect(submitQuestPR).toHaveBeenCalled());
+        const state = JSON.parse(localStorage.getItem('gameState'));
+        expect(state.github.token).toBe(token);
     });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -94,7 +94,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] Security audit 💯
         -   [x] Review content validation 💯
         -   [x] Check data sanitization 💯
-        -   [x] Audit authentication flow ✅
+        -   [x] Audit authentication flow 💯
 
 -   [ ] **Developer Ergonomics & Infrastructure Debt** (multi‑PR initiative)
     -   [x] **Unify package management (pnpm workspaces) 💯**


### PR DESCRIPTION
## Summary
- add tests verifying QuestPRForm loads, clears, and saves GitHub token
- mark changelog item for authentication audit as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx jest __tests__/QuestPRFormComponent.test.js` *(fails: Cannot find module '../build/Release/canvas.node')*

------
https://chatgpt.com/codex/tasks/task_e_689a4ef7e6f4832f988fea8c7ee0a473