### PR TITLE
docs: refresh prompt test instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -25,8 +25,10 @@ content rules see the [Item Development Guidelines](/docs/item-guidelines).
 -   **Add or update an item**
     -   Web: use the “Code” button and attach the repo.
     -   CLI: `codex "add item solar-cell-junction-box"`
--   **Ask about item data** - Web: use the “Ask” button. - CLI: `codex exec "explain frontend/src/pages/inventory/json/items/*.json"`
-    -   **Run item tests**
+-   **Ask about item data**
+    -   Web: use the “Code” button (the “Ask” button also works).
+    -   CLI: `codex exec "explain frontend/src/pages/inventory/json/items/*.json"`
+-   **Run item tests**
     -   Web: not supported yet.
     -   CLI:
         ```bash
@@ -87,10 +89,10 @@ You are an automated contributor for the DSPACE repository. Edit or
 create items under `frontend/src/pages/inventory/json/items`, choosing the
 appropriate category file. Ensure realistic details, required fields, and
 passing checks (`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
-`npm run itemValidation`, and `npm test -- itemQuality`).
+`npm run itemValidation`, and `npm run test:ci -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
 assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-committing. If a quest's text changes, run `npm test -- questQuality` and update the quest's
+committing. If a quest's text changes, run `npm run test:ci -- questQuality` and update the quest's
 `hardening` block with a fresh evaluation score.
 
 USER:
@@ -138,7 +140,7 @@ USER:
      ]
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
-   `npm run itemValidation`, and `npm test -- itemQuality`. Update docs if needed.
+   `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.
 

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -20,7 +20,7 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1. Quick start (Web vs CLI)
 
 -   **Add or update a process**
     -   Web: use the “Code” button and attach the repo.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -23,7 +23,7 @@ which covers quests, items and processes in detail.
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1. Quick start (Web vs CLI)
 
 - **Add or update a quest**
     - Web: use the “Code” button and attach the repo.
@@ -36,7 +36,7 @@ which covers quests, items and processes in detail.
     - CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm test -- questCanonical questQuality"
+        npm run test:ci -- questCanonical questQuality"
         ```
 
 See the [Codex CLI repository][codex-cli] for more flags.
@@ -50,7 +50,7 @@ See the [Codex CLI repository][codex-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
-| **Acceptance check** | e.g. “`npm test -- questCanonical questQuality` passes”.            |
+| **Acceptance check** | e.g. “`npm run test:ci -- questCanonical questQuality` passes”.     |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -75,7 +75,7 @@ REQUIREMENTS
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
-6. Run `npm test -- questCanonical questQuality` and fix any failures.
+6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 9. Update docs or dialogue as needed.
@@ -94,7 +94,7 @@ You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
 (`npm run lint`, `npm run type-check`, `npm run build`, and
-`npm test -- questCanonical questQuality`). Survey existing quests to
+`npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
 for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
@@ -126,7 +126,7 @@ USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm test -- questCanonical questQuality`. Fix any failures.
+   `npm run test:ci -- questCanonical questQuality`. Fix any failures.
 4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
@@ -174,8 +174,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-    `npm test -- questCanonical questQuality`. Update docs if needed.
+     6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+     `npm run test:ci -- questCanonical questQuality`. Update docs if needed.
    7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- clarify quick start sections for item and quest prompts
- use `npm run test:ci` in prompt docs
- align process prompt heading style
- prefer Code button when asking about item data

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c20618f58832fa77cb880eefea9d9