### PR TITLE
♻️ Extract shared JSON reader for validation scripts

### DIFF
--- a/scripts/utils/read-json.js
+++ b/scripts/utils/read-json.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+module.exports = readJson;

--- a/scripts/validate-item.js
+++ b/scripts/validate-item.js
@@ -1,23 +1,22 @@
 #!/usr/bin/env node
-const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
 const schema = require('../frontend/src/pages/inventory/jsonSchemas/item.json');
+const readJson = require('./utils/read-json');
 
 const ajv = new Ajv();
 const validate = ajv.compile(schema);
 
 function validateItem(filePath) {
-  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const data = readJson(filePath);
   const items = Array.isArray(data) ? data : [data];
   let valid = true;
   for (const item of items) {
-    const ok = validate(item);
-    if (!ok) {
+    if (!validate(item)) {
       console.error(`Validation failed for ${filePath}`);
       console.error(validate.errors);
+      valid = false;
     }
-    valid = valid && ok;
   }
   return valid;
 }

--- a/scripts/validate-quest.js
+++ b/scripts/validate-quest.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
 const schema = require('../frontend/src/pages/quests/jsonSchemas/quest.json');
+const readJson = require('./utils/read-json');
 
 const ajv = new Ajv();
 const validate = ajv.compile(schema);
 
 function validateQuest(filePath) {
-  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const data = readJson(filePath);
   const valid = validate(data);
   if (!valid) {
     console.error(`Validation failed for ${filePath}`);


### PR DESCRIPTION
## Summary
- refactor quest and item validators to use a shared JSON reader

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:root`
- `cd frontend && npm test`

```text
`npm run test:ci` could not complete in this environment (Playwright dependency install)
```

------
https://chatgpt.com/codex/tasks/task_e_68a57b8aec44832f9ca7fe2eadb50dbc