### PR TITLE
🧪 : – test preview components render details

### DIFF
--- a/frontend/__tests__/ItemPreview.test.js
+++ b/frontend/__tests__/ItemPreview.test.js
@@ -1,13 +1,28 @@
 /**
  * @jest-environment jsdom
  */
+import { render } from '@testing-library/svelte';
 import ItemPreview from '../src/components/svelte/ItemPreview.svelte';
 
-// Rendering this component directly causes issues with svelte-jester.
-// Instead, verify that it exports a valid Svelte component function.
-
 describe('ItemPreview component', () => {
-    it('exports a valid Svelte component', () => {
-        expect(typeof ItemPreview).toBe('function');
+    it('renders item details', () => {
+        const { getByText, getByAltText } = render(ItemPreview, {
+            props: {
+                name: 'Test Item',
+                description: 'Useful for testing',
+                imageUrl: '/item.png',
+                price: '10',
+                unit: 'kg',
+                type: 'resource',
+            },
+        });
+
+        getByText('Test Item');
+        getByText('Useful for testing');
+        getByText('Price: 10');
+        getByText('Unit: kg');
+        getByText('Type: resource');
+        const img = getByAltText('Item preview');
+        expect(img.getAttribute('src')).toBe('/item.png');
     });
 });

--- a/frontend/__tests__/ProcessPreview.test.js
+++ b/frontend/__tests__/ProcessPreview.test.js
@@ -1,10 +1,28 @@
 /**
  * @jest-environment jsdom
  */
+import { render } from '@testing-library/svelte';
 import ProcessPreview from '../src/components/svelte/ProcessPreview.svelte';
 
 describe('ProcessPreview component', () => {
-    it('exports a valid Svelte component', () => {
-        expect(typeof ProcessPreview).toBe('function');
+    it('renders process details', () => {
+        const { getByText } = render(ProcessPreview, {
+            props: {
+                title: 'Brew Coffee',
+                duration: '5m',
+                requireItems: [{ id: 'water', count: 1 }],
+                consumeItems: [{ id: 'beans', count: 2 }],
+                createItems: [{ id: 'coffee', count: 1 }],
+            },
+        });
+
+        getByText('Brew Coffee');
+        getByText('Duration: 5m');
+        getByText('Requires:');
+        getByText('water x 1');
+        getByText('Consumes:');
+        getByText('beans x 2');
+        getByText('Creates:');
+        getByText('coffee x 1');
     });
 });

--- a/frontend/__tests__/QuestPreview.test.js
+++ b/frontend/__tests__/QuestPreview.test.js
@@ -1,10 +1,22 @@
 /**
  * @jest-environment jsdom
  */
+import { render } from '@testing-library/svelte';
 import QuestPreview from '../src/components/svelte/QuestPreview.svelte';
 
 describe('QuestPreview component', () => {
-    it('exports a valid Svelte component', () => {
-        expect(typeof QuestPreview).toBe('function');
+    it('renders quest details', () => {
+        const { getByText, getByAltText } = render(QuestPreview, {
+            props: {
+                title: 'Test Quest',
+                description: 'A simple quest',
+                imageUrl: '/quest.png',
+            },
+        });
+
+        getByText('Test Quest');
+        getByText('A simple quest');
+        const img = getByAltText('Quest preview');
+        expect(img.getAttribute('src')).toBe('/quest.png');
     });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -46,7 +46,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Required/consumed/created items selection 💯
         -   [x] Process validation and testing 💯
         -   [x] Process state management 💯
-    -   [x] Preview and Testing
+    -   [x] Preview and Testing 💯
         -   [x] Content preview functionality 💯
         -   [x] Testing environment for custom content 💯
         -   [x] Validation feedback system 💯


### PR DESCRIPTION
## Summary
- add rendering tests for item, process, and quest preview components
- mark changelog entry for preview and testing as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689f8a35f07c832f9f4cf67822a88e63