### PR TITLE
✨: add UBI savings goal quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 
@@ -232,6 +232,7 @@ New quests in this release: 180
 
 - ubi/first-payment
 - ubi/reminder
+- ubi/savings-goal
 
 ### welcome
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 
@@ -232,6 +232,7 @@ New quests in this release: 180
 
 - ubi/first-payment
 - ubi/reminder
+- ubi/savings-goal
 
 ### welcome
 

--- a/frontend/src/pages/quests/json/ubi/savings-goal.json
+++ b/frontend/src/pages/quests/json/ubi/savings-goal.json
@@ -1,0 +1,55 @@
+{
+    "id": "ubi/savings-goal",
+    "title": "Start a Savings Jar",
+    "description": "Set aside some dUSD for future plans.",
+    "image": "/assets/quests/basicincome.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You're collecting dUSD regularly. Want to stash a bit away for a rainy day?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "decide",
+                    "text": "Sure, let's save."
+                }
+            ]
+        },
+        {
+            "id": "decide",
+            "text": "Saving helps you reach bigger goals. Set aside at least 10 dUSD now.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "deposit",
+                    "text": "Deposit 10 dUSD.",
+                    "requiresItems": [
+                        {
+                            "id": "5247a603-294a-4a34-a884-1ae20969b2a1",
+                            "count": 10
+                        }
+                    ]
+                },
+                {
+                    "type": "process",
+                    "process": "basic-income",
+                    "text": "Need to claim more first."
+                }
+            ]
+        },
+        {
+            "id": "deposit",
+            "text": "Nice! Keep adding to that jar and watch it grow.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "All saved up for now."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["ubi/first-payment"]
+}


### PR DESCRIPTION
## Summary
- add savings goal quest under ubi tree referencing dUSD and basic-income
- refresh new quests docs with updated quest count

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d7b2b3e24832fb8f01bb5557cb400