### PR TITLE
docs: remove duplicate outage links

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -61,7 +61,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">CI-failure fix prompt</a>
-            <a href="/docs/prompts-outages">Outage prompts</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -35,7 +35,6 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
--   [Outage Prompts](/docs/prompts-outages)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -6,11 +6,10 @@ slug: 'prompts-outages'
 # Outage prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository and run its own tests.
-Use this guide alongside [Codex Prompts](/docs/prompts-codex) when diagnosing an incident so the fix
-and a record land in the outage catalog.
-To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
-If these templates drift,
-refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+Use this guide alongside [Codex Prompts](/docs/prompts-codex) so every fix ships with a matching
+record in the outage catalog.
+To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta);
+if templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- tidy prompt docs: dedupe outage entries and tighten outage guidance

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689f8a06d4e4832fb5d2a1f7d971715c