### PR TITLE
Refine basil regrowth process with hardening metadata

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -563,7 +563,8 @@
     },
     {
         "id": "regrow-basil",
-        "title": "regrow basil after harvest",
+        "title": "Regrow 11 harvested basil plants in a ready hydroponics tub using 8,064 dWatts",
+        "image": "/assets/hydroponic_basil_adult.jpg",
         "requireItems": [],
         "consumeItems": [
             {
@@ -589,7 +590,19 @@
                 "count": 1
             }
         ],
-        "duration": "14d"
+        "duration": "14d",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 65
+                }
+            ]
+        }
     },
     {
         "id": "harvest-basil",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -401,7 +401,8 @@
     },
     {
         "id": "regrow-basil",
-        "title": "regrow basil after harvest",
+        "title": "Regrow 11 harvested basil plants in a ready hydroponics tub using 8,064 dWatts",
+        "image": "/assets/hydroponic_basil_adult.jpg",
         "requireItems": [],
         "consumeItems": [
             {

--- a/frontend/src/pages/processes/hardening/regrow-basil.json
+++ b/frontend/src/pages/processes/hardening/regrow-basil.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 65,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-14",
+            "date": "2025-08-14",
+            "score": 65
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- clarify regrow-basil process and link to existing assets
- record first hardening pass with score 65

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a80385c832f9a27abaca1d96bfe