### PR TITLE
docs: clarify aquarium thermometer quest

### DIFF
--- a/frontend/src/pages/quests/json/aquaria/thermometer.json
+++ b/frontend/src/pages/quests/json/aquaria/thermometer.json
@@ -1,25 +1,26 @@
 {
     "id": "aquaria/thermometer",
     "title": "Attach Aquarium Thermometer",
-    "description": "Stick a strip thermometer on the outside glass to monitor water temperature.",
+    "description": "Attach a strip thermometer outside the glass to monitor water temperature without opening the tank.",
     "image": "/assets/aquarium_thermometer.jpg",
     "npc": "/assets/npc/vega.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Your heater's running, but let's keep an eye on the temperature. Use a paper towel to dry a 5 cm patch on the outside glass just below the waterline.",
+            "text": "Wash your hands, unplug the heater to avoid burns, then use a paper towel to dry a 5 cm patch on the outside glass just below the waterline.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "attach",
-                    "text": "Ready to stick it on."
+                    "text": "Area is clean and dry.",
+                    "requiresItems": [{ "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 }]
                 }
             ]
         },
         {
             "id": "attach",
-            "text": "Peel the backing without touching the adhesive. Align the strip at eye level and press it to the glass from top to bottom for 30 seconds. Keep the strip outside the tank and away from heaters.",
+            "text": "Peel the backing without touching the adhesive. Align the strip at eye level on the dried spot and press it to the glass from top to bottom for 30 seconds. Keep the strip outside the tank and at least 5 cm from heaters.",
             "options": [
                 {
                     "type": "goto",
@@ -31,18 +32,19 @@
         },
         {
             "id": "finish",
-            "text": "Great! Wait a few minutes for the numbers to stabilize, then monitor the water temperature at a glance.",
+            "text": "Great! Wait a few minutes for the numbers to stabilize, plug the heater back in, then monitor the water temperature at a glance.",
             "options": [{ "type": "finish", "text": "All set!" }]
         }
     ],
     "rewards": [],
     "requiresQuests": ["aquaria/position-tank"],
     "hardening": {
-        "passes": 1,
-        "score": 60,
-        "emoji": "🌀",
+        "passes": 2,
+        "score": 80,
+        "emoji": "✅",
         "history": [
-            { "task": "codex-quest-hardening-2025-08-13", "date": "2025-08-13", "score": 60 }
+            { "task": "codex-quest-hardening-2025-08-13", "date": "2025-08-13", "score": 60 },
+            { "task": "codex-quest-hardening-2025-08-14", "date": "2025-08-14", "score": 80 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- clarify aquaria thermometer quest with safety notes and paper towel requirement
- refresh hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_689d6a6d996c832fb8ca2e3b6da45c38