### PR TITLE
Add image and hardening for basil harvest process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -607,6 +607,7 @@
     {
         "id": "harvest-basil",
         "title": "Harvest your hydroponic basil plants",
+        "image": "/assets/basil_harvested.jpg",
         "requireItems": [],
         "consumeItems": [
             {
@@ -624,7 +625,13 @@
                 "count": 11
             }
         ],
-        "duration": "1m"
+        "duration": "5m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     },
     {
         "id": "germinate-stevia",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -433,6 +433,7 @@
     {
         "id": "harvest-basil",
         "title": "Harvest your hydroponic basil plants",
+        "image": "/assets/basil_harvested.jpg",
         "requireItems": [],
         "consumeItems": [
             {
@@ -450,7 +451,7 @@
                 "count": 11
             }
         ],
-        "duration": "1m"
+        "duration": "5m"
     },
     {
         "id": "germinate-stevia",

--- a/frontend/src/pages/processes/hardening/harvest-basil.json
+++ b/frontend/src/pages/processes/hardening/harvest-basil.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add image and adjust duration for harvest-basil process
- register harvest-basil in hardening directory

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb653c40c832f98293afa5422e1c4