### PR TITLE
🧭 : document user journeys and test prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -49,6 +49,7 @@ import Page from '../../components/Page.astro';
         <nav>
             <a href="/docs/prs">Pull Requests</a>
             <a href="/docs/bounties">Bounties</a>
+            <a href="/docs/user-journeys">User journeys</a>
             <a href="/docs/self-hosting">Self-hosting</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
@@ -56,6 +57,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
+            <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#implementation-prompt">Codex implementation prompt</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -40,6 +40,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [NPC Prompts](/docs/prompts-npcs)
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
+-   [Playwright Test Prompts](/docs/prompts-playwright-tests)
 -   [Refactor Prompts](/docs/prompts-refactors)
 -   [Codex CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -1,0 +1,35 @@
+---
+title: 'Playwright Test Prompts'
+slug: 'prompts-playwright-tests'
+---
+
+# Playwright test prompts for the _dspace_ repo
+
+Use this template to add end-to-end coverage for journeys listed in
+[User journeys](/docs/user-journeys).
+
+> **TL;DR**
+>
+> 1. Pick a journey marked "No" in `user-journeys.md`.
+> 2. Add a Playwright test under `frontend/e2e`.
+> 3. Update `user-journeys.md` to mark it covered.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+>    and commit with an emoji.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
+
+USER:
+1. Choose an uncovered journey from `frontend/src/pages/docs/md/user-journeys.md`.
+2. Implement a Playwright test in `frontend/e2e/` for that journey.
+3. Update the coverage table in `user-journeys.md`.
+4. Run `git diff --cached | ./scripts/scan-secrets.py`.
+5. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request adding the test and documentation with all checks green.
+```

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -1,0 +1,41 @@
+---
+title: 'User Journeys and Test Coverage'
+slug: 'user-journeys'
+---
+
+# User journeys
+
+This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
+
+| Journey                    | Playwright coverage | Test file                                            |
+| -------------------------- | ------------------- | ---------------------------------------------------- |
+| Home page loads            | No                  | `frontend/e2e/backlog/home-page-basic.spec.ts`       |
+| Docs navigation            | No                  | `frontend/e2e/backlog/docs-navigation.spec.ts`       |
+| Built-in quest detail      | Yes                 | `frontend/e2e/builtin-quests.spec.ts`                |
+| Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                        |
+| Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`                |
+| Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`          |
+| Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`               |
+| Custom content integration | Yes                 | `frontend/e2e/custom-content.spec.ts`                |
+| Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`              |
+| Custom backup              | Yes                 | `frontend/e2e/custom-backup.spec.ts`                 |
+| Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`            |
+| Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts`    |
+| Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`                |
+| Cloud sync                 | No                  | `frontend/e2e/backlog/cloud-sync.spec.ts`            |
+| Manage items               | No                  | `frontend/e2e/backlog/manage-items.spec.ts`          |
+| Manage processes           | No                  | `frontend/e2e/backlog/manage-processes.spec.ts`      |
+| Manage quests              | No                  | `frontend/e2e/backlog/manage-quests.spec.ts`         |
+| Manage quests search       | No                  | `frontend/e2e/backlog/manage-quests-search.spec.ts`  |
+| Quest PR form              | No                  | `frontend/e2e/backlog/quest-pr-form.spec.ts`         |
+| Quest form validation      | No                  | `frontend/e2e/backlog/quest-form-validation.spec.ts` |
+| Quest PR validation        | No                  | `frontend/e2e/backlog/quest-pr-validation.spec.ts`   |
+| Quest success message      | No                  | `frontend/e2e/backlog/quest-success-message.spec.ts` |
+| Item/process preview       | No                  | `frontend/e2e/backlog/item-process-preview.spec.ts`  |
+| Mobile item form           | No                  | `frontend/e2e/backlog/mobile-item-form.spec.ts`      |
+| Mobile process form        | No                  | `frontend/e2e/backlog/mobile-process-form.spec.ts`   |
+| Mobile quest form          | No                  | `frontend/e2e/backlog/mobile-quest-form.spec.ts`     |
+| Touch item selector        | No                  | `frontend/e2e/backlog/touch-item-selector.spec.ts`   |
+| Touch menu navigation      | No                  | `frontend/e2e/backlog/touch-menu.spec.ts`            |
+| UI responsiveness          | No                  | `frontend/e2e/backlog/ui-responsiveness.spec.ts`     |
+| Failover status page       | No                  | `frontend/e2e/backlog/failover-status.spec.ts`       |


### PR DESCRIPTION
## What
- add user-journeys table with Playwright coverage
- add Playwright test prompt and cross-link docs

## Why
- map user journeys and highlight missing E2E tests

## How to Test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a18f3d0b50832f810bdb67cdcd10a5