### PR TITLE
feat: add hydroponic pH down solution item

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -61,6 +61,12 @@
     ],
     "rewards": []
   },
+  "05dd84f7-b9bc-4eac-93c5-5838cab84b32": {
+    "requires": [
+      "woodworking/apply-finish"
+    ],
+    "rewards": []
+  },
   "7318a5ba-fac3-476e-a532-c813ed9b18e5": {
     "requires": [],
     "rewards": [
@@ -305,6 +311,25 @@
     ],
     "rewards": []
   },
+  "c9b51052-4594-42d7-a723-82b815ab8cc2": {
+    "requires": [
+      "robotics/wheel-encoders",
+      "hydroponics/nutrient-check",
+      "firstaid/dispose-expired",
+      "electronics/solder-wire",
+      "electronics/measure-resistance",
+      "electronics/light-sensor",
+      "electronics/led-polarity",
+      "electronics/desolder-component",
+      "electronics/data-logger",
+      "electronics/continuity-test",
+      "electronics/check-battery-voltage",
+      "chemistry/ph-test",
+      "chemistry/acid-dilution",
+      "aquaria/water-testing"
+    ],
+    "rewards": []
+  },
   "e976bae6-e33c-428a-a20d-0aa8fde13c6c": {
     "requires": [
       "robotics/servo-radar",
@@ -386,6 +411,7 @@
       "hydroponics/top-off",
       "hydroponics/root-rinse",
       "hydroponics/netcup-clean",
+      "hydroponics/mint-cutting",
       "hydroponics/filter-clean",
       "hydroponics/bucket_10",
       "hydroponics/basil",
@@ -426,6 +452,7 @@
   "545aeb15-7e8b-489d-be4a-af2a59f447e1": {
     "requires": [
       "hydroponics/plug-soak",
+      "hydroponics/mint-cutting",
       "hydroponics/basil"
     ],
     "rewards": []
@@ -436,9 +463,16 @@
     ],
     "rewards": []
   },
+  "d5fbffe6-7e22-4cbc-84d3-f8f5bf023d04": {
+    "requires": [
+      "hydroponics/ph-test"
+    ],
+    "rewards": []
+  },
   "13167d6a-5617-4931-8a6e-6f463c6b8835": {
     "requires": [
       "hydroponics/ph-check",
+      "chemistry/precipitation-reaction",
       "chemistry/ph-test",
       "chemistry/ph-adjustment",
       "chemistry/buffer-solution",
@@ -461,24 +495,6 @@
       "firstaid/stop-nosebleed",
       "firstaid/learn-cpr",
       "firstaid/dispose-expired",
-      "chemistry/ph-test",
-      "chemistry/acid-dilution",
-      "aquaria/water-testing"
-    ],
-    "rewards": []
-  },
-  "c9b51052-4594-42d7-a723-82b815ab8cc2": {
-    "requires": [
-      "hydroponics/nutrient-check",
-      "firstaid/dispose-expired",
-      "electronics/solder-wire",
-      "electronics/measure-resistance",
-      "electronics/light-sensor",
-      "electronics/led-polarity",
-      "electronics/desolder-component",
-      "electronics/data-logger",
-      "electronics/continuity-test",
-      "electronics/check-battery-voltage",
       "chemistry/ph-test",
       "chemistry/acid-dilution",
       "aquaria/water-testing"
@@ -795,6 +811,12 @@
     ],
     "rewards": []
   },
+  "f6bb2c1a-0001-46bd-998a-388a488b5b5c": {
+    "requires": [],
+    "rewards": [
+      "electronics/solder-wire"
+    ]
+  },
   "6a3772b6-2550-434f-89f9-2eb53d5b139f": {
     "requires": [
       "electronics/solder-wire"
@@ -1018,6 +1040,7 @@
     "requires": [
       "astronomy/orion-nebula",
       "astronomy/light-pollution",
+      "astronomy/aurora-watch",
       "astronomy/andromeda"
     ],
     "rewards": []
@@ -1214,6 +1237,7 @@
     "requires": [
       "3dprinter/start",
       "3dprinting/phone-stand",
+      "3dprinting/nozzle-cleaning",
       "3dprinting/filament-change",
       "3dprinting/calibration-cube",
       "3dprinting/cable-clip",
@@ -1246,6 +1270,7 @@
   },
   "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4": {
     "requires": [
+      "3dprinting/nozzle-cleaning",
       "3dprinting/filament-change",
       "3dprinting/calibration-cube"
     ],

--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -331,5 +331,18 @@
                 }
             ]
         }
+    },
+    {
+        "id": "d5fbffe6-7e22-4cbc-84d3-f8f5bf023d04",
+        "name": "pH down solution",
+        "description": "500 ml phosphoric acid bottle to lower nutrient reservoir pH; includes dropper cap.",
+        "image": "/assets/hydroponics_nutrients.jpg",
+        "price": "7 dUSD",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/hydroponics/ph-test.json
+++ b/frontend/src/pages/quests/json/hydroponics/ph-test.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "measure",
-            "text": "Use a pH strip or digital meter. Add acid or base slowly until the reading hits 6.5.",
+            "text": "Use a pH strip or digital meter. Add pH down solution or base slowly until the reading hits 6.5.",
             "options": [
                 {
                     "type": "process",
@@ -33,6 +33,10 @@
                     "requiresItems": [
                         {
                             "id": "6360b1e7-84d6-4256-b085-f36fc53ef299",
+                            "count": 1
+                        },
+                        {
+                            "id": "d5fbffe6-7e22-4cbc-84d3-f8f5bf023d04",
                             "count": 1
                         }
                     ]
@@ -53,14 +57,19 @@
     "rewards": [],
     "requiresQuests": ["hydroponics/nutrient-check"],
     "hardening": {
-        "passes": 1,
-        "score": 65,
-        "emoji": "🌀",
+        "passes": 2,
+        "score": 70,
+        "emoji": "✅",
         "history": [
             {
                 "task": "codex-quest-hardening-2025-08-14",
                 "date": "2025-08-14",
                 "score": 65
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-18",
+                "date": "2025-08-18",
+                "score": 70
             }
         ]
     }


### PR DESCRIPTION
## Summary
- add pH down solution to hydroponics inventory
- require pH down solution in hydroponics pH test quest and refresh hardening score
- regenerate item quest map

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:ci`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a515a88832fb9bc98d010ea5a77