### PR TITLE
🍪 add cookie consent flow test and update journeys

### DIFF
--- a/frontend/e2e/backlog/cookie-consent.spec.ts
+++ b/frontend/e2e/backlog/cookie-consent.spec.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// TODO: Add full cookie consent flow once UI is finalized.
-test('cookie consent page renders', async ({ page }) => {
-    await page.goto('/accept_cookies');
-    await expect(page.getByText('Accept cookies')).toBeVisible();
-});

--- a/frontend/e2e/backlog/legacy-import.spec.ts
+++ b/frontend/e2e/backlog/legacy-import.spec.ts
@@ -1,0 +1,6 @@
+import { test } from '@playwright/test';
+
+// TODO: Add full legacy data import flow.
+test('legacy data import flow placeholder', async () => {
+    // Placeholder test
+});

--- a/frontend/e2e/cookie-consent.spec.ts
+++ b/frontend/e2e/cookie-consent.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Cookie consent flow', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('user can accept cookies and return', async ({ page }) => {
+        await page.goto('/accept_cookies?redirect=/');
+        const acceptLink = page.getByRole('link', { name: 'Accept cookies' });
+        await expect(acceptLink).toBeVisible();
+
+        await Promise.all([page.waitForURL('/accepted_cookies?redirect=/'), acceptLink.click()]);
+
+        await expect(page.getByText("You've accepted cookies.")).toBeVisible();
+
+        const cookies = await page.context().cookies();
+        expect(cookies.some((c) => c.name === 'acceptedCookies' && c.value === 'true')).toBe(true);
+
+        const goBack = page.getByRole('link', { name: 'Go back' });
+        await expect(goBack).toBeVisible();
+        await Promise.all([page.waitForURL('/'), goBack.click()]);
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -17,12 +17,13 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 
 > **TL;DR**
 >
-> 1. Review `user-journeys.md`, correcting errors or outdated steps.
-> 2. Pick a journey marked "No" or add new journeys; keep the table alphabetical
->    and create a placeholder spec in `frontend/e2e/backlog` for uncovered paths.
-> 3. If a placeholder exists under `frontend/e2e/backlog`, promote it to
->    `frontend/e2e` with `git mv`; otherwise add a new Playwright test.
-> 4. Update `user-journeys.md` to reflect coverage and fixes.
+> 1. Review `user-journeys.md`, correcting mistakes and keeping the coverage
+>    table sorted alphabetically.
+> 2. For journeys lacking tests, ensure a placeholder spec exists under
+>    `frontend/e2e/backlog`.
+> 3. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
+>    implement the Playwright test; otherwise add a new test file.
+> 4. Update `user-journeys.md` with coverage status and any fixes.
 > 5. Run `npx playwright install chromium` if browsers are missing.
 > 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.
@@ -41,7 +42,8 @@ USER:
 2. Select an uncovered or newly added journey and implement a Playwright test
    in `frontend/e2e/`. If a matching placeholder exists in
    `frontend/e2e/backlog`, move it with `git mv` before editing.
-3. Update the coverage table and any corrected steps in `user-journeys.md`.
+3. Update the coverage table and any corrected steps in `user-journeys.md`,
+   keeping it alphabetized.
 4. Improve this prompt if clearer guidance emerges.
 5. Run `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -6,39 +6,41 @@ slug: 'user-journeys'
 # User journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
-Tests under `frontend/e2e/backlog` are planned but not yet automated.
+Tests under `frontend/e2e/backlog` are planned but not yet automated. Entries are sorted
+alphabetically by journey name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
-| Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
-| Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
-| Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
-| Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
-| Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
-| Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
-| Custom content integration | Yes                 | `frontend/e2e/custom-content.spec.ts`             |
-| Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
-| Custom backup              | Yes                 | `frontend/e2e/custom-backup.spec.ts`              |
-| Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |
-| Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
-| Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
-| Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
-| Cookie consent flow        | No                  | --                                                |
+| Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
+| Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |
+| Custom backup              | Yes                 | `frontend/e2e/custom-backup.spec.ts`              |
+| Custom content integration | Yes                 | `frontend/e2e/custom-content.spec.ts`             |
+| Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
+| Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
+| Failover status page       | No                  | --                                                |
+| Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
+| Item/process preview       | No                  | --                                                |
+| Legacy data import         | No                  | --                                                |
 | Manage items               | No                  | --                                                |
 | Manage processes           | No                  | --                                                |
 | Manage quests              | No                  | --                                                |
 | Manage quests search       | No                  | --                                                |
-| Quest PR form              | No                  | --                                                |
-| Quest form validation      | No                  | --                                                |
-| Quest PR validation        | No                  | --                                                |
-| Quest success message      | No                  | --                                                |
-| Item/process preview       | No                  | --                                                |
 | Mobile item form           | No                  | --                                                |
 | Mobile process form        | No                  | --                                                |
 | Mobile quest form          | No                  | --                                                |
+| Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
+| Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
+| Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
+| Quest form validation      | No                  | --                                                |
+| Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
+| Quest PR form              | No                  | --                                                |
+| Quest PR validation        | No                  | --                                                |
+| Quest success message      | No                  | --                                                |
+| Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |
+| Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
 | Touch item selector        | No                  | --                                                |
 | Touch menu navigation      | No                  | --                                                |
+| Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
 | UI responsiveness          | No                  | --                                                |
-| Failover status page       | No                  | --                                                |


### PR DESCRIPTION
## Summary
- test cookie consent flow end-to-end
- track legacy import journey and alphabetize coverage table
- clarify Playwright testing prompt

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`
- `npm run test:e2e -- cookie-consent.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3c0a2d484832fbebba398d1e0073c