### PR TITLE
Add hydrogen peroxide item for net cup cleaning

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -298,12 +298,14 @@
     "requires": [
       "robotics/wheel-encoders",
       "robotics/odometry-basics",
+      "robotics/gyro-balance",
       "programming/graph-temp-data",
       "geothermal/replace-faulty-thermistor",
       "geothermal/log-ground-temperature",
       "geothermal/install-backup-thermistor",
       "geothermal/compare-seasonal-ground-temps",
       "geothermal/compare-depth-ground-temps",
+      "geothermal/check-loop-temp-delta",
       "geothermal/check-loop-outlet-temp",
       "geothermal/check-loop-inlet-temp",
       "geothermal/calibrate-ground-sensor",
@@ -336,8 +338,19 @@
     ],
     "rewards": []
   },
+  "9018feac-7213-4eef-9654-b06dbd9404ea": {
+    "requires": [
+      "3dprinting/phone-stand"
+    ],
+    "rewards": [
+      "robotics/ultrasonic-rangefinder",
+      "robotics/servo-control",
+      "robotics/line-follower"
+    ]
+  },
   "e976bae6-e33c-428a-a20d-0aa8fde13c6c": {
     "requires": [
+      "robotics/ultrasonic-rangefinder",
       "robotics/servo-radar",
       "robotics/servo-gripper",
       "robotics/servo-control",
@@ -346,20 +359,12 @@
       "robotics/obstacle-avoidance",
       "robotics/maze-navigation",
       "robotics/line-follower",
+      "robotics/gyro-balance",
       "electronics/servo-sweep"
     ],
     "rewards": [
       "electronics/measure-arduino-5v",
       "electronics/arduino-blink"
-    ]
-  },
-  "9018feac-7213-4eef-9654-b06dbd9404ea": {
-    "requires": [
-      "3dprinting/phone-stand"
-    ],
-    "rewards": [
-      "robotics/servo-control",
-      "robotics/line-follower"
     ]
   },
   "8299ac3f-c232-46d4-a007-2ad86ec70361": {
@@ -462,8 +467,10 @@
   },
   "584ca717-4ce1-4ca1-bcd3-38272a52768a": {
     "requires": [
+      "hydroponics/pump-prime",
       "hydroponics/pump-install",
-      "hydroponics/nutrient-check"
+      "hydroponics/nutrient-check",
+      "geothermal/purge-loop-air"
     ],
     "rewards": []
   },
@@ -535,6 +542,12 @@
     "requires": [
       "hydroponics/nutrient-check",
       "hydroponics/ec-check"
+    ],
+    "rewards": []
+  },
+  "50f2080e-7dd5-4c8d-a764-dfaa02ca59c3": {
+    "requires": [
+      "hydroponics/netcup-clean"
     ],
     "rewards": []
   },
@@ -1019,7 +1032,8 @@
   },
   "4d21c498-9225-4d0b-9a1a-ed65e349f0a8": {
     "requires": [
-      "composting/turn-pile"
+      "composting/turn-pile",
+      "composting/check-temperature"
     ],
     "rewards": []
   },

--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -366,5 +366,19 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "50f2080e-7dd5-4c8d-a764-dfaa02ca59c3",
+        "name": "hydrogen peroxide (3%)",
+        "description": "250 mL bottle of 3% hydrogen peroxide for sanitizing hydroponic equipment.",
+        "image": "/assets/hydroponics_nutrients.jpg",
+        "price": "1.50 dUSD",
+        "unit": "250 mL bottle",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/hydroponics/netcup-clean.json
+++ b/frontend/src/pages/quests/json/hydroponics/netcup-clean.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "soak",
-            "text": "Fill a bucket with dechlorinated water and add a splash of peroxide.",
+            "text": "Fill a bucket with dechlorinated water and mix in 5 mL of 3% hydrogen peroxide.",
             "options": [
                 {
                     "type": "process",
@@ -30,7 +30,10 @@
                     "type": "goto",
                     "goto": "scrub",
                     "text": "Water is ready",
-                    "requiresItems": [{ "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }]
+                    "requiresItems": [
+                        { "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 },
+                        { "id": "50f2080e-7dd5-4c8d-a764-dfaa02ca59c3", "count": 1 }
+                    ]
                 }
             ]
         },
@@ -62,5 +65,17 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["hydroponics/tub-scrub"]
+    "requiresQuests": ["hydroponics/tub-scrub"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-hardening-2025-08-15",
+                "date": "2025-08-15",
+                "score": 60
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- add hydrogen peroxide (3%) inventory item
- require hydrogen peroxide when cleaning hydroponic net cups

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run itemValidation`
- `npm run test:ci`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`
- `npm run check`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689eb6365abc832f98a7ce8f579efc04