### PR TITLE
♻️ refactor fs-checks image checker

### DIFF
--- a/scripts/utils/fs-checks.bench.ts
+++ b/scripts/utils/fs-checks.bench.ts
@@ -1,0 +1,11 @@
+import { bench, describe } from 'vitest';
+import { listMissingImages } from './fs-checks.js';
+
+const images = Array.from({ length: 100 }, (_, i) => `/img-${i}.png`);
+
+describe('listMissingImages benchmark', () => {
+  bench('process 100 images', () => {
+    listMissingImages(images, __dirname);
+  });
+});
+

--- a/scripts/utils/fs-checks.d.ts
+++ b/scripts/utils/fs-checks.d.ts
@@ -1,0 +1,2 @@
+export function listMissingImages(imagePaths: string[], publicDir?: string): string[];
+

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -1,6 +1,17 @@
 const fs = require('fs');
 const path = require('path');
 
+const DATA_URL_RE = /^data:/i;
+const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
+
+function decodeSafely(str) {
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+}
+
 /**
  * Returns image paths that are missing from the public directory.
  * Handles query strings, hash fragments, and percent-encoded segments.
@@ -13,26 +24,18 @@ function listMissingImages(
   imagePaths,
   publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
 ) {
-  const missing = [];
-  for (const img of imagePaths) {
+  return imagePaths.filter((img) => {
     // Strip query strings or hash fragments so existence checks aren't fooled
     const base = img.split(/[?#]/)[0];
-    if (/^data:/i.test(base) || /^(?:https?:)?\/\//i.test(base)) {
-      continue;
+    if (DATA_URL_RE.test(base) || REMOTE_URL_RE.test(base)) {
+      return false;
     }
     const rel = base.startsWith('/') ? base.slice(1) : base;
-    let decoded;
-    try {
-      decoded = decodeURIComponent(rel);
-    } catch {
-      decoded = rel;
-    }
+    const decoded = decodeSafely(rel);
     const full = path.join(publicDir, decoded);
-    if (!fs.existsSync(full)) {
-      missing.push(img);
-    }
-  }
-  return missing;
+    return !fs.existsSync(full);
+  });
 }
 
 module.exports = { listMissingImages };
+


### PR DESCRIPTION
## Summary
- streamline listMissingImages to use Array.filter
- add benchmark for listMissingImages to guard performance

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx vitest bench scripts/utils/fs-checks.bench.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2ca2bd938832f88a7504aeeabd9d0