### PR TITLE
🐛: handle non-string ids in price lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,17 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 ### Utility Functions
 
 The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
-normalizes case, spaces, and hyphens for resilient calls.
-Prices are approximate USD values.
+normalizes case, trims extra whitespace, and converts spaces or hyphens into underscores for
+resilient calls. It returns `null` for unknown or non-string inputs. Prices are approximate USD
+values.
 
 ```ts
 import { approximateIrlPrice } from "./backend/approximateIrlPrice";
 
 console.log(approximateIrlPrice("3D-Printer")); // 350
 console.log(approximateIrlPrice("unknown")); // null
+console.log(approximateIrlPrice(undefined as any)); // null
 ```
-
-normalizes case, trims extra whitespace, and converts spaces or hyphens into underscores for
-resilient calls.
-
 ## Testing
 
 DSPACE uses a comprehensive testing suite to ensure code quality and prevent regressions.

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -18,6 +18,11 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })
 
+  it('returns null for non-string input', () => {
+    expect(approximateIrlPrice(null as any)).toBeNull()
+    expect(approximateIrlPrice(undefined as any)).toBeNull()
+  })
+
   it('ignores surrounding whitespace', () => {
     expect(approximateIrlPrice(' 3d printer ')).toBe(350)
   })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -29,7 +29,10 @@ const priceTable: Record<string, number> = {
  * spaces or hyphens to underscores so callers can pass identifiers like
  * `3D-Printer`, `3d printer`, or even ` 3d_printer `.
 */
-export function approximateIrlPrice(id: string): number | null {
+export function approximateIrlPrice(id: string | null | undefined): number | null {
+  if (typeof id !== 'string') {
+    return null;
+  }
   const normalized = id.trim().toLowerCase().replace(/[\s-]+/g, '_');
   return priceTable[normalized] ?? null;
 }

--- a/outages/2025-08-15-non-string-price-lookup.json
+++ b/outages/2025-08-15-non-string-price-lookup.json
@@ -1,0 +1,11 @@
+{
+  "id": "non-string-price-lookup",
+  "date": "2025-08-15",
+  "component": "backend",
+  "rootCause": "approximateIrlPrice threw when provided non-string input",
+  "resolution": "return null for null, undefined, or non-string inputs",
+  "references": [
+    "backend/approximateIrlPrice.ts",
+    "backend/approximateIrlPrice.test.ts"
+  ]
+}


### PR DESCRIPTION
what: guard approximateIrlPrice against non-string ids; record outage
why: prevent runtime errors when ids are invalid
how to test: npm run lint && type-check && build && test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689eb62b91cc832f955cc6a9265a6dfe