### PR TITLE
📝 : – refine prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -35,7 +35,6 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
--   [Outage Prompts](/docs/prompts-outages)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -14,6 +14,7 @@ markdown or JSDoc so instructions stay current and consistent.
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 
 ```text
 SYSTEM:
@@ -24,7 +25,8 @@ committing.
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
-3. If adding a new prompt doc, link it from `prompts-codex.md` and `/docs/index`.
+3. If adding a new prompt doc, link it from `prompts-codex.md` and the docs index
+   (`frontend/src/pages/docs/index.astro`).
 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 OUTPUT:


### PR DESCRIPTION
## Summary
- clarify docs prompt TL;DR with secret scanning step
- drop duplicate Outage Prompts link in codex index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689f8a06d4e4832fb5d2a1f7d971715c