### PR TITLE
♻️ refactor fs-checks to use for-of loop

### DIFF
--- a/scripts/tests/fsChecks.bench.ts
+++ b/scripts/tests/fsChecks.bench.ts
@@ -1,0 +1,8 @@
+import { bench } from 'vitest';
+import { listMissingImages } from '../utils/fs-checks';
+
+const images = Array.from({ length: 1000 }, (_, i) => `missing-${i}.png`);
+
+bench('listMissingImages 1k missing images', () => {
+  listMissingImages(images, '/tmp');
+});

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -10,29 +10,29 @@ const path = require('path');
  * @returns {string[]}
  */
 function listMissingImages(
-    imagePaths,
-    publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
+  imagePaths,
+  publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
 ) {
-    const missing = [];
-    imagePaths.forEach((img) => {
-        // Strip query strings or hash fragments so existence checks aren't fooled
-        const base = img.split(/[?#]/)[0];
-        if (/^data:/i.test(base) || /^(?:https?:)?\/\//i.test(base)) {
-            return;
-        }
-        const rel = base.startsWith('/') ? base.slice(1) : base;
-        let decoded;
-        try {
-            decoded = decodeURIComponent(rel);
-        } catch {
-            decoded = rel;
-        }
-        const full = path.join(publicDir, decoded);
-        if (!fs.existsSync(full)) {
-            missing.push(img);
-        }
-    });
-    return missing;
+  const missing = [];
+  for (const img of imagePaths) {
+    // Strip query strings or hash fragments so existence checks aren't fooled
+    const base = img.split(/[?#]/)[0];
+    if (/^data:/i.test(base) || /^(?:https?:)?\/\//i.test(base)) {
+      continue;
+    }
+    const rel = base.startsWith('/') ? base.slice(1) : base;
+    let decoded;
+    try {
+      decoded = decodeURIComponent(rel);
+    } catch {
+      decoded = rel;
+    }
+    const full = path.join(publicDir, decoded);
+    if (!fs.existsSync(full)) {
+      missing.push(img);
+    }
+  }
+  return missing;
 }
 
 module.exports = { listMissingImages };


### PR DESCRIPTION
## Summary
- refactor listMissingImages to iterate with for-of
- add vitest benchmark for listMissingImages

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx vitest bench scripts/tests/fsChecks.bench.ts`
- `npm run coverage` *(fails: coverage file not found)*
- `node scripts/checkPatchCoverage.cjs` *(fails: coverage file not found)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a29ffcc7b4832fab77dbdf5507a6df