### PR TITLE
Add Remove a Splinter first aid quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -156,6 +156,7 @@ New quests in this release: 202
 - firstaid/change-bandage
 - firstaid/dispose-expired
 - firstaid/learn-cpr
+- firstaid/remove-splinter
 - firstaid/restock-kit
 - firstaid/sanitize-pocket-mask
 - firstaid/splint-limb

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -156,6 +156,7 @@ New quests in this release: 202
 - firstaid/change-bandage
 - firstaid/dispose-expired
 - firstaid/learn-cpr
+- firstaid/remove-splinter
 - firstaid/restock-kit
 - firstaid/sanitize-pocket-mask
 - firstaid/splint-limb

--- a/frontend/src/pages/quests/json/firstaid/remove-splinter.json
+++ b/frontend/src/pages/quests/json/firstaid/remove-splinter.json
@@ -1,0 +1,50 @@
+{
+    "id": "firstaid/remove-splinter",
+    "title": "Remove a Splinter",
+    "description": "Take out a small splinter to prevent infection.",
+    "image": "/assets/rescue.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Splinters can fester if ignored. Let's take it out carefully.",
+            "options": [{ "type": "goto", "goto": "prep", "text": "I'm ready" }]
+        },
+        {
+            "id": "prep",
+            "text": "Put on gloves and wash your hands before touching the area.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Hands are clean",
+                    "goto": "remove"
+                }
+            ]
+        },
+        {
+            "id": "remove",
+            "text": "Grip the splinter with tweezers, pull it out, then wipe with antiseptic.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Splinter removed",
+                    "requiresItems": [
+                        { "id": "997eaba9-25ee-43d5-bbdc-5d6adf03adfa", "count": 1 },
+                        { "id": "b0f10930-53aa-4d45-8bb7-9c7b17f14a5a", "count": 1 },
+                        { "id": "fc9301ec-674f-4b0d-b85e-c47140d5ae00", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Keep the area clean and watch for any redness or swelling.",
+            "options": [{ "type": "finish", "text": "Will do" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/wound-care"]
+}


### PR DESCRIPTION
## Summary
- add firstaid/remove-splinter quest requiring wound-care
- refresh new quest listings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00f1b1b58832faeb7ed81b10dd693