### PR TITLE
Add bandage disposal quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -155,6 +155,7 @@ New quests in this release: 210
 
 -   firstaid/assemble-kit
 -   firstaid/change-bandage
+-   firstaid/dispose-bandages
 -   firstaid/dispose-expired
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 233
+New quests in this release: 211
 
 ### 3dprinting
 
@@ -155,6 +155,7 @@ New quests in this release: 210
 
 -   firstaid/assemble-kit
 -   firstaid/change-bandage
+-   firstaid/dispose-bandages
 -   firstaid/dispose-expired
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter

--- a/frontend/src/pages/quests/json/firstaid/dispose-bandages.json
+++ b/frontend/src/pages/quests/json/firstaid/dispose-bandages.json
@@ -1,0 +1,56 @@
+{
+    "id": "firstaid/dispose-bandages",
+    "title": "Bag Used Bandages",
+    "description": "Use a biohazard bag to discard used bandages and wash up.",
+    "image": "/assets/rescue.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Used bandages can spread germs. Let's bag them properly.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "bag",
+                    "text": "Show me how."
+                }
+            ]
+        },
+        {
+            "id": "bag",
+            "text": "Place the used bandage and wipes in a biohazard bag, seal it, then wash your hands.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Wash hands",
+                    "goto": "bag"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Supplies bagged",
+                    "requiresItems": [
+                        {
+                            "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work. Dispose of the sealed bag with your regular trash.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "All clean!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/change-bandage"]
+}


### PR DESCRIPTION
## Summary
- add **Bag Used Bandages** quest after changing a bandage
- document new quest in v3 quest list

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b615650832f8ae7d5fe8cad4d15