### PR TITLE
Add heat-shrink tubing assortment tool and quest reward

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 224
-New quests in this release: 202
+Current quest count: 230
+New quests in this release: 208
 
 ### 3dprinting
 

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -523,5 +523,20 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "93b8fcd2-7a45-462a-94b6-6746d404e651",
+        "name": "heat-shrink tubing assortment",
+        "description": "100-piece kit of polyolefin heat-shrink tubing in assorted diameters for insulating wire splices.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "6 dUSD",
+        "type": "tool",
+        "unit": "100-piece kit",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/electronics/desolder-component.json
+++ b/frontend/src/pages/quests/json/electronics/desolder-component.json
@@ -42,15 +42,15 @@
         },
         {
             "id": "finish",
-            "text": "Nice work! Clean the tip, unplug the iron, let it cool, and recycle the scrap PCB.",
+            "text": "Nice work! Clean the tip, unplug the iron, let it cool, recycle the PCB, grab this heat-shrink kit.",
             "options": [{ "type": "finish", "text": "All cleaned up." }]
         }
     ],
-    "rewards": [],
+    "rewards": [{ "id": "93b8fcd2-7a45-462a-94b6-6746d404e651", "count": 1 }],
     "requiresQuests": ["electronics/solder-wire"],
     "hardening": {
-        "passes": 2,
-        "score": 78,
+        "passes": 3,
+        "score": 85,
         "emoji": "✅",
         "history": [
             {
@@ -62,6 +62,11 @@
                 "task": "codex-upgrade-2025-08-15",
                 "date": "2025-08-15",
                 "score": 78
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-16",
+                "date": "2025-08-16",
+                "score": 85
             }
         ]
     }


### PR DESCRIPTION
## Summary
- add heat-shrink tubing assortment tool item
- reward new tubing kit in "Desolder a component" quest and refresh hardening metadata
- sync new quest lists for updated counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a00edba554832f9d9724211001f606