### PR TITLE
♻️ Refactor price lookup and add benchmark

### DIFF
--- a/backend/approximateIrlPrice.bench.ts
+++ b/backend/approximateIrlPrice.bench.ts
@@ -1,0 +1,12 @@
+import { bench, describe } from 'vitest'
+import { approximateIrlPrice } from './approximateIrlPrice'
+
+describe('approximateIrlPrice benchmark', () => {
+  bench('lookup base id', () => {
+    approximateIrlPrice('3d_printer')
+  })
+
+  bench('lookup with normalization', () => {
+    approximateIrlPrice(' 3D-Printer ')
+  })
+})

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -22,8 +22,4 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice(null as any)).toBeNull()
     expect(approximateIrlPrice(undefined as any)).toBeNull()
   })
-
-  it('ignores surrounding whitespace', () => {
-    expect(approximateIrlPrice(' 3d printer ')).toBe(350)
-  })
 })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -19,8 +19,14 @@ const priceTable: Record<string, number> = {
   "battery_pack_1kwh": 1000,
   "solar_panel_200w": 200,
   "m2_poe_hat": 25,
-  "ssd_1tb": 120
+  "ssd_1tb": 120,
 };
+
+const NORMALIZE_REGEX = /[\s-]+/g;
+
+function normalizeId(id: string): string {
+  return id.trim().toLowerCase().replace(NORMALIZE_REGEX, '_');
+}
 
 /**
  * Look up a real‑world price for a game item.
@@ -33,6 +39,6 @@ export function approximateIrlPrice(id: string | null | undefined): number | nul
   if (typeof id !== 'string') {
     return null;
   }
-  const normalized = id.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = normalizeId(id);
   return priceTable[normalized] ?? null;
 }


### PR DESCRIPTION
## Summary
- refactor price lookup normalization with helper and regex
- add vitest benchmark for lookup normalization
- trim duplicate test case

## Testing
- `npx vitest bench backend/approximateIrlPrice.bench.ts`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a29ffcc7b4832fab77dbdf5507a6df