### PR TITLE
Refine stevia growth process and update hardening

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 215
+New quests in this release: 193
 
 ### 3dprinting
 
@@ -209,6 +209,7 @@ New quests in this release: 188
 
 ### robotics
 
+- robotics/gyro-balance
 - robotics/line-follower
 - robotics/maze-navigation
 - robotics/obstacle-avoidance

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -668,7 +668,8 @@
     },
     {
         "id": "grow-stevia",
-        "title": "grow stevia until it's ready to harvest",
+        "title": "Grow six stevia seedlings in a hydroponics tub under a 36 W lamp for four weeks",
+        "image": "/assets/hydroponic_basil_adult.jpg",
         "requireItems": [
             {
                 "id": "c8946a5f-caff-4e6d-9b9b-4dbf02bcd000",
@@ -678,7 +679,7 @@
         "consumeItems": [
             {
                 "id": "9b440191-a8be-497c-8b5a-7bbac559413b",
-                "count": 11
+                "count": 6
             },
             {
                 "id": "fc2bb989-f192-4891-8bde-78ae631dae78",
@@ -692,14 +693,26 @@
         "createItems": [
             {
                 "id": "ec5013d0-0701-4ba2-8fcf-7a5797c718b4",
-                "count": 11
+                "count": 6
             },
             {
                 "id": "dc765172-c2e4-40dd-bb5a-a399bf6d6d77",
                 "count": 1
             }
         ],
-        "duration": "28d"
+        "duration": "28d",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "regrow-stevia",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 210
-New quests in this release: 188
+Current quest count: 215
+New quests in this release: 193
 
 ### 3dprinting
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -482,7 +482,8 @@
     },
     {
         "id": "grow-stevia",
-        "title": "grow stevia until it's ready to harvest",
+        "title": "Grow six stevia seedlings in a hydroponics tub under a 36 W lamp for four weeks",
+        "image": "/assets/hydroponic_basil_adult.jpg",
         "requireItems": [
             {
                 "id": "c8946a5f-caff-4e6d-9b9b-4dbf02bcd000",
@@ -492,7 +493,7 @@
         "consumeItems": [
             {
                 "id": "9b440191-a8be-497c-8b5a-7bbac559413b",
-                "count": 11
+                "count": 6
             },
             {
                 "id": "fc2bb989-f192-4891-8bde-78ae631dae78",
@@ -506,14 +507,26 @@
         "createItems": [
             {
                 "id": "ec5013d0-0701-4ba2-8fcf-7a5797c718b4",
-                "count": 11
+                "count": 6
             },
             {
                 "id": "dc765172-c2e4-40dd-bb5a-a399bf6d6d77",
                 "count": 1
             }
         ],
-        "duration": "28d"
+        "duration": "28d",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-hardening-2025-08-14",
+                    "date": "2025-08-14",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "regrow-stevia",

--- a/frontend/src/pages/processes/hardening/grow-stevia.json
+++ b/frontend/src/pages/processes/hardening/grow-stevia.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-hardening-2025-08-14",
+            "date": "2025-08-14",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- clarify stevia growth process with realistic counts and energy
- add image and initial hardening record
- regenerate new quests list for tests
- refresh new quests counts to match quest additions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality` *(fails to complete locally)*

------
https://chatgpt.com/codex/tasks/task_e_689d8f229bd0832fb15de2252d461590