### PR TITLE
Add aquarium thermometer quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -281,6 +281,7 @@
       "geothermal/install-backup-thermistor",
       "geothermal/compare-seasonal-ground-temps",
       "geothermal/compare-depth-ground-temps",
+      "geothermal/check-loop-inlet-temp",
       "geothermal/calibrate-ground-sensor",
       "electronics/thermistor-reading",
       "electronics/servo-sweep",
@@ -360,7 +361,8 @@
       "programming/temp-alert",
       "programming/graph-temp",
       "geothermal/survey-ground-temperature",
-      "electronics/thermometer-calibration"
+      "electronics/thermometer-calibration",
+      "aquaria/thermometer"
     ],
     "rewards": []
   },
@@ -580,6 +582,12 @@
     "requires": [
       "firstaid/wound-care",
       "firstaid/restock-kit"
+    ],
+    "rewards": []
+  },
+  "7a4b8892-365f-4a56-93ce-127aa989f50d": {
+    "requires": [
+      "firstaid/wound-care"
     ],
     "rewards": []
   },
@@ -1195,9 +1203,21 @@
     ],
     "rewards": []
   },
+  "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4": {
+    "requires": [
+      "3dprinting/calibration-cube"
+    ],
+    "rewards": []
+  },
   "e37c86b0-caaf-485d-b5c1-c15f7029973c": {
     "requires": [
       "3dprinting/calibration-cube"
+    ],
+    "rewards": []
+  },
+  "60409c3f-56cf-4b9e-9e60-ca480d4896d0": {
+    "requires": [
+      "3dprinting/bed-leveling"
     ],
     "rewards": []
   }

--- a/frontend/src/pages/quests/json/aquaria/thermometer.json
+++ b/frontend/src/pages/quests/json/aquaria/thermometer.json
@@ -1,0 +1,40 @@
+{
+    "id": "aquaria/thermometer",
+    "title": "Attach Aquarium Thermometer",
+    "description": "Stick a strip thermometer to monitor water temperature.",
+    "image": "/assets/aquarium_thermometer.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your heater's running, but let's keep an eye on the temperature. Wipe a dry spot on the outside of the tank, just below the waterline.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "attach",
+                    "text": "Ready to stick it on."
+                }
+            ]
+        },
+        {
+            "id": "attach",
+            "text": "Peel the backing and press the thermometer firmly against the glass. Wait a few minutes for it to display.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Thermometer attached",
+                    "requiresItems": [{ "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Now you can monitor the water temperature at a glance.",
+            "options": [{ "type": "finish", "text": "All set!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["aquaria/position-tank"]
+}


### PR DESCRIPTION
## Summary
- add quest to stick an aquarium thermometer after positioning the tank
- map thermometer item to the new quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality` *(no test files found)*
- `SKIP_E2E=1 npm run test:ci` *(no unit tests were run)*

------
https://chatgpt.com/codex/tasks/task_e_689bc733524c832f98327925d0214955