### PR TITLE
Refine LED polarity quest and sync new quest list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/quests/json/electronics/led-polarity.json
+++ b/frontend/src/pages/quests/json/electronics/led-polarity.json
@@ -1,14 +1,14 @@
 {
     "id": "electronics/led-polarity",
     "title": "Check LED polarity with a multimeter",
-    "description": "Use a digital multimeter's diode-test mode to identify a loose 5 mm LED's anode and cathode before wiring. Disconnect all power, set parts on a dry non-conductive surface, and wear safety goggles.",
+    "description": "Use a digital multimeter's diode mode to find which lead of a loose 5 mm LED is positive. Disconnect power, work on a dry non-conductive surface, wear safety goggles, and only use the meter's built-in diode test.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Place the 5 mm LED, digital multimeter, and safety goggles on a dry, non-conductive surface. Put on the goggles and confirm all power sources are disconnected.\nWe'll use the multimeter's diode-test mode to find the anode.",
+            "text": "Place a 5 mm LED, a digital multimeter, and safety goggles on a dry, non-conductive surface. Put on the goggles and confirm all power sources are disconnected.\nWe'll switch the meter to diode mode to find the anode.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "test",
-            "text": "Set the multimeter to diode-test and insert the red probe into the VΩmA port and the black probe into COM. Keep fingers behind the guards.\nTouch the red probe to the LED's long leg (anode) and the black probe to the short leg (cathode) without letting probes or leads touch.\nThe LED should glow faintly or read about 1.8 V. Reverse the probes; it should stay dark or display OL. Stop if the LED warms or sparks.",
+            "text": "Set the multimeter to diode mode and insert the red probe into the VΩmA port and the black probe into COM, keeping fingers behind the guards.\nTouch the red probe to the LED's long leg (anode) and the black probe to the short leg (cathode) without letting probes or leads touch.\nThe LED should glow faintly or read about 1.8 V. Reverse the probes; it should stay dark or display OL. Stop immediately if the LED warms, smokes, or sparks, and don't apply external power while testing.",
             "options": [
                 {
                     "type": "goto",
@@ -48,14 +48,15 @@
     "rewards": [{ "id": "fb60696a-6c94-4e5e-9277-b62377ee6d73", "count": 1 }],
     "requiresQuests": ["electronics/check-battery-voltage"],
     "hardening": {
-        "passes": 4,
-        "score": 95,
+        "passes": 5,
+        "score": 96,
         "emoji": "💯",
         "history": [
             { "task": "codex-quest-refinement-2025-08-10", "date": "2025-08-10", "score": 60 },
             { "task": "codex-refine-2025-08-11", "date": "2025-08-11", "score": 78 },
             { "task": "codex-hardening-2025-08-12", "date": "2025-08-12", "score": 92 },
-            { "task": "codex-hardening-2025-08-12-refresh", "date": "2025-08-12", "score": 95 }
+            { "task": "codex-hardening-2025-08-12-refresh", "date": "2025-08-12", "score": 95 },
+            { "task": "codex-hardening-2025-08-15", "date": "2025-08-15", "score": 96 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- clarify multimeter diode test steps in LED polarity quest
- bump quest hardening metadata to reflect latest review
- update new quest docs with current quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eda377afc832fa108c02126b53bbf