### PR TITLE
📝: document audit step in docs prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -16,23 +16,26 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-5. Use an emoji-prefixed commit message.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
+5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with refreshed documentation and passing checks.


### PR DESCRIPTION
## Summary
- mention audit:ci in documentation prompt TL;DR
- spell out full check list in system and user steps

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8ff6ae4832fbea8d0a28ceacd5a