### PR TITLE
Update battery voltage process duration

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1620,16 +1620,21 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "3m",
+        "duration": "5m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-hardening-2025-08-10",
                     "date": "2025-08-10",
                     "score": 65
+                },
+                {
+                    "task": "codex-hardening-2025-09-25",
+                    "date": "2025-09-25",
+                    "score": 70
                 }
             ]
         }

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1464,7 +1464,7 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "3m"
+        "duration": "5m"
     },
     {
         "id": "measure-resistance",

--- a/frontend/src/pages/processes/hardening/measure-battery-voltage.json
+++ b/frontend/src/pages/processes/hardening/measure-battery-voltage.json
@@ -1,12 +1,17 @@
 {
-    "passes": 1,
-    "score": 65,
+    "passes": 2,
+    "score": 70,
     "emoji": "🌀",
     "history": [
         {
             "task": "codex-hardening-2025-08-10",
             "date": "2025-08-10",
             "score": 65
+        },
+        {
+            "task": "codex-hardening-2025-09-25",
+            "date": "2025-09-25",
+            "score": 70
         }
     ]
 }


### PR DESCRIPTION
## Summary
- adjust measure-battery-voltage process to 5m duration
- bump hardening score and regenerate processes data

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baa7ac97c832fb87ac48fb359fbdd