### PR TITLE
chore: refine printer paper item

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -223,7 +223,7 @@
     },
     {
         "id": "level-3d-printer-bed",
-        "title": "Level a 3D printer bed with a sheet of paper",
+        "title": "Level a 3D printer bed with a sheet of printer paper",
         "requireItems": [
             {
                 "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -22,19 +22,24 @@
     {
         "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0",
         "name": "sheet of printer paper",
-        "description": "Single 216 x 279 mm (8.5 x 11 in) sheet of 80 g/m² copy paper.",
+        "description": "Single 216 × 279 mm (8.5 × 11 in) sheet of 80 g/m² letter printer paper.",
         "image": "/assets/paperwork.jpg",
-        "price": "0.01 dUSD",
-        "unit": "each",
+        "price": "0.02 dUSD",
+        "unit": "sheet",
         "hardening": {
-            "passes": 1,
-            "score": 60,
-            "emoji": "🌀",
+            "passes": 2,
+            "score": 80,
+            "emoji": "✅",
             "history": [
                 {
                     "task": "codex-item-hardening-2025-08-12",
                     "date": "2025-08-12",
                     "score": 60
+                },
+                {
+                    "task": "codex-item-hardening-2025-08-13",
+                    "date": "2025-08-13",
+                    "score": 80
                 }
             ]
         }

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -151,7 +151,7 @@
     },
     {
         "id": "level-3d-printer-bed",
-        "title": "Level a 3D printer bed with a sheet of paper",
+        "title": "Level a 3D printer bed with a sheet of printer paper",
         "requireItems": [
             { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
             { "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0", "count": 1 }


### PR DESCRIPTION
## Summary
- improve printer paper item details and hardening metadata
- clarify 3D printer bed leveling process title

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm test -- itemQuality` *(fails: Missing Playwright browsers/deps)*

------
https://chatgpt.com/codex/tasks/task_e_689c2035f960832fab1c69fc6b5875e1