### PR TITLE
🩹: refresh new quests list to fix failing tests

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 201
+New quests in this release: 179
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -100,3 +100,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     set `packageManager` in `package.json` to keep installs quiet.
 -   2025-08-12 – `listMissingImages` flagged data URIs and protocol-relative sources as missing;
     ignore `data:` and `//` URLs so coverage checks only test local assets.
+-   2025-08-14 – `new-quests.md` fell behind after new quests were added; run `npm run new-quests:update`
+    and commit the refreshed file.

--- a/outages/2025-08-14-new-quests-list-outdated.json
+++ b/outages/2025-08-14-new-quests-list-outdated.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-14-new-quests-list-outdated",
+  "date": "2025-08-14",
+  "component": "docs",
+  "rootCause": "new quests were added but frontend/src/pages/docs/md/new-quests.md was not regenerated",
+  "resolution": "ran npm run new-quests:update and committed the updated new-quests.md",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md#lessons-learned"
+  ]
+}


### PR DESCRIPTION
## Summary
- regenerate new-quests.md and record outage
- document lesson about keeping generated quest list current

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d57b41bb8832f828f276be28c1bd7