### PR TITLE
docs: refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -61,7 +61,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-failure fix prompt</a>
-            <a href="/docs/prompts-outages">Outage prompts</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -7,8 +7,9 @@ slug: 'prompts-codex-ci-fix'
 
 Use this drop-in snippet whenever a GitHub Actions run for
 **democratizedspace/dspace** fails. It guides Codex to diagnose the failure and
-return a pull request that keeps the main branch green. To evolve the prompt
-docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
+return a pull request that keeps the main branch green. For general guidance,
+see [Codex Prompts](/docs/prompts-codex). To evolve the prompt docs, see the
+[Codex meta prompt](/docs/prompts-codex-meta).
 
 If this prompt ever drifts, consult the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use. For guidance on logging incidents, see the
@@ -53,8 +54,9 @@ CONTEXT:
 
 REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
-2. Commit the minimal changes needed to fix it. Before committing, run
-   `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+2. Commit the minimal changes needed to fix it using an emoji-prefixed commit
+   message. Before committing, run `git diff --cached | ./scripts/scan-secrets.py`
+   and ensure no secrets.
 3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
 4. Push to a branch named `codex/ci-fix/<short-description>`.
 5. Open a pull request that leaves all CI checks green.

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,7 +6,8 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time. If the templates themselves drift, refresh
+instructions improve themselves over time. Start with the baseline
+[Codex Prompts](/docs/prompts-codex); if the templates themselves drift, refresh
 them using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 ```text
@@ -21,6 +22,7 @@ USER:
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
 5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -35,7 +35,6 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
--   [Outage Prompts](/docs/prompts-outages)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -6,14 +6,16 @@ slug: 'prompts-docs'
 # Documentation prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and send a
-ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide when updating
-markdown or JSDoc so instructions stay current and consistent.
+ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay
+current and consistent.
 
 > **TL;DR**
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
@@ -26,6 +28,7 @@ USER:
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md` and `/docs/index`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with refreshed documentation and passing checks.


### PR DESCRIPTION
## Summary
- dedupe and cross-link Codex prompt guides
- mention emoji commits in docs and meta templates
- tidy docs index for prompt navigation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a2c29d4832f8674dac3a68b14d8