### PR TITLE
🐛 Handle percent-encoded image paths in listMissingImages

### DIFF
--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { listMissingImages } from '../utils/fs-checks';
 
 describe('listMissingImages', () => {
@@ -24,5 +27,18 @@ describe('listMissingImages', () => {
     const images = ['//cdn.example.com/remote.png'];
     const missing = listMissingImages(images);
     expect(missing).toEqual([]);
+  });
+
+  test('resolves percent-encoded paths', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'images-'));
+    try {
+      const filename = 'encoded image.png';
+      fs.writeFileSync(path.join(tmp, filename), '');
+      const images = ['encoded%20image.png'];
+      const missing = listMissingImages(images, tmp);
+      expect(missing).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -1,7 +1,18 @@
 const fs = require('fs');
 const path = require('path');
 
-function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '..', 'frontend', 'public')) {
+/**
+ * Returns image paths that are missing from the public directory.
+ * Handles query strings, hash fragments, and percent-encoded segments.
+ *
+ * @param {string[]} imagePaths
+ * @param {string} [publicDir=path.join(__dirname, '..', '..', 'frontend', 'public')]
+ * @returns {string[]}
+ */
+function listMissingImages(
+    imagePaths,
+    publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
+) {
     const missing = [];
     imagePaths.forEach((img) => {
         // Strip query strings or hash fragments so existence checks aren't fooled
@@ -10,7 +21,13 @@ function listMissingImages(imagePaths, publicDir = path.join(__dirname, '..', '.
             return;
         }
         const rel = base.startsWith('/') ? base.slice(1) : base;
-        const full = path.join(publicDir, rel);
+        let decoded;
+        try {
+            decoded = decodeURIComponent(rel);
+        } catch {
+            decoded = rel;
+        }
+        const full = path.join(publicDir, decoded);
         if (!fs.existsSync(full)) {
             missing.push(img);
         }


### PR DESCRIPTION
## Summary
- decode URI-encoded segments before checking for missing images
- test percent-encoded filenames

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `pre-commit run --all-files` *(fails: frontend/tsconfig.json is not valid JSON)*
- `make test` *(fails: no rule for target)*
- `bash scripts/checks.sh` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c25a49c00832fbdc64563050c1f6f