### PR TITLE
Add biohazard waste bag item

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1009,6 +1009,13 @@
         "price": "0.50 dUSD"
     },
     {
+        "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
+        "name": "biohazard waste bag",
+        "description": "1 L red bag for used bandages and gloves; tie shut to contain contaminated waste.",
+        "image": "/assets/rescue.jpg",
+        "price": "0.10 dUSD"
+    },
+    {
         "id": "c9b51052-4594-42d7-a723-82b815ab8cc2",
         "name": "safety goggles",
         "description": "Polycarbonate goggles with vents and adjustable strap; fit over glasses, block splashes. 100 g.",

--- a/frontend/src/pages/quests/json/firstaid/wound-care.json
+++ b/frontend/src/pages/quests/json/firstaid/wound-care.json
@@ -29,7 +29,8 @@
                         { "id": "55ace400-79ee-4b24-b7da-0b0435ab7d72", "count": 1 },
                         { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 },
                         { "id": "b0f10930-53aa-4d45-8bb7-9c7b17f14a5a", "count": 1 },
-                        { "id": "1b1030bf-9767-4b16-9ff6-a8e7de28b689", "count": 1 }
+                        { "id": "1b1030bf-9767-4b16-9ff6-a8e7de28b689", "count": 1 },
+                        { "id": "7a4b8892-365f-4a56-93ce-127aa989f50d", "count": 1 }
                     ]
                 },
                 {


### PR DESCRIPTION
## Summary
- add biohazard waste bag inventory entry
- require biohazard bag when practicing wound care

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `SKIP_E2E=1 npm test -- itemQuality`
- `SKIP_E2E=1 npm test -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689baa87e2c8832fb405cf9b829aee05