### PR TITLE
Add geothermal inlet temperature quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 188
-New quests in this release: 166
+Current quest count: 189
+New quests in this release: 167
 
 ### 3dprinting
 
@@ -145,6 +145,7 @@ New quests in this release: 166
 ### geothermal
 
 - geothermal/calibrate-ground-sensor
+- geothermal/check-loop-inlet-temp
 - geothermal/compare-depth-ground-temps
 - geothermal/compare-seasonal-ground-temps
 - geothermal/install-backup-thermistor

--- a/frontend/src/pages/quests/json/geothermal/check-loop-inlet-temp.json
+++ b/frontend/src/pages/quests/json/geothermal/check-loop-inlet-temp.json
@@ -1,0 +1,35 @@
+{
+    "id": "geothermal/check-loop-inlet-temp",
+    "title": "Check Loop Inlet Temperature",
+    "description": "Use an Arduino to log the water temperature entering the heat pump.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Curious how cool the loop returns? Let's measure the inlet temperature.",
+            "options": [{ "type": "goto", "goto": "setup", "text": "Show me how." }]
+        },
+        {
+            "id": "setup",
+            "text": "Use an Arduino Uno, run arduino-thermistor-read, dip in inlet, log data.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Temperature recorded",
+                    "process": "arduino-thermistor-read",
+                    "requiresItems": [{ "id": "72b4448e-27d9-4746-bd3a-967ff13f501b", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Logging inlet temps helps spot loop performance issues early.",
+            "options": [{ "type": "finish", "text": "Can't wait to analyze." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["geothermal/survey-ground-temperature"]
+}


### PR DESCRIPTION
## Summary
- add quest to log heat pump inlet temperature with Arduino Uno
- update new quests index with geothermal loop temperature entry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689ba9ee11b0832fbad8a6f9d94e7465