### PR TITLE
Normalize price lookup identifiers and log outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ cd frontend && npm run dev:safe
 
 The `dev:safe` command prevents common Playwright artifact errors that can occur after running tests.
 
+### Utility Functions
+
+The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
+normalizes case, spaces, and hyphens for resilient calls.
+
 ## Testing
 
 DSPACE uses a comprehensive testing suite to ensure code quality and prevent regressions.

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -6,6 +6,10 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice('3d_printer')).toBe(350)
   })
 
+  it('handles case and separator variations', () => {
+    expect(approximateIrlPrice('3D-Printer')).toBe(350)
+  })
+
   it('returns null for unknown item', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -22,6 +22,13 @@ const priceTable: Record<string, number> = {
   "ssd_1tb": 120
 };
 
+/**
+ * Look up a real‑world price for a game item.
+ *
+ * The lookup is case‑insensitive and normalizes spaces or hyphens to underscores
+ * so callers can pass identifiers like `3D-Printer` or `3d printer`.
+ */
 export function approximateIrlPrice(id: string): number | null {
-  return priceTable[id] ?? null;
+  const normalized = id.toLowerCase().replace(/[\s-]+/g, '_');
+  return priceTable[normalized] ?? null;
 }

--- a/outages/2025-08-12-case-insensitive-price-lookup.json
+++ b/outages/2025-08-12-case-insensitive-price-lookup.json
@@ -1,0 +1,8 @@
+{
+  "id": "case-insensitive-price-lookup",
+  "date": "2025-08-12",
+  "component": "backend",
+  "rootCause": "approximateIrlPrice rejected mixed-case or hyphenated item IDs",
+  "resolution": "normalized input to lowercase and replaced spaces and hyphens before lookup",
+  "references": []
+}


### PR DESCRIPTION
## Summary
- normalize `approximateIrlPrice` to handle case, spaces, and hyphens
- document utility and record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bc7a1b52c832f8273a1c784d14523