### PR TITLE
🔧 chore: rebase quest-chart workflow before push

### DIFF
--- a/.github/workflows/quest-chart.yml
+++ b/.github/workflows/quest-chart.yml
@@ -29,5 +29,7 @@ jobs:
                   git config user.email "actions@users.noreply.github.com"
                   if [ -n "$(git status --porcelain frontend/src/pages/docs/images/quest-tree-stats.txt)" ]; then
                     git add frontend/src/pages/docs/images/quest-tree-stats.txt
-                    git commit -m "chore: update quest chart data" && git push
+                    git commit -m "chore: update quest chart data"
+                    git pull --rebase origin v3
+                    git push origin HEAD:v3
                   fi


### PR DESCRIPTION
## Summary
- ensure quest-chart workflow rebases before pushing updates

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689fa5af9b14832fbd7520b31174e594