### PR TITLE
Remove deprecated npm packageManager config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-packageManager=pnpm@latest

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -88,3 +88,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     so patch coverage checks work on repositories where the default branch is `v3`.
 -   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to satisfy
     `npm run audit:ci`.
+-   2025-08-12 – `.npmrc`'s `packageManager` key made npm warn; drop the file and
+    set `packageManager` in `package.json` to keep installs quiet.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dspace",
   "version": "3.0.0",
+  "packageManager": "pnpm@9",
   "engines": {
     "node": ">=18 <22"
   },

--- a/tests/packageManager.test.ts
+++ b/tests/packageManager.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+
+describe('package.json', () => {
+  it('declares pnpm as the package manager', () => {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+    expect(pkg.packageManager).toMatch(/^pnpm@/);
+  });
+});


### PR DESCRIPTION
## Summary
- drop `.npmrc` that set `packageManager`
- declare pnpm via `packageManager` field
- document the change and add a regression test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baab20a08832f92042cad26686823