### PR TITLE
feat: add moving average temp quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -215,6 +215,7 @@ New quests in this release: 210
 -   programming/json-api
 -   programming/json-endpoint
 -   programming/median-temp
+-   programming/moving-avg-temp
 -   programming/plot-temp-cli
 -   programming/stddev-temp
 -   programming/temp-alert

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -215,6 +215,7 @@ New quests in this release: 210
 -   programming/json-api
 -   programming/json-endpoint
 -   programming/median-temp
+-   programming/moving-avg-temp
 -   programming/plot-temp-cli
 -   programming/stddev-temp
 -   programming/temp-alert

--- a/frontend/src/pages/quests/json/programming/moving-avg-temp.json
+++ b/frontend/src/pages/quests/json/programming/moving-avg-temp.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/moving-avg-temp",
+    "title": "Compute Moving Average Temperature",
+    "description": "Add a moving average to your temperature analysis script.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your average gives a big picture. Let's watch trends with a moving window.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "Let's smooth it out."
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Calculate a moving average over the last N readings in your log.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Moving average computed!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! The moving average reveals trends in real time.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Data looks smoother."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/avg-temp"]
+}


### PR DESCRIPTION
## Summary
- add moving average temperature programming quest after avg-temp
- document new quest in new-quests lists

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b615650832f8ae7d5fe8cad4d15