### PR TITLE
📚 Refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,8 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Backend prompts](/docs/prompts-backend), and [Refactor prompts](/docs/prompts-refactors).
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend),
+and [Refactor prompts](/docs/prompts-refactors).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -25,8 +26,8 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
@@ -67,12 +68,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
-| **Files to touch**   | Limits search space → faster & cheaper.                                             |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
-| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                        |
+| **Files to touch**   | Limits search space → faster & cheaper.                                                                 |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                                          |
+| **Acceptance check** | e.g. `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -94,7 +95,8 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -125,8 +127,8 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` all pass before committing. If Playwright browsers are
+`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
 USER:
@@ -153,8 +155,8 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
@@ -178,8 +180,8 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -6,7 +6,11 @@ slug: 'prompts-frontend'
 # Frontend prompts for the _dspace_ repo
 
 DSPACE's UI is built with Svelte and Astro. Use this guide when working on files inside
-`frontend/`, including Svelte components, pages, and styles. Changes should improve clarity,
+`frontend/`, including Svelte components, pages, and styles. Use it alongside
+[Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix). Changes should improve clarity,
 accessibility, or performance while keeping tests green.
 
 > **TL;DR**
@@ -14,15 +18,16 @@ accessibility, or performance while keeping tests green.
 > 1. Touch only the necessary files under `frontend/`.
 > 2. Keep components accessible, responsive, and idiomatic.
 > 3. Update or add tests in `frontend/__tests__` when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update UI code under `frontend/`.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -20,7 +20,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`,
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 >    `npm run itemValidation`, `npm run test:ci`, and
 >    `npm run test:ci -- itemQuality`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
@@ -40,6 +40,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
     -   CLI:
         ```bash
         codex exec "\
+        npm run audit:ci && \
         npm run lint && \
         npm run type-check && \
         npm run build && \
@@ -56,8 +57,9 @@ See the [OpenAI CLI docs][openai-cli] for more flags.
 
 -   **Goal sentence**: Gives the agent a north star (“Add price to `white PLA filament`”).
 -   **Files to touch**: Limits search space → faster & cheaper.
--   **Constraints**: Coding style, a11y, item schema rules.
--   **Acceptance check**:
+    -   **Constraints**: Coding style, a11y, item schema rules.
+    -   **Acceptance check**:
+    -   `npm run audit:ci`
     -   `npm run lint`
     -   `npm run type-check`
     -   `npm run build`
@@ -82,8 +84,8 @@ REQUIREMENTS
 3. Ensure the item is referenced by at least one quest or process; update those
    files and create missing processes as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, and `npm run build`.
+6. Run `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`, fixing any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.
 9. Update docs or processes if needed.
@@ -101,8 +103,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or
 create items under `frontend/src/pages/inventory/json/items`, choosing the
 appropriate category file. Ensure realistic details, required fields, and
-passing checks (`npm run lint`, `npm run type-check`, `npm run build`,
-`npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`).
+passing checks (`npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`).
 Verify the item appears in at least one quest or process, reuse existing image
 assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
 committing. If a quest's text changes, run `npm run test:ci -- questQuality` and update the quest's
@@ -125,7 +127,9 @@ Apply this prompt to refine items and track quality over time.
 
 ```text
 SYSTEM:
-You are an automated contributor for the DSPACE repository.
+You are an automated contributor for the DSPACE repository. Ensure `npm run audit:ci`,
+`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`, `npm run itemValidation`,
+and `npm run test:ci -- itemQuality` pass before committing.
 
 USER:
 1. Pick an item from `frontend/src/pages/inventory/json/items` that lacks a
@@ -152,8 +156,8 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`,
-   `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
+   `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.
 

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -19,13 +19,13 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Avoid mixing refactors with new features or fixes.
 > 3. Keep commits small and reversible.
 > 4. Include before-and-after benchmarks if performance could change.
-> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 6. Run `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
 pass before committing.
 
 USER:


### PR DESCRIPTION
## Summary
- document `npm run audit:ci` in Codex prompt guide and add link to frontend prompts
- sync frontend, item, and refactor prompt templates with audit step and cross-links

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57ad7e3a4832f83e9ee92c43fe1ba