### PR TITLE
Add Venus phases quest to astronomy track

### DIFF
--- a/frontend/src/pages/processes/processes.json
+++ b/frontend/src/pages/processes/processes.json
@@ -1877,6 +1877,23 @@
         }
     },
     {
+        "id": "observe-venus-phases",
+        "title": "Observe and sketch the phases of Venus with a basic telescope",
+        "requireItems": [
+            { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+            { "id": "98f6252e-95c2-468a-b110-69d47604df2c", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30m",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [{ "task": "codex-process-2025-08-05", "date": "2025-08-05", "score": 65 }]
+        }
+    },
+    {
         "id": "arduino-ide-install",
         "title": "Install the Arduino IDE",
         "requireItems": [

--- a/frontend/src/pages/quests/json/astronomy/venus-phases.json
+++ b/frontend/src/pages/quests/json/astronomy/venus-phases.json
@@ -1,0 +1,50 @@
+{
+    "id": "astronomy/venus-phases",
+    "title": "Track Venus's Phases",
+    "description": "Use your telescope to observe how Venus waxes and wanes like our Moon.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've charted planetary alignments; now let's follow Venus itself.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "observe",
+                    "text": "Ready for evening observations"
+                }
+            ]
+        },
+        {
+            "id": "observe",
+            "text": "At dusk, aim your telescope at the bright planet and sketch the phase each week.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "observe-venus-phases",
+                    "text": "Recording sketches"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "My log is growing",
+                    "requiresItems": [{ "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Regular notes reveal how Venus's orbit mirrors our own.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Nova!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/planetary-alignment"]
+}


### PR DESCRIPTION
## Summary
- add quest to track Venus's phases after planetary alignment
- register observe-venus-phases process requiring telescope and star chart

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689aba84afa0832f87ca0ef4c4d9ec97