### PR TITLE
Refine compost turn-pile quest and add moisture process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3930,6 +3930,32 @@
         }
     },
     {
+        "id": "measure-compost-moisture",
+        "title": "Gauge compost moisture with a probe meter",
+        "image": "/assets/bucket_water.jpg",
+        "requireItems": [
+            {
+                "id": "2b57a38d-0486-40e8-a50d-d893541b50e9",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-18",
+                    "date": "2025-08-18",
+                    "score": 60
+                }
+            ]
+        }
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3068,6 +3068,20 @@
         "duration": "1m"
     },
     {
+        "id": "measure-compost-moisture",
+        "title": "Gauge compost moisture with a probe meter",
+        "image": "/assets/bucket_water.jpg",
+        "requireItems": [
+            {
+                "id": "2b57a38d-0486-40e8-a50d-d893541b50e9",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/hardening/measure-compost-moisture.json
+++ b/frontend/src/pages/processes/hardening/measure-compost-moisture.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-18",
+            "date": "2025-08-18",
+            "score": 60
+        }
+    ]
+}

--- a/frontend/src/pages/quests/json/composting/turn-pile.json
+++ b/frontend/src/pages/quests/json/composting/turn-pile.json
@@ -3,9 +3,9 @@
     "title": "Turn Your Compost Bucket",
     "description": "Aerate the compost by stirring the mix so microbes stay active.",
     "hardening": {
-        "passes": 2,
-        "score": 65,
-        "emoji": "🌀",
+        "passes": 3,
+        "score": 90,
+        "emoji": "💯",
         "history": [
             {
                 "task": "codex-hardening-2025-08-12",
@@ -16,6 +16,11 @@
                 "task": "codex-quest-update-2025-08-16",
                 "date": "2025-08-16",
                 "score": 65
+            },
+            {
+                "task": "codex-quest-update-2025-08-18",
+                "date": "2025-08-18",
+                "score": 90
             }
         ]
     },
@@ -25,7 +30,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "A stagnant bucket can get smelly. Let's give your compost some fresh air.",
+            "text": "A stagnant bucket can smell. Wear nitrile gloves and let's give it fresh air.",
             "options": [
                 {
                     "type": "goto",
@@ -36,7 +41,7 @@
         },
         {
             "id": "mix",
-            "text": "Stir the greens and browns together until the pile feels loose and damp, not soggy.",
+            "text": "Stir greens and browns with gloved hands until loose and damp. Avoid steam.",
             "options": [
                 {
                     "type": "process",
@@ -58,6 +63,7 @@
                 {
                     "type": "goto",
                     "goto": "moisture",
+                    "process": "measure-compost-moisture",
                     "requiresItems": [
                         {
                             "id": "2b57a38d-0486-40e8-a50d-d893541b50e9",
@@ -81,7 +87,7 @@
         },
         {
             "id": "temp",
-            "text": "The probe reads about 55 °C—perfect for active decomposition.",
+            "text": "Thermometer reads 55 °C—ideal. Remove the probe carefully; it may be hot.",
             "options": [
                 {
                     "type": "goto",
@@ -92,7 +98,7 @@
         },
         {
             "id": "moisture",
-            "text": "The meter reads about 55% moisture—ideal for microbes.",
+            "text": "Meter shows 55% moisture—ideal for microbes. Rinse the probe after use.",
             "options": [
                 {
                     "type": "goto",
@@ -103,7 +109,7 @@
         },
         {
             "id": "finish",
-            "text": "Great work! Turning every few days keeps microbes happy and speeds decomposition.",
+            "text": "Great work! Turn every few days to speed decomposition. Wash hands after.",
             "options": [
                 {
                     "type": "finish",


### PR DESCRIPTION
## Summary
- clarify compost turn-pile quest with safety notes and moisture meter guidance
- add measure-compost-moisture process tied to compost moisture meter
## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a2ca2bc5e4832fb77e78cf72a37a7f