### PR TITLE
Add process for masking rocket body tube

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -910,6 +910,31 @@
         "duration": "8h 3m 13s"
     },
     {
+        "id": "mask-rocket-body-tube",
+        "title": "Mask a rocket body tube with masking tape for painting",
+        "image": "/assets/modelrocket.jpg",
+        "requireItems": [
+            {
+                "id": "1eac8955-bb70-474b-b6b0-4002ff3aa09a",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed",
+                "count": 0.1
+            }
+        ],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "assemble-rocket",
         "title": "Assemble your rocket",
         "requireItems": [],

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -730,6 +730,25 @@
         "duration": "8h 3m 13s"
     },
     {
+        "id": "mask-rocket-body-tube",
+        "title": "Mask a rocket body tube with masking tape for painting",
+        "image": "/assets/modelrocket.jpg",
+        "requireItems": [
+            {
+                "id": "1eac8955-bb70-474b-b6b0-4002ff3aa09a",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed",
+                "count": 0.1
+            }
+        ],
+        "createItems": [],
+        "duration": "3m"
+    },
+    {
         "id": "assemble-rocket",
         "title": "Assemble your rocket",
         "requireItems": [],

--- a/frontend/src/pages/processes/hardening/mask-rocket-body-tube.json
+++ b/frontend/src/pages/processes/hardening/mask-rocket-body-tube.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add `mask-rocket-body-tube` process linking masking tape and rocket body tube
- track initial hardening metadata for the new process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c2011f7f4832fb096f58577903af1