### PR TITLE
feat: add GFCI outlet tester quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 223
+New quests in this release: 201
 
 ### 3dprinting
 
@@ -130,6 +130,7 @@ New quests in this release: 194
 - electronics/solder-wire
 - electronics/soldering-intro
 - electronics/temperature-plot
+- electronics/test-gfci-outlet
 - electronics/thermistor-reading
 - electronics/thermometer-calibration
 - electronics/voltage-divider

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2513,19 +2513,30 @@
     {
         "id": "plot-temperature-data",
         "title": "Plot logged temperature data using Python and Matplotlib",
-        "requireItems": [],
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "10m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-process-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 70
                 }
             ]
         }
@@ -3913,15 +3924,33 @@
         "duration": "10m",
         "hardening": {
             "passes": 1,
-            "score": 70,
+            "score": 65,
             "emoji": "🌀",
             "history": [
                 {
-                    "task": "codex-process-hardening-2025-08-15",
+                    "task": "codex-assemble-servo-arm-2025-08-15",
                     "date": "2025-08-15",
-                    "score": 70
+                    "score": 65
                 }
             ]
         }
+    },
+    {
+        "id": "test-gfci-outlet",
+        "title": "Verify a GFCI outlet with a plug-in tester",
+        "image": "/assets/outlet.jpg",
+        "requireItems": [
+            {
+                "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481",
+                "count": 1
+            },
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
     }
 ]

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 223
+New quests in this release: 201
 
 ### 3dprinting
 
@@ -130,6 +130,7 @@ New quests in this release: 194
 - electronics/solder-wire
 - electronics/soldering-intro
 - electronics/temperature-plot
+- electronics/test-gfci-outlet
 - electronics/thermistor-reading
 - electronics/thermometer-calibration
 - electronics/voltage-divider

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3049,5 +3049,23 @@
                 }
             ]
         }
+    },
+    {
+        "id": "test-gfci-outlet",
+        "title": "Verify a GFCI outlet with a plug-in tester",
+        "image": "/assets/outlet.jpg",
+        "requireItems": [
+            {
+                "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481",
+                "count": 1
+            },
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
     }
 ]

--- a/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
+++ b/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
@@ -1,0 +1,48 @@
+{
+    "id": "electronics/test-gfci-outlet",
+    "title": "Test a GFCI Outlet",
+    "description": "Verify wiring on a GFCI outlet with a plug-in tester while wearing safety goggles.",
+    "image": "/assets/outlet.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Check the outlet for damage. Put on safety goggles and get your GFCI tester ready.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "plug",
+                    "text": "Ready to test.",
+                    "requiresItems": [
+                        { "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481", "count": 1 },
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "plug",
+            "text": "Insert the tester and note the LED pattern. Press the test button to trip the GFCI, then hit reset.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "test-gfci-outlet",
+                    "text": "Run the outlet test."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Lights show correct wiring."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Unplug the tester and keep the outlet cover closed when not in use.",
+            "options": [{ "type": "finish", "text": "Safety first!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/continuity-test"]
+}


### PR DESCRIPTION
## Summary
- add "Test a GFCI Outlet" quest after continuity testing
- register `test-gfci-outlet` process for using a plug-in tester
- record new quest in new-quests.md

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689eda2504a0832f9608f3ec412c57d4