### PR TITLE
docs: refresh Codex prompt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ everything consistent.
 For faster content development, consult our prompt guides for
 [quests](docs/prompts-quests), [items](docs/prompts-items), and
 [processes](docs/prompts-processes). Each includes ready-made templates for
-tools like GPT-4 or Claude. Combine these with the [Quest Development
+tools like GPT-4 or Claude. See [Codex prompts](docs/prompts-codex) for
+repository-wide automation and refresh templates with the
+[Codex Prompt Upgrader](docs/prompts-codex-upgrader). Combine these with the [Quest Development
 Guidelines](docs/quest-guidelines), the [Quest Template Example](docs/quest-template),
 the [Item Development Guidelines](docs/item-guidelines), the [Process Development
 Guidelines](docs/process-guidelines), and the [Quest Submission

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -56,6 +56,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
+            <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -10,7 +10,7 @@ Use this drop-in snippet whenever a GitHub Actions run for
 return a pull request that keeps the main branch green. To evolve the prompt
 docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
-If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
+If this prompt ever drifts, consult the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use.
 
 > **Human setup**

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,7 +6,8 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time.
+instructions improve themselves over time. If the templates themselves drift, refresh
+them using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 ```text
 SYSTEM:

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -6,7 +6,8 @@ slug: 'prompts-codex-upgrader'
 # Codex Prompt Upgrader
 
 Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
-instructions current—the machine that builds the machine.
+instructions current—the machine that builds the machine. See
+[Codex Prompts](/docs/prompts-codex) for the baseline templates.
 
 ```text
 SYSTEM:

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -17,6 +17,8 @@ invoking Codex on DSPACE and should evolve alongside the project.
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
 
+For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+
 ---
 
 ## 1 Quick start (Web vs CLI)

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -9,8 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
-docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For
-general content rules see the [Item Development Guidelines](/docs/item-guidelines).
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
+templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For general content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -9,7 +9,8 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
-prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
+templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 For fundamental design tips see the
 [Process Development Guidelines](/docs/process-guidelines).
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -9,8 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
-docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
-steps required to share quests with the community, see the
+docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
+templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For the steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.


### PR DESCRIPTION
## Summary
- cross-link CI-fix prompt from core Codex doc
- reference Codex Prompt Upgrader throughout prompt guides
- surface Prompt Upgrader in docs index and README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb619ed28832f8705d9db6de30672