### PR TITLE
docs: add structured outage catalog

### DIFF
--- a/frontend/src/pages/docs/md/outages.md
+++ b/frontend/src/pages/docs/md/outages.md
@@ -21,3 +21,4 @@ JSON file matching [`outages/schema.json`](../../../../outages/schema.json).
 3. Submit a PR with the new file.
 
 Agents can parse the JSON files to reason about prior outages and avoid repeating mistakes.
+Prompts for incident response should instruct agents to consult this catalog and add new entries.

--- a/frontend/src/pages/docs/md/outages.md
+++ b/frontend/src/pages/docs/md/outages.md
@@ -1,0 +1,23 @@
+---
+title: 'Outage Catalog'
+slug: 'outages'
+---
+
+# Outage Catalog
+
+A structured history of dspace outages lives under `/outages`. Each incident is stored as a
+JSON file matching [`outages/schema.json`](../../../../outages/schema.json).
+
+## Adding a record
+
+1. Create `outages/YYYY-MM-DD-<slug>.json`.
+2. Follow the schema fields:
+    - `id` – unique identifier
+    - `date` – ISO format date
+    - `component` – affected subsystem
+    - `rootCause` – brief description of the failure
+    - `resolution` – how it was fixed
+    - `references` – related PR or documentation links
+3. Submit a PR with the new file.
+
+Agents can parse the JSON files to reason about prior outages and avoid repeating mistakes.

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -88,3 +88,6 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     so patch coverage checks work on repositories where the default branch is `v3`.
 -   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to satisfy
     `npm run audit:ci`.
+
+-   2025-08-11 – Introduced a structured outage catalog under `/outages` so agents
+    can recall past incidents.

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -34,6 +34,7 @@ CONTEXT:
     `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
+- Consult existing outage entries in `/outages` for similar symptoms.
 - Constraints:
   * Keep existing behaviour intact.
   * Follow `AGENTS.md` and project style.
@@ -42,12 +43,15 @@ CONTEXT:
   * After fixing, append a bullet to the "Lessons learned" section of
     `frontend/src/pages/docs/md/prompts-codex-ci-fix.md` summarizing the cause
     and remedy.
+  * Record the incident in `/outages/YYYY-MM-DD-<slug>.json` using
+    `outages/schema.json`.
 
 REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
 2. Commit the minimal changes needed to fix it.
-3. Push to a branch named `codex/ci-fix/<short-description>`.
-4. Open a pull request that leaves all CI checks green.
+3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
+4. Push to a branch named `codex/ci-fix/<short-description>`.
+5. Open a pull request that leaves all CI checks green.
 
 OUTPUT:
 A GitHub pull request URL. Include a summary of the root cause and evidence that

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -120,3 +120,28 @@ USER:
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
+
+## Outage Prompt
+
+Use this snippet when fixing an incident so knowledge lands in the outage catalog.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository.
+
+PURPOSE:
+Diagnose an outage, implement a fix, and document it.
+
+CONTEXT:
+- Review existing records under `/outages` for similar failures.
+- After resolving, add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
+- Keep behaviour intact, add tests, and update documentation.
+
+REQUEST:
+1. Apply the fix with appropriate tests.
+2. Commit the outage entry and related docs.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+
+OUTPUT:
+A pull request referencing the new outage record and passing checks.
+```

--- a/outages/2025-08-11-openai-axios-vulnerability.json
+++ b/outages/2025-08-11-openai-axios-vulnerability.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-11-openai-axios-vulnerability",
+  "date": "2025-08-11",
+  "component": "dependency",
+  "rootCause": "openai v3 pulled a vulnerable axios version",
+  "resolution": "upgraded to openai v5 to satisfy npm audit",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md#lessons-learned"
+  ]
+}

--- a/outages/README.md
+++ b/outages/README.md
@@ -1,0 +1,16 @@
+# Outage Catalog
+
+Structured archive of past outages. Each outage is stored as a JSON file using the
+schema in `schema.json`.
+
+File naming: `YYYY-MM-DD-<slug>.json`.
+
+Required fields:
+- `id`: unique identifier
+- `date`: ISO date
+- `component`: affected subsystem
+- `rootCause`: brief description of failure cause
+- `resolution`: how it was fixed
+- `references`: array of related links (PRs, issues, docs)
+
+Agents can parse these files to learn from previous incidents.

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Outage record",
+  "type": "object",
+  "required": ["id", "date", "component", "rootCause", "resolution", "references"],
+  "properties": {
+    "id": { "type": "string" },
+    "date": { "type": "string", "format": "date" },
+    "component": { "type": "string" },
+    "rootCause": { "type": "string" },
+    "resolution": { "type": "string" },
+    "references": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document structured outage catalog for long-term incident tracking
- add JSON schema and sample entry under /outages
- note catalog in codex CI lessons learned

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baade1c6c832f8e49246cccffe865