### PR TITLE
Add wind speed measurement process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3848,5 +3848,25 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "measure-wind-speed",
+        "title": "Measure wind speed with a handheld anemometer",
+        "image": "/assets/turbine.jpg",
+        "requireItems": [
+            {
+                "id": "451d86d9-96e0-4829-af27-8a8b0be65ae4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -405,5 +405,19 @@
                 }
             ]
         }
+    },
+    {
+        "id": "451d86d9-96e0-4829-af27-8a8b0be65ae4",
+        "name": "handheld anemometer",
+        "description": "Measures wind speed up to 30 m/s; includes wrist strap.",
+        "image": "/assets/turbine.jpg",
+        "price": "20 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2992,5 +2992,15 @@
         "createItems": [],
         "duration": "15m",
         "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
+    },
+    {
+        "id": "measure-wind-speed",
+        "title": "Measure wind speed with a handheld anemometer",
+        "image": "/assets/turbine.jpg",
+        "requireItems": [{ "id": "451d86d9-96e0-4829-af27-8a8b0be65ae4", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
     }
 ]

--- a/frontend/src/pages/processes/hardening/measure-wind-speed.json
+++ b/frontend/src/pages/processes/hardening/measure-wind-speed.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add handheld anemometer item
- add process to measure wind speed with it

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb653c40c832f98293afa5422e1c4