### PR TITLE
Clarify aquarium thermometer quest and refresh new-quests list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/quests/json/aquaria/thermometer.json
+++ b/frontend/src/pages/quests/json/aquaria/thermometer.json
@@ -1,26 +1,29 @@
 {
     "id": "aquaria/thermometer",
     "title": "Attach Aquarium Thermometer",
-    "description": "Attach a strip thermometer outside the glass to monitor water temperature without opening the tank.",
+    "description": "Attach a stick-on strip thermometer outside the aquarium glass to monitor water temperature.",
     "image": "/assets/aquarium_thermometer.jpg",
     "npc": "/assets/npc/vega.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Wash your hands, unplug the heater to avoid burns, then use a paper towel to dry a 5 cm patch on the outside glass just below the waterline.",
+            "text": "Rinse your hands, unplug the heater and let it cool for 10 minutes, then dry a 5 cm patch on the outside glass just below the waterline with a clean paper towel.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "attach",
                     "text": "Area is clean and dry.",
-                    "requiresItems": [{ "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 }]
+                    "requiresItems": [
+                        { "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 },
+                        { "id": "0b85f058-38f2-4e9a-93e9-d47441608619", "count": 1 }
+                    ]
                 }
             ]
         },
         {
             "id": "attach",
-            "text": "Peel the backing without touching the adhesive. Align the strip at eye level on the dried spot and press it to the glass from top to bottom for 30 seconds. Keep the strip outside the tank and at least 5 cm from heaters.",
+            "text": "Peel the backing without touching the adhesive. Align the strip at eye level on the dry spot and press it to the glass from top to bottom for 30 seconds. Keep the strip outside the tank and at least 5 cm from heaters or direct sunlight.",
             "options": [
                 {
                     "type": "goto",
@@ -37,19 +40,20 @@
         },
         {
             "id": "finish",
-            "text": "Great! Wait a few minutes for the numbers to stabilize, plug the heater back in, then monitor the water temperature at a glance.",
+            "text": "Wait a few minutes for the numbers to stabilize. Plug the heater back in with dry hands and monitor the water temperature at a glance.",
             "options": [{ "type": "finish", "text": "All set!" }]
         }
     ],
     "rewards": [],
     "requiresQuests": ["aquaria/position-tank"],
     "hardening": {
-        "passes": 2,
-        "score": 80,
-        "emoji": "✅",
+        "passes": 3,
+        "score": 90,
+        "emoji": "💯",
         "history": [
             { "task": "codex-quest-hardening-2025-08-13", "date": "2025-08-13", "score": 60 },
-            { "task": "codex-quest-hardening-2025-08-14", "date": "2025-08-14", "score": 80 }
+            { "task": "codex-quest-hardening-2025-08-14", "date": "2025-08-14", "score": 80 },
+            { "task": "codex-quest-hardening-2025-08-16", "date": "2025-08-16", "score": 90 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- polish `aquaria/thermometer` quest with clearer safety notes and heater reference
- mark quest as fully hardened and refresh new quest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00f3aa074832fa2cead4512ff993c