### PR TITLE
Add custom output directory to backup script

### DIFF
--- a/docs/backup_system.md
+++ b/docs/backup_system.md
@@ -19,6 +19,12 @@ To back up specific paths pass them as arguments:
 node scripts/backup.mjs package.json docs
 ```
 
+To change the output directory, use `--out`:
+
+```bash
+node scripts/backup.mjs --out my-backups package.json docs
+```
+
 ## Restore
 
 Extract the desired archive and replace the existing directories:

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -64,7 +64,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
     -   [x] token.place integration 💯
 
--   [x] Infrastructure
+-   [x] Infrastructure 💯
 
     -   [x] Self‑hosted setup documentation 💯
     -   [x] Docker deployment 💯

--- a/scripts/backup.mjs
+++ b/scripts/backup.mjs
@@ -3,13 +3,25 @@ import { execSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
 
-const targets = process.argv.slice(2);
+const rawArgs = process.argv.slice(2);
+let outDir = 'backups';
+const targets = [];
+for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg === '--out' || arg === '-o') {
+        outDir = rawArgs[i + 1] ?? outDir;
+        i += 1;
+    } else {
+        targets.push(arg);
+    }
+}
+
 const sources = targets.length > 0 ? targets : ['backend', 'frontend'];
 
-const outDir = path.resolve('backups');
-mkdirSync(outDir, { recursive: true });
+const outPath = path.resolve(outDir);
+mkdirSync(outPath, { recursive: true });
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-const file = path.join(outDir, `backup-${timestamp}.tar.gz`);
+const file = path.join(outPath, `backup-${timestamp}.tar.gz`);
 const args = sources.map((p) => `'${p}'`).join(' ');
 execSync(`tar -czf '${file}' ${args}`, { stdio: 'inherit' });
 console.log(`Created backup at ${file}`);

--- a/tests/backupScript.test.ts
+++ b/tests/backupScript.test.ts
@@ -12,3 +12,13 @@ test('backup script creates tarball', () => {
     expect(files[0]).toMatch(/^backup-.*\.tar\.gz$/);
     rmSync(dir, { recursive: true, force: true });
 });
+
+test('--out writes to custom directory', () => {
+    const dir = path.resolve('tmp-backups');
+    rmSync(dir, { recursive: true, force: true });
+    execSync('node scripts/backup.mjs --out tmp-backups package.json');
+    const files = readdirSync(dir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^backup-.*\.tar\.gz$/);
+    rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- allow specifying `--out` directory in backup script
- test backup script `--out` option
- document backup directory flag and mark Infrastructure as complete

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2a018dc74832f916e903693847f3b