### PR TITLE
docs: refresh new quest list and prompts

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 189
-New quests in this release: 167
+Current quest count: 195
+New quests in this release: 173
 
 ### 3dprinting
 
@@ -31,10 +31,12 @@ New quests in this release: 167
 - aquaria/filter-rinse
 - aquaria/floating-plants
 - aquaria/guppy
+- aquaria/heater-install
 - aquaria/ph-strip-test
 - aquaria/position-tank
 - aquaria/shrimp
 - aquaria/sponge-filter
+- aquaria/thermometer
 - aquaria/walstad
 - aquaria/water-change
 - aquaria/water-testing
@@ -62,6 +64,7 @@ New quests in this release: 167
 
 - chemistry/acid-dilution
 - chemistry/acid-neutralization
+- chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
 - chemistry/safe-reaction
@@ -108,6 +111,7 @@ New quests in this release: 167
 - electronics/desolder-component
 - electronics/led-polarity
 - electronics/light-sensor
+- electronics/measure-led-current
 - electronics/measure-resistance
 - electronics/potentiometer-dimmer
 - electronics/resistor-color-check
@@ -146,6 +150,7 @@ New quests in this release: 167
 
 - geothermal/calibrate-ground-sensor
 - geothermal/check-loop-inlet-temp
+- geothermal/check-loop-outlet-temp
 - geothermal/compare-depth-ground-temps
 - geothermal/compare-seasonal-ground-temps
 - geothermal/install-backup-thermistor
@@ -208,6 +213,7 @@ New quests in this release: 167
 - rocketry/preflight-check
 - rocketry/recovery-run
 - rocketry/static-test
+- rocketry/wind-check
 
 ### sysadmin
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -101,7 +101,8 @@ committing.
 
 USER:
 1. Follow the steps above.
-2. Run the commands listed in the system prompt before committing.
+2. Run the commands listed in the system prompt, then `npm run new-quests:update`, before
+   committing.
 3. Summarize the new or updated quest in the PR description.
 4. Use an emoji-prefixed commit message.
 
@@ -125,8 +126,9 @@ USER:
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- questCanonical questQuality`. Fix any failures.
-4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
-5. Use an emoji-prefixed commit message.
+4. Run `npm run new-quests:update` to refresh the quest count docs.
+5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the new quest.


### PR DESCRIPTION
## Summary
- Regenerate new quests markdown
- Prompt contributors to update quest counts when adding quests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689bd507b9b0832fa8e16f9bf5277cac