### PR TITLE
Add spool holder 3D printing process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3848,5 +3848,30 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "3dprint-spool-holder",
+        "title": "3D print a filament spool holder on an entry-level FDM printer using 50 g of green PLA",
+        "image": "/assets/quests/benchy_25.jpg",
+        "requireItems": [
+            {
+                "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "d3590107-25ff-4de5-af3a-46e2497bfc52",
+                "count": 50
+            }
+        ],
+        "createItems": [],
+        "duration": "3h",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2992,5 +2992,15 @@
         "createItems": [],
         "duration": "15m",
         "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
+    },
+    {
+        "id": "3dprint-spool-holder",
+        "title": "3D print a filament spool holder on an entry-level FDM printer using 50 g of green PLA",
+        "image": "/assets/quests/benchy_25.jpg",
+        "requireItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }],
+        "consumeItems": [{ "id": "d3590107-25ff-4de5-af3a-46e2497bfc52", "count": 50 }],
+        "createItems": [],
+        "duration": "3h",
+        "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
     }
 ]

--- a/frontend/src/pages/processes/hardening/3dprint-spool-holder.json
+++ b/frontend/src/pages/processes/hardening/3dprint-spool-holder.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add `3dprint-spool-holder` process to base registry and hardening records
- regenerate processes listing with new entry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- processQuality`

------
https://chatgpt.com/codex/tasks/task_e_689eb6753f14832fb337cd06c3c5f8df