### PR TITLE
Add aquarium air pump item and quest requirement

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -1319,22 +1319,31 @@
     "rewards": []
   },
   "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56": {
-    "requires": [],
+    "requires": [
+      "aquaria/sponge-filter"
+    ],
     "rewards": [
       "aquaria/sponge-filter"
     ]
+  },
+  "60e517b4-5807-4983-afb8-e2aad1566587": {
+    "requires": [
+      "aquaria/sponge-filter",
+      "aquaria/shrimp"
+    ],
+    "rewards": []
+  },
+  "5d5e4e29-94b7-4a03-b73d-7420841ae686": {
+    "requires": [
+      "aquaria/sponge-filter"
+    ],
+    "rewards": []
   },
   "b494f643-a77a-4edf-be7e-5f7ff2dfba6a": {
     "requires": [],
     "rewards": [
       "aquaria/shrimp"
     ]
-  },
-  "60e517b4-5807-4983-afb8-e2aad1566587": {
-    "requires": [
-      "aquaria/shrimp"
-    ],
-    "rewards": []
   },
   "ee7d437d-7426-47cd-b691-386dd20f4e47": {
     "requires": [

--- a/frontend/src/pages/inventory/json/items/aquarium.json
+++ b/frontend/src/pages/inventory/json/items/aquarium.json
@@ -292,6 +292,19 @@
         }
     },
     {
+        "id": "5d5e4e29-94b7-4a03-b73d-7420841ae686",
+        "name": "aquarium air pump",
+        "description": "5 W diaphragm air pump moves 3 L/min for tanks up to 40 L; includes 1 m power cord.",
+        "image": "/assets/aquarium_filter.jpg",
+        "price": "15 dUSD",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
         "name": "Sponge filter",
         "description": "Air-driven sponge filter for ≤40 L (10 gal) tanks; 5 cm foam; needs 4 mm airline and air pump.",

--- a/frontend/src/pages/quests/json/aquaria/sponge-filter.json
+++ b/frontend/src/pages/quests/json/aquaria/sponge-filter.json
@@ -24,7 +24,12 @@
                 {
                     "type": "goto",
                     "goto": "install",
-                    "text": "Sponge rinsed and tubing attached."
+                    "text": "Sponge rinsed and tubing attached.",
+                    "requiresItems": [
+                        { "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56", "count": 1 },
+                        { "id": "60e517b4-5807-4983-afb8-e2aad1566587", "count": 1 },
+                        { "id": "5d5e4e29-94b7-4a03-b73d-7420841ae686", "count": 1 }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- add inventory entry for an aquarium air pump
- require air pump and tubing in sponge filter quest and regenerate item map

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a2c91e5604832f8afd6f5b2a1f9203