### PR TITLE
Add USB solder fume extractor tool

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4090,6 +4090,10 @@
             {
                 "id": "fc9301ec-674f-4b0d-b85e-c47140d5ae00",
                 "count": 1
+            },
+            {
+                "id": "3b6a44a1-86e9-46e5-a2b7-db4f9661c31c",
+                "count": 1
             }
         ],
         "consumeItems": [],

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -543,5 +543,19 @@
                 }
             ]
         }
+    },
+    {
+        "id": "3b6a44a1-86e9-46e5-a2b7-db4f9661c31c",
+        "name": "USB solder fume extractor",
+        "description": "80 mm USB fan with activated charcoal filter that draws solder smoke away from small electronics work.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "20 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3174,7 +3174,8 @@
             { "id": "526817d2-996a-4d80-b5fc-4a0a5eb9ca03", "count": 1 },
             { "id": "dad7f853-ccc9-40be-b226-89272708db84", "count": 1 },
             { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 },
-            { "id": "fc9301ec-674f-4b0d-b85e-c47140d5ae00", "count": 1 }
+            { "id": "fc9301ec-674f-4b0d-b85e-c47140d5ae00", "count": 1 },
+            { "id": "3b6a44a1-86e9-46e5-a2b7-db4f9661c31c", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [],


### PR DESCRIPTION
## Summary
- add USB solder fume extractor item to tools inventory
- require fume extractor in desolder-smd-with-wick process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a10d0a9410832fb9160f86356a611e