### PR TITLE
fix: strip ANSI codes in zero-test detection

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -155,7 +155,8 @@ npm run coverage
 ```
 
 Running `npm test` emits a warning if it detects zero tests, helping catch missing or
-misconfigured suites early.
+misconfigured suites early. The detector strips ANSI color codes so it works even when
+command output is colorized.
 
 ### End-to-End Tests
 

--- a/outages/2025-08-12-detect-zero-tests-ansi.json
+++ b/outages/2025-08-12-detect-zero-tests-ansi.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-08-12-detect-zero-tests-ansi",
+  "date": "2025-08-12",
+  "component": "test harness",
+  "rootCause": "ANSI color codes in vitest output prevented zero-test detection",
+  "resolution": "strip ANSI escape sequences before checking test output",
+  "references": [
+    "DEVELOPER_GUIDE.md#run-unit-tests",
+    "scripts/utils/detect-zero-tests.js"
+  ]
+}

--- a/scripts/tests/detectZeroTests.test.ts
+++ b/scripts/tests/detectZeroTests.test.ts
@@ -8,6 +8,13 @@ describe('hasZeroTests', () => {
     expect(hasZeroTests(output)).toBe(true);
   });
 
+  test('detects zero tests when ANSI colors are present', () => {
+    const output =
+      '\u001b[32mTest Files\u001b[0m  \u001b[31m0\u001b[0m passed\n' +
+      '\u001b[32mTests\u001b[0m  \u001b[31m0\u001b[0m passed';
+    expect(hasZeroTests(output)).toBe(true);
+  });
+
   test('does not trigger when tests are present', () => {
     const output = 'Test Files  1 passed\nTests  5 passed';
     expect(hasZeroTests(output)).toBe(false);

--- a/scripts/utils/detect-zero-tests.js
+++ b/scripts/utils/detect-zero-tests.js
@@ -1,8 +1,10 @@
 function hasZeroTests(output) {
+    // Strip ANSI color codes to ensure regex detection works with colored output
+    const clean = output.replace(/\x1B\[[0-9;]*m/g, '');
     return (
-        /Test Files\s+0\b/i.test(output) ||
-        /Tests\s+0\b/i.test(output) ||
-        /No test files? found/i.test(output)
+        /Test Files\s+0\b/i.test(clean) ||
+        /Tests\s+0\b/i.test(clean) ||
+        /No test files? found/i.test(clean)
     );
 }
 


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences before detecting zero test runs
- cover detector with colorized output test
- document detection robustness & record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bc7a1b52c832f8273a1c784d14523