### PR TITLE
docs: expose Codex prompt upgrader

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -56,6 +56,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
+            <a href="/docs/prompts-codex-upgrader">Codex prompt upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -6,7 +6,8 @@ slug: 'prompts-codex-upgrader'
 # Codex Prompt Upgrader
 
 Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
-instructions current—the machine that builds the machine.
+instructions current—the machine that builds the machine. When adding a new prompt,
+remember to link it from `prompts-codex.md` and the docs index.
 
 ```text
 SYSTEM:
@@ -17,8 +18,9 @@ all pass before committing.
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
-3. Propagate related changes across docs.
-4. Run the checks above.
+3. Link new prompt files from `prompts-codex.md` and the docs index.
+4. Propagate related changes across docs.
+5. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -130,9 +130,9 @@ A pull request with the improved prompt doc and passing checks.
 
 ## Prompt Upgrader
 
-Use this meta prompt when the Codex templates themselves need refreshing. It
-keeps our guidance current—the machine that builds the machine. A standalone
-copy lives at [`prompts-codex-upgrader.md`](/docs/prompts-codex-upgrader).
+Use this meta prompt when the Codex templates need refreshing. It keeps our
+guidance current—the machine that builds the machine. See the standalone
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader) for the full template.
 
 ```text
 SYSTEM:
@@ -144,8 +144,9 @@ USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing
    cross-links.
 2. Update prompt templates, including this file, to reflect current practices.
-3. Propagate related changes across docs.
-4. Run the checks above.
+3. Link new prompt files from `prompts-codex.md` and the docs index.
+4. Propagate related changes across docs.
+5. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.


### PR DESCRIPTION
## Summary
- document linking new prompts in Codex upgrader templates
- add Codex prompt upgrader to docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb611de6c832fb3cf26834cc5fac1