### PR TITLE
📝: add clay pebble rinse quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -172,6 +172,7 @@ New quests in this release: 188
 ### hydroponics
 
 - hydroponics/air-stone-soak
+- hydroponics/clay-pebble-rinse
 - hydroponics/ec-check
 - hydroponics/filter-clean
 - hydroponics/grow-light
@@ -209,6 +210,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -172,6 +172,7 @@ New quests in this release: 188
 ### hydroponics
 
 - hydroponics/air-stone-soak
+- hydroponics/clay-pebble-rinse
 - hydroponics/ec-check
 - hydroponics/filter-clean
 - hydroponics/grow-light

--- a/frontend/src/pages/quests/json/hydroponics/clay-pebble-rinse.json
+++ b/frontend/src/pages/quests/json/hydroponics/clay-pebble-rinse.json
@@ -1,0 +1,50 @@
+{
+    "id": "hydroponics/clay-pebble-rinse",
+    "title": "Rinse Clay Pebbles",
+    "description": "Flush dust from clay media before loading net cups.",
+    "image": "/assets/hydroponics_tub.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "New clay pebbles are dusty. A rinse keeps roots clean.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "rinse",
+                    "text": "How do I rinse them?"
+                }
+            ]
+        },
+        {
+            "id": "rinse",
+            "text": "Pour the pebbles into a bucket of dechlorinated water and swirl until clear.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "bucket-water-dechlorinated",
+                    "text": "Prepare rinse water"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Pebbles are rinsed",
+                    "requiresItems": [{ "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice. Clean media keeps the system running smooth.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Back to planting."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/tub-scrub"]
+}


### PR DESCRIPTION
## Summary
- add clay-pebble-rinse quest referencing dechlorinated water
- update new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8f310f40832f9cda67f78f6ebf27