### PR TITLE
🖼️ : add QuestForm image upload test

### DIFF
--- a/frontend/src/components/__tests__/QuestForm.spec.ts
+++ b/frontend/src/components/__tests__/QuestForm.spec.ts
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/svelte';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import QuestForm from '../svelte/QuestForm.svelte';
 
 test('submits text then clears field', async () => {
@@ -7,4 +7,32 @@ test('submits text then clears field', async () => {
     await fireEvent.input(input, { target: { value: 'Save the world' } });
     await fireEvent.submit(getByRole('form'));
     expect(input).toHaveValue('');
+});
+
+test('shows image preview after upload', async () => {
+    const original = globalThis.FileReader;
+    class MockFileReader {
+        result: string | ArrayBuffer | null = null;
+        onload: ((ev: ProgressEvent<FileReader>) => void) | null = null;
+        readAsDataURL() {
+            this.result = 'data:image/png;base64,TEST';
+            this.onload?.({
+                target: { result: this.result },
+            } as unknown as ProgressEvent<FileReader>);
+        }
+    }
+    const g = globalThis as unknown as { FileReader: typeof FileReader };
+    g.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    const { getByLabelText, getByAltText } = render(QuestForm);
+    const fileInput = getByLabelText(/Upload an Image/i);
+    const file = new File(['d'], 'test.png', { type: 'image/png' });
+
+    await fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+        expect(getByAltText('Quest preview')).toBeInTheDocument();
+    });
+
+    g.FileReader = original;
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -12,7 +12,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   [x] Custom Quest System
 
     -   [x] In‑game quest creation UI ✅
-        -   [x] Implement QuestForm component with image upload
+        -   [x] Implement QuestForm component with image upload 💯
         -   [x] Add quest validation against JSON schema
         -   [x] Create quest preview functionality 💯
         -   [x] Add quest requirements selection 💯

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -127,9 +127,9 @@ Every quest JSON file must include:
 ### Current Implementation State
 
 > **Note:** The full quest editing interface is still under development. The current implementation in
-> `QuestForm.svelte` supports basic quest properties (title, description, image) with more complete
-> dialogue editing planned for future updates. The form is mobile‑responsive and stacks action buttons
-> on small screens.
+> `QuestForm.svelte` supports basic quest properties (title, description, image) and provides a live
+> preview for uploaded images, with more complete dialogue editing planned for future updates. The
+> form is mobile‑responsive and stacks action buttons on small screens.
 
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
 You can run `npm run generate-quest --template basic` (or `branching`) to scaffold a template JSON file with placeholder dialogue.


### PR DESCRIPTION
## Summary
- add test ensuring QuestForm shows preview after image upload
- note live image preview in quest guidelines
- mark changelog entry as complete with 💯

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: Shop Functionality e2e tests)*
- `SKIP_E2E=1 npm test`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_689a4ef7e6f4832f988fea8c7ee0a473