### PR TITLE
📝 : clarify quest validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,14 @@ To validate that quests use a canonical structure with clear start and finish
 steps, run the dedicated test:
 
 ```bash
-[Quest Development Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template), and the [Quest Submission Guide](docs/quest-submission) to streamline content creation and sharing.
-Use `npm run generate-quest [--template <name>]` to scaffold a new quest with placeholder dialogue.
+npm test -- questValidation
 ```
+
+See [Quest Development Guidelines](docs/quest-guidelines), the
+[Quest Template Example](docs/quest-template), and the
+[Quest Submission Guide](docs/quest-submission) to streamline content creation
+and sharing. Use `npm run generate-quest [--template <name>]` to scaffold a new
+quest with placeholder dialogue.
 
 Custom quests often rely on new items or processes. Use [`scripts/create-content-bundle.js`](./scripts/create-content-bundle.js) to package these together. See the [Custom Content Bundles](docs/custom-bundles) guide for details.
 


### PR DESCRIPTION
what: fix README quest validation code block.
why: previous snippet mixed doc text with code.
how to test: pre-commit run --files README.md, npm run lint,
npm run type-check, npm run build, SKIP_E2E=1 npm test, pytest.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c25b10868832fa287eede21d707f1