### PR TITLE
Add compost thermometer item and quest temperature check

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -122,10 +122,27 @@
       "ubi/basicincome"
     ]
   },
+  "df7e94e2-76b9-4865-b843-2ec21feb258e": {
+    "requires": [
+      "sysadmin/resource-monitoring",
+      "sysadmin/basic-commands",
+      "devops/ssh-hardening",
+      "devops/ssd-boot",
+      "devops/private-registry",
+      "devops/k3s-deploy",
+      "devops/firewall-rules",
+      "devops/enable-https",
+      "devops/docker-compose",
+      "devops/ci-pipeline",
+      "devops/auto-updates"
+    ],
+    "rewards": []
+  },
   "80a83ecc-bcd2-400e-a469-8488a6453bb8": {
     "requires": [
       "rocketry/static-test",
-      "rocketry/parachute"
+      "rocketry/parachute",
+      "rocketry/fuel-mixture"
     ],
     "rewards": []
   },
@@ -156,6 +173,7 @@
     "requires": [],
     "rewards": [
       "rocketry/preflight-check",
+      "rocketry/fuel-mixture",
       "rocketry/firstlaunch"
     ]
   },
@@ -317,6 +335,23 @@
     ],
     "rewards": []
   },
+  "5a6bb713-ed34-4463-94ee-cfe7b8faa45c": {
+    "requires": [
+      "programming/thermistor-calibration",
+      "electronics/thermistor-reading",
+      "electronics/data-logger"
+    ],
+    "rewards": []
+  },
+  "ffe0b74a-f111-4d66-b4c3-d82965a976ac": {
+    "requires": [
+      "programming/thermistor-calibration",
+      "electronics/thermistor-reading",
+      "electronics/light-sensor",
+      "electronics/data-logger"
+    ],
+    "rewards": []
+  },
   "8e81b5e5-4aee-402c-bd04-fed9188f8c07": {
     "requires": [
       "programming/temp-logger",
@@ -334,6 +369,7 @@
       "hydroponics/tub-scrub",
       "hydroponics/top-off",
       "hydroponics/root-rinse",
+      "hydroponics/netcup-clean",
       "hydroponics/filter-clean",
       "hydroponics/bucket_10",
       "hydroponics/basil",
@@ -385,6 +421,7 @@
       "chemistry/ph-test",
       "chemistry/ph-adjustment",
       "chemistry/acid-neutralization",
+      "chemistry/acid-dilution",
       "aquaria/ph-strip-test"
     ],
     "rewards": []
@@ -401,7 +438,9 @@
       "firstaid/wound-care",
       "firstaid/stop-nosebleed",
       "firstaid/learn-cpr",
+      "firstaid/dispose-expired",
       "chemistry/ph-test",
+      "chemistry/acid-dilution",
       "aquaria/water-testing"
     ],
     "rewards": []
@@ -409,13 +448,17 @@
   "c9b51052-4594-42d7-a723-82b815ab8cc2": {
     "requires": [
       "hydroponics/nutrient-check",
+      "firstaid/dispose-expired",
       "electronics/solder-wire",
       "electronics/measure-resistance",
       "electronics/light-sensor",
       "electronics/led-polarity",
       "electronics/desolder-component",
+      "electronics/data-logger",
+      "electronics/continuity-test",
       "electronics/check-battery-voltage",
       "chemistry/ph-test",
+      "chemistry/acid-dilution",
       "aquaria/water-testing"
     ],
     "rewards": []
@@ -606,7 +649,8 @@
   "67a682f8-a8a4-4a14-8806-5ccd3620fd3b": {
     "requires": [
       "energy/solar",
-      "energy/offgrid-charger"
+      "energy/offgrid-charger",
+      "energy/charge-controller-setup"
     ],
     "rewards": []
   },
@@ -629,7 +673,8 @@
       "energy/portable-solar-panel",
       "energy/dSolar-1kW",
       "energy/dSolar-10kW",
-      "energy/dSolar-100kW"
+      "energy/dSolar-100kW",
+      "energy/charge-controller-setup"
     ],
     "rewards": []
   },
@@ -646,7 +691,6 @@
       "electronics/temperature-plot",
       "electronics/servo-sweep",
       "electronics/potentiometer-dimmer",
-      "electronics/light-sensor",
       "electronics/data-logger",
       "electronics/continuity-test"
     ],
@@ -703,19 +747,6 @@
     ],
     "rewards": []
   },
