### PR TITLE
🧽 Clarify sponge filter rinse quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -1325,9 +1325,7 @@
     "rewards": []
   },
   "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56": {
-    "requires": [
-      "aquaria/sponge-filter"
-    ],
+    "requires": ["aquaria/sponge-filter", "aquaria/filter-rinse"],
     "rewards": [
       "aquaria/sponge-filter"
     ]
@@ -1395,9 +1393,7 @@
     "rewards": []
   },
   "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1": {
-    "requires": [
-      "aquaria/filter-rinse"
-    ],
+    "requires": [],
     "rewards": []
   },
   "3f1cc002-1f7a-4301-a1c6-343f65e7f21a": {

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1409,7 +1409,7 @@
                 "count": 1
             },
             {
-                "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1",
+                "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
                 "count": 1
             },
             {
@@ -2841,10 +2841,10 @@
     },
     {
         "id": "rinse-aquarium-filter",
-        "title": "Rinse aquarium filter media in a bucket of dechlorinated water to preserve beneficial bacteria",
+        "title": "Rinse sponge filter in a bucket of dechlorinated water to preserve beneficial bacteria",
         "requireItems": [
             {
-                "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1",
+                "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
                 "count": 1
             }
         ],

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1182,7 +1182,7 @@
                 "count": 1
             },
             {
-                "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1",
+                "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
                 "count": 1
             },
             {
@@ -2330,10 +2330,10 @@
     },
     {
         "id": "rinse-aquarium-filter",
-        "title": "Rinse aquarium filter media in a bucket of dechlorinated water to preserve beneficial bacteria",
+        "title": "Rinse sponge filter in a bucket of dechlorinated water to preserve beneficial bacteria",
         "requireItems": [
             {
-                "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1",
+                "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
                 "count": 1
             }
         ],

--- a/frontend/src/pages/quests/json/aquaria/filter-rinse.json
+++ b/frontend/src/pages/quests/json/aquaria/filter-rinse.json
@@ -1,14 +1,14 @@
 {
     "id": "aquaria/filter-rinse",
     "title": "Rinse Sponge Filter",
-    "description": "Give your sponge filter a quick rinse in dechlorinated water.",
+    "description": "Unplug air pump. Rinse sponge filter in dechlorinated water to restore flow and protect bacteria.",
     "image": "/assets/aquarium_filter.jpg",
     "npc": "/assets/npc/vega.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "The sponge filter is clogging up. A rinse will keep flow gentle for shrimp.",
+            "text": "The sponge filter is clogging. Unplug the air pump so you can rinse it and keep flow gentle.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "rinse",
-            "text": "Remove the sponge and squeeze it in a bucket of dechlorinated water until the gunk is gone.",
+            "text": "Squeeze the sponge in a bucket of dechlorinated water until clear. Skip tap water to save bacteria.",
             "options": [
                 {
                     "type": "goto",
@@ -27,8 +27,14 @@
                     "text": "Filter's clean again!",
                     "process": "rinse-aquarium-filter",
                     "requiresItems": [
-                        { "id": "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1", "count": 1 },
-                        { "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50", "count": 1 }
+                        {
+                            "id": "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56",
+                            "count": 1
+                        },
+                        {
+                            "id": "71efa72a-8c87-4dc2-8e2c-9119bb28fe50",
+                            "count": 1
+                        }
                     ]
                 }
             ]
@@ -45,5 +51,17 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["aquaria/sponge-filter"]
+    "requiresQuests": ["aquaria/sponge-filter"],
+    "hardening": {
+        "passes": 1,
+        "score": 65,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-hardening-2025-08-19",
+                "date": "2025-08-19",
+                "score": 65
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- improve safety notes and item references for aquaria/filter-rinse
- align rinse-aquarium-filter process with sponge filter item
- add first hardening pass metadata

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a4caa498bc832fa8803de0220be26b