### PR TITLE
Add LED indicator assembly process

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1591,6 +1591,26 @@
         "duration": "1m"
     },
     {
+        "id": "assemble-led-indicator-module",
+        "title": "Assemble an LED indicator module on a breadboard",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "48cf736e-184c-4bd1-b9b0-15b7e9721646", "count": 1 },
+            { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
+            { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 3 },
+            { "id": "d1105b87-8185-4a30-ba55-406384be169f", "count": 1 }
+        ],
+        "consumeItems": [
+            { "id": "48cf736e-184c-4bd1-b9b0-15b7e9721646", "count": 1 },
+            { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
+            { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 3 }
+        ],
+        "createItems": [
+            { "id": "6da4a788-b743-4682-8dbe-f23d71435aa4", "count": 1 }
+        ],
+        "duration": "5m"
+    },
+    {
         "id": "measure-photoresistor",
         "title": "Measure photoresistor value with a multimeter",
         "image": "/assets/quests/basic_circuit.svg",


### PR DESCRIPTION
## Summary
- add assembly process for breadboard LED indicator module

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689aba7a93d4832f900ecd33134ecc0c