### PR TITLE
🧪 : ensure custom price table caching and error handling

### DIFF
--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -3,6 +3,7 @@ import {
   approximateIrlPrice,
   approximateIrlTotalPrice,
   __resetPriceTableCacheForTests,
+  __setMergedTableForTests,
 } from './approximateIrlPrice';
 import { writeFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
@@ -46,6 +47,19 @@ describe('approximateIrlPrice', () => {
 
     it('loads prices from a custom file', () => {
       writeFileSync(tmpFile, JSON.stringify({ custom_item: 42 }));
+      expect(approximateIrlPrice('custom_item')).toBe(42);
+    });
+
+    it('ignores invalid JSON file', () => {
+      writeFileSync(tmpFile, '{');
+      expect(approximateIrlPrice('custom_item')).toBeNull();
+    });
+
+    it('caches loaded prices', () => {
+      writeFileSync(tmpFile, JSON.stringify({ custom_item: 42 }));
+      expect(approximateIrlPrice('custom_item')).toBe(42);
+      __setMergedTableForTests(null);
+      writeFileSync(tmpFile, JSON.stringify({ custom_item: 43 }));
       expect(approximateIrlPrice('custom_item')).toBe(42);
     });
   });

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -67,6 +67,12 @@ export function __resetPriceTableCacheForTests(): void {
   mergedTable = null;
 }
 
+export function __setMergedTableForTests(
+  table: Record<string, number> | null
+): void {
+  mergedTable = table;
+}
+
 /**
  * Look up a real‑world price for a game item.
  *


### PR DESCRIPTION
## Summary
- expose merged table reset for tests
- test custom price table caching and invalid JSON

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68a584f120c0832fbc0501a9b394f896