### PR TITLE
fix: sanitize invalid durations

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,6 +101,9 @@ frontend/
 > Utility note: `src/utils/strings.js`'s `getDurationString` now omits undefined
 > remaining time to avoid displaying `undefined` in the UI.
 
+> Utility note: `src/utils/strings.js`'s `getDuration` now falls back to
+> `0.00%` for non-numeric input to prevent showing `NaN%`.
+
 ## Getting Started
 
 ### Prerequisites

--- a/frontend/src/utils/strings.js
+++ b/frontend/src/utils/strings.js
@@ -22,4 +22,7 @@ export const getDurationString = (duration, remainingTime) => {
  *   progress percentage.
  * @returns {string} The string representing the duration.
  */
-export const getDuration = (duration) => `${duration.toFixed(2)}%`;
+export const getDuration = (duration) => {
+    const num = Number(duration);
+    return Number.isFinite(num) ? `${num.toFixed(2)}%` : '0.00%';
+};

--- a/outages/2025-08-15-duration-nan.json
+++ b/outages/2025-08-15-duration-nan.json
@@ -1,0 +1,12 @@
+{
+  "id": "duration-nan",
+  "date": "2025-08-15",
+  "component": "frontend",
+  "rootCause": "getDuration returned 'NaN%' when provided non-numeric values",
+  "resolution": "sanitize duration and default to 0.00% for invalid numbers",
+  "references": [
+    "frontend/src/utils/strings.js",
+    "tests/strings.test.ts",
+    "frontend/README.md"
+  ]
+}

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -22,4 +22,10 @@ describe('getDuration', () => {
   test('formats to two decimals with percent', () => {
     expect(getDuration(3)).toBe('3.00%');
   });
+
+  test('defaults to 0% for invalid numbers', () => {
+    expect(getDuration(NaN)).toBe('0.00%');
+    // undefined should be treated as 0 at runtime
+    expect(getDuration(undefined)).toBe('0.00%');
+  });
 });


### PR DESCRIPTION
## Summary
- guard `getDuration` against invalid numeric input
- cover invalid duration case in tests and docs
- log outage record for NaN duration string

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb62b91cc832f955cc6a9265a6dfe