### PR TITLE
docs: refresh Codex prompt cross-links

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -61,7 +61,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-failure fix prompt</a>
-            <a href="/docs/prompts-outages">Outage prompts</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -7,8 +7,9 @@ slug: 'prompts-codex-ci-fix'
 
 Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
-return a pull request that keeps the main branch green. To evolve the prompt
-docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
+return a pull request that keeps the main branch green. For general prompting
+guidance, see [Codex Prompts](/docs/prompts-codex). To evolve the prompt docs,
+see the [Codex meta prompt](/docs/prompts-codex-meta).
 
 If this prompt ever drifts, consult the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use. For guidance on logging incidents, see the

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -35,7 +35,6 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
--   [Outage Prompts](/docs/prompts-outages)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -6,8 +6,11 @@ slug: 'prompts-docs'
 # Documentation prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and send a
-ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide when updating
-markdown or JSDoc so instructions stay current and consistent.
+ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
+and consistent. To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- expand docs prompt guide with links to Codex templates
- de-duplicate Codex prompt guide references
- remove extra Outage link from docs index

## Testing
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689f8a3b3144832f82b8d25a3bd1755a