### PR TITLE
docs: add outage prompt and refine process tests

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -57,6 +57,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
+            <a href="/docs/prompts-outages">Outage prompts</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -151,27 +151,6 @@ OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
 
-## Outage Prompt
+## Outage prompt
 
-Use this snippet when fixing an incident so knowledge lands in the outage catalog.
-
-```text
-SYSTEM:
-You are an automated contributor for the DSPACE repository.
-
-PURPOSE:
-Diagnose an outage, implement a fix, and document it.
-
-CONTEXT:
-- Review existing records under `/outages` for similar failures.
-- After resolving, add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
-- Keep behaviour intact, add tests, and update documentation.
-
-REQUEST:
-1. Apply the fix with appropriate tests.
-2. Commit the outage entry and related docs.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-
-OUTPUT:
-A pull request referencing the new outage record and passing checks.
-```
+See [Outage prompts](/docs/prompts-outages) for guidance on logging incidents and fixes.

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -1,0 +1,36 @@
+---
+title: 'Outage Prompts'
+slug: 'prompts-outages'
+---
+
+# Outage prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository and run its own tests.
+Use this guide when diagnosing an incident so the fix and a record land in the outage catalog.
+
+> **TL;DR**
+>
+> 1. Investigate the failure and implement a fix.
+> 2. Add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
+> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository.
+
+PURPOSE:
+Diagnose an outage, implement a fix, and document it.
+
+CONTEXT:
+- Review existing records under `/outages` for similar failures.
+- After resolving, add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
+- Keep behaviour intact, add tests, and update documentation.
+
+REQUEST:
+1. Apply the fix with appropriate tests.
+2. Commit the outage entry and related docs.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+
+OUTPUT:
+A pull request referencing the new outage record and passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -35,7 +35,7 @@ For fundamental design tips see the
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:ci -- processQuality"
+        npm run test:ci && npm run test:ci -- processQuality"
         ```
 
 See the [Codex CLI repository][codex-cli] for more flags.
@@ -49,7 +49,7 @@ See the [Codex CLI repository][codex-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add lettuce seed input to hydroponics”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                                 |
 | **Constraints**      | Coding style, a11y, process schema rules.                               |
-| **Acceptance check** | e.g. “`npm run test:ci -- processQuality` passes”.                      |
+| **Acceptance check** | e.g. “`npm run test:ci` and `npm run test:ci -- processQuality` pass”.  |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -73,7 +73,7 @@ REQUIREMENTS
 3. Ensure the process is referenced by at least one quest or item; create
    missing items or quest hooks as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check`, and `npm run build`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or items if needed.
@@ -91,8 +91,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/base.json` with corresponding
 hardening files in `frontend/src/pages/processes/hardening`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run lint`,
-`npm run type-check`, `npm run build`, and `npm run test:ci -- processQuality`).
+steps, durations, item references, and passing checks (`npm run lint`, `npm run type-check`,
+`npm run build`, `npm run test:ci`, and `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -139,10 +139,10 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:ci -- processQuality`. Update docs or items if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-7. Use an emoji-prefixed commit message like `📝 : – refine process details`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+6. Run `npm run test:ci -- processQuality`. Update docs or items if needed.
+7. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+8. Use an emoji-prefixed commit message like `📝 : – refine process details`.
 
 OUTPUT:
 A pull request with the refined process, updated hardening block and passing tests.


### PR DESCRIPTION
## Summary
- add standalone outage prompt guide
- clarify process prompts to run full test suite before quality checks
- link outage guide from codex and docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb611de6c832fb3cf26834cc5fac1