### PR TITLE
Add cloud sync Playwright test and update user journeys

### DIFF
--- a/frontend/e2e/backlog/cloud-sync.spec.ts
+++ b/frontend/e2e/backlog/cloud-sync.spec.ts
@@ -1,9 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// TODO: Cloud sync page functionality isn't working correctly; revisit this test when the feature is fixed.
-
-test('cloud sync page renders', async ({ page }) => {
-    await page.goto('/cloudsync');
-    await expect(page.getByText('GitHub Token')).toBeVisible();
-    await expect(page.getByRole('button', { name: /Upload/i })).toBeVisible();
-});

--- a/frontend/e2e/backlog/cookie-consent.spec.ts
+++ b/frontend/e2e/backlog/cookie-consent.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+// TODO: Add full cookie consent flow once UI is finalized.
+test('cookie consent page renders', async ({ page }) => {
+    await page.goto('/accept_cookies');
+    await expect(page.getByText('Accept cookies')).toBeVisible();
+});

--- a/frontend/e2e/cloud-sync.spec.ts
+++ b/frontend/e2e/cloud-sync.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+test.describe('Cloud Sync', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('renders upload form', async ({ page }) => {
+        await page.goto('/cloudsync');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByLabel(/GitHub Token/)).toBeVisible();
+        await expect(page.getByRole('button', { name: /Upload/i })).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -18,7 +18,8 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 > **TL;DR**
 >
 > 1. Review `user-journeys.md`, correcting errors or outdated steps.
-> 2. Pick a journey marked "No" or add new journeys as needed.
+> 2. Pick a journey marked "No" or add new journeys; keep the table alphabetical
+>    and create a placeholder spec in `frontend/e2e/backlog` for uncovered paths.
 > 3. If a placeholder exists under `frontend/e2e/backlog`, promote it to
 >    `frontend/e2e` with `git mv`; otherwise add a new Playwright test.
 > 4. Update `user-journeys.md` to reflect coverage and fixes.

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -12,7 +12,7 @@ Tests under `frontend/e2e/backlog` are planned but not yet automated.
 | -------------------------- | ------------------- | ------------------------------------------------- |
 | Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
 | Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
-| Built-in quest detail      | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
+| Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
 | Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
 | Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
 | Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
@@ -24,7 +24,8 @@ Tests under `frontend/e2e/backlog` are planned but not yet automated.
 | Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
 | Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
 | Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
-| Cloud sync                 | No                  | --                                                |
+| Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
+| Cookie consent flow        | No                  | --                                                |
 | Manage items               | No                  | --                                                |
 | Manage processes           | No                  | --                                                |
 | Manage quests              | No                  | --                                                |


### PR DESCRIPTION
## Summary
- cover cloud sync upload form with Playwright
- document cloud sync coverage and add cookie consent journey
- clarify Playwright prompt about backlog placeholders and ordering

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c9a31d98832f8dc73452c3edc568