### PR TITLE
✨ Improve token.place error handling

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -49,4 +49,22 @@ describe('tokenPlaceChat', () => {
         expect(body.messages[0].role).toBe('system');
         expect(result).toBe('mocked reply');
     });
+
+    test('passes abort signal to fetch', async () => {
+        loadGameState.mockReturnValue({});
+        const controller = new AbortController();
+        await tokenPlaceChat([], { signal: controller.signal });
+        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
+    });
+
+    test('throws helpful error when request fails', async () => {
+        loadGameState.mockReturnValue({});
+        fetch.mockResolvedValueOnce({
+            ok: false,
+            json: () => Promise.resolve({ error: 'bad request' }),
+        });
+        await expect(tokenPlaceChat([])).rejects.toThrow(
+            'token.place API request failed: bad request'
+        );
+    });
 });

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -60,7 +60,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Data integrity validation 💯
         -   [x] Rollback functionality 💯
 
--   [x] AI Integration
+-   [x] AI Integration 💯
 
     -   [x] token.place integration 💯
 

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -16,3 +16,6 @@ VITE_TOKEN_PLACE_URL=https://my-token-place/api npm run dev
 ```
 
 You can clear the saved URL by resetting your game state.
+
+`tokenPlaceChat` accepts an optional `AbortSignal` and throws a descriptive error when the
+service returns one, making failures easier to diagnose.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,7 +13,7 @@ const getEnvUrl = () => {
     return null;
 };
 
-export const tokenPlaceChat = async (messages) => {
+export const tokenPlaceChat = async (messages, { signal } = {}) => {
     const envUrl = getEnvUrl();
     const baseUrl = loadGameState().tokenPlace?.url || envUrl || DEFAULT_URL;
 
@@ -39,10 +39,22 @@ export const tokenPlaceChat = async (messages) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ messages: combinedMessages }),
+        signal,
     });
 
     if (!response.ok) {
-        throw new Error('token.place API request failed');
+        let details;
+        try {
+            const err = await response.json();
+            details = err.error || err.message || response.statusText;
+        } catch {
+            try {
+                details = await response.text();
+            } catch {
+                details = response.statusText;
+            }
+        }
+        throw new Error(`token.place API request failed: ${details}`);
     }
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- handle token.place API errors with descriptive messages
- allow aborting token.place requests
- document token.place options and mark AI Integration complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a10cf26ae0832f8061f105ed5d2485