### PR TITLE
✨: add helper to total item prices

### DIFF
--- a/backend/approximateIrlPrice.bench.ts
+++ b/backend/approximateIrlPrice.bench.ts
@@ -1,12 +1,19 @@
-import { bench, describe } from 'vitest'
-import { approximateIrlPrice } from './approximateIrlPrice'
+import { bench, describe } from 'vitest';
+import {
+  approximateIrlPrice,
+  approximateIrlTotalPrice,
+} from './approximateIrlPrice';
 
 describe('approximateIrlPrice benchmark', () => {
   bench('lookup base id', () => {
-    approximateIrlPrice('3d_printer')
-  })
+    approximateIrlPrice('3d_printer');
+  });
 
   bench('lookup with normalization', () => {
-    approximateIrlPrice(' 3D-Printer ')
-  })
-})
+    approximateIrlPrice(' 3D-Printer ');
+  });
+
+  bench('total price for cart', () => {
+    approximateIrlTotalPrice(['3d_printer', 'arduino_nano']);
+  });
+});

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -1,25 +1,46 @@
-import { describe, it, expect } from 'vitest'
-import { approximateIrlPrice } from './approximateIrlPrice'
+import { describe, it, expect } from 'vitest';
+import {
+  approximateIrlPrice,
+  approximateIrlTotalPrice,
+} from './approximateIrlPrice';
 
 describe('approximateIrlPrice', () => {
   it('returns price for known item', () => {
-    expect(approximateIrlPrice('3d_printer')).toBe(350)
-  })
+    expect(approximateIrlPrice('3d_printer')).toBe(350);
+  });
 
   it('handles case and separator variations', () => {
-    expect(approximateIrlPrice('3D-Printer')).toBe(350)
-  })
+    expect(approximateIrlPrice('3D-Printer')).toBe(350);
+  });
 
   it('trims leading and trailing whitespace', () => {
-    expect(approximateIrlPrice(' 3d printer ')).toBe(350)
-  })
+    expect(approximateIrlPrice(' 3d printer ')).toBe(350);
+  });
 
   it('returns null for unknown item', () => {
-    expect(approximateIrlPrice('nonexistent')).toBeNull()
-  })
+    expect(approximateIrlPrice('nonexistent')).toBeNull();
+  });
 
   it('returns null for non-string input', () => {
-    expect(approximateIrlPrice(null as any)).toBeNull()
-    expect(approximateIrlPrice(undefined as any)).toBeNull()
-  })
-})
+    expect(approximateIrlPrice(null as any)).toBeNull();
+    expect(approximateIrlPrice(undefined as any)).toBeNull();
+  });
+
+  describe('approximateIrlTotalPrice', () => {
+    it('sums prices of known items', () => {
+      expect(approximateIrlTotalPrice(['3d_printer', 'arduino_nano'])).toBe(
+        372
+      );
+    });
+
+    it('ignores unknown items and returns null when none are known', () => {
+      expect(approximateIrlTotalPrice(['nonexistent', '3d_printer'])).toBe(350);
+      expect(approximateIrlTotalPrice(['foo'])).toBeNull();
+    });
+
+    it('returns null for non-array input', () => {
+      expect(approximateIrlTotalPrice(null as any)).toBeNull();
+      expect(approximateIrlTotalPrice(undefined as any)).toBeNull();
+    });
+  });
+});

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -1,25 +1,25 @@
 const priceTable: Record<string, number> = {
-  "3d_printer": 350,
-  "arduino_nano": 22,
-  "raspberry_pi_5": 80,
-  "arduino_uno": 27,
-  "breadboard": 10,
-  "jumper_wires": 5,
-  "led": 1,
-  "resistor_220_ohm": 0.02,
-  "usb_cable": 5,
-  "servo_motor": 15,
-  "potentiometer": 1,
-  "3d_printed_phone_stand": 2,
-  "thermometer": 15,
-  "hydroponics_kit": 60,
-  "aquarium_150l": 60,
-  "goldfish": 5,
-  "ev_charger": 500,
-  "battery_pack_1kwh": 1000,
-  "solar_panel_200w": 200,
-  "m2_poe_hat": 25,
-  "ssd_1tb": 120,
+  '3d_printer': 350,
+  arduino_nano: 22,
+  raspberry_pi_5: 80,
+  arduino_uno: 27,
+  breadboard: 10,
+  jumper_wires: 5,
+  led: 1,
+  resistor_220_ohm: 0.02,
+  usb_cable: 5,
+  servo_motor: 15,
+  potentiometer: 1,
+  '3d_printed_phone_stand': 2,
+  thermometer: 15,
+  hydroponics_kit: 60,
+  aquarium_150l: 60,
+  goldfish: 5,
+  ev_charger: 500,
+  battery_pack_1kwh: 1000,
+  solar_panel_200w: 200,
+  m2_poe_hat: 25,
+  ssd_1tb: 120,
 };
 
 const NORMALIZE_REGEX = /[\s-]+/g;
@@ -34,11 +34,40 @@ function normalizeId(id: string): string {
  * The lookup is case‑insensitive, trims surrounding whitespace, and normalizes
  * spaces or hyphens to underscores so callers can pass identifiers like
  * `3D-Printer`, `3d printer`, or even ` 3d_printer `.
-*/
-export function approximateIrlPrice(id: string | null | undefined): number | null {
+ */
+export function approximateIrlPrice(
+  id: string | null | undefined
+): number | null {
   if (typeof id !== 'string') {
     return null;
   }
   const normalized = normalizeId(id);
   return priceTable[normalized] ?? null;
+}
+
+/**
+ * Sum the prices of multiple game items.
+ *
+ * Unknown or non-string identifiers are ignored. Returns `null` when no known
+ * items are provided.
+ */
+export function approximateIrlTotalPrice(
+  ids: Array<string | null | undefined> | null | undefined
+): number | null {
+  if (!Array.isArray(ids)) {
+    return null;
+  }
+
+  let total = 0;
+  let found = false;
+
+  for (const id of ids) {
+    const price = approximateIrlPrice(id);
+    if (typeof price === 'number') {
+      total += price;
+      found = true;
+    }
+  }
+
+  return found ? total : null;
 }


### PR DESCRIPTION
## Summary
- add `approximateIrlTotalPrice` to sum known item prices
- cover new helper with unit tests and benchmark

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c6c3abb4832f9ed255622b77a51a