### PR TITLE
Add print removal scraper tool to inventory

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -124,6 +124,20 @@
         }
     },
     {
+        "id": "9b985439-3c19-4fa7-b864-34a3c5c33ac4",
+        "name": "print removal scraper",
+        "description": "Thin spring-steel scraper with ergonomic handle lifts prints off the build plate without gouging.",
+        "image": "/assets/benchy.jpg",
+        "price": "6 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "5fbabfcf-27d0-48f5-a89e-7aba8ca4b913",
         "name": "claw hammer (16 oz)",
         "description": "450 g (16 oz) drop-forged steel head, curved claw and 330 mm (13 in) fiberglass handle for nails.",

--- a/frontend/src/pages/quests/json/3dprinting/calibration-cube.json
+++ b/frontend/src/pages/quests/json/3dprinting/calibration-cube.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "print",
-            "text": "Level the build plate, preheat to PLA temps, load 15 g of green PLA filament, slice, and start the print. Wear safety goggles, keep hands clear of the moving nozzle, ensure ventilation, stay nearby, and let the cube cool before removal.",
+            "text": "Level the build plate, preheat to PLA temps, load 15 g of green PLA filament, slice, and start the print. Wear safety goggles, keep hands clear of the moving nozzle, ensure ventilation, stay nearby, let the cube cool, then lift it off the plate with a print removal scraper.",
             "options": [
                 {
                     "type": "process",
@@ -29,11 +29,12 @@
                 {
                     "type": "goto",
                     "goto": "measure",
-                    "text": "Cube printed and cooled.",
+                    "text": "Cube cooled and removed.",
                     "requiresItems": [
                         { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
                         { "id": "d3590107-25ff-4de5-af3a-46e2497bfc52", "count": 15 },
-                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 },
+                        { "id": "9b985439-3c19-4fa7-b864-34a3c5c33ac4", "count": 1 }
                     ]
                 }
             ]
@@ -64,8 +65,8 @@
     "rewards": [],
     "requiresQuests": ["3dprinter/start"],
     "hardening": {
-        "passes": 2,
-        "score": 80,
+        "passes": 3,
+        "score": 82,
         "emoji": "✅",
         "history": [
             {
@@ -77,6 +78,11 @@
                 "task": "codex-quest-hardening-2025-08-12",
                 "date": "2025-08-12",
                 "score": 80
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-13",
+                "date": "2025-08-13",
+                "score": 82
             }
         ]
     }


### PR DESCRIPTION
## Summary
- add print removal scraper tool item and quest requirement
- update calibration cube quest text and hardening score

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npx vitest run tests/itemQuality.test.ts`
- `npx vitest run scripts/tests/questQuality.test.ts`
- `npm run test:ci` *(fails: Prettier formatting test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689bc7564758832f890e2af8b8a088f5