### PR TITLE
fix: correct unpinned menu item rendering

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+-   Unpinned menu items no longer render an extraneous character
 -   ENOENT errors related to missing Playwright artifact files
 -   Structured documentation for image validation requirements
 -   Improved test reliability with proper directory structure

--- a/frontend/src/components/svelte/Menu.svelte
+++ b/frontend/src/components/svelte/Menu.svelte
@@ -91,10 +91,10 @@
             {#each unpinned as item}
                 {#if item.hideIfOwned}
                     {#if mounted}
-                        <button class="active" href={''}>{item.name}f</button>
+                        <button class="active" type="button">{item.name}</button>
                     {/if}
                 {:else if item.comingSoon === true}
-                    <button class="disabled" href={''}>{item.name}</button>
+                    <button class="disabled" type="button">{item.name}</button>
                 {:else}
                     <a href={item.href}>{item.name}</a>
                 {/if}

--- a/frontend/tests/menu.test.ts
+++ b/frontend/tests/menu.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Menu component', () => {
+    it('does not include stray trailing character in unpinned template', () => {
+        const content = fs.readFileSync(
+            path.join(__dirname, '../src/components/svelte/Menu.svelte'),
+            'utf8'
+        );
+        expect(content.includes('{item.name}f')).toBe(false);
+    });
+});

--- a/outages/2025-08-15-menu-trailing-f.json
+++ b/outages/2025-08-15-menu-trailing-f.json
@@ -1,0 +1,8 @@
+{
+  "id": "menu-trailing-f",
+  "date": "2025-08-15",
+  "component": "frontend",
+  "rootCause": "A stray 'f' in Menu.svelte caused unpinned items to display with an extra character.",
+  "resolution": "Removed the typo and added tests to ensure menu items render correctly.",
+  "references": []
+}


### PR DESCRIPTION
## Summary
- fix unpinned menu items showing a stray character
- cover menu template regression with a unit test
- log outage from stray character

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 node run-tests.js`


------
https://chatgpt.com/codex/tasks/task_e_689eb62b91cc832f955cc6a9265a6dfe