### PR TITLE
feat: add helping hands tool

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -249,6 +249,20 @@
         }
     },
     {
+        "id": "87f670ce-3630-42bb-84c0-9243cf630d05",
+        "name": "helping hands",
+        "description": "Adjustable third-hand tool with alligator clips and magnifier to hold small parts while soldering.",
+        "image": "/assets/benchy.jpg",
+        "price": "10 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "2dfe683c-56f6-4026-b9e9-2d01a03b1878",
         "name": "tape measure",
         "description": "3 m (10 ft) retractable steel tape measure with metric and imperial markings.",

--- a/frontend/src/pages/quests/json/electronics/soldering-intro.json
+++ b/frontend/src/pages/quests/json/electronics/soldering-intro.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Good to see you progressing! Before soldering, let's tin that iron tip. Plug in your station and have a damp sponge ready.",
+            "text": "Good to see you progressing! Before soldering, secure your work in helping hands, plug in your station and have a damp sponge ready.",
             "options": [
                 {
                     "type": "goto",
@@ -17,6 +17,10 @@
                     "requiresItems": [
                         {
                             "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff",
+                            "count": 1
+                        },
+                        {
+                            "id": "87f670ce-3630-42bb-84c0-9243cf630d05",
                             "count": 1
                         }
                     ]
@@ -46,5 +50,17 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["electronics/basic-circuit"]
+    "requiresQuests": ["electronics/basic-circuit"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-hardening-2025-08-14",
+                "date": "2025-08-14",
+                "score": 60
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- add helping hands soldering tool with hardening stub
- require it in soldering intro quest and record hardening

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a515a88832fb9bc98d010ea5a77