### PR TITLE
📝 : refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -7,7 +7,8 @@ slug: 'prompts-codex-ci-fix'
 
 Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
-return a pull request that keeps the main branch green. To evolve the prompt
+return a pull request that keeps the main branch green. For general prompting
+tips, start with [Codex prompts](/docs/prompts-codex). To evolve the prompt
 docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
 If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
@@ -25,6 +26,7 @@ to refresh it before use.
 ```text
 SYSTEM:
 You are an automated contributor for the democratizedspace/dspace repository.
+Follow `AGENTS.md` and `README.md`.
 
 PURPOSE:
 Diagnose a failed CI run and make it pass.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -8,7 +8,8 @@ slug: 'prompts-codex'
 Codex (Web + CLI) is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR — but only if you give it a clear,
 file‑scoped prompt. This document stores the baseline instructions used when
-invoking Codex on DSPACE and should evolve alongside the project.
+invoking Codex on DSPACE and should evolve alongside the project. For failed
+GitHub Actions runs, use the [CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >
@@ -40,8 +41,8 @@ See the upstream CLI reference for more flags.
 | **Constraints**      | Coding style, a11y, perf, etc.                                   |
 | **Acceptance check** | e.g. “All `npm test` suites pass”.                               |
 
-Codex merges those instructions with any `AGENTS.md` files it finds, so keep
-prompt‑level rules short and concrete.
+Codex merges those instructions with any `AGENTS.md` files it finds and the
+repo's `README.md`, so keep prompt‑level rules short and concrete.
 
 ---
 
@@ -88,9 +89,10 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` all pass before committing. If Playwright browsers are
-missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
+`AGENTS.md` and `README.md` and ensure `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` all pass before committing. If Playwright
+browsers are missing run `npx playwright install chromium` or use
+`SKIP_E2E=1 npm run test:ci`.
 
 USER:
 1. Follow the steps above.
@@ -151,13 +153,21 @@ OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
 
+## CI-Failure Fix Prompt
+
+When GitHub Actions fails, use the
+[CI-failure fix prompt](/docs/prompts-codex-ci-fix) to debug the first
+error and craft a PR that restores the green build. The doc includes a
+"Lessons learned" log so fixes compound over time.
+
 ## Outage Prompt
 
 Use this snippet when fixing an incident so knowledge lands in the outage catalog.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`.
 
 PURPOSE:
 Diagnose an outage, implement a fix, and document it.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -54,6 +54,9 @@ See the [Codex CLI repository][codex-cli] for more flags.
     -   `npm run itemValidation`
     -   `npm run test:ci -- itemQuality` pass
 
+Codex merges those instructions with any `AGENTS.md` files it finds and the
+repo's `README.md`, so keep prompt-level rules short and concrete.
+
 ## 3. Reusable template
 
 ```text
