### PR TITLE
Add GFCI outlet test quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -133,6 +133,7 @@ New quests in this release: 210
 -   electronics/solder-wire
 -   electronics/soldering-intro
 -   electronics/temperature-plot
+-   electronics/test-gfci-outlet
 -   electronics/thermistor-reading
 -   electronics/thermometer-calibration
 -   electronics/voltage-divider

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -133,6 +133,7 @@ New quests in this release: 210
 -   electronics/solder-wire
 -   electronics/soldering-intro
 -   electronics/temperature-plot
+-   electronics/test-gfci-outlet
 -   electronics/thermistor-reading
 -   electronics/thermometer-calibration
 -   electronics/voltage-divider

--- a/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
+++ b/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
@@ -1,0 +1,45 @@
+{
+    "id": "electronics/test-gfci-outlet",
+    "title": "Test a GFCI Outlet",
+    "description": "Verify a ground-fault circuit interrupter outlet with a plug-in tester.",
+    "image": "/assets/outlet.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "GFCI outlets guard against shocks. Make sure your hands are dry and the wall plate is intact before we start.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "plug",
+                    "text": "Tester ready."
+                }
+            ]
+        },
+        {
+            "id": "plug",
+            "text": "Insert the GFCI tester fully into the outlet. Check the light pattern against the chart. Press the test button; the outlet should trip. Use the reset button to restore power and confirm the lights return to normal.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "test-gfci-outlet",
+                    "text": "Run the GFCI test."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Outlet passed.",
+                    "requiresItems": [{ "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! The GFCI is wired correctly and trips as expected. Test it monthly and replace damaged outlets.",
+            "options": [{ "type": "finish", "text": "Safety confirmed." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/continuity-test"]
+}


### PR DESCRIPTION
## Summary
- add GFCI outlet safety check quest after continuity test
- document new quest in new-quests list

## Testing
- `npm run audit:ci` *(fails: 8 vulnerabilities, 1 high)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b615650832f8ae7d5fe8cad4d15