### PR TITLE
Fix E2E coverage check by adding Jest testMatch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,11 @@
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js"
     },
+    "jest": {
+        "testMatch": [
+            "**/__tests__/**/*.test.js"
+        ]
+    },
     "devDependencies": {
         "@astrojs/svelte": "^2.1.0",
         "@babel/core": "^7.26.9",

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -102,3 +102,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     ignore `data:` and `//` URLs so coverage checks only test local assets.
 -   2025-08-14 – `new-quests.md` fell behind after new quests were added; run `npm run new-quests:update`
     and commit the refreshed file.
+-   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
+    pattern so E2E tests detect all Jest files.

--- a/outages/2025-08-14-jest-config-missing.json
+++ b/outages/2025-08-14-jest-config-missing.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-14-jest-config-missing",
+  "date": "2025-08-14",
+  "component": "frontend tests",
+  "rootCause": "E2E coverage check failed because frontend/package.json lacked a Jest testMatch pattern.",
+  "resolution": "Added Jest testMatch configuration so coverage checks find all Jest test files.",
+  "references": ["e2e/test-coverage.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- configure Jest testMatch so coverage tests find all frontend Jest files
- document outage and lesson learned

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d6a1ea250832fad2ea45050d1c912