### PR TITLE
refine soldered jumper wire item and refresh quests doc

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1337,15 +1337,21 @@
     {
         "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c",
         "name": "soldered jumper wire",
-        "description": "10 cm jumper wire with heat-shrunk solder joint for prototyping.",
+        "description": "10 cm 22 AWG stranded jumper wire with a soldered splice and 2 mm heat-shrink insulation; ~2 g.",
         "image": "/assets/quests/basic_circuit.svg",
         "price": "0.20 dUSD",
         "unit": "each",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
         }
     },
     {


### PR DESCRIPTION
## Summary
- clarify soldered jumper wire specs and add hardening metadata
- regenerate new quests list to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8653574c832fb23870864080f549