### PR TITLE
🩹 trim whitespace before price lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 ### Utility Functions
 
 The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
-normalizes case, spaces, and hyphens for resilient calls.
+trims surrounding whitespace and normalizes case, spaces, and hyphens for resilient calls.
 
 ## Testing
 

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -10,6 +10,10 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice('3D-Printer')).toBe(350)
   })
 
+  it('trims surrounding whitespace', () => {
+    expect(approximateIrlPrice(' 3d_printer ')).toBe(350)
+  })
+
   it('returns null for unknown item', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -29,6 +29,6 @@ const priceTable: Record<string, number> = {
  * so callers can pass identifiers like `3D-Printer` or `3d printer`.
  */
 export function approximateIrlPrice(id: string): number | null {
-  const normalized = id.toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = id.trim().toLowerCase().replace(/[\s-]+/g, '_');
   return priceTable[normalized] ?? null;
 }

--- a/outages/2025-08-13-trim-spaces-price-lookup.json
+++ b/outages/2025-08-13-trim-spaces-price-lookup.json
@@ -1,0 +1,8 @@
+{
+  "id": "trim-spaces-price-lookup",
+  "date": "2025-08-13",
+  "component": "backend",
+  "rootCause": "approximateIrlPrice returned null when item IDs had leading or trailing spaces",
+  "resolution": "trimmed item ID before normalizing so lookups ignore surrounding whitespace",
+  "references": []
+}


### PR DESCRIPTION
## Summary
- trim item id before approximateIrlPrice lookup
- add regression test and docs
- record outage in outages/2025-08-13-trim-spaces-price-lookup.json

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c20733198832f8676f9bc069d06f7