### PR TITLE
feat: add sysadmin user management quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
@@ -234,6 +235,7 @@ New quests in this release: 188
 
 - sysadmin/basic-commands
 - sysadmin/resource-monitoring
+- sysadmin/user-management
 
 ### ubi
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -235,6 +235,7 @@ New quests in this release: 188
 
 - sysadmin/basic-commands
 - sysadmin/resource-monitoring
+- sysadmin/user-management
 
 ### ubi
 

--- a/frontend/src/pages/quests/json/sysadmin/user-management.json
+++ b/frontend/src/pages/quests/json/sysadmin/user-management.json
@@ -1,0 +1,50 @@
+{
+    "id": "sysadmin/user-management",
+    "title": "Manage System Users",
+    "description": "Add and modify user accounts on an Ubuntu 24.04 LTS Minimal server.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Time to set up proper user accounts. Ready to add and modify users?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "manage",
+                    "text": "Create new user"
+                }
+            ]
+        },
+        {
+            "id": "manage",
+            "text": "Use adduser, passwd, and usermod to create users and assign groups.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Users configured",
+                    "requiresItems": [
+                        {
+                            "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work. Your server now has managed user accounts.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Done"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["sysadmin/resource-monitoring"]
+}


### PR DESCRIPTION
## Summary
- add `sysadmin/user-management` quest covering user account creation and modification
- document quest in `new-quests.md`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8f2f2d28832fa93250dae73419dc