### PR TITLE
📝 docs: add test prompt guide

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -55,6 +55,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-processes">Process prompts</a>
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
+            <a href="/docs/prompts-tests">Test prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -12,7 +12,8 @@ invoking Codex on DSPACE and should evolve alongside the project.
 
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
-[NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages), and [Docs prompts](/docs/prompts-docs).
+[NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
+[Test prompts](/docs/prompts-tests), and [Docs prompts](/docs/prompts-docs).
 
 > **TL;DR**
 >
@@ -33,6 +34,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Quest Prompts](/docs/prompts-quests)
 -   [NPC Prompts](/docs/prompts-npcs)
 -   [Outage Prompts](/docs/prompts-outages)
+-   [Test Prompts](/docs/prompts-tests)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -7,9 +7,10 @@ slug: 'prompts-docs'
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and send a
 ready-made PR—but only if you give it a clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
-and consistent. To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
-If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+[Codex Prompts](/docs/prompts-codex) and [Test prompts](/docs/prompts-tests) when updating
+markdown or JSDoc so instructions stay current and consistent. To keep the prompt docs evolving,
+see the [Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with
+the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-tests.md
+++ b/frontend/src/pages/docs/md/prompts-tests.md
@@ -1,0 +1,33 @@
+---
+title: 'Test Prompts'
+slug: 'prompts-tests'
+---
+
+# Test prompts for the _dspace_ repo
+
+Codex can write or update tests when given a tight, file-scoped brief.
+Use this guide alongside [Codex Prompts](/docs/prompts-codex) when modifying
+Vitest suites or adding Playwright coverage. Keep prompts short so the agent
+spends tokens running checks instead of reading prose.
+
+> **TL;DR**
+>
+> 1. Limit changes to the relevant test files.
+> 2. Provide runnable examples; code blocks should compile with `ts-node`.
+> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Scan staged changes for secrets and commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+
+USER:
+1. Add or update tests under `frontend/__tests__` or `backend/tests`.
+2. Ensure new tests cover edge cases and clearly name assertions.
+3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with the required test changes and passing checks.
+```


### PR DESCRIPTION
## Summary
- add dedicated test prompt guide and link from codex docs and index
- mention test prompts in docs prompt guide
- refresh new quests list to keep tests green

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a00e5e3128832f91d89513b8cee4db