### PR TITLE
refine flash-sd-card process hardening

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1523,8 +1523,14 @@
     },
     {
         "id": "flash-sd-card",
-        "title": "Flash Raspberry Pi OS to microSD",
-        "requireItems": [],
+        "title": "Use a laptop to flash Raspberry Pi OS onto a 64 GB microSD card",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [
             {
                 "id": "36042a2b-861a-4192-a991-98778898963a",
@@ -1537,7 +1543,19 @@
                 "count": 1
             }
         ],
-        "duration": "5m"
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "clone-os-to-ssd",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 213
+New quests in this release: 191
 
 ### 3dprinting
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1319,8 +1319,14 @@
     },
     {
         "id": "flash-sd-card",
-        "title": "Flash Raspberry Pi OS to microSD",
-        "requireItems": [],
+        "title": "Use a laptop to flash Raspberry Pi OS onto a 64 GB microSD card",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [
             {
                 "id": "36042a2b-861a-4192-a991-98778898963a",
@@ -1333,7 +1339,19 @@
                 "count": 1
             }
         ],
-        "duration": "5m"
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "clone-os-to-ssd",

--- a/frontend/src/pages/processes/hardening/flash-sd-card.json
+++ b/frontend/src/pages/processes/hardening/flash-sd-card.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-14",
+            "date": "2025-08-14",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- clarify flashing Raspberry Pi OS with a laptop and 64 GB microSD card
- document first hardening pass for flash-sd-card
- refresh new quest list counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`
- `git diff --cached | detect-secrets scan --string`


------
https://chatgpt.com/codex/tasks/task_e_689d8f1c4344832fb592563b3504ae12