### PR TITLE
feat: allow custom price table

### DIFF
--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   approximateIrlPrice,
   approximateIrlTotalPrice,
+  __resetPriceTableCacheForTests,
 } from './approximateIrlPrice';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('approximateIrlPrice', () => {
   it('returns price for known item', () => {
@@ -24,6 +28,26 @@ describe('approximateIrlPrice', () => {
   it('returns null for non-string input', () => {
     expect(approximateIrlPrice(null as any)).toBeNull();
     expect(approximateIrlPrice(undefined as any)).toBeNull();
+  });
+
+  describe('custom price table', () => {
+    let tmpFile: string;
+
+    beforeEach(() => {
+      tmpFile = join(mkdtempSync(join(tmpdir(), 'prices-')), 'prices.json');
+      process.env.DSPACE_PRICE_TABLE_FILE = tmpFile;
+      __resetPriceTableCacheForTests();
+    });
+
+    afterEach(() => {
+      delete process.env.DSPACE_PRICE_TABLE_FILE;
+      __resetPriceTableCacheForTests();
+    });
+
+    it('loads prices from a custom file', () => {
+      writeFileSync(tmpFile, JSON.stringify({ custom_item: 42 }));
+      expect(approximateIrlPrice('custom_item')).toBe(42);
+    });
   });
 
   describe('approximateIrlTotalPrice', () => {

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+
 const priceTable: Record<string, number> = {
   '3d_printer': 350,
   arduino_nano: 22,
@@ -28,6 +30,43 @@ function normalizeId(id: string): string {
   return id.trim().toLowerCase().replace(NORMALIZE_REGEX, '_');
 }
 
+let customTable: Record<string, number> | null = null;
+let mergedTable: Record<string, number> | null = null;
+
+function loadCustomTable(): Record<string, number> {
+  if (customTable) {
+    return customTable;
+  }
+  customTable = {};
+  const file = process.env.DSPACE_PRICE_TABLE_FILE;
+  if (!file) {
+    return customTable;
+  }
+  try {
+    const data = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value === 'number') {
+        customTable[normalizeId(key)] = value;
+      }
+    }
+  } catch {
+    // ignore invalid file
+  }
+  return customTable;
+}
+
+function getPriceTable(): Record<string, number> {
+  if (!mergedTable) {
+    mergedTable = { ...priceTable, ...loadCustomTable() };
+  }
+  return mergedTable;
+}
+
+export function __resetPriceTableCacheForTests(): void {
+  customTable = null;
+  mergedTable = null;
+}
+
 /**
  * Look up a real‑world price for a game item.
  *
@@ -42,7 +81,7 @@ export function approximateIrlPrice(
     return null;
   }
   const normalized = normalizeId(id);
-  return priceTable[normalized] ?? null;
+  return getPriceTable()[normalized] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- allow backend price lookups to include values from a local JSON file
- test custom price table loading

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57abaa380832fa5299523892041c1