### PR TITLE
Add Codex self-upgrade prompt and cross-link docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,5 +76,6 @@ All checks must pass before an agent-created PR is merged.
 - [UI Lifecycle Overview](frontend/src/pages/docs/md/ui-lifecycle.md)
 - [Codex Implementation Prompt](frontend/src/pages/docs/md/prompts-codex.md#implementation-prompt)
 - [Codex Upgrade Prompt](frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)
+- [Codex Self-upgrade Prompt](frontend/src/pages/docs/md/prompts-codex.md#self-upgrade-prompt)
 - [AGENTS.md Spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6)
 - [Agents.md Guide](https://agentsmd.net/)

--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -10,4 +10,11 @@ describe('docs index.astro', () => {
         const content = fs.readFileSync(docsIndexFile, 'utf8');
         expect(content).toMatch(/<a href="\/docs\/prompts-codex">Codex prompts<\/a>/);
     });
+
+    it('links to the Codex self-upgrade prompt', () => {
+        const content = fs.readFileSync(docsIndexFile, 'utf8');
+        expect(content).toMatch(
+            /<a href="\/docs\/prompts-codex#self-upgrade-prompt">Codex self-upgrade prompt<\/a>/
+        );
+    });
 });

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -55,6 +55,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
+            <a href="/docs/prompts-codex#self-upgrade-prompt">Codex self-upgrade prompt</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -125,6 +125,28 @@ OUTPUT:
 A pull request with the improved prompt doc and passing checks.
 ```
 
+## Self-upgrade prompt
+
+Use this prompt to help Codex improve its own prompt docs and propagate those upgrades.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check` and `npm run build`
+pass before committing.
+
+USER:
+1. Choose a prompt doc under `frontend/src/pages/docs/md/` that could be clearer
+   or more powerful.
+2. Upgrade the instructions, links or formatting.
+3. When updating this self-upgrade prompt, preserve the goal of building the
+   machine that builds the machine.
+4. Run the checks above.
+
+OUTPUT:
+A pull request with the refined prompt doc and passing checks.
+```
+
 ## Outage Prompt
 
 Use this snippet when fixing an incident so knowledge lands in the outage catalog.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -8,8 +8,9 @@ slug: 'prompts-items'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on items. For general
-content rules see the [Item Development Guidelines](/docs/item-guidelines).
+[Codex Prompts](/docs/prompts-codex) when working on items. To evolve this guide
+automatically, see the [Codex self-upgrade prompt](/docs/prompts-codex#self-upgrade-prompt).
+For general content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -8,8 +8,9 @@ slug: 'prompts-processes'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on processes. For
-fundamental design tips see the [Process Development Guidelines](/docs/process-guidelines).
+[Codex Prompts](/docs/prompts-codex) when working on processes. To evolve this
+guide automatically, see the [Codex self-upgrade prompt](/docs/prompts-codex#self-upgrade-prompt).
+For fundamental design tips see the [Process Development Guidelines](/docs/process-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -8,8 +8,9 @@ slug: 'prompts-quests'
 Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when working on quests. For the steps
-required to share quests with the community, see the
+[Codex Prompts](/docs/prompts-codex) when working on quests. To evolve this guide
+automatically, see the [Codex self-upgrade prompt](/docs/prompts-codex#self-upgrade-prompt). For
+the steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.


### PR DESCRIPTION
what: add Codex self-upgrade prompt, cross-links, and refresh quests doc
why: enable recursive prompt upgrades and keep quest metadata current
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d85ded3f4832f8ca5f8f7f8d7b4fc