### PR TITLE
Add flashlight battery voltage check process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3364,5 +3364,35 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "check-flashlight-battery",
+        "title": "Measure flashlight battery voltage with a digital multimeter",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                "count": 1
+            },
+            {
+                "id": "5127e156-3009-4db4-85ac-e3ea070b68f2",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-12",
+                    "date": "2025-08-12",
+                    "score": 60
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2700,5 +2700,23 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "1m"
+    },
+    {
+        "id": "check-flashlight-battery",
+        "title": "Measure flashlight battery voltage with a digital multimeter",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                "count": 1
+            },
+            {
+                "id": "5127e156-3009-4db4-85ac-e3ea070b68f2",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m"
     }
 ]

--- a/frontend/src/pages/processes/hardening/check-flashlight-battery.json
+++ b/frontend/src/pages/processes/hardening/check-flashlight-battery.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-hardening-2025-08-12",
+            "date": "2025-08-12",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add process to measure flashlight battery voltage with multimeter
- include hardening record

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- processQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689baa7ac97c832fb87ac48fb359fbdd