### PR TITLE
docs: add NPC prompt guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -53,6 +53,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>
+            <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -10,6 +10,10 @@ run its own tests, and send you a ready‑made PR — but only if you give it a 
 file‑scoped prompt. This document stores the baseline instructions used when
 invoking Codex on DSPACE and should evolve alongside the project.
 
+For task‑specific templates see [Quest prompts](/docs/prompts-quests),
+[Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes), and
+[NPC prompts](/docs/prompts-npcs).
+
 > **TL;DR**
 >
 > 1. Scope the task to one or two files.

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -1,0 +1,97 @@
+---
+title: 'NPC Prompts'
+slug: 'prompts-npcs'
+---
+
+# Writing great NPC prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository, run its own tests, and send you a ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when working on NPC bios or dialogue. Consult the [NPCs guide](/docs/npcs) for voice and lore details.
+
+> **TL;DR**
+>
+> 1. Scope changes to a single NPC.
+> 2. Specify the expected output (tests, docs).
+> 3. Stop when the spec is complete; remaining text becomes mandatory.
+
+---
+
+## 1. Quick start (Web vs CLI)
+
+-   **Add or update an NPC**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "update npc dChat"`
+-   **Ask about NPC data**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/docs/md/npcs.md"`
+-   **Run checks**
+    -   Web: not supported yet.
+    -   CLI:
+        ```bash
+        codex exec "npm run lint && npm run type-check && npm run build && npm run test:ci"
+        ```
+
+See the [Codex CLI repository][codex-cli] for more flags.
+
+---
+
+## 2. Prompt ingredients
+
+| Ingredient           | Why it matters                                                 |
+| -------------------- | -------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sample dialogue for Nova”). |
+| **Files to touch**   | Limits search space → faster & cheaper.                        |
+| **Constraints**      | Coding style, lore rules, NPC schema.                          |
+| **Acceptance check** | e.g. “All tests pass”.                                         |
+
+Codex merges those instructions with any `AGENTS.md` files it finds, so keep prompt-level rules short and concrete.
+
+---
+
+## 3. Reusable template
+
+```text
+You are working in democratizedspace/dspace.
+
+GOAL: <one sentence NPC addition or edit>.
+
+FILES OF INTEREST
+- frontend/src/pages/docs/md/npcs.md ← NPC bios and dialogue
+
+REQUIREMENTS
+1. Preserve established character voice and lore.
+2. Keep sample dialogue short and approachable.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Update related docs if needed.
+
+OUTPUT
+A pull request with the updated NPC and passing checks.
+```
+
+## Implementation Prompt
+
+Use this when you want Codex to automatically create or upgrade an NPC entry.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Edit `frontend/src/pages/docs/md/npcs.md`, adding or refining NPC sections. Maintain each character’s voice, keep sample dialogue realistic, and ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+
+USER:
+1. Follow the steps above.
+2. Summarize the NPC changes in the PR description.
+3. Use an emoji-prefixed commit message like `📝 : – update NPC dialogue`.
+
+OUTPUT:
+A pull request with the updated NPC doc and passing tests.
+```
+
+## Additional tips for AI assistance
+
+Modern assistants can be powerful collaborators. Keep in mind:
+
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
+
+[codex-cli]: https://github.com/microsoft/Codex-CLI

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -9,7 +9,7 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
-docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
 steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),
@@ -26,15 +26,15 @@ which covers quests, items and processes in detail.
 
 ## 1. Quick start (Web vs CLI)
 
-- **Add or update a quest**
-    - Web: use the “Code” button and attach the repo.
-    - CLI: `codex "add quest solar/led-basics"`
-- **Ask about quest files**
-    - Web: use the “Ask” button.
-    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
-    - Web: not supported yet.
-    - CLI:
+-   **Add or update a quest**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "add quest solar/led-basics"`
+-   **Ask about quest files**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+-   **Run quest tests**
+    -   Web: not supported yet.
+    -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
         npm run test:ci -- questCanonical questQuality"
@@ -188,10 +188,10 @@ A pull request with the refined quest, updated hardening block and passing tests
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus.
-- **Use system prompts** to guide tone and technical accuracy.
-- **Iterate on outputs** rather than expecting perfection on the first try.
-- **Fact-check technical information** since AI systems can generate plausible
-  but incorrect details.
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://github.com/microsoft/Codex-CLI


### PR DESCRIPTION
## Summary
- document NPC-specific prompt workflow
- cross-link NPC guide from codex and docs index
- tweak quest prompt wording

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb611de6c832fb3cf26834cc5fac1