### PR TITLE
Add wood finish quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 195
-New quests in this release: 173
+Current quest count: 196
+New quests in this release: 174
 
 ### 3dprinting
 
@@ -234,6 +234,7 @@ New quests in this release: 173
 
 ### woodworking
 
+- woodworking/apply-finish
 - woodworking/birdhouse
 - woodworking/bookshelf
 - woodworking/coffee-table

--- a/frontend/src/pages/quests/json/woodworking/apply-finish.json
+++ b/frontend/src/pages/quests/json/woodworking/apply-finish.json
@@ -1,0 +1,34 @@
+{
+    "id": "woodworking/apply-finish",
+    "title": "Apply a Wood Finish",
+    "description": "Cedar shows you how to brush on a protective finish to seal your project.",
+    "image": "/assets/door.jpg",
+    "npc": "/assets/npc/atlas.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your project is sanded smooth. Ready to seal it with a thin coat of finish?",
+            "options": [{ "type": "goto", "goto": "apply", "text": "I'm ready" }]
+        },
+        {
+            "id": "apply",
+            "text": "Stir the finish and brush along the grain with even strokes, wiping away any excess.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Coat applied",
+                    "requiresItems": [{ "id": "05dd84f7-b9bc-4eac-93c5-5838cab84b32", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Once it dries your project will resist wear and moisture.",
+            "options": [{ "type": "finish", "text": "Looks great!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/finish-sanding"]
+}


### PR DESCRIPTION
## Summary
- add woodworking/apply-finish quest gated by finish-sanding
- document new quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689c1ff44740832fa1bf92500d7983f1