### PR TITLE
🛡️: harden docker-compose quest

### DIFF
--- a/frontend/src/pages/quests/json/devops/docker-compose.json
+++ b/frontend/src/pages/quests/json/devops/docker-compose.json
@@ -1,11 +1,11 @@
 {
     "id": "devops/docker-compose",
     "title": "Launch DSPACE in Docker",
-    "description": "Start DSPACE in Docker and expose it with a private Cloudflare Tunnel.",
+    "description": "Start DSPACE with Docker Compose and expose it securely through a Cloudflare Tunnel.",
     "hardening": {
-        "passes": 2,
-        "score": 80,
-        "emoji": "✅",
+        "passes": 3,
+        "score": 90,
+        "emoji": "💯",
         "history": [
             {
                 "task": "codex-hardening-2025-08-12",
@@ -16,6 +16,11 @@
                 "task": "codex-hardening-2025-08-16",
                 "date": "2025-08-16",
                 "score": 80
+            },
+            {
+                "task": "codex-hardening-2025-08-19",
+                "date": "2025-08-19",
+                "score": 90
             }
         ]
     },
@@ -25,12 +30,12 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Run `docker compose up -d --build` on Pi. Stop with `docker compose down`.",
+            "text": "On your Pi, run `docker compose up -d --build` to start containers. Stop with `docker compose down`.",
             "options": [
                 {
                     "type": "process",
                     "process": "run-docker-compose",
-                    "text": "Start container."
+                    "text": "Build and run containers."
                 },
                 {
                     "type": "goto",
@@ -47,12 +52,12 @@
         },
         {
             "id": "tunnel",
-            "text": "PoE+ switch & Ethernet cable. Run `cloudflared tunnel --url localhost:3002`.",
+            "text": "Use PoE+ switch and Ethernet cable. Run `cloudflared tunnel --url localhost:3002`. Keep token safe.",
             "options": [
                 {
                     "type": "process",
                     "process": "create-cloudflare-tunnel",
-                    "text": "Run cloudflared."
+                    "text": "Expose DSPACE through Cloudflare Tunnel."
                 },
                 {
                     "type": "goto",
@@ -73,7 +78,7 @@
         },
         {
             "id": "finish",
-            "text": "Everything is running! Keep token safe. For multi see Orion's k3s guide.",
+            "text": "Everything is running! Keep the Cloudflare token secret. For multi-node setups, see the k3s guide.",
             "options": [
                 {
                     "type": "finish",


### PR DESCRIPTION
what: clarify devops/docker-compose quest and update hardening info
why: keep quest reproducible with real items and record new pass
how to test: npm run audit:ci && npm run lint && npm run type-check && npm run build && npm run test:ci -- questCanonical questQuality


------
https://chatgpt.com/codex/tasks/task_e_68a4caa498bc832fa8803de0220be26b