### PR TITLE
🧹 : add basic pre-commit configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,6 +7,10 @@ elif command -v powershell >/dev/null 2>&1; then
   powershell -NoProfile -ExecutionPolicy Bypass -File .husky/pre-commit.ps1
 else
   echo "PowerShell not found, falling back to bash script"
+  if command -v pre-commit >/dev/null 2>&1; then
+    echo "Running pre-commit checks..."
+    pre-commit run --files $(git diff --cached --name-only)
+  fi
   cd frontend
   echo "Running linting on staged files..."
   npx lint-staged

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json


### PR DESCRIPTION
## Summary
- add basic pre-commit hooks for whitespace, eof, yaml, and json checks
- run pre-commit from Husky script when available

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c199dee40832fb010fb8dbe04bb34