### PR TITLE
Add compost moisture process and quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -1119,7 +1119,8 @@
   },
   "2b57a38d-0486-40e8-a50d-d893541b50e9": {
     "requires": [
-      "composting/turn-pile"
+      "composting/turn-pile",
+      "composting/check-moisture"
     ],
     "rewards": []
   },

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3930,6 +3930,35 @@
         }
     },
     {
+        "id": "measure-compost-moisture",
+        "title": "Probe compost moisture with a compost moisture meter and record it in mission logbook",
+        "image": "/assets/bucket_water.jpg",
+        "requireItems": [
+            {
+                "id": "2b57a38d-0486-40e8-a50d-d893541b50e9",
+                "count": 1
+            },
+            {
+                "id": "70bb8d86-2c4e-4330-9705-371891934686",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [
+            {
+                "id": "280ed361-ac70-4ab9-bcd9-aee481790faf",
+                "count": 1
+            }
+        ],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -91,6 +91,7 @@ New quests in this release: 210
 
 ### composting
 
+-   composting/check-moisture
 -   composting/check-temperature
 -   composting/start
 -   composting/turn-pile

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3068,6 +3068,29 @@
         "duration": "1m"
     },
     {
+        "id": "measure-compost-moisture",
+        "title": "Probe compost moisture with a compost moisture meter and record it in mission logbook",
+        "image": "/assets/bucket_water.jpg",
+        "requireItems": [
+            {
+                "id": "2b57a38d-0486-40e8-a50d-d893541b50e9",
+                "count": 1
+            },
+            {
+                "id": "70bb8d86-2c4e-4330-9705-371891934686",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [
+            {
+                "id": "280ed361-ac70-4ab9-bcd9-aee481790faf",
+                "count": 1
+            }
+        ],
+        "duration": "1m"
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/processes/hardening/measure-compost-moisture.json
+++ b/frontend/src/pages/processes/hardening/measure-compost-moisture.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/quests/json/composting/check-moisture.json
+++ b/frontend/src/pages/quests/json/composting/check-moisture.json
@@ -1,0 +1,40 @@
+{
+    "id": "composting/check-moisture",
+    "title": "Check Compost Moisture",
+    "description": "Gauge moisture level to keep microbes happy.",
+    "image": "/assets/bucket.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Not sure if your compost is too dry or soggy? Let's check the moisture.",
+            "options": [{ "type": "goto", "goto": "probe", "text": "How do I check?" }]
+        },
+        {
+            "id": "probe",
+            "text": "Insert the compost moisture meter and note the reading.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "reading",
+                    "process": "measure-compost-moisture",
+                    "requiresItems": [{ "id": "2b57a38d-0486-40e8-a50d-d893541b50e9", "count": 1 }],
+                    "text": "Take the reading"
+                }
+            ]
+        },
+        {
+            "id": "reading",
+            "text": "The needle settles at 50%—perfectly damp.",
+            "options": [{ "type": "goto", "goto": "finish", "text": "Nice!" }]
+        },
+        {
+            "id": "finish",
+            "text": "Keep checking moisture weekly for balanced decomposition.",
+            "options": [{ "type": "finish", "text": "Will do!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["composting/start"]
+}


### PR DESCRIPTION
## Summary
- measure compost moisture and log the reading
- document new quest and update quest count

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a2c9be91f8832f93ef14f61747a5c6