### PR TITLE
feat: enforce unique quest titles

### DIFF
--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -6,6 +6,7 @@
         validateQuestData,
         validateQuestDependencies,
     } from '../../utils/customQuestValidation.js';
+    import { isQuestTitleUnique } from '../../utils/questHelpers.js';
 
     export let isEdit = false;
     export let questId = null;
@@ -95,6 +96,8 @@
             errors.title = 'Title is required';
         } else if (trimmedTitle.length < MIN_TITLE_LENGTH) {
             errors.title = `Title must be at least ${MIN_TITLE_LENGTH} characters`;
+        } else if (!isQuestTitleUnique(trimmedTitle, allQuests, isEdit ? questId : null)) {
+            errors.title = 'Title must be unique';
         }
 
         const trimmedDesc = description.trim();

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -9,7 +9,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 
 ## Development Checklist (Pre-Launch)
 
--   [x] Custom Quest System
+-   [x] Custom Quest System 💯
 
     -   [x] In‑game quest creation UI 💯
         -   [x] Implement QuestForm component with image upload 💯

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -23,20 +23,20 @@ When creating quests, focus on these primary categories:
 
 ### Core Categories
 
-- **Hydroponics**: Growing plants without soil, crucial for space habitation
-- **Aquaria**: Managing aquatic ecosystems, modeling closed-loop life support
-- **Aquaponics**: Combining fish and plant cultivation in symbiotic systems
-- **Electronics**: Basic circuitry, sensing, and control systems
-- **Energy Systems**: Solar, wind, batteries and sustainable power generation
-- **3D Printing**: Fabrication techniques for creating components and tools
+-   **Hydroponics**: Growing plants without soil, crucial for space habitation
+-   **Aquaria**: Managing aquatic ecosystems, modeling closed-loop life support
+-   **Aquaponics**: Combining fish and plant cultivation in symbiotic systems
+-   **Electronics**: Basic circuitry, sensing, and control systems
+-   **Energy Systems**: Solar, wind, batteries and sustainable power generation
+-   **3D Printing**: Fabrication techniques for creating components and tools
 
 ### Secondary Categories
 
-- **Chemistry**: Safe experiments demonstrating principles relevant to space
-- **Biology**: Experiments studying life in controlled environments
-- **Physics**: Demonstrations of physical principles in space exploration
-- **Astronomy**: Observational techniques and understanding celestial objects
-- **Materials Science**: Testing and comparing materials for various applications
+-   **Chemistry**: Safe experiments demonstrating principles relevant to space
+-   **Biology**: Experiments studying life in controlled environments
+-   **Physics**: Demonstrations of physical principles in space exploration
+-   **Astronomy**: Observational techniques and understanding celestial objects
+-   **Materials Science**: Testing and comparing materials for various applications
 
 ## Quest Structure Guidelines
 
@@ -51,9 +51,9 @@ Organize quests in a **clear progression** from beginner to advanced:
 
 ### Quest Dependencies
 
-- Make dependencies clear and logical
-- Each category should have a clear entry point
-- Advanced quests should require completion of relevant prerequisites
+-   Make dependencies clear and logical
+-   Each category should have a clear entry point
+-   Advanced quests should require completion of relevant prerequisites
 
 ## Content Guidelines
 
@@ -67,9 +67,9 @@ Organize quests in a **clear progression** from beginner to advanced:
 
 ### Safety First
 
-- Always include appropriate safety warnings
-- Recommend proper protective equipment when needed
-- Never encourage dangerous activities or improper handling of materials
+-   Always include appropriate safety warnings
+-   Recommend proper protective equipment when needed
+-   Never encourage dangerous activities or improper handling of materials
 
 ## Examples of Well-Structured Quest Sequences
 
@@ -103,30 +103,31 @@ Organize quests in a **clear progression** from beginner to advanced:
 
 Every quest JSON file must include:
 
