### PR TITLE
Add hardening metadata for heat-shrink tubing item

### DIFF
--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1163,7 +1163,13 @@
         "description": "Polyolefin tube that shrinks when heated to insulate exposed wire joints; sold per centimeter.",
         "image": "/assets/quests/basic_circuit.svg",
         "price": "0.05 dUSD",
-        "unit": "cm"
+        "unit": "cm",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     },
     {
         "id": "946bc4dd-32ee-434c-a8ed-d70cdce617f4",


### PR DESCRIPTION
## Summary
- add hardening metadata to heat-shrink tubing inventory item

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a2c91e5604832f8afd6f5b2a1f9203