### PR TITLE
💡: clarify LED polarity quest and hardening

### DIFF
--- a/frontend/src/pages/quests/json/electronics/led-polarity.json
+++ b/frontend/src/pages/quests/json/electronics/led-polarity.json
@@ -1,14 +1,14 @@
 {
     "id": "electronics/led-polarity",
     "title": "Check LED polarity with a multimeter",
-    "description": "Use a digital multimeter in diode mode to confirm a loose 5 mm LED's orientation before wiring. Disconnect power sources, work on a dry surface, and wear safety goggles.",
+    "description": "Use a digital multimeter's diode mode to identify a loose 5 mm LED's anode and cathode before wiring. Disconnect power, work on a dry surface, and wear safety goggles.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Place the LED and meter on a dry, non-conductive surface and put on safety goggles.\nWe'll use diode-test mode to find the positive lead.",
+            "text": "Set the LED and multimeter on a dry, non-conductive surface. Put on safety goggles and keep all power sources disconnected.\nWe'll use diode-test mode to find the positive lead.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "test",
-            "text": "Set the multimeter to diode mode and confirm the probes are in the diode ports. Keep fingers behind the guards. Touch the red probe to the LED's long leg (anode) and the black to the short leg (cathode) without forcing the leads or letting probes touch.\nThe LED should glow faintly or show about 1.8 V. Swap the probes; it should stay dark or display OL. Stop if the leads heat up or spark.",
+            "text": "Switch the multimeter to diode mode and confirm the probes are in the diode sockets. Keep fingers behind the guards.\nTouch the red probe to the LED's long leg (anode) and the black probe to the short leg (cathode) without letting probes or leads touch.\nThe LED should glow faintly or read about 1.8 V. Reverse the probes; it should stay dark or display OL. Stop if the LED heats up or sparks.",
             "options": [
                 {
                     "type": "goto",
@@ -36,7 +36,7 @@
         },
         {
             "id": "finish",
-            "text": "Nice! Now you know which lead is positive.\nTurn off the meter, disconnect the probes, and store the LED for your next circuit.",
+            "text": "Great! The glowing orientation marks the anode.\nTurn off the meter, disconnect the probes, and store the LED for your next circuit.",
             "options": [
                 {
                     "type": "finish",
@@ -48,12 +48,13 @@
     "rewards": [{ "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73", "count": 1 }],
     "requiresQuests": ["electronics/check-battery-voltage"],
     "hardening": {
-        "passes": 2,
-        "score": 78,
-        "emoji": "✅",
+        "passes": 3,
+        "score": 92,
+        "emoji": "💯",
         "history": [
             { "task": "codex-quest-refinement-2025-08-10", "date": "2025-08-10", "score": 60 },
-            { "task": "codex-refine-2025-08-11", "date": "2025-08-11", "score": 78 }
+            { "task": "codex-refine-2025-08-11", "date": "2025-08-11", "score": 78 },
+            { "task": "codex-hardening-2025-08-12", "date": "2025-08-12", "score": 92 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- refine LED polarity quest clarity and safety
- update hardening to 3 passes with improved score

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689aba8eb5b4832fbe012a5ea66a318b