### PR TITLE
Normalize token.place URL handling

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -29,6 +29,12 @@ describe('tokenPlaceChat', () => {
         expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
     });
 
+    test('trims trailing slash from configured url', async () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place/' } });
+        await tokenPlaceChat([]);
+        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
+    });
+
     test('falls back to env url when game state missing', async () => {
         loadGameState.mockReturnValue({});
         process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -60,7 +60,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Data integrity validation 💯
         -   [x] Rollback functionality 💯
 
--   [x] AI Integration
+-   [x] AI Integration 💯
 
     -   [x] token.place integration 💯
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -6,7 +6,7 @@ slug: 'token-place'
 DSPACE uses the [token.place](https://token.place) API for in-game AI features like chat.
 The `tokenPlaceChat` utility sends messages to the service and returns the model's reply.
 
-The API endpoint defaults to `https://token.place/api`. You can override it:
+The API endpoint defaults to `https://token.place/api`. You can override it with or without a trailing slash:
 
 -   **Game settings**: set a custom URL in your saved game state.
 -   **Environment variable**: set `VITE_TOKEN_PLACE_URL` when building or running tests.
@@ -15,4 +15,4 @@ The API endpoint defaults to `https://token.place/api`. You can override it:
 VITE_TOKEN_PLACE_URL=https://my-token-place/api npm run dev
 ```
 
-You can clear the saved URL by resetting your game state.
+You can clear the saved URL by resetting your game state. Trailing slashes are ignored.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,9 +13,12 @@ const getEnvUrl = () => {
     return null;
 };
 
+const stripTrailingSlash = (url) => url.replace(/\/+$/, '');
+
 export const tokenPlaceChat = async (messages) => {
     const envUrl = getEnvUrl();
-    const baseUrl = loadGameState().tokenPlace?.url || envUrl || DEFAULT_URL;
+    const rawBaseUrl = loadGameState().tokenPlace?.url || envUrl || DEFAULT_URL;
+    const baseUrl = stripTrailingSlash(rawBaseUrl);
 
     const systemMessage = {
         role: 'system',


### PR DESCRIPTION
## Summary
- trim trailing slashes from token.place base URL
- document token.place URL override behavior
- refresh new quests documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a00e7e7f4c832f9f567ac2189c6c37