### PR TITLE
feat: add change-bandage first aid quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -147,6 +147,7 @@ New quests in this release: 193
 ### firstaid
 
 - firstaid/assemble-kit
+- firstaid/change-bandage
 - firstaid/dispose-expired
 - firstaid/learn-cpr
 - firstaid/restock-kit

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 215
-New quests in this release: 193
+Current quest count: 216
+New quests in this release: 194
 
 ### 3dprinting
 
@@ -147,6 +147,7 @@ New quests in this release: 193
 ### firstaid
 
 - firstaid/assemble-kit
+- firstaid/change-bandage
 - firstaid/dispose-expired
 - firstaid/learn-cpr
 - firstaid/restock-kit

--- a/frontend/src/pages/quests/json/firstaid/change-bandage.json
+++ b/frontend/src/pages/quests/json/firstaid/change-bandage.json
@@ -1,0 +1,38 @@
+{
+    "id": "firstaid/change-bandage",
+    "title": "Change a Bandage",
+    "description": "Swap an old bandage for a fresh one to keep a minor cut clean.",
+    "image": "/assets/rescue.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Bandages should be changed daily so wounds heal cleanly.",
+            "options": [{ "type": "goto", "goto": "change", "text": "Let's change it" }]
+        },
+        {
+            "id": "change",
+            "text": "Wash hands, remove the old bandage, clean the cut and apply a fresh adhesive bandage.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "clean-minor-cut",
+                    "text": "Bandage changed",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "b0f10930-53aa-4d45-8bb7-9c7b17f14a5a", "count": 1 },
+                        { "id": "1b1030bf-9767-4b16-9ff6-a8e7de28b689", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep the area clean and swap the bandage again tomorrow if needed.",
+            "options": [{ "type": "finish", "text": "Got it!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/wound-care"]
+}


### PR DESCRIPTION
## Summary
- add change-bandage quest following wound-care
- document new quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eb697d6f0832f8a0a9d91ec071c93