### PR TITLE
docs: add documentation prompt guide

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -54,6 +54,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-npcs">NPC prompts</a>
+            <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -11,8 +11,8 @@ file‑scoped prompt. This document stores the baseline instructions used when
 invoking Codex on DSPACE and should evolve alongside the project.
 
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
-[Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes), and
-[NPC prompts](/docs/prompts-npcs).
+[Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
+[NPC prompts](/docs/prompts-npcs), and [Docs prompts](/docs/prompts-docs).
 
 > **TL;DR**
 >
@@ -30,6 +30,7 @@ For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs
 -   [Item Prompts](/docs/prompts-items)
 -   [Process Prompts](/docs/prompts-processes)
 -   [Quest Prompts](/docs/prompts-quests)
+-   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -1,0 +1,32 @@
+---
+title: 'Documentation Prompts'
+slug: 'prompts-docs'
+---
+
+# Documentation prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository, run tests, and send a
+ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide when updating
+markdown or JSDoc so instructions stay current and consistent.
+
+> **TL;DR**
+>
+> 1. Limit changes to the relevant docs.
+> 2. Fix outdated wording, links, or formatting.
+> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
+committing.
+
+USER:
+1. Edit or add docs under `frontend/src/pages/docs/md`.
+2. Correct stale guidance, links, or formatting.
+3. If adding a new prompt doc, link it from `prompts-codex.md` and `/docs/index`.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+
+OUTPUT:
+A pull request with refreshed documentation and passing checks.
+```


### PR DESCRIPTION
## Summary
- document reusable prompt template for docs updates
- link docs guide from codex and docs index
- sync new quests list for test parity

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ed9bb4868832f8db50d1f4f4ecd5b