### PR TITLE
feat: add nozzle-cleaning quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 195
-New quests in this release: 173
+Current quest count: 196
+New quests in this release: 174
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 173
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower

--- a/frontend/src/pages/quests/json/3dprinting/nozzle-cleaning.json
+++ b/frontend/src/pages/quests/json/3dprinting/nozzle-cleaning.json
@@ -1,0 +1,43 @@
+{
+    "id": "3dprinting/nozzle-cleaning",
+    "title": "Clear a Clogged Nozzle",
+    "description": "Heat and clean the nozzle to restore smooth extrusion.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Filament won't flow? The nozzle might be clogged. Let's clear it.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "clean",
+                    "text": "Show me how."
+                }
+            ]
+        },
+        {
+            "id": "clean",
+            "text": "Preheat to 200 °C, put on safety goggles, then gently push cleaning filament or a nozzle needle until the blockage is gone.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Flow restored.",
+                    "requiresItems": [
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Smooth extrusion again! Keep the hotend clean for reliable prints.",
+            "options": [{ "type": "finish", "text": "Back to printing." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinter/start"]
+}


### PR DESCRIPTION
## Summary
- add 3D printer nozzle cleaning quest
- document new quest in list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root -- questCanonical questQuality`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c1ffcfdf4832fabfe10e477348d11