### PR TITLE
docs: add Echo NPC and update Hydro dialogue

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -60,6 +60,7 @@ Hydro, a relaxed and affable team member, has a gift for hydroponics and sustain
 -   "I know, right? It's almost like the gamedev is awkwardly reusing existing game systems."
 -   "Let's try stevia next. Its leaves are unbelievably sweet!"
 -   "If the pH drifts, a splash of lemon juice or baking soda can nudge it back on track."
+-   "Yellow leaves? Check nutrient levels; a pinch of minerals usually sets things right."
 
 ## Orion
 
@@ -188,6 +189,22 @@ They rarely miss a detail and prefer to let records speak for themselves.
 -   "A quick signature and your blueprint enters the annals."
 -   "Careful with that relic; it's older than the guild itself."
 -   "Need a refresher on past missions? I've indexed every triumph and blunder."
+
+## Echo
+
+<img src="/assets/npc/nova.jpg" />
+
+Echo coordinates the guild's sensor drones from a quiet orbital perch.
+They have a calm demeanor and a sharp ear for anomalies.
+Echo routes signals and keeps comms clear for every mission.
+
+### Sample Dialogue
+
+-   "This is Echo on comms; I read you loud and clear."
+-   "Ping the relay buoy—if it blinks green, the link's solid."
+-   "Getting static? Rotate your antenna toward the station."
+-   "We log every packet; lose one and I'll know."
+-   "Need eyes on the horizon? I'll swing a drone that way."
 
 <style>
     img {


### PR DESCRIPTION
## Summary
- add Echo, a communications specialist, with sample dialogue
- note Hydro's yellow-leaf nutrient tip

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a10d1845b0832fa7e8df4c80bae1b6