### PR TITLE
Refine Arduino blink quest for clarity and safety

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/quests/json/electronics/arduino-blink.json
+++ b/frontend/src/pages/quests/json/electronics/arduino-blink.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Hey! Orion here. Ready to blink an LED with a microcontroller? Work on a dry, non-conductive surface, wear safety goggles, and keep the USB cable unplugged until every wire is double-checked.",
+            "text": "Hey! Orion here. Ready to blink an LED with a microcontroller? Set up on a dry, non-conductive surface. Put on safety goggles and keep the USB cable unplugged until every wire is double-checked.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "materials",
-            "text": "Gather an Arduino Uno, Breadboard, two Jumper Wires, a 220 Ω Resistor, a 5 mm LED, a USB Type-A to Type-B cable and a Laptop Computer with the Arduino IDE installed. If the IDE isn't installed, run the 'Install the Arduino IDE' process. Check that the resistor shows red-red-brown bands. Place the LED's long leg (anode) to pin 13 through the resistor and the short leg to GND. Make all connections with power still unplugged.",
+            "text": "Gather an Arduino Uno, Breadboard, two Jumper Wires, a 220 Ω Resistor, a 5 mm LED, Safety Goggles, a USB Type-A to Type-B cable and a Laptop Computer with the Arduino IDE installed. If the IDE isn't installed, run the 'Install the Arduino IDE' process. Confirm the resistor bands read red-red-brown. Put the LED's long leg on pin 13 through the resistor and the short leg to GND. Keep power unplugged while wiring.",
             "options": [
                 {
                     "type": "process",
@@ -52,6 +52,10 @@
                             "count": 1
                         },
                         {
+                            "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                            "count": 1
+                        },
+                        {
                             "id": "be3aaed8-13cc-4937-95d5-6e2c952c6612",
                             "count": 1
                         },
@@ -65,7 +69,7 @@
         },
         {
             "id": "upload",
-            "text": "Connect the board to the Laptop Computer with the USB Type-A to Type-B cable. In the Arduino IDE open File > Examples > 01.Basics > Blink. Under Tools set Board to Arduino Uno and Port to the detected device, then click Upload. Wait for 'Done uploading'; the board resets and the LED blinks once per second. Keep fingers off the circuit while it's powered.",
+            "text": "Connect the board to the Laptop Computer with the USB Type-A to Type-B cable. In the Arduino IDE open File > Examples > 01.Basics > Blink. Under Tools choose Board: Arduino Uno and the correct Port, then click Upload. Wait for 'Done uploading'; the board resets and the LED blinks once per second. Keep fingers off the circuit while it's powered.",
             "options": [
                 {
                     "type": "goto",
@@ -76,7 +80,7 @@
         },
         {
             "id": "finish",
-            "text": "Nice work—you just programmed a microcontroller. Always unplug the USB Type-A to Type-B cable before adjusting wiring and avoid staring directly into the LED. For a detailed walkthrough, open the 'Blink an LED with Arduino' process. Experiment with new patterns and sensors to build skills for bigger projects.",
+            "text": "Nice work—you just programmed a microcontroller. Always unplug the USB Type-A to Type-B cable before adjusting wiring and avoid staring directly into the LED. For a detailed walkthrough, open the 'Blink an LED with Arduino' process. Experiment with new patterns or sensors to build skills for bigger projects.",
             "options": [
                 {
                     "type": "process",
@@ -98,7 +102,7 @@
         }
     ],
     "hardening": {
-        "passes": 7,
+        "passes": 8,
         "score": 100,
         "emoji": "💯",
         "history": [
@@ -135,6 +139,11 @@
             {
                 "task": "codex-quest-refine-2025-09-17",
                 "date": "2025-09-17",
+                "score": 100
+            },
+            {
+                "task": "codex-quest-refresh-2025-09-18",
+                "date": "2025-09-18",
                 "score": 100
             }
         ]


### PR DESCRIPTION
## Summary
- sharpen instructions and safety guidance for Arduino blink quest
- require safety goggles and refresh hardening history
- sync new-quests docs with latest quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eda377afc832fa108c02126b53bbf