### PR TITLE
refine generate-ssh-key process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4320,8 +4320,8 @@
     },
     {
         "id": "generate-ssh-key",
-        "title": "Generate an SSH key pair and copy it to a node",
-        "image": "/assets/quests/basic_circuit.svg",
+        "title": "Generate an ed25519 SSH key on a Laptop Computer and use ssh-copy-id on a Pi cluster node",
+        "image": "/assets/team_esp.jpg",
         "requireItems": [
             {
                 "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
@@ -4334,12 +4334,18 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "3m",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-generate-ssh-key-2025-08-20",
+                    "date": "2025-08-20",
+                    "score": 60
+                }
+            ]
         }
     },
     {

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3331,20 +3331,26 @@
     },
     {
         "id": "generate-ssh-key",
-        "title": "Generate an SSH key pair and copy it to a node",
-        "image": "/assets/quests/basic_circuit.svg",
+        "title": "Generate an ed25519 SSH key on a Laptop Computer and use ssh-copy-id on a Pi cluster node",
+        "image": "/assets/team_esp.jpg",
         "requireItems": [
             { "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d", "count": 1 },
             { "id": "df7e94e2-76b9-4865-b843-2ec21feb258e", "count": 1 }
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "3m",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-generate-ssh-key-2025-08-20",
+                    "date": "2025-08-20",
+                    "score": 60
+                }
+            ]
         }
     },
     {

--- a/frontend/src/pages/processes/hardening/generate-ssh-key.json
+++ b/frontend/src/pages/processes/hardening/generate-ssh-key.json
@@ -1,6 +1,12 @@
 {
-    "passes": 0,
-    "score": 0,
-    "emoji": "🛠️",
-    "history": []
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-generate-ssh-key-2025-08-20",
+            "date": "2025-08-20",
+            "score": 60
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- clarify generate-ssh-key process and tie to inventory items
- update hardening info with first pass and recent score

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a57b56bf90832fb6cf7a7c54fcc9f4