### PR TITLE
Add profile page test and refine Playwright prompts

### DIFF
--- a/frontend/e2e/profile-page.spec.ts
+++ b/frontend/e2e/profile-page.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Profile Page', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('should display avatar selection message', async ({ page }) => {
+        await page.goto('/profile');
+        await page.waitForLoadState('networkidle');
+
+        const message = page.getByText(/choose a default avatar/i);
+        await expect(message).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -19,9 +19,9 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 >
 > 1. Review `user-journeys.md`, correcting mistakes and keeping the coverage
 >    table sorted alphabetically.
-> 2. For journeys lacking tests, ensure a placeholder spec exists under
+> 2. For journeys lacking tests, ensure the feature still exists and a placeholder spec lives under
 >    `frontend/e2e/backlog`; create one if missing.
-> 3. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
+> 3. If the feature exists and a placeholder is present, move it to `frontend/e2e` with `git mv` and
 >    implement the Playwright test; otherwise add a new test file.
 > 4. Update `user-journeys.md` with coverage status, test file path, and any fixes,
 >    keeping the table alphabetized.
@@ -41,7 +41,7 @@ USER:
 1. Audit `frontend/src/pages/docs/md/user-journeys.md` for mistakes and
    propose fixes or additional journeys.
 2. Select an uncovered or newly added journey and implement a Playwright test
-   in `frontend/e2e/`. If a matching placeholder exists in
+   in `frontend/e2e/`, confirming the feature still exists. If a matching placeholder exists in
    `frontend/e2e/backlog`, move it with `git mv` before editing; otherwise
    create the test file.
 3. Update the coverage table in `user-journeys.md` with the new test path and

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -9,40 +9,41 @@ This document tracks major journeys in DSPACE and whether a Playwright test cove
 Tests under `frontend/e2e/backlog` are placeholders for journeys without automation. Entries are
 sorted alphabetically by journey name.
 
-| Journey                    | Playwright coverage | Test file                                         |
-| -------------------------- | ------------------- | ------------------------------------------------- |
-| Authentication flow        | No                  | --                                                |
-| Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
-| Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
-| Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
-| Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |
-| Custom backup              | Yes                 | `frontend/e2e/custom-backup.spec.ts`              |
-| Custom content integration | Yes                 | `frontend/e2e/custom-content.spec.ts`             |
-| Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
-| Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
-| Failover status page       | Yes                 | `frontend/e2e/failover-status.spec.ts`            |
-| Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
-| Item/process preview       | No                  | --                                                |
-| Legacy data import         | No                  | --                                                |
-| Manage items               | No                  | --                                                |
-| Manage processes           | No                  | --                                                |
-| Manage quests              | No                  | --                                                |
-| Manage quests search       | No                  | --                                                |
-| Mobile item form           | No                  | --                                                |
-| Mobile process form        | No                  | --                                                |
-| Mobile quest form          | No                  | --                                                |
-| Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
-| Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
-| Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
-| Quest form validation      | No                  | --                                                |
-| Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
-| Quest PR form              | No                  | --                                                |
-| Quest PR validation        | No                  | --                                                |
-| Quest success message      | No                  | --                                                |
-| Settings page loads        | No                  | --                                                |
-| Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |
-| Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
-| Touch item selector        | No                  | --                                                |
-| Touch menu navigation      | No                  | --                                                |
-| Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
-| UI responsiveness          | No                  | --                                                |
+| Journey                     | Playwright coverage | Test file                                         |
+| --------------------------- | ------------------- | ------------------------------------------------- |
+| Authentication flow         | No                  | --                                                |
+| Built-in quest details page | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
+| Cloud sync                  | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
+| Constellations quest        | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
+| Cookie consent flow         | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |
+| Custom backup               | Yes                 | `frontend/e2e/custom-backup.spec.ts`              |
+| Custom content integration  | Yes                 | `frontend/e2e/custom-content.spec.ts`             |
+| Docs navigation             | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
+| Error pages                 | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
+| Failover status page        | Yes                 | `frontend/e2e/failover-status.spec.ts`            |
+| Home page loads             | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
+| Item/process preview        | No                  | --                                                |
+| Legacy data import          | No                  | --                                                |
+| Manage items                | No                  | --                                                |
+| Manage processes            | No                  | --                                                |
+| Manage quests               | No                  | --                                                |
+| Manage quests search        | No                  | --                                                |
+| Mobile item form            | No                  | --                                                |
+| Mobile process form         | No                  | --                                                |
+| Mobile quest form           | No                  | --                                                |
+| Page structure              | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
+| Process creation            | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
+| Profile page loads          | Yes                 | `frontend/e2e/profile-page.spec.ts`               |
+| Quest chat                  | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
+| Quest form validation       | No                  | --                                                |
+| Quest list navigation       | Yes                 | `frontend/e2e/quests.spec.ts`                     |
+| Quest PR form               | No                  | --                                                |
+| Quest PR validation         | No                  | --                                                |
+| Quest success message       | No                  | --                                                |
+| Settings page loads         | No                  | --                                                |
+| Shop workflow               | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |
+| Svelte component hydration  | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
+| Touch item selector         | No                  | --                                                |
+| Touch menu navigation       | No                  | --                                                |
+| Tutorial quest run          | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
+| UI responsiveness           | No                  | --                                                |


### PR DESCRIPTION
## Summary
- test profile page loads and shows avatar prompt
- track profile journey and clarify test prompt instructions

## Testing
- `npx playwright install chromium`
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a57b47572c832faa85b0e16ce8daa0