### PR TITLE
🩹 fix: refresh new quests list counts

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/outages/2025-08-14-new-quests-count-mismatch.json
+++ b/outages/2025-08-14-new-quests-count-mismatch.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-08-14-new-quests-count-mismatch",
+  "date": "2025-08-14",
+  "component": "docs",
+  "rootCause": "new quests added but new-quests.md was outdated, so quest counts were wrong",
+  "resolution": "ran npm run new-quests:update and committed the updated new-quests.md",
+  "references": [
+    "frontend/src/pages/docs/md/new-quests.md",
+    "scripts/update-new-quests.js"
+  ]
+}


### PR DESCRIPTION
## Summary
- regenerate new-quests.md to sync quest totals
- record outage for outdated quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689d86444674832fb80444aaf2a62cf4