### PR TITLE
Add programming quest for temperature deviation

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -210,6 +210,7 @@ New quests in this release: 201
 - programming/json-endpoint
 - programming/median-temp
 - programming/plot-temp-cli
+- programming/stddev-temp
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -210,6 +210,7 @@ New quests in this release: 201
 - programming/json-endpoint
 - programming/median-temp
 - programming/plot-temp-cli
+- programming/stddev-temp
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph

--- a/frontend/src/pages/quests/json/programming/stddev-temp.json
+++ b/frontend/src/pages/quests/json/programming/stddev-temp.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/stddev-temp",
+    "title": "Compute Temperature Standard Deviation",
+    "description": "Extend your script to report the standard deviation of daily temperature readings.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've nailed the median. Let's measure how temperatures vary.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "I'll crunch the numbers."
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Parse the log and compute the standard deviation.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Deviation computed!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Deviation helps quantify variability.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Done!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/median-temp"]
+}


### PR DESCRIPTION
## Summary
- add `programming/stddev-temp` quest after `median-temp`
- refresh new quest documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`
- ⚠️ `npm run test:ci -- questCanonical questQuality` *(failed: script hung during pre-PR checks)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a9d8234832f9b425ad2d6c0feb9