### PR TITLE
Add cross-browser clipboard utility

### DIFF
--- a/frontend/__tests__/copyToClipboard.test.js
+++ b/frontend/__tests__/copyToClipboard.test.js
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { copyToClipboard } from '../src/utils/copyToClipboard.js';
+
+describe('copyToClipboard', () => {
+    it('uses navigator.clipboard when available', async () => {
+        const writeText = vi.fn().mockResolvedValue();
+        Object.assign(navigator, { clipboard: { writeText } });
+        await copyToClipboard('hello');
+        expect(writeText).toHaveBeenCalledWith('hello');
+    });
+
+    it('falls back to execCommand when clipboard API is missing', async () => {
+        Object.assign(navigator, { clipboard: undefined });
+        const execCommand = vi.fn();
+        document.execCommand = execCommand;
+        await copyToClipboard('hi');
+        expect(execCommand).toHaveBeenCalledWith('copy');
+    });
+});

--- a/frontend/src/pages/chat/svelte/Message.svelte
+++ b/frontend/src/pages/chat/svelte/Message.svelte
@@ -6,6 +6,7 @@
     import { Remarkable } from 'remarkable';
     import { formatRelative, format } from 'date-fns';
     import { fade } from 'svelte/transition';
+    import { copyToClipboard } from '../../../utils/copyToClipboard.js';
 
     export let messageMarkdown;
     export let className;
@@ -42,11 +43,11 @@
 
     let toastVisible = false;
 
-    function copyToClipboard(event) {
+    function handleCopyButton(event) {
         if (event.target.classList.contains('copy-button')) {
             const pre = event.target.parentNode;
             const code = pre.querySelector('code').innerText;
-            navigator.clipboard.writeText(code);
+            copyToClipboard(code);
             toastVisible = true;
             setTimeout(() => {
                 toastVisible = false;
@@ -57,7 +58,7 @@
     onMount(() => {
         const copyButtons = document.querySelectorAll('.copy-button');
         copyButtons.forEach((button) => {
-            button.addEventListener('click', copyToClipboard);
+            button.addEventListener('click', handleCopyButton);
             button.addEventListener('mouseover', () => {
                 button.style.opacity = '1';
                 button.style.backgroundColor = '#68d46d';
@@ -72,7 +73,7 @@
 
         return () => {
             copyButtons.forEach((button) => {
-                button.removeEventListener('click', copyToClipboard);
+                button.removeEventListener('click', handleCopyButton);
             });
         };
     });

--- a/frontend/src/pages/contentbackup/svelte/Exporter.svelte
+++ b/frontend/src/pages/contentbackup/svelte/Exporter.svelte
@@ -1,6 +1,7 @@
 <script>
     import Chip from '../../../components/svelte/Chip.svelte';
     import { exportCustomContentString } from '../../../utils/customcontent.js';
+    import { copyToClipboard } from '../../../utils/copyToClipboard.js';
 
     let backupString = '';
     exportCustomContentString().then((str) => (backupString = str));
@@ -12,11 +13,7 @@
         <div class="code-block">
             <code>{backupString}</code>
         </div>
-        <Chip
-            text="Copy"
-            on:click={() => navigator.clipboard.writeText(backupString)}
-            inverted={true}
-        />
+        <Chip text="Copy" on:click={() => copyToClipboard(backupString)} inverted={true} />
     </div>
 </Chip>
 

--- a/frontend/src/pages/docs/md/backups.md
+++ b/frontend/src/pages/docs/md/backups.md
@@ -8,9 +8,9 @@ custom content you create.
 ## Game saves
 
 Visit the [Import/export gamesaves](/gamesaves) page to copy a snapshot of your
-entire progress. Click **Copy** to place the backup string on your clipboard or
-paste a previously saved string and click **Import** to restore it on another
-device.
+entire progress. Click **Copy** to place the backup string on your clipboard
+(works without the Clipboard API) or paste a previously saved string and click
+**Import** to restore it on another device.
 
 ## Custom content
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -83,7 +83,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Load testing custom content system 💯
         -   [x] Database performance benchmarks 💯
         -   [x] UI responsiveness metrics 💯
-    -   [x] Cross‑browser compatibility
+    -   [x] Cross‑browser compatibility 💯
         -   [x] Test IndexedDB in all major browsers 💯
         -   [x] Verify UI components across browsers 💯
         -   [x] Check offline functionality 💯

--- a/frontend/src/pages/gamesaves/svelte/Exporter.svelte
+++ b/frontend/src/pages/gamesaves/svelte/Exporter.svelte
@@ -1,6 +1,7 @@
 <script>
     import Chip from '../../../components/svelte/Chip.svelte';
     import { exportGameStateString } from '../../../utils/gameState/common.js';
+    import { copyToClipboard } from '../../../utils/copyToClipboard.js';
 
     const gameStateString = exportGameStateString();
 </script>
@@ -16,11 +17,7 @@
             </code>
         </div>
 
-        <Chip
-            text="Copy"
-            onClick={() => navigator.clipboard.writeText(gameStateString)}
-            inverted={true}
-        />
+        <Chip text="Copy" onClick={() => copyToClipboard(gameStateString)} inverted={true} />
     </div>
 </Chip>
 

--- a/frontend/src/utils/copyToClipboard.js
+++ b/frontend/src/utils/copyToClipboard.js
@@ -1,0 +1,21 @@
+/**
+ * Copy text to the clipboard with a cross-browser fallback.
+ * @param {string} text - The string to copy.
+ * @returns {Promise<void>} Resolves when the text is copied.
+ */
+export async function copyToClipboard(text) {
+    if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+}


### PR DESCRIPTION
## Summary
- add copyToClipboard util with execCommand fallback
- use shared clipboard helper in message and export pages
- document clipboard fallback and mark cross-browser compatibility done

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb622fde4832fbb461ce67cef3736