### PR TITLE
Add programming median temperature quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -201,6 +201,7 @@ New quests in this release: 193
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/median-temp
 - programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -201,6 +201,7 @@ New quests in this release: 193
 - programming/hello-sensor
 - programming/json-api
 - programming/json-endpoint
+- programming/median-temp
 - programming/plot-temp-cli
 - programming/temp-alert
 - programming/temp-email

--- a/frontend/src/pages/quests/json/programming/median-temp.json
+++ b/frontend/src/pages/quests/json/programming/median-temp.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/median-temp",
+    "title": "Compute Median Temperature",
+    "description": "Extend your script to report the median temperature from your log.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your average calculation is solid, but the median reveals outliers.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "I'll compute the median."
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Parse the temperature log and output the median value.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Median calculated!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Your data analysis keeps getting sharper.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "All done!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/avg-temp"]
+}


### PR DESCRIPTION
## Summary
- add programming/median-temp quest after avg-temp
- refresh new quests documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb697d6f0832f8a0a9d91ec071c93