### PR TITLE
🐛 fix: trim id before price lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 ### Utility Functions
 
 The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
-normalizes case, spaces, and hyphens for resilient calls.
+trims whitespace and normalizes case, spaces, and hyphens for resilient calls.
 
 ## Testing
 

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -13,4 +13,8 @@ describe('approximateIrlPrice', () => {
   it('returns null for unknown item', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })
+
+  it('ignores surrounding whitespace', () => {
+    expect(approximateIrlPrice(' 3d printer ')).toBe(350)
+  })
 })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -25,10 +25,11 @@ const priceTable: Record<string, number> = {
 /**
  * Look up a real‑world price for a game item.
  *
- * The lookup is case‑insensitive and normalizes spaces or hyphens to underscores
- * so callers can pass identifiers like `3D-Printer` or `3d printer`.
- */
+ * The lookup is case‑insensitive, trims surrounding whitespace, and normalizes
+ * spaces or hyphens to underscores so callers can pass identifiers like
+ * `3D-Printer`, `3d printer`, or even ` 3d_printer `.
+*/
 export function approximateIrlPrice(id: string): number | null {
-  const normalized = id.toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = id.trim().toLowerCase().replace(/[\s-]+/g, '_');
   return priceTable[normalized] ?? null;
 }


### PR DESCRIPTION
## Summary
- handle leading/trailing whitespace in `approximateIrlPrice`
- document whitespace-trimming behavior
- test price lookup with surrounding spaces

## Testing
- `SKIP=check-json pre-commit run --files README.md backend/approximateIrlPrice.ts backend/approximateIrlPrice.test.ts`
- `pytest`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `SKIP_E2E=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c25b10868832fa287eede21d707f1