### PR TITLE
feat: add sunspot sketch astronomy quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -67,6 +67,7 @@ New quests in this release: 210
 -   astronomy/satellite-pass
 -   astronomy/saturn-rings
 -   astronomy/star-trails
+-   astronomy/sunspot-sketch
 -   astronomy/venus-phases
 
 ### chemistry

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -67,6 +67,7 @@ New quests in this release: 210
 -   astronomy/satellite-pass
 -   astronomy/saturn-rings
 -   astronomy/star-trails
+-   astronomy/sunspot-sketch
 -   astronomy/venus-phases
 
 ### chemistry

--- a/frontend/src/pages/quests/json/astronomy/sunspot-sketch.json
+++ b/frontend/src/pages/quests/json/astronomy/sunspot-sketch.json
@@ -1,0 +1,43 @@
+{
+    "id": "astronomy/sunspot-sketch",
+    "title": "Sketch Sunspots",
+    "description": "Project the Sun onto paper with a basic telescope and sketch sunspots in your mission logbook without looking through the eyepiece.",
+    "image": "/assets/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Sunspots show the Sun's activity. We'll use projection for safety.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "project",
+                    "text": "Set up the projection."
+                }
+            ]
+        },
+        {
+            "id": "project",
+            "text": "Aim your basic telescope at the Sun and project the image onto a white card. Never look through the eyepiece.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+                        { "id": "70bb8d86-2c4e-4330-9705-371891934686", "count": 1 }
+                    ],
+                    "text": "Sunspots sketched in my logbook."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Sunspot sketches help track solar cycles. Store your telescope and logbook safely.",
+            "options": [{ "type": "finish", "text": "Solar sketch complete." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/basic-telescope"]
+}


### PR DESCRIPTION
## Summary
- add astronomy/sunspot-sketch quest requiring a basic telescope and mission logbook
- document new quest in the autogenerated new-quests lists

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b615650832f8ae7d5fe8cad4d15