### PR TITLE
Add hydroponics pump priming quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -183,6 +183,7 @@ New quests in this release: 188
 - hydroponics/ph-test
 - hydroponics/plug-soak
 - hydroponics/pump-install
+- hydroponics/pump-prime
 - hydroponics/regrow-stevia
 - hydroponics/reservoir-refresh
 - hydroponics/root-rinse
@@ -209,6 +210,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -183,6 +183,7 @@ New quests in this release: 188
 - hydroponics/ph-test
 - hydroponics/plug-soak
 - hydroponics/pump-install
+- hydroponics/pump-prime
 - hydroponics/regrow-stevia
 - hydroponics/reservoir-refresh
 - hydroponics/root-rinse

--- a/frontend/src/pages/quests/json/hydroponics/pump-prime.json
+++ b/frontend/src/pages/quests/json/hydroponics/pump-prime.json
@@ -1,0 +1,50 @@
+{
+    "id": "hydroponics/pump-prime",
+    "title": "Prime Water Pump",
+    "description": "Prep the pump so it doesn't run dry.",
+    "image": "/assets/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "New pumps need a bit of water before they work well.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "prime",
+                    "text": "Show me."
+                }
+            ]
+        },
+        {
+            "id": "prime",
+            "text": "Fill the pump housing with nutrient solution and run it a moment to push out air bubbles.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "prime-pump",
+                    "text": "Prime the pump"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Pump is primed",
+                    "requiresItems": [{ "id": "584ca717-4ce1-4ca1-bcd3-38272a52768a", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice. A primed pump circulates nutrients without cavitation.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Back to the grow bed."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/pump-install"]
+}


### PR DESCRIPTION
## Summary
- add pump priming quest for hydroponics
- update new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `npm run new-quests:update`

------
https://chatgpt.com/codex/tasks/task_e_689d8f310f40832f9cda67f78f6ebf27