### PR TITLE
Add quest to wrap a sprained ankle

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -153,6 +153,7 @@ New quests in this release: 188
 - firstaid/stop-nosebleed
 - firstaid/treat-burn
 - firstaid/wound-care
+- firstaid/wrap-ankle-sprain
 
 ### geothermal
 
@@ -209,6 +210,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2174,6 +2174,24 @@
         }
     },
     {
+        "id": "wrap-ankle-sprain",
+        "title": "Wrap a sprained ankle with an elastic bandage",
+        "image": "/assets/rescue.jpg",
+        "requireItems": [
+            {
+                "id": "31b521d2-d0d9-43bf-a7a1-f8d6195fe6d4",
+                "count": 1
+            },
+            {
+                "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m"
+    },
+    {
         "id": "practice-cpr",
         "title": "Practice 30:2 CPR on a training manikin",
         "requireItems": [

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -153,6 +153,7 @@ New quests in this release: 188
 - firstaid/stop-nosebleed
 - firstaid/treat-burn
 - firstaid/wound-care
+- firstaid/wrap-ankle-sprain
 
 ### geothermal
 

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1073,6 +1073,13 @@
         "price": "0.50 dUSD"
     },
     {
+        "id": "31b521d2-d0d9-43bf-a7a1-f8d6195fe6d4",
+        "name": "elastic bandage",
+        "description": "5 cm wide stretch wrap for stabilizing sprains.",
+        "image": "/assets/rescue.jpg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
         "name": "biohazard waste bag",
         "description": "1 L red bag for used bandages and gloves; tie shut to contain contaminated waste.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1863,6 +1863,18 @@
         "duration": "5m"
     },
     {
+        "id": "wrap-ankle-sprain",
+        "title": "Wrap a sprained ankle with an elastic bandage",
+        "image": "/assets/rescue.jpg",
+        "requireItems": [
+            { "id": "31b521d2-d0d9-43bf-a7a1-f8d6195fe6d4", "count": 1 },
+            { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m"
+    },
+    {
         "id": "practice-cpr",
         "title": "Practice 30:2 CPR on a training manikin",
         "requireItems": [

--- a/frontend/src/pages/quests/json/firstaid/wrap-ankle-sprain.json
+++ b/frontend/src/pages/quests/json/firstaid/wrap-ankle-sprain.json
@@ -1,0 +1,77 @@
+{
+    "id": "firstaid/wrap-ankle-sprain",
+    "title": "Wrap a Sprained Ankle",
+    "description": "Stabilize a minor ankle sprain with an elastic bandage.",
+    "image": "/assets/rescue.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Twisted your ankle? Let's wrap it to reduce swelling. Sit and keep the foot elevated.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "gather",
+                    "text": "Okay, what do I need?"
+                }
+            ]
+        },
+        {
+            "id": "gather",
+            "text": "Wash your hands, then slip on nitrile gloves and unroll the elastic bandage.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Hands are clean",
+                    "goto": "wrap"
+                }
+            ]
+        },
+        {
+            "id": "wrap",
+            "text": "Starting at the ball of the foot, wrap the bandage around the arch, then figure-eight around the ankle. Maintain snug pressure without cutting circulation.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wrap-ankle-sprain",
+                    "text": "Wrap the ankle"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Bandage snug and foot elevated",
+                    "requiresItems": [
+                        {
+                            "id": "31b521d2-d0d9-43bf-a7a1-f8d6195fe6d4",
+                            "count": 1
+                        },
+                        {
+                            "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep the ankle elevated and rest. Seek medical care if pain or swelling worsens.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Will do."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/wound-care"],
+    "hardening": {
+        "passes": 0,
+        "score": 0,
+        "emoji": "🛠️",
+        "history": []
+    }
+}


### PR DESCRIPTION
## Summary
- add elastic bandage item and wrapping process
- introduce "Wrap a Sprained Ankle" first aid quest
- document quest in new-quests listing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8f2f2d28832fa93250dae73419dc