### PR TITLE
docs: refresh Codex prompt templates

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -10,7 +10,7 @@ Use this drop-in snippet whenever a GitHub Actions run for
 return a pull request that keeps the main branch green. To evolve the prompt
 docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
-If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
+If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use.
 
 > **Human setup**

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,19 +6,21 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time.
+instructions improve themselves over time. For updating the Codex prompt templates
+themselves, see the [Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
 and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `npm run test:ci` pass before committing. Scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py`.
 
 USER:
 1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.
 2. Refine wording, fix links, or add new prompts when gaps appear.
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
-4. Run the checks above.
+4. Use an emoji-prefixed commit message and run the checks above.
 
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -12,13 +12,13 @@ instructions current—the machine that builds the machine.
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and
 `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-all pass before committing.
+all pass before committing. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
 3. Propagate related changes across docs.
-4. Run the checks above.
+4. Use an emoji-prefixed commit message and run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -60,6 +60,8 @@ REQUIREMENTS
 1. …
 2. …
 3. …
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Use an emoji-prefixed commit message like `📝 : – brief summary`.
 
 OUTPUT
 A pull request with the required changes and tests.
@@ -89,7 +91,8 @@ from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
 `AGENTS.md` and ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` all pass before committing. If Playwright browsers are
+and `npm run test:ci` all pass before committing. Scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py`. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
 USER:
@@ -98,7 +101,7 @@ USER:
    with `💯`, replacing any `✅` or other emoji.
 3. Replace any remaining `✅` entries in the changelog with `💯` once they meet
    the robustness standard.
-4. Document new functionality as needed.
+4. Use an emoji-prefixed commit message and document new functionality as needed.
 
 OUTPUT:
 A pull request implementing the chosen item with all tests green. Summarize the
@@ -115,14 +118,15 @@ dedicated to evolving the prompt guides themselves, see the
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
 and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `npm run test:ci` pass before committing. Scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py`.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
    `prompts-items.md`).
 2. Fix outdated instructions, links or formatting.
 3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
-4. Run the checks above.
+4. Use an emoji-prefixed commit message and run the checks above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
@@ -138,14 +142,15 @@ copy lives at [`prompts-codex-upgrader.md`](/docs/prompts-codex-upgrader).
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
 and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `npm run test:ci` pass before committing. Scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py`.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing
    cross-links.
 2. Update prompt templates, including this file, to reflect current practices.
 3. Propagate related changes across docs.
-4. Run the checks above.
+4. Use an emoji-prefixed commit message and run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -9,7 +9,8 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
-docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). To refresh
+the templates, use the [Prompt Upgrader](/docs/prompts-codex-upgrader). For
 general content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -9,7 +9,8 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
-prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). To
+refresh the templates, use the [Prompt Upgrader](/docs/prompts-codex-upgrader).
 For fundamental design tips see the
 [Process Development Guidelines](/docs/process-guidelines).
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -9,7 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
-docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
+docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). To
+refresh the templates, use the [Prompt Upgrader](/docs/prompts-codex-upgrader).
+For the
 steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),


### PR DESCRIPTION
what: update Codex prompt templates with secret-scan & commit style, link Prompt Upgrader; regen new quests list
why: keep guidance current and tests green
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_689d8eed6ed4832fa68bdabc4d630f51