### PR TITLE
Show remaining time in process component

### DIFF
--- a/frontend/src/components/__tests__/Process.spec.ts
+++ b/frontend/src/components/__tests__/Process.spec.ts
@@ -43,15 +43,21 @@ vi.mock('../../utils/gameState/processes.js', () => ({
     resumeProcess,
 }));
 
-test('pauses and resumes a process', async () => {
+test('pauses and resumes a process while showing remaining time', async () => {
     const { getByText } = render(Process, { processId: 'p1' });
+
+    await tick();
+    expect(getByText(/remaining/)).toBeTruthy();
 
     // pause the process
     await fireEvent.click(getByText('Pause'));
     expect(pauseProcess).toHaveBeenCalledWith('p1');
     await tick();
+    expect(getByText(/remaining/)).toBeTruthy();
 
     // resume the process
     await fireEvent.click(getByText('Resume'));
     expect(resumeProcess).toHaveBeenCalledWith('p1');
+    await tick();
+    expect(getByText(/remaining/)).toBeTruthy();
 });

--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -1,5 +1,6 @@
 <script>
     import ProgressBar from './ProgressBar.svelte';
+    import RemainingTime from './RemainingTime.svelte';
     import { beforeUpdate, onMount } from 'svelte';
     import {
         startProcess,
@@ -23,6 +24,7 @@
     let processStartedAt;
     let intervalId;
     let mounted = false;
+    let totalDurationSeconds;
 
     const updateState = () => {
         const processState = getProcessState(processId);
@@ -71,6 +73,7 @@
 
     $: {
         process = processes.find((p) => p.id === processId);
+        totalDurationSeconds = durationInSeconds(process.duration);
         updateState();
         clearInterval(intervalId);
         intervalId = setInterval(updateState, 100);
@@ -104,16 +107,18 @@
             {:else if state === ProcessStates.IN_PROGRESS}
                 <Chip text="Cancel" onClick={onProcessCancel} inverted={true} />
                 <Chip text="Pause" onClick={onProcessPause} inverted={true} />
-                <ProgressBar
-                    startDate={processStartedAt}
-                    totalDurationSeconds={durationInSeconds(process.duration)}
+                <ProgressBar startDate={processStartedAt} {totalDurationSeconds} />
+                <RemainingTime
+                    endDate={processStartedAt + totalDurationSeconds * 1000}
+                    totalDurationInSeconds={totalDurationSeconds}
                 />
             {:else if state === ProcessStates.PAUSED}
                 <Chip text="Cancel" onClick={onProcessCancel} inverted={true} />
                 <Chip text="Resume" onClick={onProcessResume} inverted={true} />
-                <ProgressBar
-                    startDate={processStartedAt}
-                    totalDurationSeconds={durationInSeconds(process.duration)}
+                <ProgressBar startDate={processStartedAt} {totalDurationSeconds} />
+                <RemainingTime
+                    endDate={processStartedAt + totalDurationSeconds * 1000}
+                    totalDurationInSeconds={totalDurationSeconds}
                 />
             {:else}
                 <Chip text="Collect" onClick={onProcessComplete} inverted={true} />

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -41,7 +41,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Item creation interface with `ItemForm.svelte` 💯
     -   [x] Item validation schema 💯
         -   [x] Item dependency tracking 💯
-    -   [x] Process System
+    -   [x] Process System 💯
         -   [x] Process creation UI with duration handling 💯
         -   [x] Required/consumed/created items selection 💯
         -   [x] Process validation and testing 💯

--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -169,12 +169,14 @@ Processes go through several states during their lifecycle:
 
 1. **NOT_STARTED**: Process is defined but hasn't been initiated
 2. **IN_PROGRESS**: Process is currently running, countdown is active
-3. **FINISHED**: Process has completed and is ready for collection
+3. **PAUSED**: Progress is halted but can be resumed
+4. **FINISHED**: Process has completed and is ready for collection
 
 The UI displays different controls depending on the state:
 
 -   NOT_STARTED: "Start" button
--   IN_PROGRESS: Progress bar, "Cancel" button
+-   IN_PROGRESS: Progress bar, remaining time, "Pause" and "Cancel" buttons
+-   PAUSED: Progress bar, remaining time, "Resume" and "Cancel" buttons
 -   FINISHED: "Collect" button
 
 ## Contribution Workflow


### PR DESCRIPTION
## Summary
- display remaining time for running or paused processes
- document process pause/resume states and countdown
- mark Process System as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_689f8a35f07c832f9f4cf67822a88e63