-- `id`: Unique identifier following the pattern `category/name`
-- `title`: Display title of the quest
-- `description`: Brief description explaining the quest purpose
-- `image`: Path to quest image
-- `npc`: Path to NPC avatar image
-- `start`: ID of the starting dialogue node
-- `dialogue`: Array of dialogue nodes, each containing:
-    - `id`: Node identifier
-    - `text`: NPC's dialogue text
-    - `options`: Array of player response options, including:
-        - `type`: Action type (goto, finish, process, grantsItems)
-        - `text`: Player's response text
-        - `goto`: For type:goto, target node ID
-        - `process`: For type:process, process ID
-        - `requiresItems`: Optional items needed to select option
-        - `grantsItems`: Optional items given when selecting option
-        - `requiresGitHub`: Set to `true` to disable the option until a GitHub token is saved
-- `rewards`: Items given upon quest completion
-- `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**).
-Automated tests ensure these dependencies reference existing quests and avoid cycles.
+-   `id`: Unique identifier following the pattern `category/name`
+-   `title`: Display title of the quest
+-   `description`: Brief description explaining the quest purpose
+-   `image`: Path to quest image
+-   `npc`: Path to NPC avatar image
+-   `start`: ID of the starting dialogue node
+-   `dialogue`: Array of dialogue nodes, each containing:
+    -   `id`: Node identifier
+    -   `text`: NPC's dialogue text
+    -   `options`: Array of player response options, including:
+        -   `type`: Action type (goto, finish, process, grantsItems)
+        -   `text`: Player's response text
+        -   `goto`: For type:goto, target node ID
+        -   `process`: For type:process, process ID
+        -   `requiresItems`: Optional items needed to select option
+        -   `grantsItems`: Optional items given when selecting option
+        -   `requiresGitHub`: Set to `true` to disable the option until a GitHub token is saved
+-   `rewards`: Items given upon quest completion
+-   `requiresQuests`: Array of quest IDs that must be completed first (select these in the quest form under **Quest Requirements**).
+    Automated tests ensure these dependencies reference existing quests and avoid cycles.
 
 Quest data is validated against a JSON schema. Titles and descriptions reject
 `<` and `>` characters, and `image` must be a data URL, an absolute HTTP(S)
-link, or a root-relative path.
+link, or a root-relative path. Quest titles must be unique across all existing
+quests.
 
 ### Current Implementation State
 
@@ -138,20 +139,20 @@ link, or a root-relative path.
 While the user interface for editing complex dialogue trees is being developed, quests are currently created using JSON files or through the custom content API. The future implementation will include:
 You can run `npm run generate-quest --template basic` (or `branching`) to scaffold a template JSON file with placeholder dialogue.
 
-- Dialogue node creation and editing
-- Process and item requirement selection
-- Quest dependency management
-- Preview functionality to test dialogue flow
+-   Dialogue node creation and editing
+-   Process and item requirement selection
+-   Quest dependency management
+-   Preview functionality to test dialogue flow
 
 ### Testing Your Quest
 
 Before submitting a quest, verify:
 
-- All dialogue paths lead to completion
-- Item grants and requirements function correctly
-- Process integrations work as expected
-- Educational content is accurate and clear
-- Safety warnings are included where appropriate
+-   All dialogue paths lead to completion
+-   Item grants and requirements function correctly
+-   Process integrations work as expected
+-   Educational content is accurate and clear
+-   Safety warnings are included where appropriate
 
 ## Contribution Workflow
 
@@ -173,12 +174,12 @@ Once the in-game editor is complete, the workflow will be simplified to:
 
 We're particularly interested in new quests that cover:
 
-- Sustainable energy systems
-- Small-scale biology experiments
-- Chemistry demonstrations relevant to space exploration
-- Sensor systems and data collection
-- Resource recycling and waste management
-- Low-cost astronomy projects
-- Materials testing experiments
+-   Sustainable energy systems
+-   Small-scale biology experiments
+-   Chemistry demonstrations relevant to space exploration
+-   Sensor systems and data collection
+-   Resource recycling and waste management
+-   Low-cost astronomy projects
+-   Materials testing experiments
 
 By following these guidelines, you'll create quests that engage players while advancing DSPACE's mission of democratizing space exploration through practical, hands-on education.

--- a/frontend/src/utils/questHelpers.js
+++ b/frontend/src/utils/questHelpers.js
@@ -1,0 +1,4 @@
+export function isQuestTitleUnique(title, quests = [], ignoreId = null) {
+    const lower = title.trim().toLowerCase();
+    return !quests.some((q) => q.title.trim().toLowerCase() === lower && q.id !== ignoreId);
+}

--- a/tests/quest-title-unique.test.ts
+++ b/tests/quest-title-unique.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { isQuestTitleUnique } from '../frontend/src/utils/questHelpers.js';
+
+describe('isQuestTitleUnique', () => {
+  it('detects duplicate titles', () => {
+    const quests = [
+      { id: 'q1', title: 'Existing Quest' },
+      { id: 'q2', title: 'Another Quest' },
+    ];
+    expect(isQuestTitleUnique('Existing Quest', quests)).toBe(false);
+    expect(isQuestTitleUnique('New Quest', quests)).toBe(true);
+    expect(isQuestTitleUnique('Existing Quest', quests, 'q1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce unique quest titles during custom quest creation
- document quest title uniqueness requirement

## Testing
- `npm run audit:ci` (fails: 1 high vulnerability)
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8f81098832f888049b007ab96aa