### PR TITLE
docs: remove diff-only output instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,7 +13,7 @@ invoking Codex on DSPACE and should evolve alongside the project.
 > **TL;DR**
 >
 > 1. Scope the task to one or two files.
-> 2. Say **exactly** what output you expect (diff, test, docs, etc.).
+> 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
 
@@ -33,12 +33,12 @@ See the upstream CLI reference for more flags.
 
 ## 2 Prompt ingredients
 
-| Ingredient           | Why it matters                                                     |
-| -------------------- | ------------------------------------------------------------------ |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).   |
-| **Files to touch**   | Limits search space → faster & cheaper.                            |
-| **Constraints**      | Coding style, a11y, perf, etc.                                     |
-| **Acceptance check** | e.g. “All `npm test` suites pass” or “Return a unified diff only”. |
+| Ingredient           | Why it matters                                                   |
+| -------------------- | ---------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                          |
+| **Constraints**      | Coding style, a11y, perf, etc.                                   |
+| **Acceptance check** | e.g. “All `npm test` suites pass”.                               |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -62,7 +62,7 @@ REQUIREMENTS
 3. …
 
 OUTPUT
-Return **only** the patch (diff) needed.
+A pull request with the required changes and tests.
 ```
 
 ## Implementation Prompt

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -14,7 +14,7 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 > **TL;DR**
 >
 > 1. Scope changes to a single item entry.
-> 2. Say exactly what output you expect (diff, tests, docs).
+> 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 
@@ -77,7 +77,7 @@ REQUIREMENTS
 9. Update docs or processes if needed.
 
 OUTPUT
-Return **only** the patch (diff) needed.
+A pull request with the completed item and passing checks.
 ```
 
 ## Implementation Prompt

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -14,7 +14,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 > **TL;DR**
 >
 > 1. Scope changes to a single process entry.
-> 2. Say exactly what output you expect (diff, tests, docs).
+> 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 
@@ -76,7 +76,7 @@ REQUIREMENTS
 8. Update docs or items if needed.
 
 OUTPUT
-Return **only** the patch (diff) needed.
+A pull request with the completed process and passing checks.
 ```
 
 ## Implementation Prompt

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -17,7 +17,7 @@ which covers quests, items and processes in detail.
 > **TL;DR**
 >
 > 1. Scope changes to a single quest file.
-> 2. Say exactly what output you expect (diff, tests, docs).
+> 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 
@@ -25,15 +25,15 @@ which covers quests, items and processes in detail.
 
 ## 1 Quick start (Web vs CLI)
 
--   **Add or update a quest**
-    -   Web: use the “Code” button and attach the repo.
-    -   CLI: `codex "add quest solar/led-basics"`
--   **Ask about quest files**
-    -   Web: use the “Ask” button.
-    -   CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
--   **Run quest tests**
-    -   Web: not supported yet.
-    -   CLI:
+- **Add or update a quest**
+    - Web: use the “Code” button and attach the repo.
+    - CLI: `codex "add quest solar/led-basics"`
+- **Ask about quest files**
+    - Web: use the “Ask” button.
+    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+- **Run quest tests**
+    - Web: not supported yet.
+    - CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
         npm test -- questCanonical questQuality"
@@ -80,7 +80,7 @@ REQUIREMENTS
 8. Update docs or dialogue as needed.
 
 OUTPUT
-Return **only** the patch (diff) needed.
+A pull request with the completed quest and passing checks.
 ```
 
 ## Implementation Prompt
@@ -129,7 +129,7 @@ USER:
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:
-Return only the diff with the new quest.
+A pull request with the new quest.
 ```
 
 ## Upgrade prompt for new quests
@@ -184,10 +184,10 @@ A pull request with the refined quest, updated hardening block and passing tests
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
--   **Provide clear context** about DSPACE's educational mission and sustainability focus.
--   **Use system prompts** to guide tone and technical accuracy.
--   **Iterate on outputs** rather than expecting perfection on the first try.
--   **Fact-check technical information** since AI systems can generate plausible
-    but incorrect details.
+- **Provide clear context** about DSPACE's educational mission and sustainability focus.
+- **Use system prompts** to guide tone and technical accuracy.
+- **Iterate on outputs** rather than expecting perfection on the first try.
+- **Fact-check technical information** since AI systems can generate plausible
+  but incorrect details.
 
 [codex-cli]: https://github.com/microsoft/Codex-CLI


### PR DESCRIPTION
what: remove diff-only output instructions from prompt docs
why: diff rendering on Codex is unreliable
how to test: npm run lint && npm run type-check &&
  npm run build && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689ae20a65fc832fbb5047ca8b201b82