### PR TITLE
Refine green PLA swap process and add hardening

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2965,7 +2965,8 @@
     },
     {
         "id": "swap-green-pla-filament",
-        "title": "Swap to green PLA filament on an entry-level FDM 3D printer",
+        "title": "Install green PLA filament on an entry-level FDM printer and purge 10 g",
+        "image": "/assets/pla_green.jpg",
         "requireItems": [
             {
                 "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
@@ -2983,7 +2984,19 @@
             }
         ],
         "createItems": [],
-        "duration": "10m"
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-18",
+                    "date": "2025-08-18",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "swap-white-pla-filament",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2430,7 +2430,8 @@
     },
     {
         "id": "swap-green-pla-filament",
-        "title": "Swap to green PLA filament on an entry-level FDM 3D printer",
+        "title": "Install green PLA filament on an entry-level FDM printer and purge 10 g",
+        "image": "/assets/pla_green.jpg",
         "requireItems": [
             {
                 "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
@@ -2448,7 +2449,19 @@
             }
         ],
         "createItems": [],
-        "duration": "10m"
+        "duration": "10m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-18",
+                    "date": "2025-08-18",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "swap-white-pla-filament",

--- a/frontend/src/pages/processes/hardening/swap-green-pla-filament.json
+++ b/frontend/src/pages/processes/hardening/swap-green-pla-filament.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-18",
+            "date": "2025-08-18",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
what: clarify green PLA filament swap and track hardening.
why: improve realism, item references and quality metadata.
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- npm run test:ci -- processQuality
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a2ca2c7478832fbc7fed6a22f62890