### PR TITLE
docs: refine outage and process prompts, refresh new quests tally

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -6,13 +6,15 @@ slug: 'prompts-outages'
 # Outage prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository and run its own tests.
-Use this guide when diagnosing an incident so the fix and a record land in the outage catalog.
+Use this guide when diagnosing incidents to ensure the fix and a record land in the outage catalog.
 
 > **TL;DR**
 >
 > 1. Investigate the failure and implement a fix.
-> 2. Add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
+> 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
+>    matching [`outages/schema.json`][outage-schema].
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 
 ```text
 SYSTEM:
@@ -22,15 +24,20 @@ PURPOSE:
 Diagnose an outage, implement a fix, and document it.
 
 CONTEXT:
-- Review existing records under `/outages` for similar failures.
-- After resolving, add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
+- Review existing records under [`outages`][outage-dir] for similar failures.
+- After resolving, add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
+  matching [`outages/schema.json`][outage-schema].
 - Keep behaviour intact, add tests, and update documentation.
 
 REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 OUTPUT:
 A pull request referencing the new outage record and passing checks.
 ```
+
+[outage-dir]: https://github.com/democratizedspace/dspace/tree/main/outages
+[outage-schema]: https://github.com/democratizedspace/dspace/blob/main/outages/schema.json

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -20,6 +20,7 @@ For fundamental design tips see the
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
+> 4. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 
 ---
 
@@ -36,7 +37,8 @@ For fundamental design tips see the
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:ci && npm run test:ci -- processQuality"
+        npm run test:ci && npm run test:ci -- processQuality && \
+        git diff --cached | ./scripts/scan-secrets.py"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.


### PR DESCRIPTION
## Summary
- link outage records and schema, add secret scan step
- add secret scan to process prompt TL;DR and CLI instructions
- refresh new quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ed9bb4868832f8db50d1f4f4ecd5b