### PR TITLE
Add white PLA filament swap process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2845,6 +2845,35 @@
         "duration": "10m"
     },
     {
+        "id": "swap-white-pla-filament",
+        "title": "Swap to white PLA filament on an entry-level FDM 3D printer",
+        "image": "/assets/pla_white.jpg",
+        "requireItems": [
+            {
+                "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
+                "count": 1
+            },
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6",
+                "count": 10
+            }
+        ],
+        "createItems": [],
+        "duration": "10m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "print-benchy",
         "title": "3D print a 60 mm Benchy calibration boat on an entry-level FDM printer with 15 g white PLA",
         "requireItems": [

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2337,6 +2337,18 @@
         "duration": "10m"
     },
     {
+        "id": "swap-white-pla-filament",
+        "title": "Swap to white PLA filament on an entry-level FDM 3D printer",
+        "image": "/assets/pla_white.jpg",
+        "requireItems": [
+            { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+            { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+        ],
+        "consumeItems": [{ "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 10 }],
+        "createItems": [],
+        "duration": "10m"
+    },
+    {
         "id": "print-benchy",
         "title": "3D print a 60 mm Benchy calibration boat on an entry-level FDM printer with 15 g white PLA",
         "requireItems": [

--- a/frontend/src/pages/processes/hardening/swap-white-pla-filament.json
+++ b/frontend/src/pages/processes/hardening/swap-white-pla-filament.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add process to swap to white PLA filament on FDM printer
- seed hardening file for tracking process quality

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb653c40c832f98293afa5422e1c4