### PR TITLE
📝 : – harden Completionist Award II

### DIFF
--- a/frontend/src/pages/inventory/json/items/awards.json
+++ b/frontend/src/pages/inventory/json/items/awards.json
@@ -92,9 +92,17 @@
     {
         "id": "c01676ec-27e5-4a53-9a47-24bf6c5a56a9",
         "name": "Completionist Award II",
-        "description": "Awarded for completing all of the quests available on June 30, 2023.",
+        "description": "12 cm aluminum trophy dated 2023-06-30; reward for finishing all quests.",
         "image": "/assets/completionist_award_ii.jpg",
-        "priceExemptionReason": "BETA_PLACEHOLDER"
+        "priceExemptionReason": "TROPHY",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-08-15", "date": "2025-08-15", "score": 60 }
+            ]
+        }
     },
     {
         "id": "978ce094-f4fa-4b55-9e1a-2ea76531989d",

--- a/frontend/src/pages/quests/json/completionist/display.json
+++ b/frontend/src/pages/quests/json/completionist/display.json
@@ -1,7 +1,7 @@
 {
     "id": "completionist/display",
     "title": "Show Off Your Trophy",
-    "description": "Give your Completionist Award a dedicated spot on the shelf.",
+    "description": "Give your Completionist Award II a dedicated spot on the shelf.",
     "image": "/assets/quests/completionist.jpg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",

--- a/frontend/src/pages/quests/json/completionist/polish.json
+++ b/frontend/src/pages/quests/json/completionist/polish.json
@@ -1,7 +1,7 @@
 {
     "id": "completionist/polish",
     "title": "Polish Your Trophy",
-    "description": "Keep your Completionist Award shiny and proud.",
+    "description": "Keep your Completionist Award II shiny and proud.",
     "image": "/assets/quests/completionist.jpg",
     "npc": "/assets/npc/dChat.jpg",
     "start": "start",

--- a/frontend/src/pages/quests/json/completionist/v2.json
+++ b/frontend/src/pages/quests/json/completionist/v2.json
@@ -19,7 +19,7 @@
         },
         {
             "id": "thanks",
-            "text": "Well, adventurer, because you've completed the first wave of quests!! There are certainly many more on the horizon, but you've reached a significant milestone. And for that, this Completionist Award is all yours!!",
+            "text": "Well, adventurer, because you've completed the first wave of quests!! There are certainly many more on the horizon, but you've reached a significant milestone. And for that, this Completionist Award II is all yours!!",
             "options": [
                 {
                     "type": "goto",


### PR DESCRIPTION
## Summary
- refine Completionist Award II description and trophy status
- align completionist quests with Completionist Award II

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb63d6220832f991950604123c923