### PR TITLE
Add schema-based quest validation to QuestForm

### DIFF
--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -108,14 +108,18 @@
             errors.image = 'Image is required';
         }
 
-        const { valid } = validateQuestData({
+        const { valid, errors: schemaErrors } = validateQuestData({
             title: title.trim(),
             description: description.trim(),
             image: previewUrl || '',
             requiresQuests,
         });
         if (!valid) {
-            errors.schema = 'Invalid quest data';
+            for (const [field, message] of Object.entries(schemaErrors)) {
+                if (!errors[field]) {
+                    errors[field] = message;
+                }
+            }
         }
 
         if (

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -13,7 +13,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] In‑game quest creation UI ✅
         -   [x] Implement QuestForm component with image upload 💯
-        -   [x] Add quest validation against JSON schema
+        -   [x] Add quest validation against JSON schema 💯
         -   [x] Create quest preview functionality 💯
         -   [x] Add quest requirements selection 💯
     -   [x] Quest contribution workflow ✅

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -127,9 +127,9 @@ Every quest JSON file must include:
 ### Current Implementation State
 
 > **Note:** The full quest editing interface is still under development. The current implementation in
-> `QuestForm.svelte` supports basic quest properties (title, description, image) and provides a live
-> preview for uploaded images, with more complete dialogue editing planned for future updates. The
-> form is mobile‑responsive and stacks action buttons on small screens.
+> `QuestForm.svelte` supports basic quest properties (title, description, image) with live preview
+> and validates data against the quest JSON schema. More complete dialogue editing is planned for
+> future updates. The form is mobile‑responsive and stacks action buttons on small screens.
 
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
 You can run `npm run generate-quest --template basic` (or `branching`) to scaffold a template JSON file with placeholder dialogue.

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -19,12 +19,54 @@ export const customQuestSchema = {
     required: ['title', 'description', 'image'],
 };
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(customQuestSchema);
 
 export function validateQuestData(data) {
     const valid = validate(data);
-    return { valid, errors: validate.errors };
+    if (valid) {
+        return { valid: true, errors: {} };
+    }
+
+    const errors = {};
+
+    for (const err of validate.errors || []) {
+        const field =
+            err.instancePath.replace(/^\//, '') ||
+            (err.params && err.params.missingProperty) ||
+            'schema';
+
+        switch (field) {
+            case 'title':
+            case 'description':
+                if (err.keyword === 'pattern') {
+                    errors[field] = 'HTML tags are not allowed';
+                } else if (!errors[field]) {
+                    errors[field] = err.message;
+                }
+                break;
+            case 'image':
+                if (err.keyword === 'pattern') {
+                    errors.image = 'Image must be a valid data or http(s) URL';
+                } else if (!errors.image) {
+                    errors.image = err.message;
+                }
+                break;
+            case 'requiresQuests':
+                if (err.keyword === 'uniqueItems') {
+                    errors.requiresQuests = 'Quest requirements must be unique';
+                } else {
+                    errors.requiresQuests = 'Quest requirements must be an array of strings';
+                }
+                break;
+            default:
+                if (!errors[field]) {
+                    errors[field] = err.message || 'Invalid quest data';
+                }
+        }
+    }
+
+    return { valid: false, errors };
 }
 
 export function validateQuestDependencies(depIds = [], existingQuestIds = []) {

--- a/tests/quest-schema-validation.test.ts
+++ b/tests/quest-schema-validation.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest';
+import { validateQuestData } from '../frontend/src/utils/customQuestValidation.js';
+
+test('validateQuestData flags HTML tags in title', () => {
+  const result = validateQuestData({
+    title: '<b>Bad</b>',
+    description: 'Valid description for quest.',
+    image: 'https://example.com/img.png',
+  });
+  expect(result.valid).toBe(false);
+  expect(result.errors.title).toMatch(/HTML tags/);
+});


### PR DESCRIPTION
## Summary
- validate custom quest data against JSON schema using Ajv
- surface schema errors in QuestForm and document validation
- test rejection of HTML tags in quests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baa9aafac832f8aed923d5815167f