### PR TITLE
feat: make ItemForm submit area responsive

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -255,6 +255,13 @@
         margin-top: 10px;
     }
 
+    .form-submit {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-top: 20px;
+    }
+
     .submit-button {
         font-size: 16px;
         padding: 10px 20px;
@@ -279,6 +286,15 @@
         textarea {
             width: 100%;
             font-size: 14px;
+        }
+
+        .form-submit {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .submit-button {
+            width: 100%;
         }
     }
 </style>

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -87,7 +87,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Test IndexedDB in all major browsers 💯
         -   [x] Verify UI components across browsers 💯
         -   [x] Check offline functionality 💯
-    -   [x] Mobile responsiveness
+    -   [x] Mobile responsiveness 💯
         -   [x] Adapt quest creation UI for mobile 💯
         -   [x] Test touch interactions 💯
         -   [x] Verify mobile layouts 💯

--- a/frontend/src/pages/docs/md/item-guidelines.md
+++ b/frontend/src/pages/docs/md/item-guidelines.md
@@ -46,7 +46,11 @@ Every item requires the following basic properties:
 
 Currently, the `ItemForm.svelte` component supports creating and editing items with the properties listed above. It uploads images, persists data to IndexedDB, and focuses on the fundamental aspects of items, with more advanced features planned for future updates.
 
-As you fill out the form, an `ItemPreview` component displays a live preview so you can confirm the details before submitting. The layout automatically adjusts on small screens so form fields expand to the full width for easier touch input. You can safely experiment with different values before saving—no data is written until you click **Create Item**.
+As you fill out the form, an `ItemPreview` component displays a live preview so you can
+confirm the details before submitting. The layout automatically adjusts on small screens
+so form fields expand to the full width for easier touch input, and action buttons stack
+vertically on narrow displays. You can safely experiment with different values before
+saving—no data is written until you click **Create Item**.
 
 The form provides inline validation messages if you attempt to submit without a name, description, or image, helping ensure items meet basic requirements before saving. Automated Playwright tests verify that the preview appears when entering text and that uploaded images render correctly. This ensures cross-browser compatibility of the custom item workflow.
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/tests/item-form-mobile.test.ts
+++ b/tests/item-form-mobile.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const source = readFileSync(
+  'frontend/src/components/svelte/ItemForm.svelte',
+  'utf8',
+);
+
+describe('ItemForm mobile layout', () => {
+  it('stacks submit button on narrow screens', () => {
+    expect(source).toMatch(/\.form-submit\s*{[\s\S]*display:\s*flex/);
+    expect(source).toMatch(
+      /@media \(max-width: 480px\)[\s\S]*\.form-submit\s*{[\s\S]*flex-direction:\s*column/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make ItemForm submit section use flex and stack on mobile
- document item form button stacking and mark changelog
- refresh new-quests list for test consistency

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689ed9c9331c832f8868a9d352d6a1c1