### PR TITLE
Add voltage divider electronics quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 174
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
@@ -44,6 +45,7 @@ New quests in this release: 174
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -67,6 +69,7 @@ New quests in this release: 174
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction
@@ -121,6 +124,7 @@ New quests in this release: 174
 - electronics/temperature-plot
 - electronics/thermistor-reading
 - electronics/thermometer-calibration
+- electronics/voltage-divider
 
 ### energy
 
@@ -166,6 +170,7 @@ New quests in this release: 174
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/mint-cutting
 - hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
@@ -187,6 +192,7 @@ New quests in this release: 174
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 201
-New quests in this release: 179
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -124,6 +124,7 @@ New quests in this release: 179
 - electronics/temperature-plot
 - electronics/thermistor-reading
 - electronics/thermometer-calibration
+- electronics/voltage-divider
 
 ### energy
 

--- a/frontend/src/pages/quests/json/electronics/voltage-divider.json
+++ b/frontend/src/pages/quests/json/electronics/voltage-divider.json
@@ -1,0 +1,51 @@
+{
+    "id": "electronics/voltage-divider",
+    "title": "Build a Voltage Divider",
+    "description": "Use two resistors to split 5 V into roughly 2.5 V.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Orion here. Let's make a simple voltage divider with a 220 \u03a9 and 10 k\u03a9 resistor. Keep the power supply unplugged while wiring.",
+            "options": [{ "type": "goto", "goto": "build", "text": "I'm ready" }]
+        },
+        {
+            "id": "build",
+            "text": "Place the 220 \u03a9 and 10 k\u03a9 resistors in series on the Breadboard. Connect 5 V across them and clip your multimeter to the junction.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "verify-resistor-color-code",
+                    "text": "Check resistor colors"
+                },
+                {
+                    "type": "goto",
+                    "goto": "measure",
+                    "text": "Resistors placed",
+                    "requiresItems": [
+                        { "id": "d1105b87-8185-4a30-ba55-406384be169f", "count": 1 },
+                        { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
+                        { "id": "ffe0b74a-f111-4d66-b4c3-d82965a976ac", "count": 1 },
+                        { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 },
+                        { "id": "828d6c3b-66a5-4064-b221-97630274502b", "count": 1 },
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "measure",
+            "text": "Apply power and measure the junction voltage. It should read close to 2.5 V on your multimeter.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Measured ~2.5 V" }]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! That's how a voltage divider sets a lower reference voltage.",
+            "options": [{ "type": "finish", "text": "Cool!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/basic-circuit"]
+}


### PR DESCRIPTION
## Summary
- add "Build a Voltage Divider" quest that uses resistors to create a 2.5 V reference
- document new quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a59729c832fb651cc707136451f