### PR TITLE
Add process for aquarium ammonia testing

### DIFF
--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2600,6 +2600,18 @@
         "duration": "10m"
     },
     {
+        "id": "measure-aquarium-ammonia",
+        "title": "Test aquarium water for ammonia using a liquid reagent kit",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            { "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a", "count": 1 },
+            { "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "stop-nosebleed",
         "title": "Use gloves, gauze, and antiseptic from a first aid kit to control a minor nosebleed",
         "image": "/assets/rescue.jpg",

--- a/frontend/src/pages/processes/hardening/measure-aquarium-ammonia.json
+++ b/frontend/src/pages/processes/hardening/measure-aquarium-ammonia.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add `measure-aquarium-ammonia` process for testing tank water with liquid kit
- include matching hardening metadata

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root tests/processQuality.test.ts`
- `npm run test:ci -- processQuality` *(fails: newQuestsList test mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689d8f1a57e4832f9f0099f781ca742d