### PR TITLE
feat: add aurora watch quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 195
-New quests in this release: 173
+Current quest count: 196
+New quests in this release: 174
 
 ### 3dprinting
 
@@ -44,6 +44,7 @@ New quests in this release: 173
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations

--- a/frontend/src/pages/quests/json/astronomy/aurora-watch.json
+++ b/frontend/src/pages/quests/json/astronomy/aurora-watch.json
@@ -1,0 +1,50 @@
+{
+    "id": "astronomy/aurora-watch",
+    "title": "Watch the Aurora",
+    "description": "Check the aurora forecast and step outside with a red flashlight to log the lights.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Solar winds may trigger auroras tonight. Check the forecast and head to a dark, open view.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "observe",
+                    "text": "Forecast looks promising."
+                }
+            ]
+        },
+        {
+            "id": "observe",
+            "text": "Bring a red flashlight to protect night vision and watch the northern horizon for shimmering curtains.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "I logged dancing lights!",
+                    "requiresItems": [
+                        {
+                            "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice catch! Your notes help track geomagnetic storms. Stay warm and reuse dark sites.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "I'll watch again soon."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/light-pollution"]
+}


### PR DESCRIPTION
## Summary
- add astronomy/aurora-watch quest requiring a red flashlight
- regenerate new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689c1ff44740832fa1bf92500d7983f1