### PR TITLE
🔐 refine ssh hardening quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -328,6 +328,7 @@
       "hydroponics/nutrient-check",
       "firstaid/dispose-expired",
       "electronics/solder-wire",
+      "electronics/solder-led-harness",
       "electronics/measure-resistance",
       "electronics/light-sensor",
       "electronics/led-polarity",
@@ -850,6 +851,7 @@
   "037e6065-68a7-4ad1-9b0b-7778ecfe0662": {
     "requires": [
       "electronics/voltage-divider",
+      "electronics/solder-led-harness",
       "electronics/resistor-color-check",
       "electronics/potentiometer-dimmer",
       "electronics/measure-resistance",
@@ -864,6 +866,7 @@
       "electronics/voltage-divider",
       "electronics/thermistor-reading",
       "electronics/solder-wire",
+      "electronics/solder-led-harness",
       "electronics/servo-sweep",
       "electronics/potentiometer-dimmer",
       "electronics/measure-led-current",
@@ -901,7 +904,8 @@
       "electronics/potentiometer-dimmer",
       "electronics/measure-arduino-5v",
       "electronics/light-sensor",
-      "electronics/arduino-blink"
+      "electronics/arduino-blink",
+      "devops/ssh-hardening"
     ],
     "rewards": []
   },
@@ -909,6 +913,7 @@
     "requires": [
       "electronics/tin-soldering-iron",
       "electronics/solder-wire",
+      "electronics/solder-led-harness",
       "electronics/desolder-component"
     ],
     "rewards": []
@@ -928,7 +933,8 @@
   "f6bb2c1a-0001-46bd-998a-388a488b5b5c": {
     "requires": [],
     "rewards": [
-      "electronics/solder-wire"
+      "electronics/solder-wire",
+      "electronics/solder-led-harness"
     ]
   },
   "6a3772b6-2550-434f-89f9-2eb53d5b139f": {
@@ -961,20 +967,21 @@
     ],
     "rewards": []
   },
-  "bf3d2784-d48d-4b12-b12a-75f563b5dc88": {
-    "requires": [
-      "electronics/resistor-color-check",
-      "electronics/basic-circuit"
-    ],
-    "rewards": []
-  },
   "48cf736e-184c-4bd1-b9b0-15b7e9721646": {
     "requires": [
+      "electronics/solder-led-harness",
       "electronics/potentiometer-dimmer",
       "electronics/measure-led-current",
       "electronics/led-polarity",
       "electronics/basic-circuit",
       "electronics/arduino-blink"
+    ],
+    "rewards": []
+  },
+  "bf3d2784-d48d-4b12-b12a-75f563b5dc88": {
+    "requires": [
+      "electronics/resistor-color-check",
+      "electronics/basic-circuit"
     ],
     "rewards": []
   },
@@ -1151,6 +1158,7 @@
       "astronomy/venus-phases",
       "astronomy/saturn-rings",
       "astronomy/orion-nebula",
+      "astronomy/meteor-shower",
       "astronomy/light-pollution",
       "astronomy/andromeda"
     ],
@@ -1180,6 +1188,8 @@
   "9a72fb16-fc69-45c5-beca-f25c27028977": {
     "requires": [
       "astronomy/orion-nebula",
+      "astronomy/observe-moon",
+      "astronomy/meteor-shower",
       "astronomy/light-pollution",
       "astronomy/aurora-watch",
       "astronomy/andromeda"
@@ -1189,9 +1199,22 @@
   "70bb8d86-2c4e-4330-9705-371891934686": {
     "requires": [
       "astronomy/observe-moon",
+      "astronomy/meteor-shower",
       "astronomy/light-pollution",
       "astronomy/iss-photo",
       "astronomy/iss-flyover"
+    ],
+    "rewards": []
+  },
+  "aa82b02f-2617-4474-a91b-29647e4a9780": {
+    "requires": [
+      "astronomy/observe-moon"
+    ],
+    "rewards": []
+  },
+  "4729b96d-5057-40d8-83a4-25a4fa122d98": {
+    "requires": [
+      "astronomy/observe-moon"
     ],
     "rewards": []
   },

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4234,6 +4234,50 @@
         }
     },
     {
+        "id": "generate-ssh-key",
+        "title": "Generate an SSH key pair and copy it to a node",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            },
+            {
+                "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
+        "id": "harden-sshd-config",
+        "title": "Disable password login and root SSH access, then restart sshd",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "measure-filament-diameter",
         "title": "Measure 1.75 mm filament diameter with digital calipers",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3274,6 +3274,39 @@
         }
     },
     {
+        "id": "generate-ssh-key",
+        "title": "Generate an SSH key pair and copy it to a node",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d", "count": 1 },
+            { "id": "df7e94e2-76b9-4865-b843-2ec21feb258e", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
+        "id": "harden-sshd-config",
+        "title": "Disable password login and root SSH access, then restart sshd",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [{ "id": "df7e94e2-76b9-4865-b843-2ec21feb258e", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "3m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "measure-filament-diameter",
         "title": "Measure 1.75 mm filament diameter with digital calipers",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/hardening/generate-ssh-key.json
+++ b/frontend/src/pages/processes/hardening/generate-ssh-key.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/processes/hardening/harden-sshd-config.json
+++ b/frontend/src/pages/processes/hardening/harden-sshd-config.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/quests/json/devops/ssh-hardening.json
+++ b/frontend/src/pages/quests/json/devops/ssh-hardening.json
@@ -2,13 +2,25 @@
     "id": "devops/ssh-hardening",
     "title": "Harden SSH Access",
     "description": "Use key-based authentication and disable password logins.",
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-18",
+                "date": "2025-08-18",
+                "score": 60
+            }
+        ]
+    },
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Let's secure your node's SSH service.",
+            "text": "Let's secure your Pi cluster node's SSH service. Keep a laptop handy.",
             "options": [
                 {
                     "type": "goto",
@@ -19,8 +31,13 @@
         },
         {
             "id": "keys",
-            "text": "Generate an SSH key pair and copy the public key into ~/.ssh/authorized_keys on the node.",
+            "text": "On your laptop, run `ssh-keygen -t ed25519` to create a key pair. Use `ssh-copy-id` to add the public key to `~/.ssh/authorized_keys` on the Pi cluster node. Protect the private key with a strong passphrase.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "generate-ssh-key",
+                    "text": "Generate and copy key."
+                },
                 {
                     "type": "goto",
                     "goto": "config",
@@ -29,6 +46,10 @@
                         {
                             "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
                             "count": 1
+                        },
+                        {
+                            "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                            "count": 1
                         }
                     ]
                 }
@@ -36,12 +57,23 @@
         },
         {
             "id": "config",
-            "text": "Edit /etc/ssh/sshd_config to disable password authentication and root login, then restart the service.",
+            "text": "Back up `/etc/ssh/sshd_config`. Set `PasswordAuthentication no` and `PermitRootLogin no`, then run `sudo systemctl restart ssh`. Confirm your key works before logging out.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "harden-sshd-config",
+                    "text": "Update sshd_config."
+                },
                 {
                     "type": "goto",
                     "goto": "finish",
-                    "text": "Service restarted."
+                    "text": "Service restarted.",
+                    "requiresItems": [
+                        {
+                            "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- clarify devops/ssh-hardening quest with key generation and config edits
- add generate-ssh-key and harden-sshd-config processes with metadata
- track new processes in hardening records

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `detect-secrets scan /tmp/diff.patch`

------
https://chatgpt.com/codex/tasks/task_e_68a29fcfe84c832f94361ab3d68cf6d6