### PR TITLE
feat: include biohazard bag in clean-minor-cut process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2260,18 +2260,27 @@
             {
                 "id": "55ace400-79ee-4b24-b7da-0b0435ab7d72",
                 "count": 1
+            },
+            {
+                "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
+                "count": 1
             }
         ],
         "createItems": [],
         "duration": "5m",
         "hardening": {
-            "passes": 1,
+            "passes": 2,
             "score": 65,
             "emoji": "🌀",
             "history": [
                 {
                     "task": "codex-hardening-2025-08-06",
                     "date": "2025-08-06",
+                    "score": 65
+                },
+                {
+                    "task": "codex-process-hardening-2025-08-15",
+                    "date": "2025-08-15",
                     "score": 65
                 }
             ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1949,6 +1949,10 @@
             {
                 "id": "55ace400-79ee-4b24-b7da-0b0435ab7d72",
                 "count": 1
+            },
+            {
+                "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
+                "count": 1
             }
         ],
         "createItems": [],

--- a/frontend/src/pages/processes/hardening/clean-minor-cut.json
+++ b/frontend/src/pages/processes/hardening/clean-minor-cut.json
@@ -1,11 +1,16 @@
 {
-    "passes": 1,
+    "passes": 2,
     "score": 65,
     "emoji": "🌀",
     "history": [
         {
             "task": "codex-hardening-2025-08-06",
             "date": "2025-08-06",
+            "score": 65
+        },
+        {
+            "task": "codex-process-hardening-2025-08-15",
+            "date": "2025-08-15",
             "score": 65
         }
     ]


### PR DESCRIPTION
## Summary
- include biohazard waste bag in clean-minor-cut
- record new hardening run for clean-minor-cut
- regenerate processes manifest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`
- `SKIP_E2E=1 npm run test:ci -- processQuality` *(fails: script hung)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a653dc8832f8c2d2c6b003144fc