### PR TITLE
Add GFCI outlet testing process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4047,5 +4047,25 @@
                 }
             ]
         }
+    },
+    {
+        "id": "test-gfci-outlet",
+        "title": "Verify wiring on a GFCI outlet using a plug-in tester",
+        "image": "/assets/outlet.jpg",
+        "requireItems": [
+            {
+                "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3132,5 +3132,20 @@
                 }
             ]
         }
+    },
+    {
+        "id": "test-gfci-outlet",
+        "title": "Verify wiring on a GFCI outlet using a plug-in tester",
+        "image": "/assets/outlet.jpg",
+        "requireItems": [{ "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/test-gfci-outlet.json
+++ b/frontend/src/pages/processes/hardening/test-gfci-outlet.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add process to verify GFCI outlet wiring with a plug-in tester

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`
- `npm run audit:ci` *(fails: 3 vulnerabilities)*
- `git diff --cached | ./scripts/scan-secrets.py` *(missing: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a653dc8832f8c2d2c6b003144fc