### PR TITLE
Add GFCI outlet test quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -121,6 +121,7 @@ New quests in this release: 202
 - electronics/continuity-test
 - electronics/data-logger
 - electronics/desolder-component
+- electronics/gfci-outlet-test
 - electronics/led-polarity
 - electronics/light-sensor
 - electronics/measure-arduino-5v

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 231
+New quests in this release: 209
 
 ### 3dprinting
 
@@ -121,6 +121,7 @@ New quests in this release: 202
 - electronics/continuity-test
 - electronics/data-logger
 - electronics/desolder-component
+- electronics/gfci-outlet-test
 - electronics/led-polarity
 - electronics/light-sensor
 - electronics/measure-arduino-5v

--- a/frontend/src/pages/quests/json/electronics/gfci-outlet-test.json
+++ b/frontend/src/pages/quests/json/electronics/gfci-outlet-test.json
@@ -1,0 +1,55 @@
+{
+    "id": "electronics/gfci-outlet-test",
+    "title": "Test a GFCI Outlet",
+    "description": "Use a plug-in tester to confirm a GFCI outlet trips and resets correctly.",
+    "image": "/assets/outlet.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ground-fault circuit interrupters reduce shock risk. Let's verify one works properly.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "test",
+                    "text": "Show me how."
+                }
+            ]
+        },
+        {
+            "id": "test",
+            "text": "Plug the tester into the outlet, press its button to trip the circuit, then reset the outlet.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "test-gfci-outlet",
+                    "text": "Running test"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Outlet trips and resets",
+                    "requiresItems": [
+                        {
+                            "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! The safety circuit responds as expected. Document the test date for future checks.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Will do."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/check-battery-voltage"]
+}


### PR DESCRIPTION
## Summary
- add an electronics quest to verify a GFCI outlet with a plug-in tester
- document new quest in the release notes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality` *(fails: prepare-pr checks hung installing Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a00f1b1b58832faeb7ed81b10dd693