### PR TITLE
feat: add SQLite temperature logging quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -221,6 +221,7 @@ New quests in this release: 209
 - programming/temp-graph
 - programming/temp-json-api
 - programming/temp-logger
+- programming/temp-sqlite
 - programming/thermistor-calibration
 - programming/web-server
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -221,6 +221,7 @@ New quests in this release: 209
 - programming/temp-graph
 - programming/temp-json-api
 - programming/temp-logger
+- programming/temp-sqlite
 - programming/thermistor-calibration
 - programming/web-server
 

--- a/frontend/src/pages/quests/json/programming/temp-sqlite.json
+++ b/frontend/src/pages/quests/json/programming/temp-sqlite.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-sqlite",
+    "title": "Store Temperature in SQLite",
+    "description": "Log sensor readings to a SQLite database for easy querying.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You've logged temperatures to a file. Let's store them in a database for better analysis.",
+            "options": [{ "type": "goto", "goto": "db", "text": "Sounds good." }]
+        },
+        {
+            "id": "db",
+            "text": "Create a SQLite table and insert each hourly reading into it.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Data persists!",
+                    "requiresItems": [{ "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Now you can run SQL queries to explore your readings.",
+            "options": [{ "type": "finish", "text": "Nice!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-logger"]
+}


### PR DESCRIPTION
## Summary
- add `temp-sqlite` programming quest for storing sensor readings in SQLite
- document new quest in `docs/new-quests.md`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a10d430034832fa6f748c80fbaa9cb