### PR TITLE
docs: refine Phoenix and Cedar NPC sections

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -108,15 +108,15 @@ Phoenix is a chemist focused on sustainable rocket fuel.
 They blend chemistry with conservation to push craft without scarring the planet.
 They guide recruits through quests such as
 [Demonstrate a Safe Chemical Reaction](/quests/chemistry/safe-reaction) and
-[Extract Stevia Sweetener](/quests/chemistry/stevia-extraction)
+[Mix an Efficient Rocket Fuel](/quests/rocketry/fuel-mixture)
 to show how green chemistry powers missions.
 
 ### Sample Dialogue
 
 -   "Hey, I'm Phoenix—chemistry without pollution is my specialty."
--   "Mix vinegar with baking soda; the fizz is safe yet shows energy you can harness."
--   "Dry those stevia leaves and rinse them with ethanol to pull out the sweetness."
--   "That extract will sweeten rations without a sugar crash."
+-   "Safety goggles on; propellant fumes bite harder than dragons."
+-   "We test in micro batches so a bad mix only scorches a spoon."
+-   "Keep the oxidizer chilled; warm tanks turn engines into fireworks."
 -   "Next up, we'll brew propellant that pushes rockets without scorching the skies."
 
 ## Atlas
@@ -153,6 +153,7 @@ second nature.
 -   "Sand that birdhouse so the wrens leave with all their feathers."
 -   "Step stool's next; every rung teaches balance and patience."
 -   "A wipe of oil and the grain tells its story."
+-   "Clamp the board; wandering wood wrecks cuts."
 
 ## Lyra
 


### PR DESCRIPTION
## Summary
- expand Phoenix's rocket-fuel guidance and quest references
- add safety clamp tip to Cedar's sample dialogue

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57b2d7e68832f8286c8eff7b17fdb