### PR TITLE
🌀 refine docker-compose quest with Cloudflare tunnel

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1525,6 +1525,23 @@
         "duration": "1m"
     },
     {
+        "id": "create-cloudflare-tunnel",
+        "title": "Create a Cloudflare Tunnel to port 3002",
+        "requireItems": [
+            {
+                "id": "a2f40d22-171e-4f87-b5d4-3a44aee7ad2e",
+                "count": 1
+            },
+            {
+                "id": "e709a9fc-dd12-4507-af48-5f83b386b835",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "join-k3s-cluster",
         "title": "Join nodes to a k3s cluster",
         "requireItems": [

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1351,6 +1351,23 @@
         "duration": "1m"
     },
     {
+        "id": "create-cloudflare-tunnel",
+        "title": "Create a Cloudflare Tunnel to port 3002",
+        "requireItems": [
+            {
+                "id": "a2f40d22-171e-4f87-b5d4-3a44aee7ad2e",
+                "count": 1
+            },
+            {
+                "id": "e709a9fc-dd12-4507-af48-5f83b386b835",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "join-k3s-cluster",
         "title": "Join nodes to a k3s cluster",
         "requireItems": [

--- a/frontend/src/pages/quests/json/devops/docker-compose.json
+++ b/frontend/src/pages/quests/json/devops/docker-compose.json
@@ -1,19 +1,31 @@
 {
     "id": "devops/docker-compose",
     "title": "Launch DSPACE in Docker",
-    "description": "Start the container and open a Cloudflare Tunnel.",
+    "description": "Launch the container and share it through a secure Cloudflare Tunnel.",
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-12",
+                "date": "2025-08-12",
+                "score": 60
+            }
+        ]
+    },
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "From the project directory run `docker compose up --build -d` to launch the game on port 3002.",
+            "text": "Run `docker compose up --build -d` in the project directory. Use `docker compose down` to stop.",
             "options": [
                 {
                     "type": "process",
                     "process": "run-docker-compose",
-                    "text": "Starting it up."
+                    "text": "Start container."
                 },
                 {
                     "type": "goto",
@@ -30,8 +42,13 @@
         },
         {
             "id": "tunnel",
-            "text": "Create a Cloudflare Tunnel pointing at `http://localhost:3002` so friends can reach your Pi from anywhere.",
+            "text": "Expose the service with `cloudflared tunnel --url http://localhost:3002`. Keep the token private.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "create-cloudflare-tunnel",
+                    "text": "Run cloudflared."
+                },
                 {
                     "type": "goto",
                     "goto": "finish",


### PR DESCRIPTION
## Summary
- clarify devops/docker-compose quest with stop and token safety notes
- add Cloudflare tunnel process and reference existing network gear items
- record first hardening pass for the quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689bc7479960832fa06f5ad436788cfe