### PR TITLE
docs: regenerate new quests list and prompt updates

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 189
-New quests in this release: 167
+Current quest count: 195
+New quests in this release: 173
 
 ### 3dprinting
 
@@ -31,10 +31,12 @@ New quests in this release: 167
 - aquaria/filter-rinse
 - aquaria/floating-plants
 - aquaria/guppy
+- aquaria/heater-install
 - aquaria/ph-strip-test
 - aquaria/position-tank
 - aquaria/shrimp
 - aquaria/sponge-filter
+- aquaria/thermometer
 - aquaria/walstad
 - aquaria/water-change
 - aquaria/water-testing
@@ -62,6 +64,7 @@ New quests in this release: 167
 
 - chemistry/acid-dilution
 - chemistry/acid-neutralization
+- chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
 - chemistry/safe-reaction
@@ -108,6 +111,7 @@ New quests in this release: 167
 - electronics/desolder-component
 - electronics/led-polarity
 - electronics/light-sensor
+- electronics/measure-led-current
 - electronics/measure-resistance
 - electronics/potentiometer-dimmer
 - electronics/resistor-color-check
@@ -146,6 +150,7 @@ New quests in this release: 167
 
 - geothermal/calibrate-ground-sensor
 - geothermal/check-loop-inlet-temp
+- geothermal/check-loop-outlet-temp
 - geothermal/compare-depth-ground-temps
 - geothermal/compare-seasonal-ground-temps
 - geothermal/install-backup-thermistor
@@ -208,6 +213,7 @@ New quests in this release: 167
 - rocketry/preflight-check
 - rocketry/recovery-run
 - rocketry/static-test
+- rocketry/wind-check
 
 ### sysadmin
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -76,8 +76,9 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm test -- questCanonical questQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
-8. Update docs or dialogue as needed.
+7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
+8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+9. Update docs or dialogue as needed.
 
 OUTPUT
 A pull request with the completed quest and passing checks.
@@ -102,8 +103,9 @@ committing.
 USER:
 1. Follow the steps above.
 2. Run the commands listed in the system prompt before committing.
-3. Summarize the new or updated quest in the PR description.
-4. Use an emoji-prefixed commit message.
+3. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
+4. Summarize the new or updated quest in the PR description.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request implementing the quest with all tests green.
@@ -125,8 +127,9 @@ USER:
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm test -- questCanonical questQuality`. Fix any failures.
-4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
-5. Use an emoji-prefixed commit message.
+4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
+5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the new quest.

--- a/tests/newQuestsList.test.ts
+++ b/tests/newQuestsList.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import update from '../scripts/update-new-quests.js';
+import { globSync } from 'glob';
 
 type Group = { tree: string; quests: string[] };
 type Section = {
@@ -56,5 +57,18 @@ describe('new quests list', () => {
       after,
       'Run `npm run new-quests:update` and commit the changes.'
     ).toBe(before);
+  });
+
+  it('lists total quest count accurately', () => {
+    const questDir = path.join(
+      __dirname,
+      '../frontend/src/pages/quests/json'
+    );
+    const questFiles = globSync('**/*.json', { cwd: questDir });
+    const doc = fs.readFileSync(listPath, 'utf8');
+    const match = doc.match(/Current quest count: (\d+)/);
+    expect(match).not.toBeNull();
+    const docCount = Number(match[1]);
+    expect(docCount).toBe(questFiles.length);
   });
 });


### PR DESCRIPTION
## Summary
- regenerate new quests index to reflect latest quests
- document running `npm run new-quests:update` in quest prompts
- add unit test to fail when quest list count mismatches quest files

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd507b9b0832fa8e16f9bf5277cac