### PR TITLE
feat: add 3d printing belt tension quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 
@@ -24,6 +24,7 @@ New quests in this release: 180
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
+- 3dprinting/x-belt-tension
 
 ### aquaria
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 202
-New quests in this release: 180
+Current quest count: 205
+New quests in this release: 183
 
 ### 3dprinting
 
@@ -24,6 +24,7 @@ New quests in this release: 180
 - 3dprinting/phone-stand
 - 3dprinting/retraction-test
 - 3dprinting/temperature-tower
+- 3dprinting/x-belt-tension
 
 ### aquaria
 

--- a/frontend/src/pages/quests/json/3dprinting/x-belt-tension.json
+++ b/frontend/src/pages/quests/json/3dprinting/x-belt-tension.json
@@ -1,0 +1,65 @@
+{
+    "id": "3dprinting/x-belt-tension",
+    "title": "Tighten the X-axis Belt",
+    "description": "Keep your prints sharp by safely tightening a loose X-axis belt.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Noticing layer shifts? Let's dial in that X-axis belt tension.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "tension",
+                    "text": "Show me how."
+                }
+            ]
+        },
+        {
+            "id": "tension",
+            "text": "Power off the printer, loosen the belt clamp, pull the belt snug, and retighten. Keep fingers clear of sharp edges.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "tighten-x-belt",
+                    "text": "Walk me through each step."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Belt tightened and moving smoothly.",
+                    "requiresItems": [
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "60409c3f-56cf-4b9e-9e60-ca480d4896d0", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Your printer should track cleanly along the X-axis now.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Time to print!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinter/start"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-hardening-2025-10-15",
+                "date": "2025-10-15",
+                "score": 60
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add x-axis belt tension quest
- record new quest in docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`

------
https://chatgpt.com/codex/tasks/task_e_689d7ad7a554832f84a7084144c641fc