### PR TITLE
Add sprained ankle treatment quest

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/treat-sprain.json
+++ b/frontend/src/pages/quests/json/firstaid/treat-sprain.json
@@ -1,0 +1,50 @@
+{
+    "id": "firstaid/treat-sprain",
+    "title": "Treat a Sprained Ankle",
+    "description": "Stabilize a sprained ankle to reduce swelling and pain.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Twisted your ankle? RICE helps: rest, ice, compression, elevation.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "wrap",
+                    "text": "Show me."
+                }
+            ]
+        },
+        {
+            "id": "wrap",
+            "text": "Sit, elevate the ankle, then wrap it snugly with an elastic bandage.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Bandaged and raised",
+                    "requiresItems": [
+                        {
+                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep it elevated and seek medical care if swelling or pain persists.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Will do."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}


### PR DESCRIPTION
## Summary
- add treat-sprain quest referencing first aid kit

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689aba899a30832fbb2e27c3c2dc745d