### PR TITLE
docs: refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -9,7 +9,12 @@ DSPACE is mostly frontend code, but some backend pieces support self-hosting via
 [Sugarkube's RasPi cluster](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md).
 Use this guide when editing `backend/` modules. Contributions must deliver clear user value and
 honor end-user privacy, dignity, and agency as outlined in
-[Gabriel](https://github.com/futuroptimist/gabriel).
+[Gabriel](https://github.com/futuroptimist/gabriel). Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) so instructions stay consistent. To keep the
+prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If
+these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub
+Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,7 +13,8 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), [Backend prompts](/docs/prompts-backend), and
+[Docs prompts](/docs/prompts-docs), [Backend prompts](/docs/prompts-backend),
+[Playwright test prompts](/docs/prompts-playwright-tests), and
 [Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
@@ -25,8 +26,8 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`; scan staged changes with
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
@@ -65,12 +66,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                        |
-| **Files to touch**   | Limits search space → faster & cheaper.                                                                 |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                                          |
-| **Acceptance check** | e.g. `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
+| **Files to touch**   | Limits search space → faster & cheaper.                                             |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
+| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -92,7 +93,7 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -123,8 +124,8 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
+`AGENTS.md` and ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
 USER:
@@ -151,8 +152,8 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
@@ -176,8 +177,8 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing


### PR DESCRIPTION
## Summary
- link backend prompts to Codex prompt ecosystem
- streamline Codex prompt checks and reference Playwright guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c6c9cff8832f992541a2f60702a8