### PR TITLE
📝 : – refresh prompts docs secret scan guidance

### DIFF
--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 205
-New quests in this release: 183
+Current quest count: 209
+New quests in this release: 187
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -72,7 +72,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | npx ripsecrets --stdin` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.
 9. Update docs or processes if needed.
 
@@ -92,7 +92,7 @@ appropriate category file. Ensure realistic details, required fields, and
 passing checks (`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
 `npm run itemValidation`, and `npm run test:ci -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
-assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+assets, and scan for secrets with `git diff --cached | npx ripsecrets --stdin` before
 committing. If a quest's text changes, run `npm run test:ci -- questQuality` and update the quest's
 `hardening` block with a fresh evaluation score.
 
@@ -142,7 +142,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
    `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run `git diff --cached | npx ripsecrets --stdin` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -32,7 +32,8 @@ fundamental design tips see the [Process Development Guidelines](/docs/process-g
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && npm run test:ci -- processQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && \\
+        npm run test:ci -- processQuality"
         ```
 
 See the [Codex CLI repository][codex-cli] for more flags.
@@ -72,7 +73,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check`, and `npm run build`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | npx ripsecrets --stdin` and ensure no secrets.
 8. Update docs or items if needed.
 
 OUTPUT
@@ -92,7 +93,7 @@ steps, durations, item references, and passing checks (`npm run lint`,
 `npm run type-check`, `npm run build`, and `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
-`git diff --cached | ./scripts/scan-secrets.py` before committing.
+`git diff --cached | npx ripsecrets --stdin` before committing.
 
 USER:
 1. Follow the steps above.
@@ -138,7 +139,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci -- processQuality`. Update docs or items if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run `git diff --cached | npx ripsecrets --stdin` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine process details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -77,7 +77,7 @@ REQUIREMENTS
 5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
-8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+8. Run `git diff --cached | npx ripsecrets --stdin` and ensure no secrets.
 9. Update docs or dialogue as needed.
 
 OUTPUT
@@ -97,8 +97,7 @@ completion nodes, at least one item or process reference, and passing checks
 `npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
-for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-committing.
+for secrets with `git diff --cached | npx ripsecrets --stdin` before committing.
 
 USER:
 1. Follow the steps above.
@@ -128,7 +127,7 @@ USER:
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci -- questCanonical questQuality`. Fix any failures.
 4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
-5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Scan for secrets with `git diff --cached | npx ripsecrets --stdin` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -176,7 +175,7 @@ USER:
    }
      6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
      `npm run test:ci -- questCanonical questQuality`. Update docs if needed.
-   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   7. Run `git diff --cached | npx ripsecrets --stdin` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
 OUTPUT:


### PR DESCRIPTION
## Summary
- replace scan-secrets.py with ripsecrets in prompts docs
- sync new-quests list to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`
- `npm run test:ci` *(fails: playwright: not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d8630faf0832f936ac445c07242c8