### PR TITLE
🐛 : skip rpi deploy job without secrets

### DIFF
--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -23,8 +23,8 @@ jobs:
     # Skip the job on push events unless all secrets are defined
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (secrets.RPI_HOST != '' && secrets.RPI_USER != '' &&
-       secrets.RPI_SSH_KEY != '' && secrets.GHCR_TOKEN != '')
+      (secrets.RPI_HOST && secrets.RPI_USER &&
+       secrets.RPI_SSH_KEY && secrets.GHCR_TOKEN)
     runs-on: ubuntu-latest
     env:
       RPI_HOST: ${{ secrets.RPI_HOST || inputs.RPI_HOST }}


### PR DESCRIPTION
what: gate rpi deploy workflow on required secrets
why: avoid failing runs when credentials are absent
how to test: npm run lint && npm run type-check && npm run build && SKIP_E2E=1 npm test
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689af493c360832fb036db68db50639b