### PR TITLE
Add dark adaptation stargazing process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3364,5 +3364,35 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "dark-adapt-eyes",
+        "title": "Dark-adapt your eyes for stargazing",
+        "image": "/assets/quests/start.png",
+        "requireItems": [
+            {
+                "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                "count": 1
+            },
+            {
+                "id": "98f6252e-95c2-468a-b110-69d47604df2c",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "15m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-2025-08-30",
+                    "date": "2025-08-30",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2700,5 +2700,23 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "dark-adapt-eyes",
+        "title": "Dark-adapt your eyes for stargazing",
+        "image": "/assets/quests/start.png",
+        "requireItems": [
+            {
+                "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                "count": 1
+            },
+            {
+                "id": "98f6252e-95c2-468a-b110-69d47604df2c",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "15m"
     }
 ]

--- a/frontend/src/pages/processes/hardening/dark-adapt-eyes.json
+++ b/frontend/src/pages/processes/hardening/dark-adapt-eyes.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-2025-08-30",
+            "date": "2025-08-30",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add `dark-adapt-eyes` process using a red flashlight and planisphere star chart
- record initial hardening metadata for the new process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689baa7ac97c832fb87ac48fb359fbdd