### PR TITLE
📝 : – refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -58,7 +58,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
-            <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
+            <a href="/docs/prompts-playwright-tests">Playwright Test prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#implementation-prompt">Codex implementation prompt</a>

--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -18,15 +18,16 @@ honor end-user privacy, dignity, and agency as outlined in
 > 2. Minimize data collection and obtain explicit user consent before storing or
 >    transmitting information.
 > 3. Add or update tests in `backend/__tests__` when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update backend files under `backend/`.

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -27,6 +27,8 @@ to refresh it before use. For guidance on logging incidents, see the
 ```text
 SYSTEM:
 You are an automated contributor for the democratizedspace/dspace repository.
+Follow `AGENTS.md` and `README.md`. Ensure `npm run audit:ci`, `npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 PURPOSE:
 Diagnose a failed CI run and make it pass.
@@ -36,8 +38,8 @@ CONTEXT:
   error.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-  * Run `npm run lint`, `npm run type-check`, `npm run build`, and
-    `npm run test:ci` locally.
+  * Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+    `npm run build`, and `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -14,8 +14,9 @@ see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:ci` pass before
+committing.
 
 USER:
 1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -15,8 +15,8 @@ workflows.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and
-`README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-all pass before committing.
+`README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` all pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,7 +13,8 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), [Backend prompts](/docs/prompts-backend), and
+[Docs prompts](/docs/prompts-docs), [Backend prompts](/docs/prompts-backend),
+[Playwright Test prompts](/docs/prompts-playwright-tests), and
 [Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
@@ -92,7 +93,8 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -16,15 +16,16 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -19,8 +19,8 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Scope changes to a single NPC.
 > 2. Specify the expected output (tests, docs).
 > 3. Stop when the spec is complete; remaining text becomes mandatory.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -37,7 +37,8 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && npm run test:ci"
+        codex exec "npm run audit:ci && npm run lint && npm run type-check && \
+        npm run build && npm run test:ci"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -71,7 +72,8 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Preserve established character voice and lore.
 2. Keep sample dialogue short and approachable.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Update related docs if needed.
 
@@ -88,8 +90,9 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit
 `frontend/src/pages/docs/md/npcs.md`, adding or refining NPC sections.
 Maintain each character’s voice, keep sample dialogue realistic, and
-ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass. Scan for secrets with
+`git diff --cached | ./scripts/scan-secrets.py`
 before committing.
 
 USER:
@@ -114,7 +117,8 @@ USER:
 2. Improve characterization and ensure dialogue stays concise and in-universe.
 3. Reuse existing image assets; do not add new images.
 4. Cross-reference related quests or processes and update them if needed.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 7. Use an emoji-prefixed commit message like `📝 : – refine NPC bio`.
 

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -17,13 +17,16 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 1. Investigate the failure and implement a fix.
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 PURPOSE:
 Diagnose an outage, implement a fix, and document it.
@@ -37,7 +40,8 @@ CONTEXT:
 REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -23,15 +23,16 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 >    `frontend/e2e` with `git mv`; otherwise add a new Playwright test.
 > 4. Update `user-journeys.md` to reflect coverage and fixes.
 > 5. Run `npx playwright install chromium` if browsers are missing.
-> 6. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 7. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >    and commit with an emoji.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` pass before committing.
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/user-journeys.md` for mistakes and

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -21,8 +21,8 @@ For fundamental design tips see the
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -39,8 +39,8 @@ For fundamental design tips see the
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:ci && npm run test:ci -- processQuality && \
+        codex exec "npm run audit:ci && npm run lint && npm run type-check && \
+        npm run build && npm run test:ci && npm run test:ci -- processQuality && \
         git diff --cached | ./scripts/scan-secrets.py"
         ```
 
@@ -79,7 +79,8 @@ REQUIREMENTS
 3. Ensure the process is referenced by at least one quest or item; create
    missing items or quest hooks as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or items if needed.
@@ -97,8 +98,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/base.json` with corresponding
 hardening files in `frontend/src/pages/processes/hardening`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run lint`,
-`npm run type-check`, `npm run build`, `npm run test:ci`, and
+steps, durations, item references, and passing checks (`npm run audit:ci`,
+`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`, and
 `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
@@ -146,7 +147,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality`. Update docs or items if needed.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 8. Use an emoji-prefixed commit message like `📝 : – refine process details`.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -23,8 +23,8 @@ which covers quests, items and processes in detail.
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -41,8 +41,8 @@ which covers quests, items and processes in detail.
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:ci -- questCanonical questQuality"
+        codex exec "npm run audit:ci && npm run lint && npm run type-check && \
+        npm run build && npm run test:ci -- questCanonical questQuality"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -80,7 +80,8 @@ REQUIREMENTS
 3. Find the most natural predecessor quest and update the `requiresQuests`
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check` and `npm run build`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, and
+   `npm run build`.
 6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
@@ -99,7 +100,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
-(`npm run lint`, `npm run type-check`, `npm run build`, and
+(`npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -17,13 +17,15 @@ only if you give it a clear, file-scoped prompt. Use this guide alongside
 > 1. Change internals without altering behaviour.
 > 2. Keep commits small and reversible.
 > 3. Include before/after benchmarks if performance might change.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 5. Run `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Refactor code in the specified files without changing behaviour.


### PR DESCRIPTION
## Summary
- document Playwright test prompts in Codex guide
- require `npm run audit:ci` across prompt templates

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2c90c89a0832f83aa4f6d7036aa25