### PR TITLE
docs: refine NPC prompt guidance and sync new quest counts

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -44,7 +44,7 @@ For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs
 | Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
 | CI automation  | –                           | `codex exec --full-auto "run npm test"` |
 
-See the upstream CLI reference for more flags.
+See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ---
 
@@ -177,3 +177,5 @@ A pull request refreshing the Codex prompt docs with passing checks.
 ## Outage prompt
 
 See [Outage prompts](/docs/prompts-outages) for guidance on logging incidents and fixes.
+
+[openai-cli]: https://github.com/openai/openai-cli

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -30,7 +30,7 @@ Codex is a sandboxed engineering agent that can open this repository, run its ow
         codex exec "npm run lint && npm run type-check && npm run build && npm run test:ci"
         ```
 
-See the [Codex CLI repository][codex-cli] for more flags.
+See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ---
 
@@ -85,6 +85,27 @@ OUTPUT:
 A pull request with the updated NPC doc and passing tests.
 ```
 
+## Upgrade prompt for existing NPCs
+
+Use this prompt to refine NPC bios and dialogue over time.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository.
+
+USER:
+1. Pick an NPC from `frontend/src/pages/docs/md/npcs.md` that needs clearer voice or updated facts.
+2. Improve characterization and ensure dialogue stays concise and in-universe.
+3. Reuse existing image assets; do not add new images.
+4. Cross-reference related quests or processes and update them if needed.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+7. Use an emoji-prefixed commit message like `📝 : – refine NPC bio`.
+
+OUTPUT:
+A pull request with the refined NPC and passing checks.
+```
+
 ## Additional tips for AI assistance
 
 Modern assistants can be powerful collaborators. Keep in mind:
@@ -94,4 +115,4 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Iterate on outputs** rather than expecting perfection on the first try.
 -   **Fact-check technical information** since AI systems can generate plausible but incorrect details.
 
-[codex-cli]: https://github.com/microsoft/Codex-CLI
+[openai-cli]: https://github.com/openai/openai-cli


### PR DESCRIPTION
## Summary
- link prompt docs to OpenAI CLI
- add upgrade template for existing NPCs
- sync new quest counts across docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ed9bb4868832f8db50d1f4f4ecd5b