### PR TITLE
📝 : cross-link CI fix prompt across Codex docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -62,7 +62,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-upgrader">Prompt Upgrader</a>
-            <a href="/docs/prompts-codex-ci-fix">CI-failure fix prompt</a>
+            <a href="/docs/prompts-codex-ci-fix">Codex CI-failure fix prompt</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -7,7 +7,8 @@ slug: 'prompts-codex-meta'
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
 instructions improve themselves over time. If the templates themselves drift, refresh
-them using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+them using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing
+workflows, see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 ```text
 SYSTEM:

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -7,8 +7,10 @@ slug: 'prompts-codex-upgrader'
 
 Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
 instructions current—the machine that builds the machine. See
-[Codex Prompts](/docs/prompts-codex) for the baseline templates and the
-[Codex Meta Prompt](/docs/prompts-codex-meta) for routine maintenance.
+[Codex Prompts](/docs/prompts-codex) for the baseline templates, the
+[Codex Meta Prompt](/docs/prompts-codex-meta) for routine maintenance, and the
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix) for troubleshooting failing
+workflows.
 
 ```text
 SYSTEM:

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,7 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), and [Refactor prompts](/docs/prompts-refactors).
-For specialized workflows use the [CI-failure fix prompt](/docs/prompts-codex-ci-fix),
+For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
@@ -28,7 +28,7 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the [Codex Prompt Upgrade
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
-[CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 ---
 
@@ -41,7 +41,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [Refactor Prompts](/docs/prompts-refactors)
--   [CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
+-   [Codex CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)
 -   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -10,6 +10,7 @@ ready-made PR—but only if given a clear, file-scoped prompt. Use this guide al
 [Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
 and consistent. To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
 If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -11,6 +11,7 @@ clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on items. To keep the prompt
 docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
 templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 For general content rules see the [Item Development Guidelines](/docs/item-guidelines).
 
 > **TL;DR**

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -11,7 +11,8 @@ Use this guide alongside [Codex Prompts](/docs/prompts-codex) when working on NP
 Consult the [NPCs guide](/docs/npcs) for voice and lore details.
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
 If these templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs,
+use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -10,6 +10,7 @@ Use this guide alongside [Codex Prompts](/docs/prompts-codex) so every fix ships
 record in the outage catalog.
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta);
 if templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -11,6 +11,7 @@ clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on processes. To keep the
 prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
 templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 For fundamental design tips see the
 [Process Development Guidelines](/docs/process-guidelines).
 

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -11,6 +11,7 @@ clear, file‑scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when working on quests. To keep the prompt
 docs improving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
 templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 For the steps required to share quests with the community, see the
 [Quest Submission Guide](/docs/quest-submission). Comprehensive content
 guidelines live in our [Content Development Guide](/docs/content-development),

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -9,7 +9,8 @@ Codex is a sandboxed engineering agent that can open this repository and send a 
 —but only if you give it a clear, file-scoped prompt. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex) when refactoring code. To keep the prompt docs evolving, see the
 [Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- link Codex CI-failure fix prompt from core prompt docs
- surface CI-failure fix prompt on docs index
- sync prompt templates with CI-failure guidance

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a10cfa7390832f8a69676a77a88e2d