### PR TITLE
docs: fix PR guide link

### DIFF
--- a/frontend/src/pages/docs/md/prs.md
+++ b/frontend/src/pages/docs/md/prs.md
@@ -3,7 +3,7 @@ title: 'Pull Requests'
 slug: 'prs'
 ---
 
-Pull requests are welcome! See our [Contribution Guide](/CONTRIBUTORS.md) for details on how to get started.
+Pull requests are welcome! See our [Contribution Guide](/CONTRIBUTING.md) for details on how to get started.
 
 Before opening a pull request:
 


### PR DESCRIPTION
## Summary
- fix stale link to CONTRIBUTING guide in PR docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | detect-secrets scan --string`

------
https://chatgpt.com/codex/tasks/task_e_68a2c9108700832f9cc33452d0915957