### PR TITLE
🐛: handle missing remaining time in duration string

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -98,6 +98,9 @@ frontend/
 └── public/             # Static assets
 ```
 
+> Utility note: `src/utils/strings.js`'s `getDurationString` now omits undefined
+> remaining time to avoid displaying `undefined` in the UI.
+
 ## Getting Started
 
 ### Prerequisites

--- a/frontend/src/utils/strings.js
+++ b/frontend/src/utils/strings.js
@@ -2,14 +2,18 @@
  * Returns a string representation of the duration and remaining time.
  * @param {number} duration - The duration value, representing the current
  *   progress percentage.
- * @param {string} remainingTime - The remaining time, represented as a
- *   human-readable string.
+ * @param {string} [remainingTime] - The remaining time, represented as a
+ *   human-readable string. If omitted, only the duration is returned.
  * @returns {string} The string representing the duration and remaining time.
- *   If the duration is less than 100%, the remaining time will also be included.
+ *   If the duration is less than 100% and remaining time is provided, it will
+ *   be included in the returned string.
  */
 export const getDurationString = (duration, remainingTime) => {
-    let durationStr = `${getDuration(duration)}`;
-    return duration < 100 ? `${durationStr} - ${remainingTime}` : durationStr;
+    const durationStr = getDuration(duration);
+    if (duration < 100 && remainingTime) {
+        return `${durationStr} - ${remainingTime}`;
+    }
+    return durationStr;
 };
 
 /**

--- a/outages/2025-08-14-duration-string-undefined.json
+++ b/outages/2025-08-14-duration-string-undefined.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-14-duration-string-undefined",
+  "date": "2025-08-14",
+  "component": "frontend",
+  "rootCause": "getDurationString showed 'undefined' when remaining time was absent",
+  "resolution": "skip appending remaining time when it is missing",
+  "references": ["frontend/src/utils/strings.js", "tests/strings.test.ts"]
+}

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getDurationString,
+  getDuration,
+} from '../frontend/src/utils/strings.js';
+
+describe('getDurationString', () => {
+  test('includes remaining time when duration below 100', () => {
+    expect(getDurationString(75.1234, '5s')).toBe('75.12% - 5s');
+  });
+
+  test('omits remaining time when duration is 100', () => {
+    expect(getDurationString(100, '0s')).toBe('100.00%');
+  });
+
+  test('handles missing remaining time gracefully', () => {
+    expect(getDurationString(50, undefined)).toBe('50.00%');
+  });
+});
+
+describe('getDuration', () => {
+  test('formats to two decimals with percent', () => {
+    expect(getDuration(3)).toBe('3.00%');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid displaying `undefined` when remaining time is missing
- document duration helper and log outage
- cover duration helpers with a regression test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d6a2b095c832f813b794d49827d3c