### PR TITLE
Fix spaced item price lookup and document outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 ### Utility Functions
 
 The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
-normalizes case, spaces, and hyphens for resilient calls.
+normalizes case, trims extra whitespace, converts spaces or hyphens into underscores,
+and falls back to removing underscores when the canonical ID omits them.
 Prices are approximate USD values.
 
 ```ts
@@ -53,9 +54,6 @@ import { approximateIrlPrice } from "./backend/approximateIrlPrice";
 console.log(approximateIrlPrice("3D-Printer")); // 350
 console.log(approximateIrlPrice("unknown")); // null
 ```
-
-normalizes case, trims extra whitespace, and converts spaces or hyphens into underscores for
-resilient calls.
 
 ## Testing
 

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -18,7 +18,9 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })
 
-  it('ignores surrounding whitespace', () => {
-    expect(approximateIrlPrice(' 3d printer ')).toBe(350)
+  it('matches items whose canonical IDs lack underscores', () => {
+    expect(approximateIrlPrice('gold fish')).toBe(5)
+    expect(approximateIrlPrice('gold-fish')).toBe(5)
+    expect(approximateIrlPrice('gold_fish')).toBe(5)
   })
 })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -25,11 +25,16 @@ const priceTable: Record<string, number> = {
 /**
  * Look up a real‑world price for a game item.
  *
- * The lookup is case‑insensitive, trims surrounding whitespace, and normalizes
- * spaces or hyphens to underscores so callers can pass identifiers like
- * `3D-Printer`, `3d printer`, or even ` 3d_printer `.
-*/
+ * The lookup is case‑insensitive, trims surrounding whitespace, and
+ * normalizes spaces or hyphens to underscores so callers can pass
+ * identifiers like `3D-Printer`, `3d printer`, or even ` 3d_printer `.
+ * When an underscored lookup misses, it falls back to a version with all
+ * underscores removed to support canonical IDs without separators.
+ */
 export function approximateIrlPrice(id: string): number | null {
   const normalized = id.trim().toLowerCase().replace(/[\s-]+/g, '_');
-  return priceTable[normalized] ?? null;
+  const direct = priceTable[normalized];
+  if (direct !== undefined) return direct;
+  const collapsed = normalized.replace(/_/g, '');
+  return priceTable[collapsed] ?? null;
 }

--- a/outages/2025-08-15-spaced-item-price-lookup.json
+++ b/outages/2025-08-15-spaced-item-price-lookup.json
@@ -1,0 +1,12 @@
+{
+  "id": "spaced-item-price-lookup",
+  "date": "2025-08-15",
+  "component": "backend",
+  "rootCause": "approximateIrlPrice missed items when input used spaces or hyphens but ID lacked underscores",
+  "resolution": "added a fallback that removes underscores after normalizing input",
+  "references": [
+    "backend/approximateIrlPrice.ts",
+    "backend/approximateIrlPrice.test.ts",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- allow `approximateIrlPrice` to fall back to underscore-free keys
- cover spaced goldfish lookups in tests and docs
- record outage for spaced item price lookup

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d6a2b095c832f813b794d49827d3c