### PR TITLE
📝 refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -55,7 +55,8 @@ CONTEXT:
 REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
 2. Commit the minimal changes needed to fix it. Before committing, run
-   `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets. Use an
+   emoji-prefixed commit message.
 3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
 4. Push to a branch named `codex/ci-fix/<short-description>`.
 5. Open a pull request that leaves all CI checks green.

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -6,9 +6,10 @@ slug: 'prompts-codex-meta'
 # Codex Meta Prompt
 
 Use this prompt when you want Codex to upgrade DSPACE's prompt documentation so the
-instructions improve themselves over time. If the templates themselves drift, refresh
-them using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing
-workflows, see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+instructions improve themselves over time. For baseline conventions, see
+[Codex Prompts](/docs/prompts-codex). If the templates themselves drift, refresh them
+using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing workflows,
+see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 ```text
 SYSTEM:
@@ -22,6 +23,7 @@ USER:
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
 5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,9 +13,11 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), and [Refactor prompts](/docs/prompts-refactors).
+[Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
+and [Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
-the [Codex meta prompt](/docs/prompts-codex-meta), and the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+the [Codex meta prompt](/docs/prompts-codex-meta), and the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**
 >
@@ -157,6 +159,8 @@ USER:
 2. Fix outdated instructions, links or formatting.
 3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -5,11 +5,15 @@ slug: 'prompts-playwright-tests'
 
 # Playwright test prompts for the _dspace_ repo
 
-Use this template to add end-to-end coverage for journeys listed in
-[User journeys](/docs/user-journeys). While working, review the existing
-journeys for inaccuracies or misunderstandings and expand the list as new
-features land. Treat this prompt as living documentation—periodically refine
-it using other `prompts-*.md` files for inspiration.
+Use this template alongside [Codex Prompts](/docs/prompts-codex) to add
+end-to-end coverage for journeys listed in [User journeys](/docs/user-journeys).
+While working, review the existing journeys for inaccuracies or misunderstandings
+and expand the list as new features land. To keep the prompt docs evolving, see
+the [Codex meta prompt](/docs/prompts-codex-meta). If these templates drift,
+refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For
+failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+Treat this prompt as living documentation—periodically refine it using other
+`prompts-*.md` files for inspiration.
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- cross-link Playwright test guide from Codex prompts
- add baseline, commit, and CI-fix references across Codex templates

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a0246300832f8e7a9820670ff1c9