### PR TITLE
feat: quest schema validation

### DIFF
--- a/frontend/src/components/__tests__/QuestForm.spec.ts
+++ b/frontend/src/components/__tests__/QuestForm.spec.ts
@@ -36,3 +36,11 @@ test('shows image preview after upload', async () => {
 
     g.FileReader = original;
 });
+
+test('rejects title with forbidden characters', async () => {
+    const { getByLabelText, getByRole, findByText } = render(QuestForm);
+    const titleInput = getByLabelText(/Title/i);
+    await fireEvent.input(titleInput, { target: { value: '<b>' } });
+    await fireEvent.submit(getByRole('form'));
+    await findByText('Invalid characters');
+});

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -108,14 +108,24 @@
             errors.image = 'Image is required';
         }
 
-        const { valid } = validateQuestData({
+        const { valid, errors: schemaErrors } = validateQuestData({
             title: title.trim(),
             description: description.trim(),
             image: previewUrl || '',
             requiresQuests,
         });
-        if (!valid) {
-            errors.schema = 'Invalid quest data';
+        if (!valid && schemaErrors) {
+            schemaErrors.forEach((err) => {
+                const field = err.instancePath.replace('/', '');
+                if (!field) return;
+                if (field === 'image' && !errors.image) {
+                    errors.image = 'Invalid image format';
+                } else if (field === 'requiresQuests' && !errors.requiresQuests) {
+                    errors.requiresQuests = 'Invalid quest dependency';
+                } else if (!errors[field]) {
+                    errors[field] = 'Invalid characters';
+                }
+            });
         }
 
         if (

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -11,17 +11,17 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
 -   [x] Custom Quest System
 
-    -   [x] In‑game quest creation UI ✅
+    -   [x] In‑game quest creation UI 💯
         -   [x] Implement QuestForm component with image upload 💯
-        -   [x] Add quest validation against JSON schema
+        -   [x] Add quest validation against JSON schema 💯
         -   [x] Create quest preview functionality 💯
         -   [x] Add quest requirements selection 💯
-    -   [x] Quest contribution workflow ✅
+    -   [x] Quest contribution workflow 💯
         -   [x] Implement quest PR submission form 💯
         -   [x] Add quest review interface 💯
-        -   [x] Create pull request generation system ✅
-    -   [x] Quest validation and testing ✅
-        -   [x] Expand test suite for custom quests ✅
+        -   [x] Create pull request generation system 💯
+    -   [x] Quest validation and testing 💯
+        -   [x] Expand test suite for custom quests 💯
         -   [x] Add validation for quest dependencies 💯
         -   [x] Implement quest simulation testing 💯
     -   [x] Quest submission process documentation 💯
@@ -37,7 +37,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
 -   [x] Custom Items and Processes (using the same system as quests)
 
-    -   [x] Item Management ✅
+    -   [x] Item Management 💯
         -   [x] Item creation interface with `ItemForm.svelte` 💯
     -   [x] Item validation schema 💯
         -   [x] Item dependency tracking 💯

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -122,7 +122,11 @@ Every quest JSON file must include:
         - `requiresGitHub`: Set to `true` to disable the option until a GitHub token is saved
 - `rewards`: Items given upon quest completion
 - `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**).
-  Automated tests ensure these dependencies reference existing quests and avoid cycles.
+Automated tests ensure these dependencies reference existing quests and avoid cycles.
+
+Quest data is validated against a JSON schema. Titles and descriptions reject
+`<` and `>` characters, and `image` must be a data URL, an absolute HTTP(S)
+link, or a root-relative path.
 
 ### Current Implementation State
 

--- a/frontend/src/utils/customQuestValidation.js
+++ b/frontend/src/utils/customQuestValidation.js
@@ -19,7 +19,7 @@ export const customQuestSchema = {
     required: ['title', 'description', 'image'],
 };
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(customQuestSchema);
 
 export function validateQuestData(data) {

--- a/tests/questSchemaValidation.test.ts
+++ b/tests/questSchemaValidation.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { validateQuestData } from '../frontend/src/utils/customQuestValidation.js';
+
+describe('custom quest schema validation', () => {
+  it('rejects angle brackets in title', () => {
+    const { valid, errors } = validateQuestData({
+      title: '<tag>',
+      description: 'long enough description',
+      image: '/img.png',
+      requiresQuests: []
+    });
+    expect(valid).toBe(false);
+    expect(errors?.[0]?.instancePath).toBe('/title');
+  });
+
+  it('accepts valid quest data', () => {
+    const { valid } = validateQuestData({
+      title: 'My Quest',
+      description: 'A valid description at least ten chars',
+      image: '/img.png',
+      requiresQuests: []
+    });
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- surface JSON schema errors in QuestForm
- document schema validation rules
- mark changelog entries as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test`
- `npm run test:root`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689c204fa6c0832fa7451854ebdecfde