### PR TITLE
🩹 fix: keep new quests docs in sync

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 
@@ -210,6 +210,7 @@ New quests in this release: 183
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
+- robotics/odometry-basics
 - robotics/pan-tilt
 - robotics/servo-arm
 - robotics/servo-control

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/outages/2025-08-14-new-quests-doc-desync.json
+++ b/outages/2025-08-14-new-quests-doc-desync.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-14-new-quests-doc-desync",
+  "date": "2025-08-14",
+  "component": "docs",
+  "rootCause": "New quest files were added but new-quests markdown wasn't regenerated, causing stale counts.",
+  "resolution": "Updated update-new-quests.js to refresh docs/new-quests.md and added a test to keep copies in sync.",
+  "references": ["tests/newQuestsList.test.ts"]
+}

--- a/scripts/update-new-quests.js
+++ b/scripts/update-new-quests.js
@@ -2,7 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const outputFile = path.join(
+const frontendOutput = path.join(
   __dirname,
   '..',
   'frontend',
@@ -12,6 +12,7 @@ const outputFile = path.join(
   'md',
   'new-quests.md'
 );
+const docsOutput = path.join(__dirname, '..', 'docs', 'new-quests.md');
 
 const PRE_V2_COMMIT = 'fc840def24c5140411d2892f468960acb8250681';
 const V2_COMMIT = '93a834691af174b3c8b9895e9a27ce72e10e8299';
@@ -127,7 +128,8 @@ function generateMarkdown(sections) {
 function main() {
   const sections = getReleaseSections();
   const content = generateMarkdown(sections);
-  fs.writeFileSync(outputFile, content);
+  fs.writeFileSync(frontendOutput, content);
+  fs.writeFileSync(docsOutput, content);
 }
 
 if (require.main === module) {

--- a/tests/newQuestsList.test.ts
+++ b/tests/newQuestsList.test.ts
@@ -71,4 +71,13 @@ describe('new quests list', () => {
     const docCount = Number(match[1]);
     expect(docCount).toBe(questFiles.length);
   });
+
+  it('syncs root docs copy', () => {
+    const rootDoc = fs.readFileSync(
+      path.join(__dirname, '../docs/new-quests.md'),
+      'utf8'
+    );
+    const frontendDoc = fs.readFileSync(listPath, 'utf8');
+    expect(rootDoc).toBe(frontendDoc);
+  });
 });


### PR DESCRIPTION
what: regenerate new-quests docs and sync root copy automatically
why: new quests added without doc refresh left counts stale
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
outage: outages/2025-08-14-new-quests-doc-desync.json
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689d86444674832fb80444aaf2a62cf4