### PR TITLE
Add change bandage quest

### DIFF
--- a/frontend/src/pages/quests/json/firstaid/change-bandage.json
+++ b/frontend/src/pages/quests/json/firstaid/change-bandage.json
@@ -1,0 +1,51 @@
+{
+    "id": "firstaid/change-bandage",
+    "title": "Change a Bandage",
+    "description": "Replace a used bandage to keep a wound clean and dry.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A fresh bandage helps a cut heal. Ready to swap the old one?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "change",
+                    "text": "Let's do it"
+                }
+            ]
+        },
+        {
+            "id": "change",
+            "text": "Wash your hands, remove the used bandage, and cover the wound with a new sterile one.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Hands washed and bandage replaced",
+                    "goto": "finish",
+                    "requiresItems": [
+                        {
+                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Change the dressing daily and watch for redness or swelling.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Will do"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/wound-care"]
+}


### PR DESCRIPTION
## Summary
- add `firstaid/change-bandage` quest that covers washing hands and replacing a used dressing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bc733524c832f98327925d0214955