### PR TITLE
feat: refine completionist award details

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/awards.json
+++ b/frontend/src/pages/inventory/json/items/awards.json
@@ -78,9 +78,17 @@
     {
         "id": "1394c366-5078-49cf-b24e-c748e8428234",
         "name": "Completionist Award",
-        "description": "Awarded for completing all of the quests available on January 1, 2023.",
+        "description": "15 cm aluminum trophy etched 'Completionist 2023'; reward for finishing every quest on 2023-01-01.",
         "image": "/assets/completionist_award.jpg",
-        "priceExemptionReason": "BETA_PLACEHOLDER"
+        "priceExemptionReason": "TROPHY",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-08-16", "date": "2025-08-16", "score": 65 }
+            ]
+        }
     },
     {
         "id": "96e11500-a2ce-4531-a1b5-3a92c44fcb9d",


### PR DESCRIPTION
## Summary
- clarify Completionist Award description and add initial hardening record
- sync new quests list to satisfy tests

## Testing
- `npm run audit:ci` *(fails: 8 vulnerabilities)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`

------
https://chatgpt.com/codex/tasks/task_e_68a00edd826c832f919ecfe600dd39a4