### PR TITLE
Add multimeter calibration quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -117,6 +117,7 @@ New quests in this release: 209
 
 - electronics/arduino-blink
 - electronics/basic-circuit
+- electronics/calibrate-multimeter
 - electronics/check-battery-voltage
 - electronics/continuity-test
 - electronics/data-logger

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 231
-New quests in this release: 209
+Current quest count: 232
+New quests in this release: 210
 
 ### 3dprinting
 
@@ -117,6 +117,7 @@ New quests in this release: 209
 
 - electronics/arduino-blink
 - electronics/basic-circuit
+- electronics/calibrate-multimeter
 - electronics/check-battery-voltage
 - electronics/continuity-test
 - electronics/data-logger

--- a/frontend/src/pages/quests/json/electronics/calibrate-multimeter.json
+++ b/frontend/src/pages/quests/json/electronics/calibrate-multimeter.json
@@ -1,0 +1,39 @@
+{
+    "id": "electronics/calibrate-multimeter",
+    "title": "Calibrate Your Multimeter",
+    "description": "Zero your digital multimeter against a 220 Ω reference resistor before measurements.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Accuracy matters. Ready to check your meter against a known resistor?",
+            "options": [{ "type": "goto", "goto": "calibrate", "text": "Show me the steps." }]
+        },
+        {
+            "id": "calibrate",
+            "text": "Clip the probes to a 220 Ω resistor and adjust the meter until it reads within tolerance.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Reading matches the reference",
+                    "process": "calibrate-multimeter",
+                    "requiresItems": [
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 },
+                        { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 },
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your readings will be more reliable now. Store the meter and resistor safely.",
+            "options": [{ "type": "finish", "text": "All set." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/measure-resistance"]
+}


### PR DESCRIPTION
## Summary
- add quest for calibrating a multimeter against a 220 Ω resistor
- document new quest in `new-quests.md`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a10d430034832fa6f748c80fbaa9cb