### PR TITLE
feat: add hydroponic measuring syringe

### DIFF
--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -295,6 +295,20 @@
         }
     },
     {
+        "id": "f1d1b5ad-ef3b-4ba7-9e69-4b8c97043d62",
+        "name": "50 mL measuring syringe",
+        "description": "Reusable 50 mL plastic syringe with clear markings for precise nutrient dosing.",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "price": "2 dUSD",
+        "unit": "each",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "71655665-4a59-41f4-9084-dad4d976df91",
         "name": "EC meter",
         "description": "Handheld EC meter (0–2000 ppm) for monitoring hydroponic nutrient strength.",

--- a/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/nutrient-check.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "add",
-            "text": "Slip on nitrile gloves and safety goggles. Measure the manufacturer-recommended dose of hydroponic nutrient solution, dissolve it in a bucket of clean water, then slowly pour it into the reservoir. Keep the submersible water pump running so the solution mixes evenly, wipe up any splashes immediately, and dip a pH strip to confirm the solution is between 5.5 and 6.5.",
+            "text": "Slip on nitrile gloves and safety goggles. Use a 50 mL syringe to measure the manufacturer-recommended dose of hydroponic nutrient solution, dissolve it in a bucket of clean water, then slowly pour it into the reservoir. Keep the submersible water pump running so the solution mixes evenly, wipe up any splashes immediately, and dip a pH strip to confirm the solution is between 5.5 and 6.5.",
             "options": [
                 {
                     "type": "process",
@@ -40,6 +40,10 @@
                         },
                         {
                             "id": "584ca717-4ce1-4ca1-bcd3-38272a52768a",
+                            "count": 1
+                        },
+                        {
+                            "id": "f1d1b5ad-ef3b-4ba7-9e69-4b8c97043d62",
                             "count": 1
                         },
                         {
@@ -84,9 +88,9 @@
     "rewards": [],
     "requiresQuests": ["hydroponics/basil"],
     "hardening": {
-        "passes": 3,
-        "score": 90,
-        "emoji": "💯",
+        "passes": 4,
+        "score": 80,
+        "emoji": "✅",
         "history": [
             {
                 "task": "codex-hardening-2025-08-04",
@@ -102,6 +106,11 @@
                 "task": "codex-refine-2025-08-05",
                 "date": "2025-08-05",
                 "score": 90
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-14",
+                "date": "2025-08-14",
+                "score": 80
             }
         ]
     }


### PR DESCRIPTION
## Summary
- add 50 mL measuring syringe item
- require syringe for hydroponic nutrient check and refresh hardening score

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a515a88832fb9bc98d010ea5a77