### PR TITLE
📝 : – clarify docs prompt instructions and sync new quests list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -5,8 +5,8 @@ slug: 'prompts-docs'
 
 # Documentation prompts for the _dspace_ repo
 
-Codex is a sandboxed engineering agent that can open this repository, run tests, and send a
-ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside
+Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
+ready-made PR—but only if given a clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
 and consistent. To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
 If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -16,7 +16,8 @@ If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/pr
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 4. Scan for secrets and use an emoji-prefixed commit message.
+> 4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+>    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
@@ -27,7 +28,8 @@ committing.
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
-3. If adding a new prompt doc, link it from `prompts-codex.md` and `/docs/index`.
+3. If adding a new prompt doc, link it from `prompts-codex.md`
+   and the docs index (`frontend/src/pages/docs/index.astro`).
 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 5. Use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- clarify secret scan instructions in docs prompt guide
- sync auto-generated new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | detect-secrets-hook`


------
https://chatgpt.com/codex/tasks/task_e_68a00e5e3128832f91d89513b8cee4db