### PR TITLE
Add resistor lead trimming process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3364,5 +3364,39 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "trim-resistor-leads",
+        "title": "Trim resistor leads with wire cutters",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                "count": 1
+            },
+            {
+                "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+                "count": 1
+            },
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-trim-resistor-leads-2025-08-12",
+                    "date": "2025-08-12",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2700,5 +2700,27 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "trim-resistor-leads",
+        "title": "Trim resistor leads with wire cutters",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                "count": 1
+            },
+            {
+                "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+                "count": 1
+            },
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s"
     }
 ]

--- a/frontend/src/pages/processes/hardening/trim-resistor-leads.json
+++ b/frontend/src/pages/processes/hardening/trim-resistor-leads.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-trim-resistor-leads-2025-08-12",
+            "date": "2025-08-12",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add `trim-resistor-leads` process for prepping resistors with wire cutters
- harden `trim-resistor-leads`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baa7ac97c832fb87ac48fb359fbdd