### PR TITLE
Add brass tip cleaner process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ SKIP_E2E=1 npm test
 - Consult `frontend/src/pages/docs/md/npcs.md` for character voice and keep it updated.
 - Use `npm run generate-quest [--template <name>]` to scaffold dialogue quickly; templates live in `frontend/src/pages/quests/templates`.
 - Archive deprecated quests under `frontend/src/pages/quests/archive`.
+- After adding or removing quests, run `npm run new-quests:update` and commit the
+  generated `docs/new-quests.md` and its frontend copy to keep quest counts in sync.
 
 ## UI Guidelines
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4391,5 +4391,29 @@
                 }
             ]
         }
+    },
+    {
+        "id": "use-brass-tip-cleaner",
+        "title": "Clean soldering iron tip using a brass wire sponge",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff",
+                "count": 1
+            },
+            {
+                "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -36,6 +36,8 @@ This guide describes how to submit your custom quests to become part of the offi
 7. **Authorize GitHub** by entering a personal access token with `repo` scope. The token is only used client-side to push your quest and is stored locally so you won't need to re-enter it (see [Authentication Flow](/docs/authentication)).
 8. **Create the pull request** directly from the form. This uploads your quest to a new branch and opens a draft PR.
 9. **Respond to feedback** from reviewers until your quest meets project standards.
+10. **Regenerate the new quests list** by running `npm run new-quests:update` and
+    committing the updated `/docs/new-quests.md` to keep quest counts accurate.
 
 Maintainers can review submitted quests at `/quests/review`, approving or rejecting them before merge.
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3373,5 +3373,23 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "2m"
+    },
+    {
+        "id": "use-brass-tip-cleaner",
+        "title": "Clean soldering iron tip using a brass wire sponge",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
+            { "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/use-brass-tip-cleaner.json
+++ b/frontend/src/pages/processes/hardening/use-brass-tip-cleaner.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add `use-brass-tip-cleaner` process with hardening stub

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b54bf80832fbf93cf57bfc968d7