### PR TITLE
📝 : add Codex meta prompt and refresh docs

### DIFF
--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -6,8 +6,9 @@ import { describe, it, expect } from 'vitest';
 const docsIndexFile = path.join(__dirname, '../src/pages/docs/index.astro');
 
 describe('docs index.astro', () => {
-    it('links to the Codex prompts docs page', () => {
+    it('links to Codex prompt docs', () => {
         const content = fs.readFileSync(docsIndexFile, 'utf8');
         expect(content).toMatch(/<a href="\/docs\/prompts-codex">Codex prompts<\/a>/);
+        expect(content).toMatch(/<a href="\/docs\/prompts-codex-meta">Codex meta prompt<\/a>/);
     });
 });

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -55,6 +55,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
+            <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -7,7 +7,8 @@ slug: 'prompts-codex-ci-fix'
 
 Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
-return a pull request that keeps the main branch green.
+return a pull request that keeps the main branch green. To evolve the prompt
+docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
 > **Human setup**
 >

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -1,0 +1,25 @@
+---
+title: 'Codex Meta Prompt'
+slug: 'prompts-codex-meta'
+---
+
+# Codex Meta Prompt
+
+Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
+instructions improve themselves over time.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.
+2. Refine wording, fix links, or add new prompts when gaps appear.
+3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with upgraded prompt docs and passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -107,19 +107,22 @@ completed task and test results in the PR body.
 
 ## Upgrade Prompt
 
-Use this prompt to refine DSPACE's own prompt documentation.
+Use this prompt to refine DSPACE's own prompt documentation. For a template
+dedicated to evolving the prompt guides themselves, see the
+[Codex meta prompt](/docs/prompts-codex-meta).
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check` and `npm run build`
-pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
    `prompts-items.md`).
 2. Fix outdated instructions, links or formatting.
-3. Run the checks above.
+3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
+4. Run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -8,8 +8,9 @@ slug: 'prompts-items'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on items. For general
-content rules see the [Item Development Guidelines](/docs/item-guidelines).
+[Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For
+general content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -8,8 +8,10 @@ slug: 'prompts-processes'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on processes. For
-fundamental design tips see the [Process Development Guidelines](/docs/process-guidelines).
+[Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
+For fundamental design tips see the
+[Process Development Guidelines](/docs/process-guidelines).
 
 > **TL;DR**
 >
@@ -32,7 +34,8 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && npm run test:ci -- processQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \
+        npm run test:ci -- processQuality"
         ```
 
 See the [Codex CLI repository][codex-cli] for more flags.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -8,8 +8,9 @@ slug: 'prompts-quests'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on quests. For the steps
-required to share quests with the community, see the
+[Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
+docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
+steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.


### PR DESCRIPTION
what: add meta prompt and link across Codex docs; refresh new quests list
why: let Codex evolve prompts and keep tests in sync
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_689d85ded3f4832f8ca5f8f7f8d7b4fc