### PR TITLE
Remove unsupported Playwright headless flag

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -53,12 +53,7 @@ export default defineConfig({
             name: 'chromium',
             use: {
                 launchOptions: {
-                    args: [
-                        '--no-sandbox',
-                        '--disable-setuid-sandbox',
-                        '--disable-dev-shm-usage',
-                        '--headless=new',
-                    ],
+                    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
                 },
             },
             // Specify output directories for this project

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -102,3 +102,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     ignore `data:` and `//` URLs so coverage checks only test local assets.
 -   2025-08-14 – `new-quests.md` fell behind after new quests were added; run `npm run new-quests:update`
     and commit the refreshed file.
+-   2025-08-14 – Playwright E2E tests searched for `chromium_headless_shell` due to `--headless=new`;
+    dropping the flag lets default Chromium run without extra binaries.

--- a/outages/2025-08-14-playwright-headless-shell.json
+++ b/outages/2025-08-14-playwright-headless-shell.json
@@ -1,0 +1,10 @@
+{
+  "id": "playwright-headless-shell",
+  "date": "2025-08-14",
+  "component": "playwright",
+  "rootCause": "Playwright launched with --headless=new, requiring an uninstalled chromium_headless_shell binary.",
+  "resolution": "Removed the flag so Playwright uses the bundled chromium.",
+  "references": [
+    "https://playwright.dev/docs/browsers#install-browsers"
+  ]
+}


### PR DESCRIPTION
## Summary
- drop `--headless=new` from Playwright config so default chromium works
- document fix and record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `cd frontend && npx playwright test e2e/error-pages.spec.ts --project=chromium --workers=1`


------
https://chatgpt.com/codex/tasks/task_e_689d6a1ea250832fad2ea45050d1c912