### PR TITLE
✨ Support alias item IDs in price lookup

### DIFF
--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -14,6 +14,10 @@ describe('approximateIrlPrice', () => {
     expect(approximateIrlPrice(' 3d printer ')).toBe(350)
   })
 
+  it('resolves known alias', () => {
+    expect(approximateIrlPrice('rpi5')).toBe(80)
+  })
+
   it('returns null for unknown item', () => {
     expect(approximateIrlPrice('nonexistent')).toBeNull()
   })

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -22,6 +22,10 @@ const priceTable: Record<string, number> = {
   "ssd_1tb": 120,
 };
 
+const aliasTable: Record<string, string> = {
+  rpi5: "raspberry_pi_5",
+};
+
 const NORMALIZE_REGEX = /[\s-]+/g;
 
 function normalizeId(id: string): string {
@@ -34,11 +38,17 @@ function normalizeId(id: string): string {
  * The lookup is case‑insensitive, trims surrounding whitespace, and normalizes
  * spaces or hyphens to underscores so callers can pass identifiers like
  * `3D-Printer`, `3d printer`, or even ` 3d_printer `.
+ *
+ * Common aliases are supported. For example, `rpi5` resolves to `raspberry_pi_5`.
 */
 export function approximateIrlPrice(id: string | null | undefined): number | null {
   if (typeof id !== 'string') {
     return null;
   }
-  const normalized = normalizeId(id);
+  let normalized = normalizeId(id);
+  const alias = aliasTable[normalized];
+  if (alias) {
+    normalized = alias;
+  }
   return priceTable[normalized] ?? null;
 }


### PR DESCRIPTION
## Summary
- allow price lookup to resolve alias ids like `rpi5`

## Testing
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68a2c6c3abb4832f9ed255622b77a51a