### PR TITLE
📝 refine Atlas NPC voice

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -118,15 +118,17 @@ to show how green chemistry powers missions.
 
 <img src="/assets/npc/atlas.jpg" />
 
-Atlas is a humanoid robot assistant designed to help with physical tasks that require strength and precision. With advanced AI capabilities, Atlas can perform a variety of tasks, from heavy lifting to delicate assembly work, making it an invaluable asset to the team. As our trusty robotic companion, Atlas ensures that we can accomplish our goals more efficiently and safely than ever before.
+Atlas is the guild's heavy-lift robot. Shock-absorbing armor and balanced servos let Atlas haul
+crates and steady delicate assemblies. They often help with aquarium setups like
+[Move the Walstad tank](/quests/aquaria/position-tank).
 
 ### Sample Dialogue
 
--   "Hello! I'm Atlas, your robotic assistant. Let me handle the heavy lifting."
--   "On three ... one, two, three! Easy does it."
--   "I'll keep the load steady while you guide it into place."
--   "Great work! The tank is secure on the stand."
--   "Anytime you need more muscle, just give me a shout."
+-   "Need a hand? I'm Atlas—built for muscle and finesse."
+-   "Clear the path and keep your back straight; I'll take the weight."
+-   "Lift on my count: one, two, three."
+-   "Set it down gently; glass likes patience."
+-   "Call anytime you need more torque."
 
 ## Cedar
 

--- a/frontend/src/pages/quests/json/aquaria/position-tank.json
+++ b/frontend/src/pages/quests/json/aquaria/position-tank.json
@@ -1,14 +1,14 @@
 {
     "id": "aquaria/position-tank",
     "title": "Move the Walstad tank",
-    "description": "With Atlas's help, lift the empty 80 L Walstad aquarium onto a sturdy stand. Clear the path, lift with your legs and keep the glass supported.",
+    "description": "Atlas helps you lift the empty 80 L Walstad aquarium onto a sturdy stand. Clear the path, lift with your legs and keep the glass supported.",
     "image": "/assets/quests/walstad.jpg",
     "npc": "/assets/npc/atlas.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Hello! I'm Atlas. Vega said you needed help moving that empty 80 liter tank onto the stand. Make sure the path is clear and lift with your legs, not your back.",
+            "text": "Atlas here. Vega said you need this empty 80 liter tank on the stand. Clear the path and lift with your legs.",
             "options": [
                 {
                     "type": "goto",
@@ -23,7 +23,7 @@
         },
         {
             "id": "lift",
-            "text": "I'll take most of the weight. On three—one, two, three! Keep the tank level and your back straight.",
+            "text": "I'll take most of the weight. On three—one, two, three. Keep the tank level and your back straight.",
             "options": [
                 {
                     "type": "goto",
@@ -34,7 +34,7 @@
         },
         {
             "id": "place",
-            "text": "Great job. Set it down gently, then check the stand is level and the corners are supported before letting go.",
+            "text": "Set it down gently; check the stand is level before letting go.",
             "options": [
                 {
                     "type": "goto",
@@ -45,7 +45,7 @@
         },
         {
             "id": "heat",
-            "text": "Let's warm up the tank with the heater before adding livestock. Ensure the heater is submerged before plugging it into a GFCI outlet.",
+            "text": "Warm the tank with the heater before adding livestock. Make sure it's submerged before plugging into a GFCI outlet.",
             "options": [
                 {
                     "type": "process",


### PR DESCRIPTION
## Summary
- clarify Atlas as heavy-lift robot and link to Walstad tank quest
- tighten Move the Walstad tank quest dialogue

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c9a1871c832f837809c243f367dc