### PR TITLE
feat: add CLI plotting quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 195
-New quests in this release: 173
+Current quest count: 196
+New quests in this release: 174
 
 ### 3dprinting
 
@@ -187,6 +187,7 @@ New quests in this release: 173
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/quests/json/programming/plot-temp-cli.json
+++ b/frontend/src/pages/quests/json/programming/plot-temp-cli.json
@@ -1,0 +1,49 @@
+{
+    "id": "programming/plot-temp-cli",
+    "title": "Plot Temperature Data via CLI",
+    "description": "Use Python to turn your temperature log into a line chart.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've gathered plenty of readings. Let's transform them into a picture.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "script",
+                    "text": "Show me the script"
+                }
+            ]
+        },
+        {
+            "id": "script",
+            "text": "Run a Python script to read the log and draw a line graph with Matplotlib.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "plot-temperature-data",
+                    "text": "Running the plot script"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "The chart is rendered"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Visualizing data makes patterns jump out.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Done"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-logger"]
+}


### PR DESCRIPTION
## Summary
- add programming quest for plotting temperature logs via CLI
- update new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c1ffcfdf4832fabfe10e477348d11