### PR TITLE
Add solder wick desoldering process

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -298,12 +298,14 @@
     "requires": [
       "robotics/wheel-encoders",
       "robotics/odometry-basics",
+      "robotics/gyro-balance",
       "programming/graph-temp-data",
       "geothermal/replace-faulty-thermistor",
       "geothermal/log-ground-temperature",
       "geothermal/install-backup-thermistor",
       "geothermal/compare-seasonal-ground-temps",
       "geothermal/compare-depth-ground-temps",
+      "geothermal/check-loop-temp-delta",
       "geothermal/check-loop-outlet-temp",
       "geothermal/check-loop-inlet-temp",
       "geothermal/calibrate-ground-sensor",
@@ -336,8 +338,19 @@
     ],
     "rewards": []
   },
+  "9018feac-7213-4eef-9654-b06dbd9404ea": {
+    "requires": [
+      "3dprinting/phone-stand"
+    ],
+    "rewards": [
+      "robotics/ultrasonic-rangefinder",
+      "robotics/servo-control",
+      "robotics/line-follower"
+    ]
+  },
   "e976bae6-e33c-428a-a20d-0aa8fde13c6c": {
     "requires": [
+      "robotics/ultrasonic-rangefinder",
       "robotics/servo-radar",
       "robotics/servo-gripper",
       "robotics/servo-control",
@@ -346,20 +359,12 @@
       "robotics/obstacle-avoidance",
       "robotics/maze-navigation",
       "robotics/line-follower",
+      "robotics/gyro-balance",
       "electronics/servo-sweep"
     ],
     "rewards": [
       "electronics/measure-arduino-5v",
       "electronics/arduino-blink"
-    ]
-  },
-  "9018feac-7213-4eef-9654-b06dbd9404ea": {
-    "requires": [
-      "3dprinting/phone-stand"
-    ],
-    "rewards": [
-      "robotics/servo-control",
-      "robotics/line-follower"
     ]
   },
   "8299ac3f-c232-46d4-a007-2ad86ec70361": {
@@ -463,7 +468,8 @@
   "584ca717-4ce1-4ca1-bcd3-38272a52768a": {
     "requires": [
       "hydroponics/pump-install",
-      "hydroponics/nutrient-check"
+      "hydroponics/nutrient-check",
+      "geothermal/purge-loop-air"
     ],
     "rewards": []
   },

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3751,6 +3751,39 @@
         }
     },
     {
+        "id": "wick-solder-joint",
+        "title": "Wick away solder from a PCB joint with a soldering iron",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff",
+                "count": 1
+            },
+            {
+                "id": "526817d2-996a-4d80-b5fc-4a0a5eb9ca03",
+                "count": 1
+            },
+            {
+                "id": "c9b51052-4594-42d7-a723-82b815ab8cc2",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "526817d2-996a-4d80-b5fc-4a0a5eb9ca03",
+                "count": 0.05
+            }
+        ],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "desolder-through-hole",
         "title": "Heat a through-hole joint and clear it with a spring-loaded pump while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2920,6 +2920,19 @@
         "duration": "2m"
     },
     {
+        "id": "wick-solder-joint",
+        "title": "Wick away solder from a PCB joint with a soldering iron",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+            { "id": "526817d2-996a-4d80-b5fc-4a0a5eb9ca03", "count": 1 },
+            { "id": "c9b51052-4594-42d7-a723-82b815ab8cc2", "count": 1 }
+        ],
+        "consumeItems": [{ "id": "526817d2-996a-4d80-b5fc-4a0a5eb9ca03", "count": 0.05 }],
+        "createItems": [],
+        "duration": "3m"
+    },
+    {
         "id": "desolder-through-hole",
         "title": "Heat a through-hole joint and clear it with a spring-loaded pump while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/hardening/wick-solder-joint.json
+++ b/frontend/src/pages/processes/hardening/wick-solder-joint.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/quests/json/electronics/desolder-component.json
+++ b/frontend/src/pages/quests/json/electronics/desolder-component.json
@@ -35,8 +35,15 @@
         },
         {
             "id": "desolder",
-            "text": "Heat a joint, trigger the sucker, hit other lead, then wiggle the part free.",
-            "options": [{ "type": "goto", "goto": "finish", "text": "Component removed." }]
+            "text": "Heat a joint and use solder wick to absorb molten solder, then pull the lead free.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wick-solder-joint",
+                    "text": "Use solder wick to clear solder"
+                },
+                { "type": "goto", "goto": "finish", "text": "Component removed." }
+            ]
         },
         {
             "id": "finish",


### PR DESCRIPTION
## Summary
- add `wick-solder-joint` process for clearing PCB pads with solder wick
- link desolder component quest to the new process
- sync generated process and quest docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8f1a57e4832f9f0099f781ca742d