### PR TITLE
Fail run-tests when root tests missing

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -154,9 +154,9 @@ npm test
 npm run coverage
 ```
 
-Running `npm test` emits a warning if it detects zero tests, helping catch missing or
-misconfigured suites early. The detector strips ANSI color codes so it works even when
-command output is colorized.
+Running `npm test` fails if it detects zero tests, preventing false positives when
+test suites are missing or misconfigured. The detector strips ANSI color codes so it
+works even when command output is colorized.
 
 ### End-to-End Tests
 

--- a/outages/2025-08-14-run-tests-zero-tests-passed.json
+++ b/outages/2025-08-14-run-tests-zero-tests-passed.json
@@ -1,0 +1,11 @@
+{
+  "id": "run-tests-zero-tests-passed",
+  "date": "2025-08-14",
+  "component": "test harness",
+  "rootCause": "run-tests.js only warned when no root tests ran, allowing CI to pass with zero tests",
+  "resolution": "exit with an error when zero root tests are detected",
+  "references": [
+    "scripts/utils/detect-zero-tests.js",
+    "scripts/tests/run-tests.test.ts"
+  ]
+}

--- a/run-tests.js
+++ b/run-tests.js
@@ -21,37 +21,57 @@ const colors = {
     red: '\x1b[31m'
 };
 
-console.log(`${colors.bright}${colors.magenta}DSPACE Testing Suite${colors.reset}`);
-console.log(`${colors.cyan}Running comprehensive tests before PR submission...${colors.reset}\n`);
+function runTests(exec = execSync, platform = os.platform()) {
+    console.log(`${colors.bright}${colors.magenta}DSPACE Testing Suite${colors.reset}`);
+    console.log(
+        `${colors.cyan}Running comprehensive tests before PR submission...${colors.reset}\n`
+    );
 
-try {
-    console.log(`${colors.yellow}Running root unit tests...${colors.reset}`);
-    const rootOutput = execSync('npm run test:root', {
-        encoding: 'utf-8',
-        stdio: 'pipe'
-    });
-    process.stdout.write(rootOutput);
-    if (hasZeroTests(rootOutput)) {
-        console.warn(`${colors.yellow}Warning: no root tests were run.${colors.reset}`);
-    }
-
-    // Determine which script to run based on OS
-    if (os.platform() === 'win32') {
-        console.log(`${colors.yellow}Detected Windows OS, running PowerShell script...${colors.reset}`);
-        execSync('powershell -File .\\frontend\\scripts\\prepare-pr.ps1', {
-            stdio: 'inherit'
+    try {
+        console.log(`${colors.yellow}Running root unit tests...${colors.reset}`);
+        const rootOutput = exec('npm run test:root', {
+            encoding: 'utf-8',
+            stdio: 'pipe'
         });
-    } else {
-        console.log(`${colors.yellow}Detected Unix-like OS, running Bash script...${colors.reset}`);
-        execSync('bash ./frontend/scripts/prepare-pr.sh', {
-            stdio: 'inherit'
-        });
-    }
+        process.stdout.write(rootOutput);
+        if (hasZeroTests(rootOutput)) {
+            console.error(`${colors.red}Error: no root tests were run.${colors.reset}`);
+            return 1;
+        }
 
-    console.log(`\n${colors.bright}${colors.green}All tests completed successfully!${colors.reset}`);
-    process.exit(0);
-} catch (error) {
-    console.error(`\n${colors.bright}${colors.red}Tests failed with error:${colors.reset}`);
-    console.error(error.message);
-    process.exit(1);
-} 
+        // Determine which script to run based on OS
+        if (platform === 'win32') {
+            console.log(
+                `${colors.yellow}Detected Windows OS, running PowerShell script...${colors.reset}`
+            );
+            exec('powershell -File .\\frontend\\scripts\\prepare-pr.ps1', {
+                stdio: 'inherit'
+            });
+        } else {
+            console.log(
+                `${colors.yellow}Detected Unix-like OS, running Bash script...${colors.reset}`
+            );
+            exec('bash ./frontend/scripts/prepare-pr.sh', {
+                stdio: 'inherit'
+            });
+        }
+
+        console.log(
+            `\n${colors.bright}${colors.green}All tests completed successfully!${colors.reset}`
+        );
+        return 0;
+    } catch (error) {
+        console.error(
+            `\n${colors.bright}${colors.red}Tests failed with error:${colors.reset}`
+        );
+        console.error(error.message);
+        return 1;
+    }
+}
+
+if (require.main === module) {
+    const code = runTests();
+    process.exit(code);
+}
+
+module.exports = { runTests };

--- a/scripts/tests/run-tests.test.ts
+++ b/scripts/tests/run-tests.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const { runTests } = require('../../run-tests');
+
+describe('runTests', () => {
+  test('fails when no root tests run', () => {
+    const exec = vi.fn().mockReturnValue('No test files found, exiting with code 0');
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = runTests(exec, 'linux');
+    expect(code).toBe(1);
+    expect(exec).toHaveBeenCalledWith('npm run test:root', { encoding: 'utf-8', stdio: 'pipe' });
+    expect(exec).toHaveBeenCalledTimes(1);
+    write.mockRestore();
+  });
+
+  test('runs platform script when tests pass', () => {
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce('Test Files  1 passed\nTests  1 passed')
+      .mockReturnValueOnce('');
+    const code = runTests(exec, 'linux');
+    expect(code).toBe(0);
+    expect(exec).toHaveBeenNthCalledWith(2, 'bash ./frontend/scripts/prepare-pr.sh', { stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- fail run-tests.js when no root tests run
- document zero-test enforcement and log outage 2025-08-14-run-tests-zero-tests-passed

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d6a2b095c832f813b794d49827d3c