### PR TITLE
docs: refresh Codex prompt references

### DIFF
--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -7,9 +7,13 @@ slug: 'prompts-backend'
 
 DSPACE is mostly frontend code, but some backend pieces support self-hosting via
 [Sugarkube's RasPi cluster](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md).
-Use this guide when editing `backend/` modules. Contributions must deliver clear user value and
-honor end-user privacy, dignity, and agency as outlined in
-[Gabriel](https://github.com/futuroptimist/gabriel).
+Use this guide alongside [Codex Prompts](/docs/prompts-codex) when editing
+`backend/` modules. Contributions must deliver clear user value and honor
+end-user privacy, dignity, and agency as outlined in
+[Gabriel](https://github.com/futuroptimist/gabriel). To keep the prompt docs
+evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
+templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,8 +13,8 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors).
+[Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
+[Backend prompts](/docs/prompts-backend), and [Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).


### PR DESCRIPTION
## Summary
- link backend prompts to Codex meta/upgrader/CI-fix docs
- mention Playwright test prompts in Codex overview

## Testing
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8f35dd0832fb8b5a1f7ebac7f4e