### PR TITLE
fix: pin pnpm semver to restore installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Make sure you have **Node.js 18 or 20 LTS** installed. The CI runs on Node.js 20
 git clone https://github.com/democratizedspace/dspace.git
 cd dspace
 node --version # ensure Node.js 18 or 20 is in use
+# pnpm 9.0.0 is configured via packageManager
 pnpm install
 ```
 

--- a/outages/2025-08-12-pnpm-package-manager-semver.json
+++ b/outages/2025-08-12-pnpm-package-manager-semver.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-12-pnpm-package-manager-semver",
+  "date": "2025-08-12",
+  "component": "build",
+  "rootCause": "package.json used pnpm@9 without full semver, so corepack blocked installs",
+  "resolution": "updated package.json to pin pnpm@9.0.0 and added a test to enforce semver",
+  "references": [
+    "README.md#local-development"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dspace",
   "version": "3.0.0",
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": ">=18 <22"
   },

--- a/tests/packageManager.test.ts
+++ b/tests/packageManager.test.ts
@@ -3,8 +3,8 @@ import { join } from 'path';
 import { describe, it, expect } from 'vitest';
 
 describe('package.json', () => {
-  it('declares pnpm as the package manager', () => {
+  it('declares pnpm with a full semver version', () => {
     const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
-    expect(pkg.packageManager).toMatch(/^pnpm@/);
+    expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/);
   });
 });


### PR DESCRIPTION
## Summary
- pin packageManager to pnpm@9.0.0 to satisfy corepack
- test package.json for full semver
- document pnpm version and log outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:root`


------
https://chatgpt.com/codex/tasks/task_e_689bc7a1b52c832f8273a1c784d14523