### PR TITLE
feat: add aquarium pH balancing quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -30,6 +30,7 @@ New quests in this release: 201
 ### aquaria
 
 - aquaria/aquarium-light
+- aquaria/balance-ph
 - aquaria/breeding
 - aquaria/filter-rinse
 - aquaria/floating-plants

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -30,6 +30,7 @@ New quests in this release: 201
 ### aquaria
 
 - aquaria/aquarium-light
+- aquaria/balance-ph
 - aquaria/breeding
 - aquaria/filter-rinse
 - aquaria/floating-plants

--- a/frontend/src/pages/quests/json/aquaria/balance-ph.json
+++ b/frontend/src/pages/quests/json/aquaria/balance-ph.json
@@ -1,0 +1,42 @@
+{
+    "id": "aquaria/balance-ph",
+    "title": "Balance aquarium pH",
+    "description": "Use buffer solution to adjust tank pH and confirm stability.",
+    "image": "/assets/pH_strip.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "pH is off. Let's bring it back into range.",
+            "options": [{ "type": "goto", "goto": "buffer", "text": "Ready to adjust" }]
+        },
+        {
+            "id": "buffer",
+            "text": "Add the buffer according to instructions and stir well.",
+            "options": [
+                { "type": "process", "process": "adjust-ph", "text": "Adjust pH" },
+                { "type": "goto", "goto": "verify", "text": "Buffer added" }
+            ]
+        },
+        {
+            "id": "verify",
+            "text": "Check the pH again to ensure it's stable.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "pH stable",
+                    "requiresItems": [{ "id": "13167d6a-5617-4931-8a6e-6f463c6b8835", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work keeping your fish comfortable!",
+            "options": [{ "type": "finish", "text": "Happy fish" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["aquaria/ph-strip-test"]
+}


### PR DESCRIPTION
## Summary
- add `aquaria/balance-ph` quest to adjust and verify tank pH
- document new quest in release notes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689f8a9d8234832f9b425ad2d6c0feb9