### PR TITLE
docs: link OpenAI CLI reference in prompts guide

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2513,19 +2513,30 @@
     {
         "id": "plot-temperature-data",
         "title": "Plot logged temperature data using Python and Matplotlib",
-        "requireItems": [],
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "10m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-process-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 70
                 }
             ]
         }
@@ -3913,13 +3924,13 @@
         "duration": "10m",
         "hardening": {
             "passes": 1,
-            "score": 70,
+            "score": 65,
             "emoji": "🌀",
             "history": [
                 {
-                    "task": "codex-process-hardening-2025-08-15",
+                    "task": "codex-assemble-servo-arm-2025-08-15",
                     "date": "2025-08-15",
-                    "score": 70
+                    "score": 65
                 }
             ]
         }

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -36,7 +36,7 @@ For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs
 
 ---
 
-## 1 Quick start (Web vs CLI)
+## 1. Quick start (Web vs CLI)
 
 | Use‑case       | Codex Web (ChatGPT sidebar) | Codex CLI                               |
 | -------------- | --------------------------- | --------------------------------------- |
@@ -44,7 +44,7 @@ For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs
 | Ask a question | “Ask” button                | `codex exec "explain utils/time.ts"`    |
 | CI automation  | –                           | `codex exec --full-auto "run npm test"` |
 
-See the upstream CLI reference for more flags.
+See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ---
 
@@ -177,3 +177,5 @@ A pull request refreshing the Codex prompt docs with passing checks.
 ## Outage prompt
 
 See [Outage prompts](/docs/prompts-outages) for guidance on logging incidents and fixes.
+
+[openai-cli]: https://github.com/openai/openai-cli


### PR DESCRIPTION
## Summary
- add explicit OpenAI CLI link and heading punctuation to `prompts-codex.md`
- regenerate new-quests docs and processes to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ed9d07cb8832fabcfd943a9ab00f8