### PR TITLE
feat: add temperature dashboard quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -216,6 +216,7 @@ New quests in this release: 202
 - programming/plot-temp-cli
 - programming/stddev-temp
 - programming/temp-alert
+- programming/temp-dashboard
 - programming/temp-email
 - programming/temp-graph
 - programming/temp-json-api

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -216,6 +216,7 @@ New quests in this release: 202
 - programming/plot-temp-cli
 - programming/stddev-temp
 - programming/temp-alert
+- programming/temp-dashboard
 - programming/temp-email
 - programming/temp-graph
 - programming/temp-json-api

--- a/frontend/src/pages/quests/json/programming/temp-dashboard.json
+++ b/frontend/src/pages/quests/json/programming/temp-dashboard.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-dashboard",
+    "title": "Build Temperature Dashboard",
+    "description": "Show live readings on a web page that fetches your JSON endpoint.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your API serves raw numbers. Let's visualize them on a simple page.",
+            "options": [{ "type": "goto", "goto": "dashboard", "text": "Let's do it." }]
+        },
+        {
+            "id": "dashboard",
+            "text": "Create an HTML page that fetches `/temp` and updates the DOM with the latest value.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Page shows current temperature!",
+                    "requiresItems": [{ "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! You have a live dashboard for your sensor.",
+            "options": [{ "type": "finish", "text": "Cool!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-json-api"]
+}


### PR DESCRIPTION
## Summary
- add programming quest to build a web dashboard for live temperature readings
- document quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00f1b1b58832faeb7ed81b10dd693