### PR TITLE
🪚 Add cutting board woodworking quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 196
-New quests in this release: 174
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 174
 - 3dprinting/cable-clip
 - 3dprinting/calibration-cube
 - 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
@@ -44,6 +45,7 @@ New quests in this release: 174
 ### astronomy
 
 - astronomy/andromeda
+- astronomy/aurora-watch
 - astronomy/basic-telescope
 - astronomy/comet-tracking
 - astronomy/constellations
@@ -67,6 +69,7 @@ New quests in this release: 174
 - chemistry/buffer-solution
 - chemistry/ph-adjustment
 - chemistry/ph-test
+- chemistry/precipitation-reaction
 - chemistry/safe-reaction
 - chemistry/stevia-crystals
 - chemistry/stevia-extraction
@@ -166,6 +169,7 @@ New quests in this release: 174
 - hydroponics/filter-clean
 - hydroponics/grow-light
 - hydroponics/lettuce
+- hydroponics/mint-cutting
 - hydroponics/netcup-clean
 - hydroponics/nutrient-check
 - hydroponics/ph-check
@@ -187,6 +191,7 @@ New quests in this release: 174
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph
@@ -238,6 +243,7 @@ New quests in this release: 174
 - woodworking/birdhouse
 - woodworking/bookshelf
 - woodworking/coffee-table
+- woodworking/cutting-board
 - woodworking/finish-sanding
 - woodworking/picture-frame
 - woodworking/planter-box

--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 201
-New quests in this release: 179
+Current quest count: 202
+New quests in this release: 180
 
 ### 3dprinting
 
@@ -243,6 +243,7 @@ New quests in this release: 179
 - woodworking/birdhouse
 - woodworking/bookshelf
 - woodworking/coffee-table
+- woodworking/cutting-board
 - woodworking/finish-sanding
 - woodworking/picture-frame
 - woodworking/planter-box

--- a/frontend/src/pages/quests/json/woodworking/cutting-board.json
+++ b/frontend/src/pages/quests/json/woodworking/cutting-board.json
@@ -1,0 +1,50 @@
+{
+    "id": "woodworking/cutting-board",
+    "title": "Make a Cutting Board",
+    "description": "Glue up a compact cutting board for kitchen prep.",
+    "image": "/assets/door.jpg",
+    "npc": "/assets/npc/atlas.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready to craft something useful? Let's build a simple cutting board.",
+            "options": [{ "type": "goto", "goto": "gather", "text": "I'm ready" }]
+        },
+        {
+            "id": "gather",
+            "text": "We'll laminate two hardwood boards with wood glue. Grab the materials.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [
+                        { "id": "6c075116-ebd1-4147-8666-ec6338ca251e", "count": 2 },
+                        { "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399", "count": 1 }
+                    ],
+                    "text": "Take boards and glue"
+                },
+                {
+                    "type": "goto",
+                    "goto": "glue",
+                    "requiresItems": [
+                        { "id": "6c075116-ebd1-4147-8666-ec6338ca251e", "count": 2 },
+                        { "id": "30a7cd72-cf99-4ed7-9a4c-f30a68a4a399", "count": 1 }
+                    ],
+                    "text": "Materials ready"
+                }
+            ]
+        },
+        {
+            "id": "glue",
+            "text": "Spread glue, clamp the boards, and let the bond cure. Sand until smooth.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Board smoothed" }]
+        },
+        {
+            "id": "finish",
+            "text": "Great! You've got a fresh cutting board ready for chopping.",
+            "options": [{ "type": "finish", "text": "Time to prep veggies" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["woodworking/picture-frame"]
+}


### PR DESCRIPTION
## Summary
- add cutting board quest referencing boards and glue
- refresh new-quests docs with latest count

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d6a63c76c832f81cc6dbc120e17c7