### PR TITLE
Add log water parameters quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -35,6 +35,7 @@ New quests in this release: 193
 - aquaria/floating-plants
 - aquaria/guppy
 - aquaria/heater-install
+- aquaria/log-water-parameters
 - aquaria/ph-strip-test
 - aquaria/position-tank
 - aquaria/shrimp

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -35,6 +35,7 @@ New quests in this release: 193
 - aquaria/floating-plants
 - aquaria/guppy
 - aquaria/heater-install
+- aquaria/log-water-parameters
 - aquaria/ph-strip-test
 - aquaria/position-tank
 - aquaria/shrimp

--- a/frontend/src/pages/quests/json/aquaria/log-water-parameters.json
+++ b/frontend/src/pages/quests/json/aquaria/log-water-parameters.json
@@ -1,0 +1,49 @@
+{
+    "id": "aquaria/log-water-parameters",
+    "title": "Log Water Parameters",
+    "description": "Record your aquarium's test results in a logbook to spot trends.",
+    "image": "/assets/paperwork.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You just tested the water. Let's record today's numbers so we can track the tank's health over time.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "log",
+                    "text": "Open the logbook."
+                }
+            ]
+        },
+        {
+            "id": "log",
+            "text": "Write the date and readings for ammonia, nitrite, nitrate and pH in your water test logbook.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "log-aquarium-test-results",
+                    "text": "Record the results."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "All readings logged.",
+                    "requiresItems": [
+                        { "id": "83fe7eee-135e-4885-9ce0-9042b9fb860a", "count": 1 },
+                        { "id": "8d30133e-0fbb-4e0f-845b-44d721a1f6b2", "count": 1 },
+                        { "id": "b8602362-2035-4f00-9376-f48d8668cf38", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great recordkeeping! Regular logs help catch issues early.",
+            "options": [{ "type": "finish", "text": "I'll keep logging." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["aquaria/water-testing"]
+}


### PR DESCRIPTION
## Summary
- add aquaria quest to log water test results
- refresh new-quests index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb697d6f0832f8a0a9d91ec071c93