### PR TITLE
🛠️ : refactor zero test detection and add benchmark

### DIFF
--- a/scripts/tests/detectZeroTests.bench.ts
+++ b/scripts/tests/detectZeroTests.bench.ts
@@ -1,0 +1,9 @@
+import { bench } from 'vitest';
+
+const { hasZeroTests } = require('../utils/detect-zero-tests');
+
+const output = 'Test Files  0 passed\nTests  0 passed';
+
+bench('hasZeroTests on zero-test output', () => {
+  hasZeroTests(output);
+});

--- a/scripts/utils/detect-zero-tests.js
+++ b/scripts/utils/detect-zero-tests.js
@@ -1,11 +1,14 @@
+const ANSI_REGEX = /\x1B\[[0-9;]*m/g;
+const ZERO_TEST_PATTERNS = [
+  /Test Files\s+0\b/i,
+  /Tests\s+0\b/i,
+  /No test files? found/i
+];
+
 function hasZeroTests(output) {
-    // Strip ANSI color codes to ensure regex detection works with colored output
-    const clean = output.replace(/\x1B\[[0-9;]*m/g, '');
-    return (
-        /Test Files\s+0\b/i.test(clean) ||
-        /Tests\s+0\b/i.test(clean) ||
-        /No test files? found/i.test(clean)
-    );
+  // Strip ANSI color codes to ensure regex detection works with colored output
+  const clean = output.replace(ANSI_REGEX, '');
+  return ZERO_TEST_PATTERNS.some((pattern) => pattern.test(clean));
 }
 
 module.exports = { hasZeroTests };


### PR DESCRIPTION
what: factor out regexes in hasZeroTests and add benchmark
why: improve clarity and allow perf tracking
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a2ca2bd938832f88a7504aeeabd9d0