### PR TITLE
docs: refresh Codex prompt templates

### DIFF
--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -22,16 +22,16 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 2. Minimize data collection and obtain explicit user consent before storing or
 >    transmitting information.
 > 3. Add or update tests in `backend/__tests__` when behavior changes.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Update backend files under `backend/`.

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -36,8 +36,8 @@ CONTEXT:
   error.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-  * Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-    `npm run build`, and `npm run test:ci` locally.
+  * Run `npm run lint`, `npm run type-check`, `npm run build`, and
+    `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.
@@ -98,8 +98,8 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     query and hash parts before checking so coverage tests don't flag valid assets.
 -   2025-08-10 – `checkPatchCoverage.cjs` assumed `origin/main`; detect the origin's HEAD branch
     so patch coverage checks work on repositories where the default branch is `v3`.
--   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to satisfy
-    `npm run audit:ci`.
+-   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to fix the
+    dependency audit.
 -   2025-08-11 – Introduced a structured outage catalog under `/outages` so agents
     can recall past incidents.
 -   2025-08-12 – `listMissingImages` flagged remote URLs as missing assets; skip `http` and

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -14,8 +14,8 @@ see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
 
 USER:
 1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -15,8 +15,8 @@ workflows.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and
-`README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` all pass before committing.
+`README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` all pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,8 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Backend prompts](/docs/prompts-backend), and [Refactor prompts](/docs/prompts-refactors).
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
+[Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -25,16 +25,16 @@ current and consistent. To keep these templates evolving, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
 
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci`.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -19,8 +19,8 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Scope changes to a single NPC.
 > 2. Specify the expected output (tests, docs).
 > 3. Stop when the spec is complete; remaining text becomes mandatory.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`; scan staged changes with
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -38,7 +38,6 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
     -   CLI:
         ```bash
         codex exec "\
-        npm run audit:ci && \
         npm run lint && \
         npm run type-check && \
         npm run build && \
@@ -76,8 +75,8 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Preserve established character voice and lore.
 2. Keep sample dialogue short and approachable.
-3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
-   and `npm run test:ci`.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Update related docs if needed.
 
@@ -94,8 +93,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit
 `frontend/src/pages/docs/md/npcs.md`, adding or refining NPC sections.
 Maintain each character’s voice, keep sample dialogue realistic, and ensure
-`npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+`npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 before committing.
 
 USER:
@@ -120,8 +119,8 @@ USER:
 2. Improve characterization and ensure dialogue stays concise and in-universe.
 3. Reuse existing image assets; do not add new images.
 4. Cross-reference related quests or processes and update them if needed.
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
-   and `npm run test:ci`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 7. Use an emoji-prefixed commit message like `📝 : – refine NPC bio`.
 

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -17,8 +17,8 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 1. Investigate the failure and implement a fix.
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
-> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Use an emoji-prefixed commit message.
 
@@ -38,8 +38,8 @@ CONTEXT:
 REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
-3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci`.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -26,16 +26,16 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 > 4. Update `user-journeys.md` with coverage status, test file path, and any fixes,
 >    keeping the table alphabetized.
 > 5. Run `npx playwright install chromium` if browsers are missing.
-> 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`.
+> 6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 7. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >    and commit with an emoji.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/user-journeys.md` for mistakes and

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -21,8 +21,8 @@ For fundamental design tips see the
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`; scan staged changes with
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -40,7 +40,7 @@ For fundamental design tips see the
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run audit:ci && npm run test:ci && \
+        npm run test:ci && \
         npm run test:ci -- processQuality && \
         git diff --cached | ./scripts/scan-secrets.py"
         ```
@@ -80,8 +80,8 @@ REQUIREMENTS
 3. Ensure the process is referenced by at least one quest or item; create
    missing items or quest hooks as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Update docs or items if needed.
@@ -99,8 +99,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/base.json` with corresponding
 hardening files in `frontend/src/pages/processes/hardening`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run audit:ci`,
-`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`, and
+steps, durations, item references, and passing checks (`npm run lint`,
+`npm run type-check`, `npm run build`, `npm run test:ci`, and
 `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
@@ -148,8 +148,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality`. Update docs or items if needed.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 8. Use an emoji-prefixed commit message like `📝 : – refine process details`.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -23,8 +23,8 @@ which covers quests, items and processes in detail.
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`; scan staged changes with
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 ---
@@ -42,7 +42,7 @@ which covers quests, items and processes in detail.
     -   CLI:
         ```bash
         codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run audit:ci && npm run test:ci -- questCanonical questQuality"
+        npm run test:ci -- questCanonical questQuality"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -80,8 +80,7 @@ REQUIREMENTS
 3. Find the most natural predecessor quest and update the `requiresQuests`
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check` and
-   `npm run build`.
+5. Run `npm run lint`, `npm run type-check` and `npm run build`.
 6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
@@ -100,7 +99,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
-(`npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+(`npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
@@ -132,9 +131,8 @@ existing quests in that tree as examples for tone and structure.
 USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
-3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci -- questCanonical questQuality`.
-   Fix any failures.
+3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci -- questCanonical questQuality`. Fix any failures.
 4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
@@ -182,7 +180,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-    6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
     `npm run test:ci -- questCanonical questQuality`. Update docs if needed.
    7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
    8. Use an emoji-prefixed commit message.


### PR DESCRIPTION
## Summary
- drop `npm run audit:ci` from all Codex prompt guides
- add missing link to Frontend prompts

## Testing
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `git diff --cached > /tmp/diff.patch && detect-secrets scan /tmp/diff.patch`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57aeb8dcc832f8db412f9dad04aed