### PR TITLE
docs: refresh content guidance and quest list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -100,7 +100,6 @@ Before submitting:
 
 For more advanced contributors interested in extending core game functionality:
 
--   Review the [DSPACE Architecture](/docs/architecture) documentation
 -   Follow the [Developer Guide](https://github.com/democratizedspace/dspace/blob/v3/DEVELOPER_GUIDE.md)
 -   Start with small enhancements before proposing major changes
 
@@ -109,7 +108,7 @@ For more advanced contributors interested in extending core game functionality:
 -   [Discord Community](https://discord.gg/A3UAfYvnxM): Discuss ideas and get feedback
 -   [GitHub Repository](https://github.com/democratizedspace/dspace): View source code and submit changes
 -   [Documentation](/docs): Browse all game documentation
--   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTORS.md): General contribution guidelines
+-   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTING.md): General contribution guidelines
 
 By following these guidelines, you'll create high-quality content that enhances the DSPACE experience while contributing to our mission of democratizing space exploration through practical, hands-on education.
-Remember to run `npm run check` to verify formatting and linting before submitting.
+Before submitting, run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` to keep the codebase healthy.

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 


### PR DESCRIPTION
## Summary
- remove stale architecture reference and point to CONTRIBUTING guide
- regenerate new quests list for latest quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68a00ed569a4832f889d823372946ab1