### PR TITLE
Refine bucket water process details

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -145,7 +145,8 @@
     },
     {
         "id": "bucket-water-chlorinated",
-        "title": "Use a sink to fill a 19 L (5 gal) bucket with tap water",
+        "title": "Fill a 19 L (5 gal) bucket with chlorinated tap water from a sink",
+        "image": "/assets/bucket_water.jpg",
         "requireItems": [
             {
                 "id": "799ace33-1336-46c0-904a-9f16778230f1",
@@ -164,16 +165,21 @@
                 "count": 1
             }
         ],
-        "duration": "30s",
+        "duration": "3m",
         "hardening": {
-            "passes": 1,
-            "score": 60,
-            "emoji": "🌀",
+            "passes": 2,
+            "score": 80,
+            "emoji": "✅",
             "history": [
                 {
                     "task": "codex-hardening-2025-08-05",
                     "date": "2025-08-05",
                     "score": 60
+                },
+                {
+                    "task": "codex-hardening-2025-08-16",
+                    "date": "2025-08-16",
+                    "score": 80
                 }
             ]
         }

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -97,7 +97,8 @@
     },
     {
         "id": "bucket-water-chlorinated",
-        "title": "Use a sink to fill a 19 L (5 gal) bucket with tap water",
+        "title": "Fill a 19 L (5 gal) bucket with chlorinated tap water from a sink",
+        "image": "/assets/bucket_water.jpg",
         "requireItems": [
             {
                 "id": "799ace33-1336-46c0-904a-9f16778230f1",
@@ -116,7 +117,7 @@
                 "count": 1
             }
         ],
-        "duration": "30s"
+        "duration": "3m"
     },
     {
         "id": "3dprint-benchy",

--- a/frontend/src/pages/processes/hardening/bucket-water-chlorinated.json
+++ b/frontend/src/pages/processes/hardening/bucket-water-chlorinated.json
@@ -1,12 +1,17 @@
 {
-    "passes": 1,
-    "score": 60,
-    "emoji": "🌀",
+    "passes": 2,
+    "score": 80,
+    "emoji": "✅",
     "history": [
         {
             "task": "codex-hardening-2025-08-05",
             "date": "2025-08-05",
             "score": 60
+        },
+        {
+            "task": "codex-hardening-2025-08-16",
+            "date": "2025-08-16",
+            "score": 80
         }
     ]
 }


### PR DESCRIPTION
## Summary
- clarify bucket-water-chlorinated process and add image
- upgrade hardening to pass 2 with score 80
- sync new quests doc to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00f1029f8832f902386e08905801c