### PR TITLE
Ignore data and protocol-relative image URLs in fs checks

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -98,3 +98,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `https` paths so coverage checks ignore external images.
 -   2025-08-12 – `.npmrc`'s `packageManager` key made npm warn; drop the file and
     set `packageManager` in `package.json` to keep installs quiet.
+-   2025-08-12 – `listMissingImages` flagged data URIs and protocol-relative sources as missing;
+    ignore `data:` and `//` URLs so coverage checks only test local assets.

--- a/outages/2025-08-12-list-missing-images-data-protocol.json
+++ b/outages/2025-08-12-list-missing-images-data-protocol.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-12-list-missing-images-data-protocol",
+  "date": "2025-08-12",
+  "component": "scripts",
+  "rootCause": "listMissingImages flagged data URIs and protocol-relative sources as missing files",
+  "resolution": "ignore data and protocol-relative URLs so coverage checks only verify local assets",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md#lessons-learned"
+  ]
+}

--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -13,4 +13,16 @@ describe('listMissingImages', () => {
     const missing = listMissingImages(images);
     expect(missing).toEqual([]);
   });
+
+  test('ignores data URLs', () => {
+    const images = ['data:image/png;base64,AAAA'];
+    const missing = listMissingImages(images);
+    expect(missing).toEqual([]);
+  });
+
+  test('ignores protocol-relative URLs', () => {
+    const images = ['//cdn.example.com/remote.png'];
+    const missing = listMissingImages(images);
+    expect(missing).toEqual([]);
+  });
 });

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -6,7 +6,7 @@ function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '.
     imagePaths.forEach((img) => {
         // Strip query strings or hash fragments so existence checks aren't fooled
         const base = img.split(/[?#]/)[0];
-        if (/^https?:\/\//i.test(base)) {
+        if (/^data:/i.test(base) || /^(?:https?:)?\/\//i.test(base)) {
             return;
         }
         const rel = base.startsWith('/') ? base.slice(1) : base;


### PR DESCRIPTION
## Summary
- prevent `listMissingImages` from flagging data URIs or protocol-relative links
- document the incident in `/outages`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bc789b018832f9bfb8f4c6b10d3a6