### PR TITLE
Add MIT license validation test

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -75,7 +75,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Monitoring setup 💯
     -   [x] Migration from Netlify 💯
 
--   [x] License Migration
+-   [x] License Migration 💯
 
 -   [x] Testing & QA 💯
 

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('license compliance', () => {
+  it('root package.json has MIT license', () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+    expect(pkg.license).toBe('MIT');
+  });
+
+  it('frontend package.json has MIT license', () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'frontend', 'package.json'), 'utf8'));
+    expect(pkg.license).toBe('MIT');
+  });
+
+  it('LICENSE file contains MIT License header', () => {
+    const license = readFileSync(join(process.cwd(), 'LICENSE'), 'utf8');
+    expect(license).toContain('MIT License');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests to ensure root and frontend packages declare MIT license and that the LICENSE file contains the MIT header
- mark license migration as complete in changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a35f07c832f9f4cf67822a88e63