### PR TITLE
docs: add storm fallback line to Echo

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -213,6 +213,7 @@ Echo routes signals and keeps comms clear for every mission.
 -   "Getting static? Rotate your antenna toward the station."
 -   "We log every packet; lose one and I'll know."
 -   "Need eyes on the horizon? I'll swing a drone that way."
+-   "Storm rolling in; hop to channel two if comms crackle."
 
 <style>
     img {


### PR DESCRIPTION
## Summary
- add storm-channel tip to Echo's sample dialogue

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(script missing)*
- `detect-secrets scan frontend/src/pages/docs/md/npcs.md`


------
https://chatgpt.com/codex/tasks/task_e_68a2c9897ce8832faae0e24bee0ec3a4