### PR TITLE
docs: add Quill NPC to guide

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -167,6 +167,21 @@ They design compact arrays that keep the metaguild's gear humming far from any o
 -   "A cloud rolled in—no worries, the battery will bridge the gap."
 -   "Keep the cells clean and they'll power your adventures for years."
 
+## Quill
+
+<img src="/assets/npc/orion.jpg" />
+
+Quill is the metaguild's quiet historian, preserving mission logs and schematics.
+They rarely miss a detail and prefer to let records speak for themselves.
+
+### Sample Dialogue
+
+-   "Ah, another chapter begins. Mind if I document your quest?"
+-   "Facts first, feelings second—that's the archivist's creed."
+-   "A quick signature and your blueprint enters the annals."
+-   "Careful with that relic; it's older than the guild itself."
+-   "Need a refresher on past missions? I've indexed every triumph and blunder."
+
 <style>
     img {
         float: left;


### PR DESCRIPTION
## Summary
- add Quill historian NPC with sample dialogue
- sync new quest counts to keep docs and tests aligned

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a00ee5b010832f99d39b215c629af6