### PR TITLE
docs: refresh Codex prompt links

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -18,7 +18,8 @@ all pass before committing.
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
-4. Link new prompt files from `prompts-codex.md` and the docs index.
+3. Link new prompt files from `prompts-codex.md` and the docs index.
+4. Propagate related changes across docs.
 5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Run the checks above.
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -11,8 +11,8 @@ file‑scoped prompt. This document stores the baseline instructions used when
 invoking Codex on DSPACE and should evolve alongside the project.
 
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
-[Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes), and
-[NPC prompts](/docs/prompts-npcs).
+[Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
+[NPC prompts](/docs/prompts-npcs), and [Outage prompts](/docs/prompts-outages).
 
 > **TL;DR**
 >
@@ -31,6 +31,7 @@ For failing GitHub Actions runs, use the dedicated [CI-failure fix prompt](/docs
 -   [Process Prompts](/docs/prompts-processes)
 -   [Quest Prompts](/docs/prompts-quests)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
+-   [Outage Prompts](/docs/prompts-outages)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 
@@ -168,12 +169,13 @@ USER:
 2. Update prompt templates, including this file, to reflect current practices.
 3. Link new prompt files from `prompts-codex.md` and the docs index.
 4. Propagate related changes across docs.
-5. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
 
-## Outage prompt
+## Outage prompts
 
 See [Outage prompts](/docs/prompts-outages) for guidance on logging incidents and fixes.

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -5,7 +5,12 @@ slug: 'prompts-npcs'
 
 # Writing great NPC prompts for the _dspace_ repo
 
-Codex is a sandboxed engineering agent that can open this repository, run its own tests, and send you a ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when working on NPC bios or dialogue. Consult the [NPCs guide](/docs/npcs) for voice and lore details.
+Codex is a sandboxed engineering agent that can open this repository, run its own tests, and
+send you a ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide
+alongside [Codex Prompts](/docs/prompts-codex) when working on NPC bios or dialogue. Consult the
+[NPCs guide](/docs/npcs) for voice and lore details. To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -5,14 +5,18 @@ slug: 'prompts-outages'
 
 # Outage prompts for the _dspace_ repo
 
-Codex is a sandboxed engineering agent that can open this repository and run its own tests.
-Use this guide when diagnosing an incident so the fix and a record land in the outage catalog.
+Codex is a sandboxed engineering agent that can open this repository and run its own tests. Use
+this guide when diagnosing an incident so the fix and a record land in the outage catalog. Use it
+alongside [Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >
 > 1. Investigate the failure and implement a fix.
 > 2. Add `outages/YYYY-MM-DD-<slug>.json` matching `outages/schema.json`.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 ```text
 SYSTEM:
@@ -30,6 +34,7 @@ REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 
 OUTPUT:
 A pull request referencing the new outage record and passing checks.


### PR DESCRIPTION
what: add outage prompt links and meta references, refresh new quests list.
why: keep Codex guidance and docs in sync.
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689ed9d274b4832f93466e294604d47f