### PR TITLE
feat: serve temperature as JSON

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -213,6 +213,7 @@ New quests in this release: 201
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph
+- programming/temp-json-api
 - programming/temp-logger
 - programming/thermistor-calibration
 - programming/web-server

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -213,6 +213,7 @@ New quests in this release: 201
 - programming/temp-alert
 - programming/temp-email
 - programming/temp-graph
+- programming/temp-json-api
 - programming/temp-logger
 - programming/thermistor-calibration
 - programming/web-server

--- a/frontend/src/pages/quests/json/programming/temp-json-api.json
+++ b/frontend/src/pages/quests/json/programming/temp-json-api.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-json-api",
+    "title": "Serve Temperature as JSON",
+    "description": "Expose the latest sensor reading at a JSON endpoint.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your API returns static data. Let's feed it live temperature readings.",
+            "options": [{ "type": "goto", "goto": "code", "text": "Sounds great." }]
+        },
+        {
+            "id": "code",
+            "text": "Read the sensor and respond with JSON like `{ \"temp\": 22.5 }` at `/temp`.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Endpoint streaming data!",
+                    "requiresItems": [{ "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Clients can now fetch the current temperature from your server.",
+            "options": [{ "type": "finish", "text": "API live." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/json-api"]
+}


### PR DESCRIPTION
## Summary
- add programming/temp-json-api quest to expose current readings via API
- document new quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689f8a9d8234832f9b425ad2d6c0feb9