### PR TITLE
📝 : – add clean paintbrush process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3668,5 +3668,29 @@
                 }
             ]
         }
+    },
+    {
+        "id": "clean-paintbrush",
+        "title": "Rinse a paintbrush in a bucket of water to remove paint",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            {
+                "id": "05dd84f7-b9bc-4eac-93c5-5838cab84b32",
+                "count": 1
+            },
+            {
+                "id": "0564d441-7367-412e-b709-dad770814a39",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2879,5 +2879,17 @@
                 }
             ]
         }
+    },
+    {
+        "id": "clean-paintbrush",
+        "title": "Rinse a paintbrush in a bucket of water to remove paint",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            { "id": "05dd84f7-b9bc-4eac-93c5-5838cab84b32", "count": 1 },
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m"
     }
 ]

--- a/frontend/src/pages/processes/hardening/clean-paintbrush.json
+++ b/frontend/src/pages/processes/hardening/clean-paintbrush.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
Adds clean-paintbrush process with hardening stub.

Why:
- expand task coverage for post-paint cleanup.

How to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci -- processQuality

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d6a7a5484832fb6425195317c0859