### PR TITLE
Add prerequisite for net cup cleaning quest

### DIFF
--- a/frontend/src/pages/quests/json/hydroponics/netcup-clean.json
+++ b/frontend/src/pages/quests/json/hydroponics/netcup-clean.json
@@ -29,7 +29,8 @@
                 {
                     "type": "goto",
                     "goto": "scrub",
-                    "text": "Water is ready"
+                    "text": "Water is ready",
+                    "requiresItems": [{ "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }]
                 }
             ]
         },
@@ -61,5 +62,5 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": []
+    "requiresQuests": ["hydroponics/tub-scrub"]
 }


### PR DESCRIPTION
## Summary
- require tub scrub before net cup cleaning
- gate water-ready step on dechlorinated bucket

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ae016c820832fb467cc1f380bf1b8