### PR TITLE
🌀 refine CI pipeline quest with GitHub workflow

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -144,7 +144,6 @@
       "devops/fail2ban",
       "devops/enable-https",
       "devops/docker-compose",
-      "devops/ci-pipeline",
       "devops/auto-updates"
     ],
     "rewards": []
@@ -1116,6 +1115,12 @@
     ],
     "rewards": []
   },
+  "306793ac-e420-4859-9742-9076fff6ab57": {
+    "requires": [
+      "devops/ci-pipeline"
+    ],
+    "rewards": []
+  },
   "4d21c498-9225-4d0b-9a1a-ed65e349f0a8": {
     "requires": [
       "composting/turn-pile",
@@ -1325,7 +1330,10 @@
     "rewards": []
   },
   "496b4ebb-43c8-42d7-a921-fc6ee9d6ae56": {
-    "requires": ["aquaria/sponge-filter", "aquaria/filter-rinse"],
+    "requires": [
+      "aquaria/sponge-filter",
+      "aquaria/filter-rinse"
+    ],
     "rewards": [
       "aquaria/sponge-filter"
     ]
@@ -1390,10 +1398,6 @@
     "requires": [
       "aquaria/floating-plants"
     ],
-    "rewards": []
-  },
-  "6fe61da2-6aa3-447e-aad5-c65b1b8da1f1": {
-    "requires": [],
     "rewards": []
   },
   "3f1cc002-1f7a-4301-a1c6-343f65e7f21a": {

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1719,6 +1719,24 @@
         "duration": "5m"
     },
     {
+        "id": "create-ci-workflow",
+        "title": "Add a GitHub Actions CI workflow",
+        "requireItems": [
+            {
+                "id": "52593d07-908b-4109-92cf-826b2184ef6f",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [
+            {
+                "id": "306793ac-e420-4859-9742-9076fff6ab57",
+                "count": 1
+            }
+        ],
+        "duration": "5m"
+    },
+    {
         "id": "run-docker-compose",
         "title": "Launch DSPACE with Docker Compose",
         "requireItems": [

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -1076,6 +1076,20 @@
         "priceExemptionReason": "BETA_PLACEHOLDER"
     },
     {
+        "id": "52593d07-908b-4109-92cf-826b2184ef6f",
+        "name": "GitHub repository",
+        "description": "A remote Git repository hosted on GitHub.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
+        "id": "306793ac-e420-4859-9742-9076fff6ab57",
+        "name": "CI workflow file",
+        "description": "A `.github/workflows/ci.yml` that runs tests on push.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "priceExemptionReason": "BETA_PLACEHOLDER"
+    },
+    {
         "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
         "name": "basic telescope",
         "description": "A simple refracting telescope for backyard astronomy.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1486,6 +1486,24 @@
         "duration": "5m"
     },
     {
+        "id": "create-ci-workflow",
+        "title": "Add a GitHub Actions CI workflow",
+        "requireItems": [
+            {
+                "id": "52593d07-908b-4109-92cf-826b2184ef6f",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [
+            {
+                "id": "306793ac-e420-4859-9742-9076fff6ab57",
+                "count": 1
+            }
+        ],
+        "duration": "5m"
+    },
+    {
         "id": "run-docker-compose",
         "title": "Launch DSPACE with Docker Compose",
         "requireItems": [

--- a/frontend/src/pages/quests/json/devops/ci-pipeline.json
+++ b/frontend/src/pages/quests/json/devops/ci-pipeline.json
@@ -2,6 +2,18 @@
     "id": "devops/ci-pipeline",
     "title": "Set Up a CI Pipeline",
     "description": "Configure GitHub Actions to run tests whenever you push.",
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-hardening-2025-08-19",
+                "date": "2025-08-19",
+                "score": 60
+            }
+        ]
+    },
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
@@ -19,15 +31,20 @@
         },
         {
             "id": "edit",
-            "text": "Create a `.github/workflows/ci.yml` file that installs dependencies and runs `npm run test:pr`.",
+            "text": "Create a `.github/workflows/ci.yml` that installs dependencies and runs `npm run test:pr`. Keep tokens secret and grant minimal permissions.",
             "options": [
+                {
+                    "type": "process",
+                    "process": "create-ci-workflow",
+                    "text": "Write the workflow file."
+                },
                 {
                     "type": "goto",
                     "goto": "finish",
                     "text": "Workflow added.",
                     "requiresItems": [
                         {
-                            "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                            "id": "306793ac-e420-4859-9742-9076fff6ab57",
                             "count": 1
                         }
                     ]


### PR DESCRIPTION
## Summary
- clarify CI pipeline quest with safety notes and process link
- add GitHub repository and CI workflow items with new process
- record hardening pass for quest

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a4d118ef1c832fa38af42150c8f6e1