### PR TITLE
feat: add backup quest for completionist trophy

### DIFF
--- a/frontend/src/pages/quests/json/completionist/backup.json
+++ b/frontend/src/pages/quests/json/completionist/backup.json
@@ -1,0 +1,50 @@
+{
+    "id": "completionist/backup",
+    "title": "Backup Your Trophy",
+    "description": "Make a digital copy so your Completionist Award lives on.",
+    "image": "/assets/quests/completionist.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Photos fade, storage fails. Want to archive your trophy safely?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "capture",
+                    "text": "Let's secure a backup"
+                }
+            ]
+        },
+        {
+            "id": "capture",
+            "text": "Snap a crisp photo and upload it to your vault.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Backup complete",
+                    "requiresItems": [
+                        {
+                            "id": "c01676ec-27e5-4a53-9a47-24bf6c5a56a9",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Now even a meteor can't erase your accomplishment.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Safe and sound"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["completionist/v2"]
+}


### PR DESCRIPTION
## Summary
- add backup quest to completionist set

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality` *(fails: Prettier formatting test timed out)*


------
https://chatgpt.com/codex/tasks/task_e_689ba9ee11b0832fbad8a6f9d94e7465