### PR TITLE
docs: add cross-link prompt to docs guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -58,6 +58,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
+            <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -42,6 +42,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [NPC Prompts](/docs/prompts-npcs)
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
+-   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
 -   [Backend Prompts](/docs/prompts-backend)
 -   [Playwright Test Prompts](/docs/prompts-playwright-tests)
 -   [Refactor Prompts](/docs/prompts-refactors)

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -6,11 +6,12 @@ slug: 'prompts-docs'
 # Documentation prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
-ready-made PR—but only if given a clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when updating markdown or JSDoc so instructions stay current
-and consistent. To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta).
-If these templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
-For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+ready-made PR — but only if given a clear, file-scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when updating Markdown or JSDoc so instructions stay
+current and consistent. To keep these templates evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If they drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >
@@ -36,4 +37,24 @@ USER:
 
 OUTPUT:
 A pull request with refreshed documentation and passing checks.
+```
+
+## Cross-link check prompt
+
+Use this when adding or renaming docs to keep internal links current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
+committing.
+
+USER:
+1. Audit the documentation for missing or broken cross-links.
+2. Update `frontend/src/pages/docs/index.astro` and related guides to reference the new pages.
+3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with updated links and passing checks.
 ```


### PR DESCRIPTION
## Summary
- add cross-link check prompt to documentation prompts
- link the new section from Codex prompts and docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c6c874c0832f9acede17007bc9a7