### PR TITLE
🧹 streamline fs-checks listMissingImages

### DIFF
--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -4,13 +4,13 @@ const path = require('path');
 const DATA_URL_RE = /^data:/i;
 const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
 
-function decodeSafely(str) {
+const decodeSafely = (str) => {
   try {
     return decodeURIComponent(str);
   } catch {
     return str;
   }
-}
+};
 
 /**
  * Returns image paths that are missing from the public directory.
@@ -25,15 +25,11 @@ function listMissingImages(
   publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
 ) {
   return imagePaths.filter((img) => {
-    // Strip query strings or hash fragments so existence checks aren't fooled
     const base = img.split(/[?#]/)[0];
-    if (DATA_URL_RE.test(base) || REMOTE_URL_RE.test(base)) {
-      return false;
-    }
-    const rel = base.startsWith('/') ? base.slice(1) : base;
-    const decoded = decodeSafely(rel);
-    const full = path.join(publicDir, decoded);
-    return !fs.existsSync(full);
+    if (DATA_URL_RE.test(base) || REMOTE_URL_RE.test(base)) return false;
+
+    const decoded = decodeSafely(base.startsWith('/') ? base.slice(1) : base);
+    return !fs.existsSync(path.join(publicDir, decoded));
   });
 }
 


### PR DESCRIPTION
## Summary
- streamline listMissingImages path checks by reducing temp vars

## Testing
- npm run lint
- npm run type-check
- npm run build
- npx vitest bench scripts/utils/fs-checks.bench.ts
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68a57b8aec44832f9ca7fe2eadb50dbc