### PR TITLE
Refresh Codex prompt docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -57,6 +57,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
+            <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -10,7 +10,7 @@ Use this drop-in snippet whenever a GitHub Actions run for
 return a pull request that keeps the main branch green. To evolve the prompt
 docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
-If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
+If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use.
 
 > **Human setup**
@@ -43,12 +43,13 @@ CONTEXT:
   * Keep existing behaviour intact.
   * Follow `AGENTS.md` and project style.
   * Add or update tests proving the fix.
-  * Update documentation when necessary.
-  * After fixing, append a bullet to the "Lessons learned" section of
-    `frontend/src/pages/docs/md/prompts-codex-ci-fix.md` summarizing the cause
-    and remedy.
-  * Record the incident in `/outages/YYYY-MM-DD-<slug>.json` using
-    `outages/schema.json`.
+    * Update documentation when necessary.
+    * After fixing, append a bullet to the "Lessons learned" section of
+      `frontend/src/pages/docs/md/prompts-codex-ci-fix.md` summarizing the cause
+      and remedy.
+    * Record the incident in `/outages/YYYY-MM-DD-<slug>.json` using
+      `outages/schema.json`.
+    * Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
@@ -56,6 +57,7 @@ REQUEST:
 3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
 4. Push to a branch named `codex/ci-fix/<short-description>`.
 5. Open a pull request that leaves all CI checks green.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A GitHub pull request URL. Include a summary of the root cause and evidence that

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,7 +6,8 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time.
+instructions improve themselves over time. For a template that audits all prompt docs,
+see the [Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 ```text
 SYSTEM:
@@ -19,6 +20,8 @@ USER:
 2. Refine wording, fix links, or add new prompts when gaps appear.
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -19,7 +19,11 @@ USER:
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
 3. Propagate related changes across docs.
 4. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
+
+See also [Codex prompts](/docs/prompts-codex) and the [Codex meta prompt](/docs/prompts-codex-meta).

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -99,6 +99,8 @@ USER:
 3. Replace any remaining `✅` entries in the changelog with `💯` once they meet
    the robustness standard.
 4. Document new functionality as needed.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request implementing the chosen item with all tests green. Summarize the
@@ -123,6 +125,8 @@ USER:
 2. Fix outdated instructions, links or formatting.
 3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
@@ -146,10 +150,21 @@ USER:
 2. Update prompt templates, including this file, to reflect current practices.
 3. Propagate related changes across docs.
 4. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
+
+## Related prompt docs
+
+-   [Quest prompts](/docs/prompts-quests)
+-   [Item prompts](/docs/prompts-items)
+-   [Process prompts](/docs/prompts-processes)
+-   [CI-failure fix prompt](/docs/prompts-codex-ci-fix)
+-   [Codex meta prompt](/docs/prompts-codex-meta)
+-   [Prompt Upgrader](/docs/prompts-codex-upgrader)
 
 ## Outage Prompt
 
@@ -171,6 +186,8 @@ REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request referencing the new outage record and passing checks.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -9,8 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
-docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For
-general content rules see the [Item Development Guidelines](/docs/item-guidelines).
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta) and the
+[Prompt Upgrader](/docs/prompts-codex-upgrader). For general content rules see
+the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -9,9 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
-prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
-For fundamental design tips see the
-[Process Development Guidelines](/docs/process-guidelines).
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta) and
+the [Prompt Upgrader](/docs/prompts-codex-upgrader). For fundamental design tips
+see the [Process Development Guidelines](/docs/process-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -9,11 +9,12 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
-docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
-steps required to share quests with the community, see the
-[Quest Submission Guide](/docs/quest-submission). Comprehensive content
-guidelines live in our [Content Development Guide](/docs/content-development),
-which covers quests, items and processes in detail.
+docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta) and the
+[Prompt Upgrader](/docs/prompts-codex-upgrader). For the steps required to share
+quests with the community, see the [Quest Submission Guide](/docs/quest-submission).
+Comprehensive content guidelines live in our
+[Content Development Guide](/docs/content-development), which covers quests,
+items and processes in detail.
 
 > **TL;DR**
 >
@@ -26,15 +27,15 @@ which covers quests, items and processes in detail.
 
 ## 1. Quick start (Web vs CLI)
 
-- **Add or update a quest**
-    - Web: use the “Code” button and attach the repo.
-    - CLI: `codex "add quest solar/led-basics"`
-- **Ask about quest files**
-    - Web: use the “Ask” button.
-    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
-    - Web: not supported yet.
-    - CLI:
+-   **Add or update a quest**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "add quest solar/led-basics"`
+-   **Ask about quest files**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+-   **Run quest tests**
+    -   Web: not supported yet.
+    -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
         npm run test:ci -- questCanonical questQuality"
@@ -188,10 +189,10 @@ A pull request with the refined quest, updated hardening block and passing tests
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus.
-- **Use system prompts** to guide tone and technical accuracy.
-- **Iterate on outputs** rather than expecting perfection on the first try.
-- **Fact-check technical information** since AI systems can generate plausible
-  but incorrect details.
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://github.com/microsoft/Codex-CLI


### PR DESCRIPTION
## Summary
- clarify Codex templates with secret scanning and commit style steps
- cross-link prompt guides and expose the Prompt Upgrader in the docs index
- regenerate new-quests list to keep docs in sync

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689d8eed6ed4832fa68bdabc4d630f51