### PR TITLE
Fix process JSON and refresh new quests list

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 174
-New quests in this release: 152
+Current quest count: 181
+New quests in this release: 159
 
 ### 3dprinting
 
@@ -31,6 +31,7 @@ New quests in this release: 152
 - aquaria/filter-rinse
 - aquaria/floating-plants
 - aquaria/guppy
+- aquaria/ph-strip-test
 - aquaria/position-tank
 - aquaria/shrimp
 - aquaria/sponge-filter
@@ -54,6 +55,7 @@ New quests in this release: 152
 - astronomy/orion-nebula
 - astronomy/planetary-alignment
 - astronomy/satellite-pass
+- astronomy/saturn-rings
 - astronomy/star-trails
 
 ### chemistry
@@ -68,6 +70,7 @@ New quests in this release: 152
 
 ### completionist
 
+- completionist/catalog
 - completionist/display
 - completionist/polish
 - completionist/reminder
@@ -75,6 +78,7 @@ New quests in this release: 152
 ### composting
 
 - composting/start
+- composting/turn-pile
 
 ### devops
 
@@ -143,6 +147,7 @@ New quests in this release: 152
 - geothermal/install-backup-thermistor
 - geothermal/log-ground-temperature
 - geothermal/monitor-heat-pump-energy
+- geothermal/replace-faulty-thermistor
 - geothermal/survey-ground-temperature
 
 ### hydroponics
@@ -152,6 +157,7 @@ New quests in this release: 152
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
 - hydroponics/ph-test
@@ -215,6 +221,7 @@ New quests in this release: 152
 - woodworking/bookshelf
 - woodworking/coffee-table
 - woodworking/finish-sanding
+- woodworking/picture-frame
 - woodworking/planter-box
 - woodworking/step-stool
 - woodworking/tool-rack

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -22,15 +22,15 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 ## 1 Quick start (Web vs CLI)
 
-- **Add or update an item**
-    - Web: use the “Code” button and attach the repo.
-    - CLI: `codex "add item solar-cell-junction-box"`
-- **Ask about item data**
-    - Web: use the “Ask” button.
-    - CLI: `codex exec "explain frontend/src/pages/inventory/json/items/*.json"`
-- **Run item tests**
-    - Web: not supported yet.
-    - CLI:
+-   **Add or update an item**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "add item solar-cell-junction-box"`
+-   **Ask about item data**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/inventory/json/items/*.json"`
+-   **Run item tests**
+    -   Web: not supported yet.
+    -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && npm run itemValidation && npm test -- itemQuality"
         ```
@@ -151,10 +151,10 @@ A pull request with the refined item, updated hardening block and passing tests.
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus.
-- **Use system prompts** to guide tone and technical accuracy.
-- **Iterate on outputs** rather than expecting perfection on the first try.
-- **Fact-check technical information** since AI systems can generate plausible
-  but incorrect details.
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://github.com/microsoft/Codex-CLI

--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1619,9 +1619,7 @@
         "id": "wear-anti-static-wrist-strap",
         "title": "Attach an anti-static wrist strap before handling electronics",
         "image": "/assets/quests/basic_circuit.svg",
-        "requireItems": [
-            { "id": "d30d7a65-bd11-42a2-89c1-2828e990a3b2", "count": 1 }
-        ],
+        "requireItems": [{ "id": "d30d7a65-bd11-42a2-89c1-2828e990a3b2", "count": 1 }],
         "consumeItems": [],
         "createItems": [],
         "duration": "30s"
@@ -2537,11 +2535,8 @@
             "passes": 1,
             "score": 60,
             "emoji": "🌀",
-            "history": [
-                { "task": "codex-hardening-2025-08-11", "date": "2025-08-11", "score": 60 }
-            ]
+            "history": [{ "task": "codex-hardening-2025-08-11", "date": "2025-08-11", "score": 60 }]
         }
-        "duration": "1m"
     },
     {
         "id": "turn-compost-bucket",


### PR DESCRIPTION
## Summary
- remove stray duration property from `start-compost-bin` process
- regenerate `new-quests` document
- format item prompt documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689a82ec0c50832fa8b877fd3b2cc2d9