### PR TITLE
refine arduino blink quest safety

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -987,7 +987,8 @@
   "bf3d2784-d48d-4b12-b12a-75f563b5dc88": {
     "requires": [
       "electronics/resistor-color-check",
-      "electronics/basic-circuit"
+      "electronics/basic-circuit",
+      "electronics/arduino-blink"
     ],
     "rewards": []
   },
@@ -1325,7 +1326,10 @@
     "rewards": []
   },
   "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56": {
-    "requires": ["aquaria/sponge-filter", "aquaria/filter-rinse"],
+    "requires": [
+      "aquaria/sponge-filter",
+      "aquaria/filter-rinse"
+    ],
     "rewards": [
       "aquaria/sponge-filter"
     ]
@@ -1390,10 +1394,6 @@
     "requires": [
       "aquaria/floating-plants"
     ],
-    "rewards": []
-  },
-  "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1": {
-    "requires": [],
     "rewards": []
   },
   "3f1cc002-1f7a-4301-a1c6-343f65e7f21a": {

--- a/frontend/src/pages/quests/json/electronics/arduino-blink.json
+++ b/frontend/src/pages/quests/json/electronics/arduino-blink.json
@@ -8,7 +8,7 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "Hey! Orion here. Ready to blink an LED with a microcontroller? Work on a dry, non-conductive surface, discharge static on a grounded object, wear safety goggles, and keep the USB Type-A to Type-B cable unplugged until every wire is double-checked.",
+            "text": "Hey! Orion here. Ready to blink an LED with a microcontroller? Work on a dry, non-conductive surface, discharge static by touching a grounded object, keep liquids away, wear safety goggles, and leave the USB Type-A to Type-B cable unplugged until every wire is double-checked.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "materials",
-            "text": "Gather an Arduino Uno, Breadboard, two Jumper Wires, a 220 Ω Resistor, a 5 mm LED, Safety Goggles, a USB Type-A to Type-B cable, and a Laptop Computer with the Arduino IDE installed. If the IDE isn't installed, run the 'Install the Arduino IDE' process. Confirm the resistor bands read red-red-brown (220 Ω). Place the LED's long leg (anode) into digital pin 13 through the resistor and its short leg (cathode) to GND. Keep power unplugged while wiring.",
+            "text": "Gather an Arduino Uno, Breadboard, two Jumper Wires, a 220 Ω Resistor, a 5 mm LED, Safety Goggles, a USB Type-A to Type-B cable, a Laptop Computer with the Arduino IDE installed, and a Resistor Color Chart. If the IDE isn't installed, run the 'Install the Arduino IDE' process. Use the chart to confirm the resistor bands read red-red-brown (220 Ω). Place the LED's long leg (anode) into digital pin 13 through the resistor and its short leg (cathode) to GND. Keep power unplugged while wiring.",
             "options": [
                 {
                     "type": "process",
@@ -49,6 +49,10 @@
                         },
                         {
                             "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                            "count": 1
+                        },
+                        {
+                            "id": "bf3d2784-d48d-4b12-b12a-75f563b5dc88",
                             "count": 1
                         },
                         {
@@ -102,7 +106,7 @@
         }
     ],
     "hardening": {
-        "passes": 9,
+        "passes": 10,
         "score": 100,
         "emoji": "💯",
         "history": [
@@ -149,6 +153,11 @@
             {
                 "task": "codex-quest-polish-2025-09-19",
                 "date": "2025-09-19",
+                "score": 100
+            },
+            {
+                "task": "codex-quest-update-2025-09-20",
+                "date": "2025-09-20",
                 "score": 100
             }
         ]


### PR DESCRIPTION
## Summary
- clarify safety guidance for Arduino blink quest and reference resistor color chart
- map resistor color chart to the quest and refresh hardening metadata

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a4d118ef1c832fa38af42150c8f6e1