### PR TITLE
✨ Improve Button accessibility and responsiveness

### DIFF
--- a/frontend/__tests__/Button.test.js
+++ b/frontend/__tests__/Button.test.js
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const buttonFile = path.join(__dirname, '../src/components/Button.astro');
+
+describe('Button.astro', () => {
+    it('supports aria-label attribute for accessibility', () => {
+        const content = fs.readFileSync(buttonFile, 'utf8');
+        expect(content).toMatch(/aria-label=\{ariaLabel\}/);
+    });
+
+    it('uses responsive spacing units', () => {
+        const content = fs.readFileSync(buttonFile, 'utf8');
+        expect(content).toMatch(/margin: 1rem auto/);
+        expect(content).toMatch(/padding: 0.625rem 1rem/);
+        expect(content).toMatch(/@media \(max-width: 600px\)/);
+    });
+});

--- a/frontend/src/components/Button.astro
+++ b/frontend/src/components/Button.astro
@@ -1,19 +1,30 @@
 ---
-const { text, href } = Astro.props;
+const { text, href, ariaLabel } = Astro.props;
 ---
 
-<a href={href}>{text}</a>
+<a href={href} aria-label={ariaLabel} role="button" class="button">{text}</a>
 
 <style>
-	a {
-        background-color: #2f5b2f;
-		color: white;
-		border-radius: 100px;
-		text-decoration: none;
-        white-space: nowrap;
-        padding: 10px;
-        margin: 50px;
-		display: flex;
-		justify-content: center;
-	}
+.button {
+  background-color: #2f5b2f;
+  color: white;
+  border-radius: 100px;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0.625rem 1rem;
+  margin: 1rem auto;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+.button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+@media (max-width: 600px) {
+  .button {
+    width: 100%;
+    margin: 0.5rem 0;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- add aria-label support and responsive spacing to Button
- cover component with unit test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57b030574832fbfbb2000644785ef