### PR TITLE
Require desoldering pump for component removal quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -138,6 +138,18 @@
     ],
     "rewards": []
   },
+  "15e3dd7e-374b-4233-b8c9-117e3057f009": {
+    "requires": [],
+    "rewards": [
+      "rocketry/wind-check"
+    ]
+  },
+  "451d86d9-96e0-4829-af27-8a8b0be65ae4": {
+    "requires": [
+      "rocketry/wind-check"
+    ],
+    "rewards": []
+  },
   "80a83ecc-bcd2-400e-a469-8488a6453bb8": {
     "requires": [
       "rocketry/static-test",
@@ -281,6 +293,7 @@
       "geothermal/install-backup-thermistor",
       "geothermal/compare-seasonal-ground-temps",
       "geothermal/compare-depth-ground-temps",
+      "geothermal/check-loop-outlet-temp",
       "geothermal/check-loop-inlet-temp",
       "geothermal/calibrate-ground-sensor",
       "electronics/thermistor-reading",
@@ -362,7 +375,8 @@
       "programming/graph-temp",
       "geothermal/survey-ground-temperature",
       "electronics/thermometer-calibration",
-      "aquaria/thermometer"
+      "aquaria/thermometer",
+      "aquaria/heater-install"
     ],
     "rewards": []
   },
@@ -427,6 +441,7 @@
       "hydroponics/ph-check",
       "chemistry/ph-test",
       "chemistry/ph-adjustment",
+      "chemistry/buffer-solution",
       "chemistry/acid-neutralization",
       "chemistry/acid-dilution",
       "aquaria/ph-strip-test"
@@ -709,6 +724,7 @@
     ],
     "rewards": [
       "electronics/resistor-color-check",
+      "electronics/measure-led-current",
       "electronics/led-polarity",
       "electronics/check-battery-voltage",
       "electronics/basic-circuit"
@@ -742,6 +758,7 @@
     "requires": [
       "electronics/thermistor-reading",
       "electronics/potentiometer-dimmer",
+      "electronics/measure-led-current",
       "electronics/light-sensor",
       "electronics/basic-circuit",
       "electronics/arduino-blink"
@@ -754,6 +771,7 @@
       "electronics/solder-wire",
       "electronics/servo-sweep",
       "electronics/potentiometer-dimmer",
+      "electronics/measure-led-current",
       "electronics/light-sensor",
       "electronics/basic-circuit",
       "electronics/arduino-blink"
@@ -777,9 +795,22 @@
     ],
     "rewards": []
   },
+  "6a3772b6-2550-434f-89f9-2eb53d5b139f": {
+    "requires": [
+      "electronics/solder-wire"
+    ],
+    "rewards": []
+  },
+  "96083990-f333-4e42-ab04-7eb2a234570e": {
+    "requires": [
+      "electronics/solder-wire"
+    ],
+    "rewards": []
+  },
   "828d6c3b-66a5-4064-b221-97630274502b": {
     "requires": [
       "electronics/servo-sweep",
+      "electronics/measure-led-current",
       "electronics/basic-circuit"
     ],
     "rewards": []
@@ -789,6 +820,7 @@
       "electronics/resistor-color-check",
       "electronics/potentiometer-dimmer",
       "electronics/measure-resistance",
+      "electronics/measure-led-current",
       "electronics/basic-circuit",
       "electronics/arduino-blink"
     ],
@@ -804,6 +836,7 @@
   "48cf736e-184c-4bd1-b9b0-15b7e9721646": {
     "requires": [
       "electronics/potentiometer-dimmer",
+      "electronics/measure-led-current",
       "electronics/led-polarity",
       "electronics/basic-circuit",
       "electronics/arduino-blink"
@@ -819,6 +852,7 @@
   "5127e156-3009-4db4-85ac-e3ea070b68f2": {
     "requires": [
       "electronics/measure-resistance",
+      "electronics/measure-led-current",
       "electronics/light-sensor",
       "electronics/led-polarity",
       "electronics/continuity-test",
@@ -843,6 +877,12 @@
     "requires": [
       "electronics/light-sensor",
       "electronics/data-logger"
+    ],
+    "rewards": []
+  },
+  "6f2bbb48-8620-4f22-b487-d1d7db34ab22": {
+    "requires": [
+      "electronics/desolder-component"
     ],
     "rewards": []
   },
@@ -1103,7 +1143,8 @@
   },
   "0b85f058-38f2-4e9a-93e9-d47441608619": {
     "requires": [
-      "aquaria/position-tank"
+      "aquaria/position-tank",
+      "aquaria/heater-install"
     ],
     "rewards": []
   },
@@ -1204,6 +1245,13 @@
     "rewards": []
   },
   "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4": {
+    "requires": [
+      "3dprinting/filament-change",
+      "3dprinting/calibration-cube"
+    ],
+    "rewards": []
+  },
+  "9b985439-3c19-4fa7-b864-34a3c5c33ac4": {
     "requires": [
       "3dprinting/calibration-cube"
     ],

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -86,7 +86,7 @@
     {
         "id": "6f2bbb48-8620-4f22-b487-d1d7db34ab22",
         "name": "desoldering pump",
-        "description": "Spring-loaded vacuum pump for removing molten solder from circuit boards.",
+        "description": "Spring-loaded aluminum pump with 1 mm PTFE tip for removing molten solder; 30 g.",
         "image": "/assets/quests/basic_circuit.svg",
         "price": "8 dUSD",
         "type": "tool",

--- a/frontend/src/pages/quests/json/electronics/desolder-component.json
+++ b/frontend/src/pages/quests/json/electronics/desolder-component.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "prep",
-            "text": "Grab iron kit and solder sucker or braid. Heat iron; keep leads tidy.",
+            "text": "Grab iron kit, safety goggles, and solder sucker or braid. Heat iron; keep leads tidy.",
             "options": [
                 {
                     "type": "goto",
@@ -27,6 +27,7 @@
                     "text": "Tools ready.",
                     "requiresItems": [
                         { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+                        { "id": "6f2bbb48-8620-4f22-b487-d1d7db34ab22", "count": 1 },
                         { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 }
                     ]
                 }
@@ -44,5 +45,11 @@
         }
     ],
     "requiresQuests": ["electronics/solder-wire"],
-    "rewards": []
+    "rewards": [],
+    "hardening": {
+        "passes": 0,
+        "score": 0,
+        "emoji": "🛠️",
+        "history": []
+    }
 }


### PR DESCRIPTION
## Summary
- describe desoldering pump with PTFE tip
- require desoldering pump in "Desolder a component" quest and add hardening

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `SKIP_E2E=1 npm test -- itemQuality`
- `SKIP_E2E=1 npm test -- questQuality`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c2031b844832fb25c8834c0f51a91