### PR TITLE
📝: refine pH down solution details and quest counts

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1117,10 +1117,23 @@
     },
     {
         "id": "7c811503-d0ca-4254-825a-ebeb06a88231",
-        "name": "pH down solution (phosphoric acid)",
-        "description": "Dilute acid used to lower nutrient solution pH.",
-        "image": "/assets/quests/basic_circuit.svg",
-        "price": "8 dUSD"
+        "name": "pH down solution (500 mL)",
+        "description": "500 mL bottle of phosphoric acid to lower hydroponic nutrient pH; includes dropper.",
+        "image": "/assets/hydroponics_nutrients.jpg",
+        "price": "10 dUSD",
+        "unit": "bottle",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 65
+                }
+            ]
+        }
     },
     {
         "id": "9cdd41b1-392e-40c2-8072-0c1351b1a26b",


### PR DESCRIPTION
## Summary
- clarify pH down solution item with volume, realistic price, and hardening metadata
- refresh new quests counts to reflect current quest total

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8653574c832fb23870864080f549