### PR TITLE
Add flashlight battery replacement process

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4146,5 +4146,34 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "replace-flashlight-battery",
+        "title": "Install a fresh 9 V battery in a red flashlight",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "9a72fb16-fc69-45c5-beca-f25c27028977",
+                "count": 1
+            },
+            {
+                "id": "8299ac3f-c232-46d4-a007-2ad86ec70361",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "80d30825-a42b-4add-b715-322e1713952c",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3212,5 +3212,23 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "replace-flashlight-battery",
+        "title": "Install a fresh 9 V battery in a red flashlight",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "9a72fb16-fc69-45c5-beca-f25c27028977", "count": 1 },
+            { "id": "8299ac3f-c232-46d4-a007-2ad86ec70361", "count": 1 }
+        ],
+        "consumeItems": [{ "id": "80d30825-a42b-4add-b715-322e1713952c", "count": 1 }],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/replace-flashlight-battery.json
+++ b/frontend/src/pages/processes/hardening/replace-flashlight-battery.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add `replace-flashlight-battery` process with item links and hardening
- refresh generated processes and new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00ef6c770832fb9bf84f60e5d65d4