### PR TITLE
📝 docs: add approximateIrlPrice example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 
 The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
 normalizes case, spaces, and hyphens for resilient calls.
+Prices are approximate USD values.
+
+```ts
+import { approximateIrlPrice } from "./backend/approximateIrlPrice";
+
+console.log(approximateIrlPrice("3D-Printer")); // 350
+console.log(approximateIrlPrice("unknown")); // null
+```
+
 
 ## Testing
 


### PR DESCRIPTION
what: document TypeScript usage of approximateIrlPrice
why: clarify price lookup and null handling
how:
- pre-commit run --all-files (fails: frontend/tsconfig.json invalid)
- pre-commit run --files README.md
- pytest
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c25b10868832fa287eede21d707f1