### PR TITLE
📝 : – refine bed leveling quest safety and references

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -222,6 +222,23 @@
         }
     },
     {
+        "id": "level-3d-printer-bed",
+        "title": "Level a 3D printer bed with a sheet of paper",
+        "requireItems": [
+            {
+                "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
+                "count": 1
+            },
+            {
+                "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m"
+    },
+    {
         "id": "3dprint-rocket",
         "title": "3D print a 100 mm model rocket using 91 g of green PLA on an entry-level FDM printer",
         "image": "/assets/modelrocket.jpg",

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -20,6 +20,19 @@
         }
     },
     {
+        "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0",
+        "name": "sheet of printer paper",
+        "description": "Single 216 x 279 mm (8.5 x 11 in) sheet of 80 g/m² copy paper.",
+        "image": "/assets/paperwork.jpg",
+        "price": "0.01 dUSD",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "8f54a592-09de-4340-829b-7288897eb4c7",
         "name": "Edison Model M",
         "description": "Mid-size electric sedan with 75 kWh battery (~400 km range) and highway driver-assist; seats five.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -150,6 +150,17 @@
         "duration": "1h 30m"
     },
     {
+        "id": "level-3d-printer-bed",
+        "title": "Level a 3D printer bed with a sheet of paper",
+        "requireItems": [
+            { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+            { "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m"
+    },
+    {
         "id": "3dprint-rocket",
         "title": "3D print a 100 mm model rocket using 91 g of green PLA on an entry-level FDM printer",
         "image": "/assets/modelrocket.jpg",

--- a/frontend/src/pages/quests/json/3dprinting/bed-leveling.json
+++ b/frontend/src/pages/quests/json/3dprinting/bed-leveling.json
@@ -1,14 +1,14 @@
 {
     "id": "3dprinting/bed-leveling",
     "title": "Level the Print Bed",
-    "description": "Ensure the first layer sticks by leveling your build plate.",
+    "description": "Ensure the first layer sticks by safely leveling your build plate.",
     "image": "/assets/quests/benchy_25.jpg",
     "npc": "/assets/npc/sydney.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Uneven prints? Let's get that bed level for a perfect first layer.",
+            "text": "Uneven prints? Let's get that bed level safely for a perfect first layer.",
             "options": [
                 {
                     "type": "goto",
@@ -19,17 +19,20 @@
         },
         {
             "id": "level",
-            "text": "Use a sheet of paper to adjust each corner until you feel slight drag.",
+            "text": "Let the bed cool, then slide a sheet of printer paper between the nozzle and bed. Adjust each corner until you feel slight drag and keep fingers clear of hot surfaces.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "level-3d-printer-bed",
+                    "text": "Walk me through the steps."
+                },
                 {
                     "type": "goto",
                     "goto": "finish",
                     "text": "Bed is level and ready!",
                     "requiresItems": [
-                        {
-                            "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
-                            "count": 1
-                        }
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0", "count": 1 }
                     ]
                 }
             ]
@@ -46,5 +49,17 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["3dprinter/start"]
+    "requiresQuests": ["3dprinter/start"],
+    "hardening": {
+        "passes": 1,
+        "score": 65,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-refinement-2025-08-12",
+                "date": "2025-08-12",
+                "score": 65
+            }
+        ]
+    }
 }


### PR DESCRIPTION
what: add printer paper item, leveling process, and safety note for bed-leveling quest.
why: ensure reproducible guidance and clear safety, with inventory and process grounding.
how to test:
- npm run lint
- npm run type-check
- npm run build
- SKIP_E2E=1 npm test -- questCanonical questQuality
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689baa707148832f89a8ff0ded8f40f6