### PR TITLE
Refine parachute item and sync quest docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -518,9 +518,22 @@
     {
         "id": "80a83ecc-bcd2-400e-a469-8488a6453bb8",
         "name": "parachute",
-        "description": "A parachute for model rockets.",
+        "description": "30 cm (12 in) nylon parachute with six shroud lines; ~15 g.",
         "image": "/assets/parachute.jpg",
-        "price": "30 dUSD"
+        "price": "7 dUSD",
+        "unit": "each",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-16",
+                    "date": "2025-08-16",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "84324403-0bd8-411a-b575-a3c966c8a73e",


### PR DESCRIPTION
## Summary
- detail parachute inventory item with realistic specs and price
- add hardening metadata for first polish pass
- refresh new quest documentation

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `CI=1 npm run test:ci -- itemQuality`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a00edd826c832f919ecfe600dd39a4