### PR TITLE
📝 : – refine prompt docs wording

### DIFF
--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -6,8 +6,8 @@ slug: 'prompts-docs'
 # Documentation prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
-ready-made PR—but only if given a clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
+ready-made PR—but only with a clear, file-scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc to keep instructions current
 and consistent. To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
 If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
@@ -17,7 +17,7 @@ If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/pr
 > 2. Fix outdated wording, links, or formatting.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
->    and use an emoji-prefixed commit message.
+>    and commit with an emoji prefix (e.g., `📝 : – update docs`).
 
 ```text
 SYSTEM:
@@ -28,7 +28,7 @@ committing.
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
-3. If adding a new prompt doc, link it from `prompts-codex.md`
+3. If you add a new prompt doc, also link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 5. Use an emoji-prefixed commit message.

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -6,7 +6,7 @@ slug: 'prompts-processes'
 # Writing great process prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository,
-run its own tests, and send you a ready‑made PR—but only if you give it a
+run its own tests, and send a ready‑made PR—but only if you provide a
 clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
 prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
@@ -17,12 +17,12 @@ For fundamental design tips see the
 > **TL;DR**
 >
 > 1. Scope changes to a single process entry.
-> 2. Say exactly what output you expect (tests, docs).
+> 2. Specify exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
->    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
+>    `npm run test:ci`. Scan staged changes with
+>    `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ---
 
@@ -57,7 +57,7 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 | **Acceptance check** | e.g. “`npm run test:ci` and `npm run test:ci -- processQuality` pass”.  |
 
 Codex merges these instructions with any `AGENTS.md` files in scope, so keep
-prompt‑level rules short and concrete.
+prompt‑level rules concise and concrete.
 
 ---
 


### PR DESCRIPTION
what: polish documentation and process prompt guides.
why: clarify instructions and commit conventions.
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68a10ce5f780832fbe0c0929eca2283f