### PR TITLE
✨ : add count option to db benchmark script

### DIFF
--- a/frontend/scripts/db-benchmark.js
+++ b/frontend/scripts/db-benchmark.js
@@ -9,7 +9,17 @@ async function main() {
     }
     global.window.indexedDB = indexedDB;
 
-    const result = await runDbBenchmark();
+    const args = process.argv.slice(2);
+    let count;
+    const countIndex = args.findIndex((a) => a === '--count' || a === '-c');
+    if (countIndex !== -1) {
+        const value = Number.parseInt(args[countIndex + 1], 10);
+        if (!Number.isNaN(value)) {
+            count = value;
+        }
+    }
+
+    const result = await runDbBenchmark(count ? { count } : undefined);
     console.log(JSON.stringify(result, null, 2));
 }
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -77,9 +77,9 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
 -   [x] License Migration
 
--   [x] Testing & QA
+-   [x] Testing & QA 💯
 
-    -   [x] Performance testing
+    -   [x] Performance testing 💯
         -   [x] Load testing custom content system 💯
         -   [x] Database performance benchmarks 💯
         -   [x] UI responsiveness metrics 💯

--- a/frontend/src/pages/docs/md/db-benchmark.md
+++ b/frontend/src/pages/docs/md/db-benchmark.md
@@ -10,6 +10,12 @@ Run the benchmark with:
 npm run db:benchmark
 ```
 
+Pass `--count <n>` to adjust the number of records:
+
+```bash
+npm run db:benchmark -- --count 100
+```
+
 The script inserts and reads sample records, printing JSON metrics like:
 
 ```json

--- a/frontend/src/utils/dbBenchmark.js
+++ b/frontend/src/utils/dbBenchmark.js
@@ -21,9 +21,19 @@ export async function runDbBenchmark({ count = DEFAULT_BENCHMARK_COUNT } = {}) {
     await openCustomContentDB();
     const startInsert = performance.now();
     for (let i = 0; i < count; i++) {
-        await saveItem({ id: `item-${i}`, name: `Item ${i}` });
-        await saveProcess({ id: `proc-${i}`, title: `Process ${i}` });
-        await saveQuest({ id: `quest-${i}`, title: `Quest ${i}` });
+        await saveItem({ id: `item-${i}`, name: `Item ${i}`, description: `Benchmark item ${i}` });
+        await saveProcess({
+            id: `proc-${i}`,
+            title: `Process ${i}`,
+            duration: '1h',
+            requireItems: [{ id: `item-${i}`, count: 1 }],
+        });
+        await saveQuest({
+            id: `quest-${i}`,
+            title: `Quest ${i}`,
+            description: `Benchmark quest ${i}`,
+            image: '/placeholder.png',
+        });
     }
     const insertMs = performance.now() - startInsert;
 

--- a/tests/dbBenchmarkCli.test.ts
+++ b/tests/dbBenchmarkCli.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const execFileAsync = promisify(execFile);
+
+describe('db-benchmark CLI', () => {
+    it('accepts --count option', async () => {
+        const script = path.join(__dirname, '../frontend/scripts/db-benchmark.js');
+        const { stdout } = await execFileAsync('node', [script, '--count', '5']);
+        const result = JSON.parse(stdout);
+        expect(result.itemCount).toBe(5);
+        expect(result.processCount).toBe(5);
+        expect(result.questCount).toBe(5);
+    });
+});


### PR DESCRIPTION
## Summary
- allow configuring record count via `--count`
- benchmark inserts valid records and document flag
- cover CLI usage and mark performance testing complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d6a2311e4832f9f5bde55672e4d87