### PR TITLE
Add database benchmark script and docs

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -81,7 +81,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] Performance testing
         -   [x] Load testing custom content system 💯
-        -   [x] Database performance benchmarks
+        -   [x] Database performance benchmarks 💯
         -   [x] UI responsiveness metrics 💯
     -   [x] Cross‑browser compatibility
         -   [x] Test IndexedDB in all major browsers 💯

--- a/frontend/src/pages/docs/md/db-benchmark.md
+++ b/frontend/src/pages/docs/md/db-benchmark.md
@@ -1,0 +1,25 @@
+---
+title: 'Database Benchmark'
+slug: 'db-benchmark'
+---
+
+DSPACE includes a utility to measure IndexedDB performance for custom content.
+Run the benchmark with:
+
+```bash
+npm run db:benchmark
+```
+
+The script inserts and reads sample records, printing JSON metrics like:
+
+```json
+{
+    "insertMs": 12.5,
+    "readMs": 4.2,
+    "itemCount": 50,
+    "processCount": 50,
+    "questCount": 50
+}
+```
+
+Use this to track database performance during development.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "generate:item-map": "node scripts/generate-item-dependencies.js",
     "new-quests:update": "node scripts/update-new-quests.js",
     "audit:ci": "npm audit --omit=dev --audit-level=high && npm --prefix frontend install --package-lock-only --ignore-scripts && npm --prefix frontend audit --omit=dev --audit-level=high && rm frontend/package-lock.json",
-    "ci:install": "HUSKY=0 pnpm install --frozen-lockfile --reporter=append-only"
+    "ci:install": "HUSKY=0 pnpm install --frozen-lockfile --reporter=append-only",
+    "db:benchmark": "node frontend/scripts/db-benchmark.js"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/scripts/tests/dbBenchmarkScript.test.ts
+++ b/scripts/tests/dbBenchmarkScript.test.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+test('package.json contains db:benchmark script', () => {
+  const pkgPath = path.join(process.cwd(), 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  expect(pkg.scripts['db:benchmark']).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- expose db:benchmark npm script and document usage
- verify script presence with unit test
- mark database performance benchmarks as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689adfedf85c832fb4beff5f3b36adeb