### PR TITLE
🛡️ Verify MIT license metadata and refresh quest docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -75,7 +75,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Monitoring setup 💯
     -   [x] Migration from Netlify 💯
 
--   [x] License Migration
+-   [x] License Migration 💯
 
 -   [x] Testing & QA 💯
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+// Ensure repository license metadata has migrated to MIT
+
+describe('license metadata', () => {
+  test('package.json declares MIT license', () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+    expect(pkg.license).toBe('MIT');
+  });
+
+  test('package-lock.json root package uses MIT license', () => {
+    const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+    expect(lock.packages?.['']?.license).toBe('MIT');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure license metadata stays MIT with a small unit test
- mark License Migration as complete in changelog
- regenerate new-quests docs so quest counts stay in sync

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689ed9c9331c832f8868a9d352d6a1c1