### PR TITLE
Add migration tests for local-first architecture

### DIFF
--- a/frontend/__tests__/migrations.test.js
+++ b/frontend/__tests__/migrations.test.js
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'fake-indexeddb/auto';
+import { vi } from 'vitest';
+
+const itemValidator = vi.fn(() => ({ valid: true, errors: [] }));
+const processValidator = vi.fn(() => ({ valid: true, errors: [] }));
+const questValidator = vi.fn(() => ({ valid: true, errors: [] }));
+
+vi.mock('../src/utils/customItemValidation.js', () => ({
+    validateItemData: itemValidator,
+}));
+vi.mock('../src/utils/customProcessValidation.js', () => ({
+    validateProcessData: processValidator,
+}));
+vi.mock('../src/utils/customQuestValidation.js', () => ({
+    validateQuestData: questValidator,
+}));
+
+const { runMigrations, getCurrentSchemaVersion } = await import('../src/utils/migrations.js');
+
+function openDb() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open('test-migrations', 1);
+        request.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            db.createObjectStore('meta');
+            ['items', 'processes', 'quests'].forEach((name) => {
+                const store = db.createObjectStore(name, { keyPath: 'id' });
+                store.add({ id: '1' });
+            });
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function getRecord(db, store, id) {
+    const tx = db.transaction(store, 'readonly');
+    const obj = tx.objectStore(store);
+    const req = obj.get(id);
+    return new Promise((resolve, reject) => {
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = (e) => reject(e.target.error);
+    });
+}
+
+describe('migrations.runMigrations', () => {
+    let db;
+    beforeEach(async () => {
+        indexedDB.deleteDatabase('test-migrations');
+        db = await openDb();
+    });
+    afterEach(() => {
+        db.close();
+    });
+
+    test('applies migrations and updates schema', async () => {
+        await runMigrations(db, 3);
+        const record = await getRecord(db, 'items', '1');
+        expect(record.createdAt).toBeTruthy();
+        expect(record.updatedAt).toBeTruthy();
+        const version = await getCurrentSchemaVersion(db);
+        expect(version).toBe(3);
+    });
+
+    test('throws when validation fails', async () => {
+        itemValidator.mockReturnValueOnce({ valid: false, errors: ['invalid'] });
+        await expect(runMigrations(db, 3)).rejects.toThrow('Data integrity validation failed');
+    });
+});

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -51,7 +51,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Testing environment for custom content 💯
         -   [x] Validation feedback system 💯
 
--   [x] Local‑First Architecture
+-   [x] Local‑First Architecture 💯
 
     -   [x] IndexedDB implementation 💯
     -   [x] Data migration system 💯


### PR DESCRIPTION
## Summary
- test migration handling and version updates in IndexedDB
- mark Local-First Architecture checklist item as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm_config_yes=true npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a10cf26ae0832f8061f105ed5d2485