### PR TITLE
🩹: fix textbox color syntax

### DIFF
--- a/frontend/src/components/Card.astro
+++ b/frontend/src/components/Card.astro
@@ -6,7 +6,7 @@ const { href, title, body, textbox, disabled, image, duration } = Astro.props;
 
 {
 // TODO: make this a Disableable and do a ternary on hazard instead
-disabled 
+disabled
 	?
 		<div>
 		<li class="link-card disabled">
@@ -123,16 +123,16 @@ disabled
 	.disabled {
 		border-color: red;
 	}
-	
+
 	.textbox {
 		background-color: #7d9b7e;
 		border-color: #997529;
-		border-radius: 0.35rem;
-		padding: 0.1em 0.1em;
-		color: red);
-		opacity: 1;
-		border-color: red;
-	}
+                border-radius: 0.35rem;
+                padding: 0.1em 0.1em;
+                color: red;
+                opacity: 1;
+                border-color: red;
+        }
 
 	span {
 	    width: 100%;


### PR DESCRIPTION
## Summary
- remove stray parenthesis in Card component textbox color rule

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run check`
- `npm run audit:ci`
- `SKIP_E2E=1 npm test`
- `npm run test:ci`
- `pre-commit run --files frontend/src/components/Card.astro`
- `pre-commit run --all-files` *(fails: frontend/tsconfig.json invalid JSON)*
- `make test` *(fails: No rule to make target 'test')*
- `bash scripts/checks.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c25a49c00832fbdc64563050c1f6f