### PR TITLE
📝 : – expand Codex prompts with self-upgrader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,5 +76,6 @@ All checks must pass before an agent-created PR is merged.
 - [UI Lifecycle Overview](frontend/src/pages/docs/md/ui-lifecycle.md)
 - [Codex Implementation Prompt](frontend/src/pages/docs/md/prompts-codex.md#implementation-prompt)
 - [Codex Upgrade Prompt](frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)
+- [Codex Prompt Upgrader](frontend/src/pages/docs/md/prompts-codex-upgrader.md)
 - [AGENTS.md Spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6)
 - [Agents.md Guide](https://agentsmd.net/)

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -9,6 +9,9 @@ Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
 return a pull request that keeps the main branch green.
 
+If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
+to refresh it before use.
+
 > **Human setup**
 >
 > 1. Optional: paste a failing job URL on the first line of a new ChatGPT

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -1,0 +1,25 @@
+---
+title: 'Codex Prompt Upgrader'
+slug: 'prompts-codex-upgrader'
+---
+
+# Codex Prompt Upgrader
+
+Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
+instructions current—the machine that builds the machine.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and
+`README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+all pass before committing.
+
+USER:
+1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
+2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
+3. Propagate related changes across docs.
+4. Run the checks above.
+
+OUTPUT:
+A pull request refreshing the Codex prompt docs with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -89,8 +89,8 @@ from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
 `AGENTS.md` and ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm test` all pass before committing. If Playwright browsers are missing
-run `npx playwright install chromium` or use `SKIP_E2E=1 npm test`.
+and `npm run test:ci` all pass before committing. If Playwright browsers are
+missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
 USER:
 1. Follow the steps above.
@@ -112,8 +112,8 @@ Use this prompt to refine DSPACE's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check` and `npm run build`
-pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
@@ -123,6 +123,29 @@ USER:
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
+```
+
+## Prompt Upgrader
+
+Use this meta prompt when the Codex templates themselves need refreshing. It
+keeps our guidance current—the machine that builds the machine. A standalone
+copy lives at [`prompts-codex-upgrader.md`](/docs/prompts-codex-upgrader).
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing
+   cross-links.
+2. Update prompt templates, including this file, to reflect current practices.
+3. Propagate related changes across docs.
+4. Run the checks above.
+
+OUTPUT:
+A pull request refreshing the Codex prompt docs with passing checks.
 ```
 
 ## Outage Prompt


### PR DESCRIPTION
## Summary
- add Prompt Upgrader meta prompt for maintaining Codex templates
- run test:ci in Implementation and Upgrade prompts
- refresh new quests list to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d85ded3f4832f8ca5f8f7f8d7b4fc