### PR TITLE
Add Arduino 5 V measurement quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 174
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
@@ -44,6 +45,7 @@ New quests in this release: 174
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -67,6 +69,7 @@ New quests in this release: 174
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction
@@ -111,6 +114,7 @@ New quests in this release: 174
 - electronics/desolder-component
 - electronics/led-polarity
 - electronics/light-sensor
+- electronics/measure-arduino-5v
 - electronics/measure-led-current
 - electronics/measure-resistance
 - electronics/potentiometer-dimmer
@@ -166,6 +170,7 @@ New quests in this release: 174
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/mint-cutting
 - hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
@@ -187,6 +192,7 @@ New quests in this release: 174
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 201
-New quests in this release: 179
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -114,6 +114,7 @@ New quests in this release: 179
 - electronics/desolder-component
 - electronics/led-polarity
 - electronics/light-sensor
+- electronics/measure-arduino-5v
 - electronics/measure-led-current
 - electronics/measure-resistance
 - electronics/potentiometer-dimmer

--- a/frontend/src/pages/quests/json/electronics/measure-arduino-5v.json
+++ b/frontend/src/pages/quests/json/electronics/measure-arduino-5v.json
@@ -1,0 +1,62 @@
+{
+    "id": "electronics/measure-arduino-5v",
+    "title": "Measure Arduino 5 V output",
+    "description": "Verify the 5 V pin on an Arduino Uno with a multimeter.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Orion here. Let's verify your board's 5 V rail. Keep work areas dry.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "materials",
+                    "text": "What gear do we need?"
+                }
+            ]
+        },
+        {
+            "id": "materials",
+            "text": "Grab an Arduino Uno, laptop, USB Type-B cable, and a digital multimeter. Power the board only after everything is connected.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "measure",
+                    "text": "Gear ready. Let's measure.",
+                    "process": "measure-arduino-5v",
+                    "requiresItems": [
+                        { "id": "72b4448e-27d9-4746-bd3a-967ff13f501b", "count": 1 },
+                        { "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d", "count": 1 },
+                        { "id": "be3aaed8-13cc-4937-95d5-6e2c952c6612", "count": 1 },
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "measure",
+            "text": "Connect the board to the laptop and set the meter to 20 V DC. Touch red to 5 V and black to GND. A reading near 5 V means the regulator works.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "It shows around 5 V."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Disconnect power before wiring new circuits to avoid shorts.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [{ "id": "e976bae6-e33c-428a-a20d-0aa8fde13c6c", "count": 1 }],
+    "requiresQuests": ["electronics/arduino-blink"]
+}


### PR DESCRIPTION
## Summary
- add "Measure Arduino 5 V output" quest after Arduino blink
- document new quest in `new-quests.md`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a59729c832fb651cc707136451f