### PR TITLE
docs: refine NPC dialogue and sync quest data

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2513,19 +2513,30 @@
     {
         "id": "plot-temperature-data",
         "title": "Plot logged temperature data using Python and Matplotlib",
-        "requireItems": [],
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "10m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-process-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 70
                 }
             ]
         }
@@ -3913,13 +3924,13 @@
         "duration": "10m",
         "hardening": {
             "passes": 1,
-            "score": 70,
+            "score": 65,
             "emoji": "🌀",
             "history": [
                 {
-                    "task": "codex-process-hardening-2025-08-15",
+                    "task": "codex-assemble-servo-arm-2025-08-15",
                     "date": "2025-08-15",
-                    "score": 70
+                    "score": 65
                 }
             ]
         }

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -49,7 +49,7 @@ Nova, an ingenious engineer with a quick wit, excels at rocketry. She designs an
 
 <img src="/assets/npc/hydro.jpg" />
 
-Hydro, a relaxed and affable team member, has a gift for hydroponics and sustainable farming. They ensure the crew has a steady supply of food during lengthy space missions. Growing up on a small Earth farm, Hydro acquired a strong appreciation for sustainable agriculture. In college, they studied biology and became intrigued by hydroponics as a method for cultivating crops in harsh environments.
+Hydro, a relaxed and affable team member, has a gift for hydroponics and sustainable farming. They ensure the crew has a steady supply of food during lengthy space missions. Growing up on a small Earth farm, Hydro acquired a strong appreciation for sustainable agriculture. In college, they studied biology and became intrigued by hydroponics as a method for cultivating crops in harsh environments. They monitor nutrient levels and light cycles, turning complex science into friendly chatter that keeps novices engaged.
 
 ### Sample Dialogue
 
@@ -59,6 +59,7 @@ Hydro, a relaxed and affable team member, has a gift for hydroponics and sustain
 -   "Now that you've got your hydroponics tub, you'll need some dechlorinated water."
 -   "I know, right? It's almost like the gamedev is awkwardly reusing existing game systems."
 -   "Let's try stevia next. Its leaves are unbelievably sweet!"
+-   "If the pH drifts, a splash of lemon juice or baking soda can nudge it back on track."
 
 ## Orion
 
@@ -123,7 +124,7 @@ Atlas is a humanoid robot assistant designed to help with physical tasks that re
 
 <img src="/assets/npc/atlas.jpg" />
 
-Cedar is a seasoned woodworker who loves guiding newcomers. Years of building furniture have made them patient and detail-oriented. Cedar will help you master safe tool use and gradually tackle bigger projects.
+Cedar is a seasoned woodworker who loves guiding newcomers. Years of building furniture have made them patient and detail-oriented, with a knack for turning scrap into sturdy furniture. Cedar will help you master safe tool use, respect the grain, and gradually tackle bigger projects.
 
 ### Sample Dialogue
 
@@ -132,6 +133,7 @@ Cedar is a seasoned woodworker who loves guiding newcomers. Years of building fu
 -   "Keep your fingers clear of the blade and let the saw do the work."
 -   "Nice job on that birdhouse! Sand the edges so our feathered friends stay safe."
 -   "Ready for a bigger project? A sturdy step stool will test your skills."
+-   "Once it's assembled, a light coat of oil will make that grain pop."
 
 <style>
     img {


### PR DESCRIPTION
## Summary
- polish Hydro doc with nutrient monitoring and pH tip
- expand Cedar doc with scrap-savvy guidance
- sync quest counts and generated processes to keep tests green

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eda5b0860832f9b7067da62f4220e