### PR TITLE
Add compost temperature measurement process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3576,6 +3576,32 @@
         }
     },
     {
+        "id": "measure-compost-temperature",
+        "title": "Check core temperature of a compost pile with a compost thermometer",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            {
+                "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2820,6 +2820,20 @@
         "duration": "2m"
     },
     {
+        "id": "measure-compost-temperature",
+        "title": "Check core temperature of a compost pile with a compost thermometer",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            {
+                "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/hardening/measure-compost-temperature.json
+++ b/frontend/src/pages/processes/hardening/measure-compost-temperature.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-14",
+            "date": "2025-08-14",
+            "score": 60
+        }
+    ]
+}

--- a/frontend/src/pages/quests/json/composting/turn-pile.json
+++ b/frontend/src/pages/quests/json/composting/turn-pile.json
@@ -41,6 +41,7 @@
                 {
                     "type": "goto",
                     "goto": "temp",
+                    "process": "measure-compost-temperature",
                     "requiresItems": [
                         {
                             "id": "4d21c498-9225-4d0b-9a1a-ed65e349f0a8",


### PR DESCRIPTION
## Summary
- add process to check compost pile temperature
- track hardening for new process
- link compost quest option to new process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a7a5484832fb6425195317c0859