### PR TITLE
fix: ignore remote URLs in image check

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -88,3 +88,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     so patch coverage checks work on repositories where the default branch is `v3`.
 -   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to satisfy
     `npm run audit:ci`.
+-   2025-08-12 – `listMissingImages` flagged remote URLs as missing assets; skip `http` and
+    `https` paths so coverage checks ignore external images.

--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -7,4 +7,10 @@ describe('listMissingImages', () => {
     const missing = listMissingImages(images);
     expect(missing).toEqual([]);
   });
+
+  test('ignores remote URLs', () => {
+    const images = ['https://example.com/remote.png'];
+    const missing = listMissingImages(images);
+    expect(missing).toEqual([]);
+  });
 });

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -6,6 +6,9 @@ function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '.
     imagePaths.forEach((img) => {
         // Strip query strings or hash fragments so existence checks aren't fooled
         const base = img.split(/[?#]/)[0];
+        if (/^https?:\/\//i.test(base)) {
+            return;
+        }
         const rel = base.startsWith('/') ? base.slice(1) : base;
         const full = path.join(publicDir, rel);
         if (!fs.existsSync(full)) {


### PR DESCRIPTION
## Summary
- skip http/https images in listMissingImages
- test that remote URLs aren't flagged as missing
- document lesson about ignoring external images in coverage checks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baab20a08832f92042cad26686823