### PR TITLE
feat: add energy inventory check quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance
@@ -243,6 +244,7 @@ New quests in this release: 188
 
 ### welcome
 
+- welcome/check-energy
 - welcome/connect-github
 - welcome/intro-inventory
 - welcome/run-tests

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 214
+New quests in this release: 192
 
 ### 3dprinting
 
@@ -244,6 +244,7 @@ New quests in this release: 188
 
 ### welcome
 
+- welcome/check-energy
 - welcome/connect-github
 - welcome/intro-inventory
 - welcome/run-tests

--- a/frontend/src/pages/quests/json/welcome/check-energy.json
+++ b/frontend/src/pages/quests/json/welcome/check-energy.json
@@ -1,0 +1,36 @@
+{
+    "id": "welcome/check-energy",
+    "title": "Check Your Energy",
+    "description": "Confirm your dWatt stash after running the smart plug.",
+    "image": "/assets/quests/howtodoquests.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Open the inventory and look at your energy items. Let's confirm the smart plug run paid off.",
+            "options": [{ "type": "goto", "goto": "verify", "text": "Checking energy" }]
+        },
+        {
+            "id": "verify",
+            "text": "Do you see at least 1000 dWatt? That spark will power future quests.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Energy confirmed",
+                    "requiresItems": [
+                        { "id": "061fd221-404a-4bd1-9432-3e25b0f17a2c", "count": 1000 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep stacking energy for upcoming projects.",
+            "options": [{ "type": "finish", "text": "Onward!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["welcome/smart-plug-test"]
+}


### PR DESCRIPTION
## Summary
- add welcome quest that verifies energy stash after smart plug run
- document new quest in quest listings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689d8f310f40832f9cda67f78f6ebf27