### PR TITLE
Add settings page and refine test prompt

### DIFF
--- a/frontend/e2e/backlog/profile-page.spec.ts
+++ b/frontend/e2e/backlog/profile-page.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+
+// TODO: implement Profile page navigation test
+// This placeholder ensures a spec exists for tracking coverage.
+test('Profile page loads', async ({ page }) => {
+    await page.goto('/profile');
+});

--- a/frontend/e2e/backlog/settings-page.spec.ts
+++ b/frontend/e2e/backlog/settings-page.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: implement Settings page navigation test
-// This placeholder ensures a spec exists for tracking coverage.
-test.skip('Settings page loads', async ({ page }) => {
-    await page.goto('/settings');
-});

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Settings route', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('loads settings page', async ({ page }) => {
+        await page.goto('/settings');
+        await expect(page.getByRole('heading', { level: 2, name: 'Settings' })).toBeVisible();
+        await expect(page.getByRole('heading', { level: 2, name: 'Coming soon' })).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -24,7 +24,8 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 > 3. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
 >    implement the Playwright test; otherwise add a new test file.
 > 4. Update `user-journeys.md` with coverage status, test file path, and any fixes,
->    keeping the table alphabetized.
+>    keeping the table alphabetized. Verify apparent 404s aren't missing routes;
+>    if a page should exist, add a stub instead of asserting a 404.
 > 5. Run `npx playwright install chromium` if browsers are missing.
 > 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -33,13 +33,14 @@ sorted alphabetically by journey name.
 | Mobile quest form          | No                  | --                                                |
 | Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
 | Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
+| Profile page loads         | No                  | --                                                |
 | Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
 | Quest form validation      | No                  | --                                                |
 | Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
 | Quest PR form              | No                  | --                                                |
 | Quest PR validation        | No                  | --                                                |
 | Quest success message      | No                  | --                                                |
-| Settings page loads        | No                  | --                                                |
+| Settings page loads        | Yes                 | `frontend/e2e/settings-page.spec.ts`              |
 | Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |
 | Svelte component hydration | Yes                 | `frontend/e2e/svelte-component-hydration.spec.ts` |
 | Touch item selector        | No                  | --                                                |

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -1,0 +1,5 @@
+---
+import Page from '../components/Page.astro';
+---
+
+<Page title="Settings" message="Coming soon" />


### PR DESCRIPTION
## Summary
- add stub Settings page and cover it with a Playwright test
- document Settings coverage and caution against assuming 404s in prompt

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx playwright test e2e/settings-page.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a57b47572c832faa85b0e16ce8daa0