### PR TITLE
✨ : add POST data quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -206,6 +206,7 @@ New quests in this release: 201
 - programming/graph-temp
 - programming/graph-temp-data
 - programming/hello-sensor
+- programming/http-post
 - programming/json-api
 - programming/json-endpoint
 - programming/median-temp

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 223
-New quests in this release: 201
+Current quest count: 224
+New quests in this release: 202
 
 ### 3dprinting
 
@@ -206,6 +206,7 @@ New quests in this release: 201
 - programming/graph-temp
 - programming/graph-temp-data
 - programming/hello-sensor
+- programming/http-post
 - programming/json-api
 - programming/json-endpoint
 - programming/median-temp

--- a/frontend/src/pages/quests/json/programming/http-post.json
+++ b/frontend/src/pages/quests/json/programming/http-post.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/http-post",
+    "title": "Accept POST Data",
+    "description": "Update your server to handle POST requests and log JSON payloads.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your API serves data. Now let's accept data from clients.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "I'm ready"
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Modify your server to read JSON from POST requests to /submit and print it.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "POST endpoint working!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your service can now ingest data from clients.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Nice!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/json-api"]
+}


### PR DESCRIPTION
## Summary
- add programming quest to accept JSON POST submissions
- document quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_689f8a9d8234832f9b425ad2d6c0feb9