### PR TITLE
Add Raspberry Pi case 3D printing quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -22,6 +22,7 @@ New quests in this release: 209
 - 3dprinting/filament-change
 - 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
+- 3dprinting/pi-case
 - 3dprinting/retraction-test
 - 3dprinting/spool-holder
 - 3dprinting/temperature-tower

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -22,6 +22,7 @@ New quests in this release: 209
 - 3dprinting/filament-change
 - 3dprinting/nozzle-cleaning
 - 3dprinting/phone-stand
+- 3dprinting/pi-case
 - 3dprinting/retraction-test
 - 3dprinting/spool-holder
 - 3dprinting/temperature-tower

--- a/frontend/src/pages/quests/json/3dprinting/pi-case.json
+++ b/frontend/src/pages/quests/json/3dprinting/pi-case.json
@@ -1,0 +1,45 @@
+{
+    "id": "3dprinting/pi-case",
+    "title": "Print a Raspberry Pi Case",
+    "description": "Protect your Raspberry Pi with a custom 3D printed case.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Got a bare Raspberry Pi? Let's print a snap-fit case to shield it.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "print",
+                    "text": "Sure, tell me what to do."
+                }
+            ]
+        },
+        {
+            "id": "print",
+            "text": "Grab a Pi case STL, slice with cooling on, print in PLA, keep ports clear.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Case printed and Pi secured.",
+                    "requiresItems": [{ "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Your Pi is protected and ready for projects.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "On to the next build."
+                }
+            ]
+        }
+    ],
+    "rewards": [{ "id": "5247a603-294a-4a34-a884-1ae20969b2a1", "count": 5 }],
+    "requiresQuests": ["3dprinter/start"]
+}


### PR DESCRIPTION
## Summary
- add Raspberry Pi case 3D printing quest
- document new quest in release notes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a10d4ed358832f8685db4b8c5d79b3