### PR TITLE
Add brass tip cleaner item

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -930,6 +930,12 @@
     ],
     "rewards": []
   },
+  "3dbf1701-5cc0-4443-b9bf-4275b33513d0": {
+    "requires": [
+      "electronics/tin-soldering-iron"
+    ],
+    "rewards": []
+  },
   "f6bb2c1a-0001-46bd-998a-388a488b5b5c": {
     "requires": [],
     "rewards": [

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -564,5 +564,19 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0",
+        "name": "brass tip cleaner",
+        "description": "Brass wire sponge in a holder for cleaning soldering iron tips without water.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "5 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/electronics/soldering-intro.json
+++ b/frontend/src/pages/quests/json/electronics/soldering-intro.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Good to see you progressing! Before soldering, lay out a silicone mat, secure your work in helping hands, plug in your station, and have a damp sponge ready.",
+            "text": "Good to see you progressing! Before soldering, lay out a silicone mat, secure your work in helping hands, plug in your station, keep a brass tip cleaner nearby, and have a damp sponge ready.",
             "options": [
                 {
                     "type": "goto",
@@ -25,6 +25,10 @@
                         },
                         {
                             "id": "cd0e1512-9b4e-4450-92ab-b298852ca5e7",
+                            "count": 1
+                        },
+                        {
+                            "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0",
                             "count": 1
                         }
                     ]
@@ -56,7 +60,7 @@
     "rewards": [],
     "requiresQuests": ["electronics/basic-circuit"],
     "hardening": {
-        "passes": 2,
+        "passes": 3,
         "score": 60,
         "emoji": "🌀",
         "history": [
@@ -68,6 +72,11 @@
             {
                 "task": "codex-quest-hardening-2025-08-15",
                 "date": "2025-08-15",
+                "score": 60
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-17",
+                "date": "2025-08-17",
                 "score": 60
             }
         ]


### PR DESCRIPTION
## Summary
- add brass tip cleaner tool item
- require cleaner in Tin a Soldering Iron quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a2c91e5604832f8afd6f5b2a1f9203