### PR TITLE
🔦 add flashlight battery check quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 223
+New quests in this release: 201
 
 ### 3dprinting
 
@@ -116,6 +116,7 @@ New quests in this release: 194
 - electronics/arduino-blink
 - electronics/basic-circuit
 - electronics/check-battery-voltage
+- electronics/check-flashlight-battery
 - electronics/continuity-test
 - electronics/data-logger
 - electronics/desolder-component

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 223
+New quests in this release: 201
 
 ### 3dprinting
 
@@ -116,6 +116,7 @@ New quests in this release: 194
 - electronics/arduino-blink
 - electronics/basic-circuit
 - electronics/check-battery-voltage
+- electronics/check-flashlight-battery
 - electronics/continuity-test
 - electronics/data-logger
 - electronics/desolder-component

--- a/frontend/src/pages/quests/json/electronics/check-flashlight-battery.json
+++ b/frontend/src/pages/quests/json/electronics/check-flashlight-battery.json
@@ -1,0 +1,54 @@
+{
+    "id": "electronics/check-flashlight-battery",
+    "title": "Check a flashlight battery",
+    "description": "Measure a 9 V battery in a flashlight with a multimeter.",
+    "image": "/assets/battery.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Remove the flashlight battery. Set it on a dry, non-conductive surface with multimeter and goggles.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "measure",
+                    "text": "Battery and tools ready."
+                }
+            ]
+        },
+        {
+            "id": "measure",
+            "text": "Set the meter to 20 V DC. Touch red to positive and black to negative terminals. Keep probes steady.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "check-flashlight-battery",
+                    "text": "Run the voltage check."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "It reads about 9.0 V.",
+                    "requiresItems": [
+                        { "id": "9a72fb16-fc69-45c5-beca-f25c27028977", "count": 1 },
+                        { "id": "80d30825-a42b-4add-b715-322e1713952c", "count": 1 },
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Reinstall the battery or recycle it if voltage is low. Power off the meter and store your gear.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Thanks, Orion!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/continuity-test"]
+}


### PR DESCRIPTION
## Summary
- add electronics quest to check a flashlight battery with a multimeter
- update new quests doc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eda2504a0832f9608f3ec412c57d4