### PR TITLE
docs: refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -56,6 +56,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
+            <a href="/docs/prompts-codex-upgrader">Prompt upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-fix prompt</a>
         </nav>
     </span>

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -8,10 +8,11 @@ slug: 'prompts-codex-ci-fix'
 Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
 return a pull request that keeps the main branch green. To evolve the prompt
-docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
+docs, see the [Codex meta prompt](/docs/prompts-codex-meta) and
+[Codex prompts](/docs/prompts-codex).
 
-If this prompt ever drifts, consult the [Prompt Upgrader](/docs/prompts-codex#prompt-upgrader)
-to refresh it before use.
+If this prompt ever drifts, consult the
+[Prompt Upgrader](/docs/prompts-codex-upgrader) to refresh it before use.
 
 > **Human setup**
 >
@@ -42,9 +43,9 @@ CONTEXT:
 - Constraints:
   * Keep existing behaviour intact.
   * Follow `AGENTS.md` and project style.
-  * Add or update tests proving the fix.
-  * Update documentation when necessary.
-  * After fixing, append a bullet to the "Lessons learned" section of
+ * Add or update tests proving the fix.
+ * Update documentation when necessary.
+ * After fixing, append a bullet to the "Lessons learned" section of
     `frontend/src/pages/docs/md/prompts-codex-ci-fix.md` summarizing the cause
     and remedy.
   * Record the incident in `/outages/YYYY-MM-DD-<slug>.json` using
@@ -54,8 +55,9 @@ REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
 2. Commit the minimal changes needed to fix it.
 3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
-4. Push to a branch named `codex/ci-fix/<short-description>`.
-5. Open a pull request that leaves all CI checks green.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Push to a branch named `codex/ci-fix/<short-description>`.
+6. Open a pull request that leaves all CI checks green.
 
 OUTPUT:
 A GitHub pull request URL. Include a summary of the root cause and evidence that

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,7 +6,10 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time.
+instructions improve themselves over time. See
+[Codex prompts](/docs/prompts-codex) for general usage, the
+[Prompt Upgrader](/docs/prompts-codex-upgrader) for bulk refreshes, and the
+[CI-failure fix prompt](/docs/prompts-codex-ci-fix) when CI jobs fail.
 
 ```text
 SYSTEM:
@@ -18,7 +21,8 @@ USER:
 1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.
 2. Refine wording, fix links, or add new prompts when gaps appear.
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
-4. Run the checks above.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Run the checks above.
 
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -6,7 +6,10 @@ slug: 'prompts-codex-upgrader'
 # Codex Prompt Upgrader
 
 Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
-instructions current—the machine that builds the machine.
+instructions current—the machine that builds the machine. See
+[Codex prompts](/docs/prompts-codex) for general usage, the
+[Codex meta prompt](/docs/prompts-codex-meta) for focused edits, and the
+[CI-failure fix prompt](/docs/prompts-codex-ci-fix) for broken pipelines.
 
 ```text
 SYSTEM:
@@ -18,7 +21,8 @@ USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
 3. Propagate related changes across docs.
-4. Run the checks above.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -8,7 +8,12 @@ slug: 'prompts-codex'
 Codex (Web + CLI) is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR — but only if you give it a clear,
 file‑scoped prompt. This document stores the baseline instructions used when
-invoking Codex on DSPACE and should evolve alongside the project.
+invoking Codex on DSPACE and should evolve alongside the project. Related guides:
+[Quest prompts](/docs/prompts-quests), [Item prompts](/docs/prompts-items),
+[Process prompts](/docs/prompts-processes), the
+[Codex meta prompt](/docs/prompts-codex-meta), the
+[Prompt Upgrader](/docs/prompts-codex-upgrader), and the
+[CI‑failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >
@@ -21,11 +26,11 @@ invoking Codex on DSPACE and should evolve alongside the project.
 
 ## 1 Quick start (Web vs CLI)
 
-| Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
-| -------------- | --------------------------- | --------------------------------------- |
-| Ad‑hoc feature | “Code” button, attach repo  | `codex "add buy‑button to ProcessView"` |
-| Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
-| CI automation  | –                           | `codex exec --full-auto "run npm test"` |
+| Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                                                                                         |
+| -------------- | --------------------------- | ------------------------------------------------------------------------------------------------- |
+| Ad‑hoc feature | “Code” button, attach repo  | `codex "add buy‑button to ProcessView"`                                                           |
+| Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`                                                              |
+| CI automation  | –                           | `codex exec --full-auto "npm run lint && npm run type-check && npm run build && npm run test:ci"` |
 
 See the upstream CLI reference for more flags.
 
@@ -33,12 +38,12 @@ See the upstream CLI reference for more flags.
 
 ## 2 Prompt ingredients
 
-| Ingredient           | Why it matters                                                   |
-| -------------------- | ---------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”). |
-| **Files to touch**   | Limits search space → faster & cheaper.                          |
-| **Constraints**      | Coding style, a11y, perf, etc.                                   |
-| **Acceptance check** | e.g. “All `npm test` suites pass”.                               |
+| Ingredient           | Why it matters                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                          |
+| **Files to touch**   | Limits search space → faster & cheaper.                                                   |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                            |
+| **Acceptance check** | e.g. “`npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass”. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -145,7 +150,8 @@ USER:
    cross-links.
 2. Update prompt templates, including this file, to reflect current practices.
 3. Propagate related changes across docs.
-4. Run the checks above.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+5. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -9,8 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready-made PR—but only if you give it a
 clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
-docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). For
-general content rules see the [Item Development Guidelines](/docs/item-guidelines).
+docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta) and the
+[Prompt Upgrader](/docs/prompts-codex-upgrader). For general content rules see the
+[Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -9,9 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
-prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
-For fundamental design tips see the
-[Process Development Guidelines](/docs/process-guidelines).
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta) and
+the [Prompt Upgrader](/docs/prompts-codex-upgrader). For fundamental design tips
+see the [Process Development Guidelines](/docs/process-guidelines).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -9,8 +9,9 @@ Codex is a sandboxed engineering agent that can open this repository,
 run its own tests, and send you a ready‑made PR—but only if you give it a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
-docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). For the
-steps required to share quests with the community, see the
+docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta) and the
+[Prompt Upgrader](/docs/prompts-codex-upgrader). For the steps required to share
+quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),
 which covers quests, items and processes in detail.
@@ -26,15 +27,15 @@ which covers quests, items and processes in detail.
 
 ## 1. Quick start (Web vs CLI)
 
-- **Add or update a quest**
-    - Web: use the “Code” button and attach the repo.
-    - CLI: `codex "add quest solar/led-basics"`
-- **Ask about quest files**
-    - Web: use the “Ask” button.
-    - CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
-- **Run quest tests**
-    - Web: not supported yet.
-    - CLI:
+-   **Add or update a quest**
+    -   Web: use the “Code” button and attach the repo.
+    -   CLI: `codex "add quest solar/led-basics"`
+-   **Ask about quest files**
+    -   Web: use the “Ask” button.
+    -   CLI: `codex exec "explain frontend/src/pages/quests/json/*.json"`
+-   **Run quest tests**
+    -   Web: not supported yet.
+    -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
         npm run test:ci -- questCanonical questQuality"
@@ -188,10 +189,10 @@ A pull request with the refined quest, updated hardening block and passing tests
 
 Modern assistants can be powerful collaborators. Keep in mind:
 
-- **Provide clear context** about DSPACE's educational mission and sustainability focus.
-- **Use system prompts** to guide tone and technical accuracy.
-- **Iterate on outputs** rather than expecting perfection on the first try.
-- **Fact-check technical information** since AI systems can generate plausible
-  but incorrect details.
+-   **Provide clear context** about DSPACE's educational mission and sustainability focus.
+-   **Use system prompts** to guide tone and technical accuracy.
+-   **Iterate on outputs** rather than expecting perfection on the first try.
+-   **Fact-check technical information** since AI systems can generate plausible
+    but incorrect details.
 
 [codex-cli]: https://github.com/microsoft/Codex-CLI


### PR DESCRIPTION
## Summary
- add missing cross-links across Codex prompt guides
- update CI examples and secret-scan steps in templates
- link prompt upgrader from docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb62a52d4832fa88775b84610499c