### PR TITLE
🧹 : – add pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 echo "Running pre-commit hooks"
+if command -v pre-commit >/dev/null 2>&1; then
+  echo "Running Python pre-commit checks..."
+  pre-commit run --files $(git diff --cached --name-only)
+else
+  echo "pre-commit not installed; skipping Python pre-commit checks"
+fi
 if command -v pwsh >/dev/null 2>&1; then
   pwsh -NoProfile -ExecutionPolicy Bypass -File .husky/pre-commit.ps1
 elif command -v powershell >/dev/null 2>&1; then

--- a/.husky/pre-commit.ps1
+++ b/.husky/pre-commit.ps1
@@ -1,8 +1,14 @@
 ﻿#!/usr/bin/env pwsh
 $ErrorActionPreference = "Stop"
 Write-Host "Running pre-commit checks..." -ForegroundColor Blue
-Write-Host "Running lint-staged on changed files..." -ForegroundColor Yellow
+Write-Host "Running Python pre-commit checks..." -ForegroundColor Yellow
+if (Get-Command pre-commit -ErrorAction SilentlyContinue) {
+    pre-commit run --files $(git diff --cached --name-only)
+} else {
+    Write-Host "pre-commit not installed; skipping" -ForegroundColor DarkYellow
+}
 
+Write-Host "Running lint-staged on changed files..." -ForegroundColor Yellow
 npx lint-staged
 
 if ($LASTEXITCODE -ne 0) {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,12 @@ Thank you for your interest in helping the project! Below is a quick overview of
    ```bash
    pnpm install
    ```
-   Husky hooks install automatically. Use `npm run ci:install` in CI to skip them.
+  Husky hooks install automatically. Use `npm run ci:install` in CI to skip them.
+
+3. Install additional Git hooks via [pre-commit](https://pre-commit.com/):
+   ```bash
+   pre-commit install
+   ```
 
 ## Development Workflow
 
@@ -19,8 +24,8 @@ Thank you for your interest in helping the project! Below is a quick overview of
   npm run check
   ```
 - The test suite verifies file formatting, so unformatted changes will fail CI.
-- The pre-commit hook validates quest and item schemas, runs `lint-staged`, `npm run check`,
-  and `npm test`. Run it manually with:
+- The pre-commit hook validates quest and item schemas, runs `lint-staged`, checks from
+  `.pre-commit-config.yaml`, `npm run check`, and `npm test`. Run it manually with:
     ```bash
     npm test
     ```


### PR DESCRIPTION
## Summary
- add basic pre-commit config with common checks
- run pre-commit from existing husky scripts
- document hook installation in CONTRIBUTING

## Testing
- `pre-commit run --files $(git diff --cached --name-only)`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci` (partial)


------
https://chatgpt.com/codex/tasks/task_e_689c199dee40832fb010fb8dbe04bb34