### PR TITLE
Refine basil seedling item and refresh quest list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 
@@ -210,6 +210,7 @@ New quests in this release: 183
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
+- robotics/odometry-basics
 - robotics/pan-tilt
 - robotics/servo-arm
 - robotics/servo-control

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -133,9 +133,17 @@
     {
         "id": "5712947f-716c-4f71-b28d-fcb811631080",
         "name": "basil seedling",
-        "description": "A basil seedling that has been germinated in a rockwool cube.",
+        "description": "Two-week-old Genovese basil in a 3 cm rockwool plug, ~5 cm tall and ~5 g.",
         "image": "/assets/basil_seedlings.jpg",
-        "priceExemptionReason": "BETA_PLACEHOLDER"
+        "price": "1 dUSD",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-08-14", "date": "2025-08-14", "score": 60 }
+            ]
+        }
     },
     {
         "id": "79f1ea64-c58f-4f7a-8e7e-8dcca24fd1be",


### PR DESCRIPTION
## Summary
- detail basil seedling item with realistic price, units, and hardening
- refresh new quests list for up-to-date counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8653574c832fb23870864080f549