### PR TITLE
docs: refine prompt guides

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -19,7 +19,7 @@ invoking Codex on DSPACE and should evolve alongside the project.
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1. Quick start (Web vs CLI)
 
 | Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
 | -------------- | --------------------------- | --------------------------------------- |
@@ -31,7 +31,7 @@ See the upstream CLI reference for more flags.
 
 ---
 
-## 2 Prompt ingredients
+## 2. Prompt ingredients
 
 | Ingredient           | Why it matters                                                   |
 | -------------------- | ---------------------------------------------------------------- |
@@ -45,7 +45,7 @@ prompt‑level rules short and concrete.
 
 ---
 
-## 3 Reusable template
+## 3. Reusable template
 
 ```text
 You are working in democratizedspace/dspace.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -29,7 +29,7 @@ For fundamental design tips see the
     -   CLI: `codex "add process 3dprinting/solar-mount"`
 -   **Ask about process data**
     -   Web: use the “Ask” button.
-    -   CLI: `codex exec "explain frontend/src/generated/processes.json"`
+    -   CLI: `codex exec "explain frontend/src/pages/processes/base.json"`
 -   **Run process tests**
     -   Web: not supported yet.
     -   CLI:
@@ -42,7 +42,7 @@ See the [Codex CLI repository][codex-cli] for more flags.
 
 ---
 
-## 2 Prompt ingredients
+## 2. Prompt ingredients
 
 | Ingredient           | Why it matters                                                          |
 | -------------------- | ----------------------------------------------------------------------- |
@@ -51,12 +51,12 @@ See the [Codex CLI repository][codex-cli] for more flags.
 | **Constraints**      | Coding style, a11y, process schema rules.                               |
 | **Acceptance check** | e.g. “`npm run test:ci -- processQuality` passes”.                      |
 
-Codex merges those instructions with any `AGENTS.md` files it finds, so keep
+Codex merges these instructions with any `AGENTS.md` files in scope, so keep
 prompt‑level rules short and concrete.
 
 ---
 
-## 3 Reusable template
+## 3. Reusable template
 
 ```text
 You are working in democratizedspace/dspace.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -11,8 +11,9 @@ clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
 docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
 steps required to share quests with the community, see the
-[Quest Submission Guide](/docs/quest-submission). Comprehensive content
-guidelines live in our [Content Development Guide](/docs/content-development),
+[Quest Submission Guide](/docs/quest-submission). For quest design best
+practices, see the [Quest Guidelines](/docs/quest-guidelines). Comprehensive
+content guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.
 
 > **TL;DR**
@@ -44,7 +45,7 @@ See the [Codex CLI repository][codex-cli] for more flags.
 
 ---
 
-## 2 Prompt ingredients
+## 2. Prompt ingredients
 
 | Ingredient           | Why it matters                                                      |
 | -------------------- | ------------------------------------------------------------------- |
@@ -58,7 +59,7 @@ prompt‑level rules short and concrete.
 
 ---
 
-## 3 Reusable template
+## 3. Reusable template
 
 ```text
 You are working in democratizedspace/dspace.


### PR DESCRIPTION
## Summary
- standardize numbering across prompt guides
- fix process data reference in process prompt doc
- link quest guidelines from quest prompt doc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb611de6c832fb3cf26834cc5fac1