### PR TITLE
Require thermometer for aquarium temperature check process

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -281,6 +281,7 @@
       "geothermal/install-backup-thermistor",
       "geothermal/compare-seasonal-ground-temps",
       "geothermal/compare-depth-ground-temps",
+      "geothermal/check-loop-inlet-temp",
       "geothermal/calibrate-ground-sensor",
       "electronics/thermistor-reading",
       "electronics/servo-sweep",
@@ -580,6 +581,12 @@
     "requires": [
       "firstaid/wound-care",
       "firstaid/restock-kit"
+    ],
+    "rewards": []
+  },
+  "7a4b8892-365f-4a56-93ce-127aa989f50d": {
+    "requires": [
+      "firstaid/wound-care"
     ],
     "rewards": []
   },
@@ -1195,9 +1202,21 @@
     ],
     "rewards": []
   },
+  "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4": {
+    "requires": [
+      "3dprinting/calibration-cube"
+    ],
+    "rewards": []
+  },
   "e37c86b0-caaf-485d-b5c1-c15f7029973c": {
     "requires": [
       "3dprinting/calibration-cube"
+    ],
+    "rewards": []
+  },
+  "60409c3f-56cf-4b9e-9e60-ca480d4896d0": {
+    "requires": [
+      "3dprinting/bed-leveling"
     ],
     "rewards": []
   }

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3005,11 +3005,27 @@
             {
                 "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60",
                 "count": 1
+            },
+            {
+                "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07",
+                "count": 1
             }
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "30s"
+        "duration": "30s",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-09-15",
+                    "date": "2025-09-15",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "stop-nosebleed",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2426,6 +2426,10 @@
             {
                 "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60",
                 "count": 1
+            },
+            {
+                "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07",
+                "count": 1
             }
         ],
         "consumeItems": [],

--- a/frontend/src/pages/processes/hardening/check-aquarium-temperature.json
+++ b/frontend/src/pages/processes/hardening/check-aquarium-temperature.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-hardening-2025-09-15",
+            "date": "2025-09-15",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- require aquarium thermometer to verify water temperature
- add hardening record for `check-aquarium-temperature`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bc74af6d0832f9ce07e6e95626c2e