### PR TITLE
✨ add precipitation reaction chemistry quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 195
-New quests in this release: 173
+Current quest count: 196
+New quests in this release: 174
 
 ### 3dprinting
 
@@ -67,6 +67,7 @@ New quests in this release: 173
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction

--- a/frontend/src/pages/quests/json/chemistry/precipitation-reaction.json
+++ b/frontend/src/pages/quests/json/chemistry/precipitation-reaction.json
@@ -1,0 +1,50 @@
+{
+    "id": "chemistry/precipitation-reaction",
+    "title": "Form a Precipitate",
+    "description": "Mix two solutions until a solid appears.",
+    "image": "/assets/pH_strip.jpg",
+    "npc": "/assets/npc/phoenix.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Grab beakers, safety gear, and two clear salt solutions.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "mix",
+                    "text": "Solutions are ready."
+                }
+            ]
+        },
+        {
+            "id": "mix",
+            "text": "Combine the solutions slowly while stirring. Watch for a cloud forming.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Rinse off any splashes."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "A solid precipitate settles.",
+                    "requiresItems": [{ "id": "13167d6a-5617-4931-8a6e-6f463c6b8835", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Filter and label the precipitate for later study.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Sample collected."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["chemistry/ph-test"]
+}


### PR DESCRIPTION
## Summary
- add precipitation reaction quest to chemistry tree
- document updated quest count

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c1ffcfdf4832fabfe10e477348d11