### PR TITLE
Add sprained ankle first aid quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 174
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
@@ -44,6 +45,7 @@ New quests in this release: 174
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -67,6 +69,7 @@ New quests in this release: 174
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction
@@ -144,6 +147,7 @@ New quests in this release: 174
 - firstaid/splint-limb
 - firstaid/stop-nosebleed
 - firstaid/treat-burn
+- firstaid/treat-sprain
 - firstaid/wound-care
 
 ### geothermal
@@ -166,6 +170,7 @@ New quests in this release: 174
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/mint-cutting
 - hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
@@ -187,6 +192,7 @@ New quests in this release: 174
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 201
-New quests in this release: 179
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -147,6 +147,7 @@ New quests in this release: 179
 - firstaid/splint-limb
 - firstaid/stop-nosebleed
 - firstaid/treat-burn
+- firstaid/treat-sprain
 - firstaid/wound-care
 
 ### geothermal

--- a/frontend/src/pages/quests/json/firstaid/treat-sprain.json
+++ b/frontend/src/pages/quests/json/firstaid/treat-sprain.json
@@ -1,0 +1,79 @@
+{
+    "id": "firstaid/treat-sprain",
+    "title": "Treat a Sprained Ankle",
+    "description": "Rest, cool, compress, and elevate a sprained ankle to reduce swelling before seeking medical help.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ouch, that twist looked bad. Let's keep swelling down with RICE.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "rest",
+                    "text": "What should I do first?"
+                }
+            ]
+        },
+        {
+            "id": "rest",
+            "text": "Sit and remove your shoe. Wash your hands before touching the injury.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Hands are clean",
+                    "goto": "ice"
+                }
+            ]
+        },
+        {
+            "id": "ice",
+            "text": "Wrap a cold pack in cloth and apply for 20 minutes to limit swelling.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "compress",
+                    "text": "Cold pack applied",
+                    "requiresItems": [
+                        {
+                            "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "compress",
+            "text": "Wrap with an elastic bandage, snug but not tight, to reduce swelling.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "elevate",
+                    "text": "Bandage in place"
+                }
+            ]
+        },
+        {
+            "id": "elevate",
+            "text": "Elevate the ankle above your heart. Rest and get medical care if pain persists.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "I'll rest up"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": [],
+    "hardening": {
+        "passes": 0,
+        "score": 0,
+        "emoji": "🛠️",
+        "history": []
+    }
+}


### PR DESCRIPTION
## Summary
- add treat-sprain quest referencing first aid kit and hand washing
- refresh new-quests docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a63c76c832f81cc6dbc120e17c7