### PR TITLE
Add goldfish process hardening

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1262,6 +1262,7 @@
     {
         "id": "add-goldfish",
         "title": "Add a goldfish to your aquarium",
+        "image": "/assets/aquarium_goldfish.jpg",
         "requireItems": [
             {
                 "id": "ee7d437d-7426-47cd-b691-386dd20f4e47",
@@ -1284,7 +1285,13 @@
                 "count": 1
             }
         ],
-        "duration": "1m"
+        "duration": "10m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     },
     {
         "id": "feed-goldfish",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1088,6 +1088,7 @@
     {
         "id": "add-goldfish",
         "title": "Add a goldfish to your aquarium",
+        "image": "/assets/aquarium_goldfish.jpg",
         "requireItems": [
             {
                 "id": "ee7d437d-7426-47cd-b691-386dd20f4e47",
@@ -1110,7 +1111,7 @@
                 "count": 1
             }
         ],
-        "duration": "1m"
+        "duration": "10m"
     },
     {
         "id": "feed-goldfish",

--- a/frontend/src/pages/processes/hardening/add-goldfish.json
+++ b/frontend/src/pages/processes/hardening/add-goldfish.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add image and realistic duration for `add-goldfish`
- record initial hardening metadata for goldfish process
- regenerate `processes.json`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689bc74af6d0832f9ce07e6e95626c2e