### PR TITLE
feat: add aquarium water test logging process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3111,6 +3111,40 @@
         }
     },
     {
+        "id": "log-aquarium-test-results",
+        "title": "Record aquarium water parameters in a logbook using a liquid test kit",
+        "image": "/assets/paperwork.jpg",
+        "requireItems": [
+            {
+                "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a",
+                "count": 1
+            },
+            {
+                "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2",
+                "count": 1
+            },
+            {
+                "id": "b8602362-2035-4f00-9376-f48d8668cf38",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-17",
+                    "date": "2025-08-17",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "stop-nosebleed",
         "title": "Use gloves, gauze, and antiseptic from a first aid kit to control a minor nosebleed",
         "image": "/assets/rescue.jpg",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2485,6 +2485,19 @@
         "duration": "30s"
     },
     {
+        "id": "log-aquarium-test-results",
+        "title": "Record aquarium water parameters in a logbook using a liquid test kit",
+        "image": "/assets/paperwork.jpg",
+        "requireItems": [
+            { "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a", "count": 1 },
+            { "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2", "count": 1 },
+            { "id": "b8602362-2035-4f00-9376-f48d8668cf38", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10m"
+    },
+    {
         "id": "stop-nosebleed",
         "title": "Use gloves, gauze, and antiseptic from a first aid kit to control a minor nosebleed",
         "image": "/assets/rescue.jpg",

--- a/frontend/src/pages/processes/hardening/log-aquarium-test-results.json
+++ b/frontend/src/pages/processes/hardening/log-aquarium-test-results.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-17",
+            "date": "2025-08-17",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add `log-aquarium-test-results` process requiring aquarium, liquid test kit, and logbook
- track process hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c2011f7f4832fb096f58577903af1