### PR TITLE
✨ Add odometry basics robotics quest

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 
@@ -207,6 +207,7 @@ New quests in this release: 180
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
+- robotics/odometry-basics
 - robotics/pan-tilt
 - robotics/servo-arm
 - robotics/servo-control

--- a/frontend/src/pages/quests/json/robotics/odometry-basics.json
+++ b/frontend/src/pages/quests/json/robotics/odometry-basics.json
@@ -1,0 +1,48 @@
+{
+    "id": "robotics/odometry-basics",
+    "title": "Track distance with wheel encoders",
+    "description": "Use encoder pulses to compute how far your robot travels.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Want to track how far your bot rolls? We'll turn encoder ticks into centimeters.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "wire",
+                    "text": "Let's wire it up."
+                }
+            ]
+        },
+        {
+            "id": "wire",
+            "text": "Power off, wear goggles, send VCC/GND to Arduino, and hook A/B leads to pins 2 & 3.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "Wired and safe.",
+                    "requiresItems": [
+                        { "id": "71fafa9a-3998-4763-a63a-279acc4ca603", "count": 2 },
+                        { "id": "72b4448e-27d9-4746-bd3a-967ff13f501b", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Upload code to count pulses times wheel size. Roll one meter and check the log.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Distance recorded!"
+                }
+            ]
+        }
+    ],
+    "requiresQuests": ["robotics/wheel-encoders"],
+    "rewards": []
+}


### PR DESCRIPTION
## Summary
- add odometry basics quest under robotics
- refresh new quests markdown

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d7ad7a554832f84a7084144c641fc