### PR TITLE
Add compost harvest quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 174
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
@@ -44,6 +45,7 @@ New quests in this release: 174
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -67,6 +69,7 @@ New quests in this release: 174
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction
@@ -81,6 +84,7 @@ New quests in this release: 174
 
 ### composting
 
+- composting/harvest-compost
 - composting/start
 - composting/turn-pile
 
@@ -166,6 +170,7 @@ New quests in this release: 174
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/mint-cutting
 - hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
@@ -187,6 +192,7 @@ New quests in this release: 174
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 201
-New quests in this release: 179
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -84,6 +84,7 @@ New quests in this release: 179
 
 ### composting
 
+- composting/harvest-compost
 - composting/start
 - composting/turn-pile
 

--- a/frontend/src/pages/quests/json/composting/harvest-compost.json
+++ b/frontend/src/pages/quests/json/composting/harvest-compost.json
@@ -1,0 +1,47 @@
+{
+    "id": "composting/harvest-compost",
+    "title": "Harvest Finished Compost",
+    "description": "Sift mature compost to enrich your garden soil.",
+    "image": "/assets/bucket.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your bucket has been breaking down scraps for weeks. Let's see if it's ready to use.",
+            "options": [{ "type": "goto", "goto": "check", "text": "How do I tell?" }]
+        },
+        {
+            "id": "check",
+            "text": "Finished compost smells earthy and has cooled. Give it a stir and check the core before using it.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "turn-compost-bucket",
+                    "text": "Stir and check again."
+                },
+                {
+                    "type": "goto",
+                    "goto": "sift",
+                    "requiresItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
+                        { "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8", "count": 1 }
+                    ],
+                    "text": "It's cool and crumbly."
+                }
+            ]
+        },
+        {
+            "id": "sift",
+            "text": "Screen out larger bits so only fine compost remains for the garden.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "All sifted!" }]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Spread the rich compost and watch your plants thrive.",
+            "options": [{ "type": "finish", "text": "Time to plant." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["composting/turn-pile"]
+}


### PR DESCRIPTION
## Summary
- add Harvest Finished Compost quest following composting/turn-pile
- document new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a59729c832fb651cc707136451f