@@ -87,15 +90,16 @@ Use this when you want Codex to automatically create or upgrade an item.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. Edit or
-create items under `frontend/src/pages/inventory/json/items`, choosing the
-appropriate category file. Ensure realistic details, required fields, and
-passing checks (`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
-`npm run itemValidation`, and `npm run test:ci -- itemQuality`).
-Verify the item appears in at least one quest or process, reuse existing image
-assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-committing. If a quest's text changes, run `npm run test:ci -- questQuality` and update the quest's
-`hardening` block with a fresh evaluation score.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Edit or create items under
+`frontend/src/pages/inventory/json/items`, choosing the appropriate category
+file. Ensure realistic details, required fields, and passing checks (`npm run
+lint`, `npm run type-check`, `npm run build`, `npm run test:ci`, `npm run
+itemValidation`, and `npm run test:ci -- itemQuality`). Verify the item appears
+in at least one quest or process, reuse existing image assets, and scan for
+secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+If a quest's text changes, run `npm run test:ci -- questQuality` and update the
+quest's `hardening` block with a fresh evaluation score.
 
 USER:
 1. Follow the steps above.
@@ -114,7 +118,8 @@ Apply this prompt to refine items and track quality over time.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`.
 
 USER:
 1. Pick an item from `frontend/src/pages/inventory/json/items` that lacks a

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -51,8 +51,8 @@ See the [Codex CLI repository][codex-cli] for more flags.
 | **Constraints**      | Coding style, a11y, process schema rules.                               |
 | **Acceptance check** | e.g. “`npm run test:ci -- processQuality` passes”.                      |
 
-Codex merges those instructions with any `AGENTS.md` files it finds, so keep
-prompt‑level rules short and concrete.
+Codex merges those instructions with any `AGENTS.md` files it finds and the
+repo's `README.md`, so keep prompt‑level rules short and concrete.
 
 ---
 
@@ -88,13 +88,14 @@ Use this when you want Codex to automatically create or upgrade a process.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. Edit or create
-processes under `frontend/src/pages/processes/base.json` with corresponding
-hardening files in `frontend/src/pages/processes/hardening`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run lint`,
-`npm run type-check`, `npm run build`, and `npm run test:ci -- processQuality`).
-Verify the process links to existing quests or items, add missing registry
-entries if needed, reuse existing image assets, and scan for secrets with
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Edit or create processes under
+`frontend/src/pages/processes/base.json` with corresponding hardening files in
+`frontend/src/pages/processes/hardening`. Ensure realistic steps, durations,
+item references, and passing checks (`npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci -- processQuality`). Verify the process
+links to existing quests or items, add missing registry entries if needed,
+reuse existing image assets, and scan for secrets with
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
@@ -113,7 +114,8 @@ Use this prompt to refine processes and track quality as the game evolves.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`.
 
 USER:
 1. Pick a process from `frontend/src/generated/processes.json` that lacks a

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -53,8 +53,8 @@ See the [Codex CLI repository][codex-cli] for more flags.
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
 | **Acceptance check** | e.g. “`npm run test:ci -- questCanonical questQuality` passes”.     |
 
-Codex merges those instructions with any `AGENTS.md` files it finds, so keep
-prompt‑level rules short and concrete.
+Codex merges those instructions with any `AGENTS.md` files it finds and the
+repo's `README.md`, so keep prompt‑level rules short and concrete.
 
 ---
 
@@ -91,15 +91,15 @@ Use this when you want Codex to automatically create or upgrade a quest.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. Edit or create
-quests under `frontend/src/pages/quests/json`. Ensure start, middle and
-completion nodes, at least one item or process reference, and passing checks
-(`npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci -- questCanonical questQuality`). Survey existing quests to
-pick a natural predecessor and update `requiresQuests` accordingly. Add missing
-items or processes to their registries, reuse existing image assets, and scan
-for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-committing.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Edit or create quests under
+`frontend/src/pages/quests/json`. Ensure start, middle and completion nodes, at
+least one item or process reference, and passing checks (`npm run lint`, `npm
+run type-check`, `npm run build`, and `npm run test:ci -- questCanonical
+questQuality`). Survey existing quests to pick a natural predecessor and update
+`requiresQuests` accordingly. Add missing items or processes to their
+registries, reuse existing image assets, and scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Follow the steps above.
@@ -119,9 +119,10 @@ hand‑crafted quests on `main` are good references for tone and structure.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. List
-the folders under `frontend/src/pages/quests/json` and pick one at random. Use
-existing quests in that tree as examples for tone and structure.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. List the folders under `frontend/src/pages/quests/json` and
+pick one at random. Use existing quests in that tree as examples for tone and
+structure.
 
 USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
@@ -147,7 +148,8 @@ while the hardening loop tracks refinement passes over time.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`.
 
 USER:
 1. Pick a quest ID from `frontend/src/pages/quests/json` that also appears in


### PR DESCRIPTION
what: link CI-failure fix prompt and align templates with AGENTS.md and README.md.
why: keep Codex prompt guidance current.
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci.


------
https://chatgpt.com/codex/tasks/task_e_689eb619ed28832f8705d9db6de30672