### PR TITLE
Add soldered jumper wire inventory item

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1304,6 +1304,20 @@
         }
     },
     {
+        "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c",
+        "name": "soldered jumper wire",
+        "description": "10 cm jumper wire with heat-shrunk solder joint for prototyping.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "0.20 dUSD",
+        "unit": "each",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "280ed361-ac70-4ab9-bcd9-aee481790faf",
         "name": "mission log entry",
         "description": "One handwritten entry recording a mission event in the logbook.",

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -45,7 +45,7 @@
             "options": [{ "type": "finish", "text": "Thanks, Orion!" }]
         }
     ],
-    "rewards": [],
+    "rewards": [{ "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c", "count": 1 }],
     "requiresQuests": [],
     "hardening": {
         "passes": 3,


### PR DESCRIPTION
## Summary
- add soldered jumper wire inventory item
- reward solder-wire quest with newly crafted wire

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm test -- itemQuality`
- `npm test -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c2031b844832fb25c8834c0f51a91