### PR TITLE
docs: wrap item prompt test commands

### DIFF
--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -40,7 +40,8 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && npm run audit:ci && npm run itemValidation && npm run test:ci && npm run test:ci -- itemQuality"
+        codex exec "npm run lint && npm run type-check && npm run build && npm run audit:ci && \
+        npm run itemValidation && npm run test:ci && npm run test:ci -- itemQuality"
         ```
 
 See the [OpenAI CLI docs][openai-cli] for more flags.
@@ -78,7 +79,8 @@ REQUIREMENTS
 3. Ensure the item is referenced by at least one quest or process; update those
    files and create missing processes as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.


### PR DESCRIPTION
## Summary
- wrap long `codex exec` command in item prompts guide for readability
- adjust requirement list to respect 100-char line limit

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails to finish pre-PR checks; tests themselves pass)*


------
https://chatgpt.com/codex/tasks/task_e_68a2a01e84d0832f84fc7d690da3b721