### PR TITLE
fix: guard listMissingImages path traversal

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2513,19 +2513,30 @@
     {
         "id": "plot-temperature-data",
         "title": "Plot logged temperature data using Python and Matplotlib",
-        "requireItems": [],
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            }
+        ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "10m",
         "hardening": {
-            "passes": 1,
-            "score": 65,
+            "passes": 2,
+            "score": 70,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-process-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
+                    "score": 70
                 }
             ]
         }
@@ -3913,13 +3924,13 @@
         "duration": "10m",
         "hardening": {
             "passes": 1,
-            "score": 70,
+            "score": 65,
             "emoji": "🌀",
             "history": [
                 {
-                    "task": "codex-process-hardening-2025-08-15",
+                    "task": "codex-assemble-servo-arm-2025-08-15",
                     "date": "2025-08-15",
-                    "score": 70
+                    "score": 65
                 }
             ]
         }

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 216
-New quests in this release: 194
+Current quest count: 222
+New quests in this release: 200
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -112,3 +112,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-15 – `listMissingImages` allowed path traversal outside the public directory; resolve paths
+    and ensure lookups stay within the public folder.

--- a/outages/2025-08-15-list-missing-images-path-traversal.json
+++ b/outages/2025-08-15-list-missing-images-path-traversal.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-15-list-missing-images-path-traversal",
+  "date": "2025-08-15",
+  "component": "scripts",
+  "rootCause": "listMissingImages accepted encoded '../' segments and treated files outside public dir as present",
+  "resolution": "resolve paths and ensure they stay within the public directory before existence checks",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md#lessons-learned"
+  ]
+}

--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -41,4 +41,11 @@ describe('listMissingImages', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test('treats path traversal outside public dir as missing', () => {
+    const publicDir = path.join(__dirname, '..', '..', 'frontend', 'public');
+    const images = ['..%2F..%2FREADME.md'];
+    const missing = listMissingImages(images, publicDir);
+    expect(missing).toEqual(images);
+  });
 });

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -28,7 +28,13 @@ function listMissingImages(
             decoded = rel;
         }
         const full = path.join(publicDir, decoded);
-        if (!fs.existsSync(full)) {
+        const resolved = path.resolve(full);
+        const root = path.resolve(publicDir);
+        if (!resolved.startsWith(root + path.sep)) {
+            missing.push(img);
+            return;
+        }
+        if (!fs.existsSync(resolved)) {
             missing.push(img);
         }
     });


### PR DESCRIPTION
## Summary
- constrain listMissingImages to public directory
- add regression test and outage entry
- regenerate new-quests docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eda3e9670832f9775e4f3c7e426ca