### PR TITLE
docs: mention audit check in prompt guides

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -25,8 +25,8 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -18,7 +18,8 @@ current and consistent. To keep these templates evolving, see the
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
 > 3. Link new prompt docs from `prompts-codex.md` and the docs index.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- note `npm run audit:ci` in Codex prompt TLDR
- note `npm run audit:ci` in documentation prompt TLDR

## Testing
- `npm run audit:ci` (fails: 8 vulnerabilities, 1 high)
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` (fails: Playwright browser install hangs)
- `npm run test:root` (fails: repository sanity file missing)
- `npm --prefix frontend test` (fails: noConflictMarkers missing file)
- `git diff --cached | ./scripts/scan-secrets.py` (fails: script missing)

------
https://chatgpt.com/codex/tasks/task_e_68a57af4f76c832f9224ae8605322b50