### PR TITLE
feat: add digital caliper calibration process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4391,5 +4391,34 @@
                 }
             ]
         }
+    },
+    {
+        "id": "calibrate-digital-calipers",
+        "title": "Zero digital calipers on closed jaws after wiping them with a paper towel",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "e37c86b0-caaf-485d-b5c1-c15f7029973c",
+                "count": 1
+            },
+            {
+                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3373,5 +3373,23 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "2m"
+    },
+    {
+        "id": "calibrate-digital-calipers",
+        "title": "Zero digital calipers on closed jaws after wiping them with a paper towel",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "e37c86b0-caaf-485d-b5c1-c15f7029973c", "count": 1 },
+            { "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 }
+        ],
+        "consumeItems": [{ "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 }],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/calibrate-digital-calipers.json
+++ b/frontend/src/pages/processes/hardening/calibrate-digital-calipers.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add calibration process for zeroing digital calipers with a paper towel
- document hardening baseline

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a57b54bf80832fbf93cf57bfc968d7