### PR TITLE
📚: expand Playwright test prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -6,15 +6,20 @@ slug: 'prompts-playwright-tests'
 # Playwright test prompts for the _dspace_ repo
 
 Use this template to add end-to-end coverage for journeys listed in
-[User journeys](/docs/user-journeys).
+[User journeys](/docs/user-journeys). While working, review the existing
+journeys for inaccuracies or misunderstandings and expand the list as new
+features land. Treat this prompt as living documentation—periodically refine
+it using other `prompts-*.md` files for inspiration.
 
 > **TL;DR**
 >
-> 1. Pick a journey marked "No" in `user-journeys.md`.
-> 2. Add a Playwright test under `frontend/e2e`.
-> 3. Update `user-journeys.md` to mark it covered.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+> 1. Review `user-journeys.md`, correcting errors or outdated steps.
+> 2. Pick a journey marked "No" or add new journeys as needed.
+> 3. Add a Playwright test under `frontend/e2e`.
+> 4. Update `user-journeys.md` to reflect coverage and fixes.
+> 5. Iterate on this prompt when improvements surface.
+> 6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 7. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >    and commit with an emoji.
 
 ```text
@@ -24,12 +29,16 @@ Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci` pass before committing.
 
 USER:
-1. Choose an uncovered journey from `frontend/src/pages/docs/md/user-journeys.md`.
-2. Implement a Playwright test in `frontend/e2e/` for that journey.
-3. Update the coverage table in `user-journeys.md`.
-4. Run `git diff --cached | ./scripts/scan-secrets.py`.
-5. Use an emoji-prefixed commit message.
+1. Audit `frontend/src/pages/docs/md/user-journeys.md` for mistakes and
+   propose fixes or additional journeys.
+2. Select an uncovered or newly added journey and implement a Playwright test
+   in `frontend/e2e/`.
+3. Update the coverage table and any corrected steps in `user-journeys.md`.
+4. Improve this prompt if clearer guidance emerges.
+5. Run `git diff --cached | ./scripts/scan-secrets.py`.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
-A pull request adding the test and documentation with all checks green.
+A pull request adding the test, doc updates, and any prompt refinements with all
+checks green.
 ```


### PR DESCRIPTION
## What
- expand Playwright test prompt to correct and extend user journeys
- encourage meta improvements using other prompt docs

## Why
- keep journey coverage accurate and growing
- refine prompt via meta review

## How to test
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- npm run audit:ci # fails: send <0.19.0 vuln

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a266310750832f92beb4bc41bebc46