### PR TITLE
Add hand drying process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1945,6 +1945,37 @@
         }
     },
     {
+        "id": "dry-hands",
+        "title": "Dry your hands with a paper towel",
+        "image": "/assets/paperwork.jpg",
+        "requireItems": [
+            {
+                "id": "799ace33-1336-46c0-904a-9f16778230f1",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "30s",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-12",
+                    "date": "2025-08-12",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "pack-first-aid-kit",
         "title": "Pack a basic first aid kit",
         "requireItems": [],

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1694,6 +1694,25 @@
         "duration": "1m"
     },
     {
+        "id": "dry-hands",
+        "title": "Dry your hands with a paper towel",
+        "image": "/assets/paperwork.jpg",
+        "requireItems": [
+            {
+                "id": "799ace33-1336-46c0-904a-9f16778230f1",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "30s"
+    },
+    {
         "id": "pack-first-aid-kit",
         "title": "Pack a basic first aid kit",
         "requireItems": [],

--- a/frontend/src/pages/processes/hardening/dry-hands.json
+++ b/frontend/src/pages/processes/hardening/dry-hands.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-hardening-2025-08-12",
+            "date": "2025-08-12",
+            "score": 60
+        }
+    ]
+}

--- a/frontend/src/pages/quests/json/firstaid/assemble-kit.json
+++ b/frontend/src/pages/quests/json/firstaid/assemble-kit.json
@@ -19,12 +19,24 @@
         },
         {
             "id": "gather",
-            "text": "Wash with soap and water 20s. Set out bandages, gauze pads, antiseptic wipes, nitrile gloves.",
+            "text": "Wash with soap and water 20s, then dry with a paper towel. Set out bandages, gauze pads, antiseptic wipes, nitrile gloves.",
             "options": [
                 {
                     "type": "process",
                     "process": "wash-hands",
                     "text": "Hands are clean",
+                    "goto": "dry"
+                }
+            ]
+        },
+        {
+            "id": "dry",
+            "text": "Dry your hands before handling supplies.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "dry-hands",
+                    "text": "Hands are dry",
                     "goto": "pack"
                 }
             ]


### PR DESCRIPTION
## Summary
- add dry-hands process consuming a paper towel
- update first aid kit quest to require drying hands
- record hardening info and regenerate processes list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689bc74af6d0832f9ce07e6e95626c2e