### PR TITLE
refine red flashlight item and process

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2513,19 +2513,30 @@
     {
         "id": "plot-temperature-data",
         "title": "Plot logged temperature data using Python and Matplotlib",
-        "requireItems": [],
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "10m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-process-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 70
                 }
             ]
         }
@@ -3828,7 +3839,7 @@
     },
     {
         "id": "check-flashlight-battery",
-        "title": "Measure flashlight battery voltage with a digital multimeter",
+        "title": "Measure a red flashlight's 9 V battery with a digital multimeter",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             {
@@ -3913,13 +3924,13 @@
         "duration": "10m",
         "hardening": {
             "passes": 1,
-            "score": 70,
+            "score": 65,
             "emoji": "🌀",
             "history": [
                 {
-                    "task": "codex-process-hardening-2025-08-15",
+                    "task": "codex-assemble-servo-arm-2025-08-15",
                     "date": "2025-08-15",
-                    "score": 70
+                    "score": 65
                 }
             ]
         }

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1034,9 +1034,22 @@
     {
         "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
         "name": "red flashlight",
-        "description": "A flashlight with a red filter to preserve night vision.",
-        "image": "/assets/quests/basic_circuit.svg",
-        "price": "5 dUSD"
+        "description": "50 lumen handheld light with red lens to preserve night vision; runs ~3 h on a 9 V battery.",
+        "image": "/assets/aquarium_light.jpg",
+        "price": "8 dUSD",
+        "unit": "flashlight",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "09af703f-7054-4b33-a67d-4035d58bdfb7",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2981,7 +2981,7 @@
     },
     {
         "id": "check-flashlight-battery",
-        "title": "Measure flashlight battery voltage with a digital multimeter",
+        "title": "Measure a red flashlight's 9 V battery with a digital multimeter",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             {


### PR DESCRIPTION
## Summary
- clarify red flashlight specs and add hardening info
- note flashlight battery in check-flashlight-battery process
- update new quest totals for failing tests

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eda024f00832fb682f660bcfff7b7