### PR TITLE
Add water test logbook item and quest requirement

### DIFF
--- a/frontend/src/pages/inventory/json/items/aquarium.json
+++ b/frontend/src/pages/inventory/json/items/aquarium.json
@@ -303,5 +303,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "b8602362-2035-4f00-9376-f48d8668cf38",
+        "name": "water test logbook",
+        "description": "Waterproof A5 notebook with 100 pre-numbered pages for recording aquarium parameters.",
+        "image": "/assets/paperwork.jpg",
+        "price": "4 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-12",
+                    "date": "2025-08-12",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/aquaria/water-testing.json
+++ b/frontend/src/pages/quests/json/aquaria/water-testing.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "The tank should be cycling nicely. Grab the Aquarium liquid test kit and protective gear so we can confirm it's safe for shrimp.",
+            "text": "The tank should be cycling nicely. Grab the Aquarium liquid test kit, protective gear, and a logbook so we can confirm it's safe for shrimp.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "explain",
-            "text": "Rinse each tube with tank water, fill to the 5 mL line, then add the specified drops from the Aquarium liquid test kit. Cap and shake away from your face. Wear nitrile gloves and safety goggles to avoid contact with the reagents. Ammonia and nitrite must read 0 ppm; keep nitrate under 40 ppm.",
+            "text": "Rinse each tube with tank water, fill to the 5 mL line, then add the specified drops from the Aquarium liquid test kit. Cap and shake away from your face. Wear nitrile gloves and safety goggles to avoid contact with the reagents, then log the readings in your water test logbook. Ammonia and nitrite must read 0 ppm; keep nitrate under 40 ppm.",
             "options": [
                 {
                     "type": "goto",
@@ -36,6 +36,10 @@
                         },
                         {
                             "id": "c9b51052-4594-42d7-a723-82b815ab8cc2",
+                            "count": 1
+                        },
+                        {
+                            "id": "b8602362-2035-4f00-9376-f48d8668cf38",
                             "count": 1
                         }
                     ]
@@ -66,14 +70,15 @@
     ],
     "requiresQuests": ["aquaria/walstad"],
     "hardening": {
-        "passes": 4,
-        "score": 94,
+        "passes": 5,
+        "score": 95,
         "emoji": "💯",
         "history": [
             { "task": "codex-hardening-2025-08-04", "date": "2025-08-04", "score": 60 },
             { "task": "codex-upgrade-2025-08-04", "date": "2025-08-04", "score": 80 },
             { "task": "codex-upgrade-2025-08-06", "date": "2025-08-06", "score": 92 },
-            { "task": "codex-upgrade-2025-08-10", "date": "2025-08-10", "score": 94 }
+            { "task": "codex-upgrade-2025-08-10", "date": "2025-08-10", "score": 94 },
+            { "task": "codex-quest-refinement-2025-08-12", "date": "2025-08-12", "score": 95 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- add water test logbook inventory item
- require logbook and logging in water testing quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `SKIP_E2E=1 npm test -- itemQuality`
- `SKIP_E2E=1 npm test -- questQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689adffb50f0832fb2af2607b50dcc04