### PR TITLE
Add silicone soldering mat item

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -255,7 +255,11 @@
             "score": 65,
             "emoji": "🌀",
             "history": [
-                { "task": "codex-item-hardening-2025-08-11", "date": "2025-08-11", "score": 65 }
+                {
+                    "task": "codex-item-hardening-2025-08-11",
+                    "date": "2025-08-11",
+                    "score": 65
+                }
             ]
         }
     },
@@ -366,7 +370,11 @@
             "score": 65,
             "emoji": "🌀",
             "history": [
-                { "task": "codex-item-hardening-2025-08-12", "date": "2025-08-12", "score": 65 }
+                {
+                    "task": "codex-item-hardening-2025-08-12",
+                    "date": "2025-08-12",
+                    "score": 65
+                }
             ]
         }
     },
@@ -437,6 +445,20 @@
         "description": "Plug-in tester with three LEDs and test button to verify wiring and GFCI outlets; 50 g.",
         "image": "/assets/outlet.jpg",
         "price": "12 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
+        "id": "cd0e1512-9b4e-4450-92ab-b298852ca5e7",
+        "name": "silicone soldering mat",
+        "description": "300 mm × 200 mm silicone mat with compartments for screws and tools; heat-resistant to 500 °C.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "15 dUSD",
         "type": "tool",
         "hardening": {
             "passes": 0,

--- a/frontend/src/pages/quests/json/electronics/soldering-intro.json
+++ b/frontend/src/pages/quests/json/electronics/soldering-intro.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Good to see you progressing! Before soldering, secure your work in helping hands, plug in your station and have a damp sponge ready.",
+            "text": "Good to see you progressing! Before soldering, lay out a silicone mat, secure your work in helping hands, plug in your station, and have a damp sponge ready.",
             "options": [
                 {
                     "type": "goto",
@@ -21,6 +21,10 @@
                         },
                         {
                             "id": "87f670ce-3630-42bb-84c0-9243cf630d05",
+                            "count": 1
+                        },
+                        {
+                            "id": "cd0e1512-9b4e-4450-92ab-b298852ca5e7",
                             "count": 1
                         }
                     ]
@@ -52,13 +56,18 @@
     "rewards": [],
     "requiresQuests": ["electronics/basic-circuit"],
     "hardening": {
-        "passes": 1,
+        "passes": 2,
         "score": 60,
         "emoji": "🌀",
         "history": [
             {
                 "task": "codex-quest-hardening-2025-08-14",
                 "date": "2025-08-14",
+                "score": 60
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-15",
+                "date": "2025-08-15",
                 "score": 60
             }
         ]


### PR DESCRIPTION
## Summary
- add silicone soldering mat tool item and reference it in tin soldering quest
- refresh new-quests docs with updated quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`

------
https://chatgpt.com/codex/tasks/task_e_689ed9fd6278832f83c57f0a859fc34b