### PR TITLE
docs: refine Phoenix bio and sync quest counts

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -94,17 +94,20 @@ Vega is an expert in aquariums and terrariums, with years of experience in desig
 
 <img src="/assets/npc/phoenix.jpg" />
 
-Phoenix is a professional chemist specializing in sustainable rocket fuel development. With a strong background in chemistry and a focus on environmental conservation, they are committed to finding innovative solutions for the space industry that have a minimal impact on our planet. Phoenix's work has the potential to revolutionize space travel by making it more eco-friendly and accessible to a wider range of people.
+Phoenix is a chemist focused on sustainable rocket fuel.
+They blend chemistry with conservation to push craft without scarring the planet.
+They guide recruits through quests such as
+[Demonstrate a Safe Chemical Reaction](/quests/chemistry/safe-reaction) and
+[Extract Stevia Sweetener](/quests/chemistry/stevia-extraction)
+to show how green chemistry powers missions.
 
 ### Sample Dialogue
 
--   "You've made some impressive strides in 3D printing. Your next challenge is to print 10 Benchies."
--   "Well done! These Benchies look fantastic. Keep honing your 3D printing skills."
--   "You've shown great progress with your 3D printing! Your next goal is to print 25 Benchies."
--   "Excellent job! Your fleet of Benchies is growing. Keep up the great work."
--   "You've truly mastered the art of 3D printing Benchies. Now, let's take things to the next level. I want to see a fleet of 100 Benchies."
--   "Dry those stevia leaves gently and we'll extract their sweetness."
--   "Add a splash of ethanol and you'll get pure stevia crystals as it dries."
+-   "Hey, I'm Phoenix—chemistry without pollution is my specialty."
+-   "Mix vinegar with baking soda; the fizz is safe yet shows energy you can harness."
+-   "Dry those stevia leaves and rinse them with ethanol to pull out the sweetness."
+-   "That extract will sweeten rations without a sugar crash."
+-   "Next up, we'll brew propellant that pushes rockets without scorching the skies."
 
 ## Atlas
 

--- a/frontend/src/pages/quests/json/chemistry/safe-reaction.json
+++ b/frontend/src/pages/quests/json/chemistry/safe-reaction.json
@@ -8,17 +8,17 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Phoenix here, your resident chemist. I'd like to show you how a simple reaction demonstrates eco-friendly fuel chemistry. Interested?",
+            "text": "Phoenix here. Want to see a simple reaction that proves how green propellants release energy?",
             "options": [{ "type": "goto", "goto": "mix", "text": "Absolutely!" }]
         },
         {
             "id": "mix",
-            "text": "Carefully mix baking soda with vinegar in this open bottle. The fizzing gas is harmless but shows how fuel chemistry releases energy.",
+            "text": "Mix baking soda with vinegar in an open bottle. The fizz is harmless yet shows fuel releasing energy.",
             "options": [{ "type": "goto", "goto": "finish", "text": "The reaction is bubbling!" }]
         },
         {
             "id": "finish",
-            "text": "Great job! We'll build on this sustainable experiment later to design clean rocket fuel.",
+            "text": "Great job! We'll build on this clean experiment to design sustainable rocket fuel later.",
             "options": [{ "type": "finish", "text": "Can't wait!" }]
         }
     ],

--- a/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
+++ b/frontend/src/pages/quests/json/chemistry/stevia-extraction.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Phoenix here. Those stevia leaves you grew can be turned into a potent sweetener. Interested in an extraction demo?",
+            "text": "Phoenix here. Those stevia leaves become sweetener. Want an extraction demo?",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "extract",
-            "text": "Dry your homegrown leaves, crush them slightly, and steep them just below boiling. Filter the liquid using a funnel and paper as shown in [/docs/chemistry-lab](/docs/chemistry-lab).",
+            "text": "Dry leaves, crush, steep below boiling, then filter. See docs/chemistry.",
             "options": [
                 {
                     "type": "process",
@@ -41,7 +41,7 @@
         },
         {
             "id": "finish",
-            "text": "Great work! This homemade stevia extract will sweeten drinks without any sugar. Next we'll purify it into crystals for longer storage.",
+            "text": "Great job! This extract sweetens without sugar. Next we make crystals.",
             "options": [
                 {
                     "type": "finish",


### PR DESCRIPTION
## Summary
- clarify Phoenix's role with cleaner voice and quest links
- align Phoenix-related quests with concise eco-chemistry dialogue
- sync new quest count docs for CI

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a00ef69b68832fba5b2501dbf63b38