-  "5a6bb713-ed34-4463-94ee-cfe7b8faa45c": {
-    "requires": [
-      "electronics/thermistor-reading"
-    ],
-    "rewards": []
-  },
-  "ffe0b74a-f111-4d66-b4c3-d82965a976ac": {
-    "requires": [
-      "electronics/thermistor-reading",
-      "electronics/light-sensor"
-    ],
-    "rewards": []
-  },
   "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d": {
     "requires": [
       "electronics/thermistor-reading",
@@ -752,7 +783,8 @@
   },
   "bf3d2784-d48d-4b12-b12a-75f563b5dc88": {
     "requires": [
-      "electronics/resistor-color-check"
+      "electronics/resistor-color-check",
+      "electronics/basic-circuit"
     ],
     "rewards": []
   },
@@ -787,29 +819,23 @@
     ],
     "rewards": []
   },
-  "d30d7a65-bd11-42a2-89c1-2828e990a3b2": {
-    "requires": [
-      "electronics/light-sensor"
-    ],
-    "rewards": []
-  },
   "be3aaed8-13cc-4937-95d5-6e2c952c6612": {
     "requires": [
+      "electronics/light-sensor",
       "electronics/arduino-blink"
     ],
     "rewards": []
   },
-  "df7e94e2-76b9-4865-b843-2ec21feb258e": {
+  "d30d7a65-bd11-42a2-89c1-2828e990a3b2": {
     "requires": [
-      "devops/ssh-hardening",
-      "devops/ssd-boot",
-      "devops/private-registry",
-      "devops/k3s-deploy",
-      "devops/firewall-rules",
-      "devops/enable-https",
-      "devops/docker-compose",
-      "devops/ci-pipeline",
-      "devops/auto-updates"
+      "electronics/light-sensor",
+      "electronics/data-logger"
+    ],
+    "rewards": []
+  },
+  "ce92a1a9-c817-40f0-92b1-24aff053903d": {
+    "requires": [
+      "electronics/continuity-test"
     ],
     "rewards": []
   },
@@ -868,6 +894,12 @@
       "devops/monitoring",
       "devops/log-maintenance",
       "devops/daily-backups"
+    ],
+    "rewards": []
+  },
+  "4d21c498-9225-4d0b-9a1a-ed65e349f0a8": {
+    "requires": [
+      "composting/turn-pile"
     ],
     "rewards": []
   },
@@ -984,6 +1016,12 @@
     "requires": [
       "aquaria/water-testing",
       "aquaria/shrimp"
+    ],
+    "rewards": []
+  },
+  "b8602362-2035-4f00-9376-f48d8668cf38": {
+    "requires": [
+      "aquaria/water-testing"
     ],
     "rewards": []
   },

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -281,5 +281,19 @@
                 }
             ]
         }
+    },
+    {
+        "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8",
+        "name": "compost thermometer",
+        "description": "30 cm stainless probe thermometer reading 0–100 °C for monitoring compost core temperature.",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "price": "12 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/composting/turn-pile.json
+++ b/frontend/src/pages/quests/json/composting/turn-pile.json
@@ -2,6 +2,18 @@
     "id": "composting/turn-pile",
     "title": "Turn Your Compost Bucket",
     "description": "Aerate the compost by stirring the mix so microbes stay active.",
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-12",
+                "date": "2025-08-12",
+                "score": 60
+            }
+        ]
+    },
     "image": "/assets/bucket.jpg",
     "npc": "/assets/npc/nova.jpg",
     "start": "start",
@@ -28,6 +40,17 @@
                 },
                 {
                     "type": "goto",
+                    "goto": "temp",
+                    "requiresItems": [
+                        {
+                            "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8",
+                            "count": 1
+                        }
+                    ],
+                    "text": "Check core temperature"
+                },
+                {
+                    "type": "goto",
                     "goto": "finish",
                     "requiresItems": [
                         {
@@ -36,6 +59,17 @@
                         }
                     ],
                     "text": "Looks aerated now"
+                }
+            ]
+        },
+        {
+            "id": "temp",
+            "text": "The probe reads about 55 °C—perfect for active decomposition.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Great, I'll keep turning"
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- add compost thermometer inventory item
- let turn-pile quest check compost temperature and record hardening
- regenerate item quest map

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `SKIP_E2E=1 npm test -- itemQuality`
- `SKIP_E2E=1 npm test -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689baa87e2c8832fb405cf9b829aee05