### PR TITLE
feat: add heat gun tool for solder quest

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -125,6 +125,26 @@
         }
     },
     {
+        "id": "a8f184ec-c9d0-4a4b-b6a1-c58c1c297b26",
+        "name": "heat gun",
+        "description": "1200 W heat gun with 300 °C and 600 °C settings and a built-in stand for shrinking tubing.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "20 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "5127e156-3009-4db4-85ac-e3ea070b68f2",
         "name": "digital multimeter",
         "description": "Handheld multimeter with manual 20 V DC range, measures up to 600 V, 10 A and 2 MΩ. Includes test probes and replaceable fuse.",

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -1,7 +1,7 @@
 {
     "id": "electronics/solder-wire",
     "title": "Solder a Wire Connection",
-    "description": "Join jumper wires with a soldering kit and heat-shrink tubing. Ventilate and wear safety goggles.",
+    "description": "Join jumper wires with a soldering kit, heat-shrink tubing, and a heat gun. Ventilate and wear safety goggles.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
@@ -13,7 +13,7 @@
         },
         {
             "id": "prep",
-            "text": "Gather the soldering iron kit, flux pen, wire stripper, two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper, slide the tubing over one lead, heat the iron on its stand, keep cords tidy, and avoid fumes.",
+            "text": "Gather the soldering iron kit, flux pen, wire stripper, and heat gun. Add two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper and slide the tubing over one lead. Heat the iron on its stand, keep cords tidy, and avoid fumes. Use the heat gun to shrink the tubing after soldering.",
             "options": [
                 {
                     "type": "process",
@@ -35,7 +35,8 @@
                         { "id": "6a3772b6-2550-434f-89f9-2eb53d5b139f", "count": 1 },
                         { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 },
                         { "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 },
-                        { "id": "dad7f853-ccc9-40be-b226-89272708db84", "count": 1 }
+                        { "id": "dad7f853-ccc9-40be-b226-89272708db84", "count": 1 },
+                        { "id": "a8f184ec-c9d0-4a4b-b6a1-c58c1c297b26", "count": 1 }
                     ]
                 }
             ]
@@ -49,13 +50,14 @@
     "rewards": [{ "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c", "count": 1 }],
     "requiresQuests": [],
     "hardening": {
-        "passes": 3,
-        "score": 92,
+        "passes": 4,
+        "score": 94,
         "emoji": "💯",
         "history": [
             { "task": "codex-refine-2025-08-07", "date": "2025-08-07", "score": 60 },
             { "task": "codex-solder-wire-polish-2025-08-07", "date": "2025-08-07", "score": 78 },
-            { "task": "codex-solder-wire-hardening-2025-08-12", "date": "2025-08-12", "score": 92 }
+            { "task": "codex-solder-wire-hardening-2025-08-12", "date": "2025-08-12", "score": 92 },
+            { "task": "codex-solder-wire-hardening-2025-08-15", "date": "2025-08-15", "score": 94 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- add heat gun tool with price and hardening metadata
- require heat gun in solder-wire quest preparation and completion

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb6365abc832f98a7ce8f579efc04