### PR TITLE
📝 Refresh stale doc links

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20221005.md
+++ b/frontend/src/pages/docs/md/changelog/20221005.md
@@ -7,6 +7,7 @@ slug: '20221005'
 -   The [homepage](/) now shows the most recent changelog entry, with a button to view the older entries.
 -   Each [Docs](docs) page (e.g. [/docs/about](/docs/about)) now takes up the entire width of the main content area, as opposed to only half of it before.
 -   [Settings](/settings) page now has an appearance similar to the Docs page.
--   Made the [Inventory](/inventory) page dynamically load a list of items from the [item registry](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/inventory/json/items).
+-   Made the [Inventory](/inventory) page dynamically load a list of items from the
+    [item registry](https://github.com/democratizedspace/dspace/blob/main/frontend/src/pages/inventory/json/items).
 -   Added a small bit of [Roadmap](/docs/roadmap).
 -   Some docs updates (namely, [About](/docs/about), [Mission](/docs/mission), [Roadmap](/docs/roadmap), [Frequently Asked Questions](/docs/faq), [Glossary](/docs/glossary), and [Contribute](/docs/contribute)).

--- a/frontend/src/pages/docs/md/changelog/20221019.md
+++ b/frontend/src/pages/docs/md/changelog/20221019.md
@@ -5,7 +5,9 @@ slug: '20221019'
 
 -   Overhauled the [Inventory](/inventory) and [Quests](/quests) pages.
 -   You can now manually create any of the items on the item page (e.g. [/inventory/item/1](/inventory/item/1)).
--   Set cooldowns for all [items](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/inventory/json/items). If cooldown is not specified, default to 5 minutes.
+-   Set cooldowns for all
+    [items](https://github.com/democratizedspace/dspace/blob/main/frontend/src/pages/inventory/json/items).
+    If cooldown is not specified, default to 5 minutes.
 -   You can now finish the [first 3D printing quest](/quests/play/0) and collect your reward.
 -   Material and machine requirements don't apply yet but will in the future.
 -   Path for quests is now `/quests/play/\[id\]` instead of `/quests/\[id\]` (e.g. [/quests/play/0](/quests/play/0)).

--- a/frontend/src/pages/docs/md/changelog/20230915.md
+++ b/frontend/src/pages/docs/md/changelog/20230915.md
@@ -34,4 +34,7 @@ In the short term, you can now export your game state on the [gamesaves](/gamesa
 
 ## Reliability improvements and code health improvements
 
-This is a pretty minor update content-wise, but this update also adds a lot of important code, like instructions on what meta tags to inject in the HTML pages for SEO purposes. Additionally, game state related code has significantly increased test coverage. This is all in [preparation](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTORS.md) for finding incentives (e.g. bounties) for third-party contributors.
+This is a pretty minor update content-wise, but this update also adds a lot of important code, like
+instructions on what meta tags to inject in the HTML pages for SEO purposes. Additionally, game
+state related code has significantly increased test coverage. This is all in
+[preparation](../../../../../CONTRIBUTORS.md) for finding incentives (e.g. bounties) for third-party contributors.

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -100,7 +100,7 @@ Before submitting:
 
 For more advanced contributors interested in extending core game functionality:
 
--   Follow the [Developer Guide](https://github.com/democratizedspace/dspace/blob/v3/DEVELOPER_GUIDE.md)
+-   Follow the [Developer Guide](/DEVELOPER_GUIDE.md)
 -   Start with small enhancements before proposing major changes
 
 ## Community Resources
@@ -108,7 +108,7 @@ For more advanced contributors interested in extending core game functionality:
 -   [Discord Community](https://discord.gg/A3UAfYvnxM): Discuss ideas and get feedback
 -   [GitHub Repository](https://github.com/democratizedspace/dspace): View source code and submit changes
 -   [Documentation](/docs): Browse all game documentation
--   [Contribution Guide](https://github.com/democratizedspace/dspace/blob/v3/CONTRIBUTING.md): General contribution guidelines
+-   [Contribution Guide](/CONTRIBUTING.md): General contribution guidelines
 
 By following these guidelines, you'll create high-quality content that enhances the DSPACE experience while contributing to our mission of democratizing space exploration through practical, hands-on education.
 Before submitting, run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` to keep the codebase healthy.


### PR DESCRIPTION
## Summary
- update content development guide to use repo-relative developer and contribution links
- fix docs changelog pages referencing old `v3` paths
- use relative link to repository contributors list

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a57af4f76c832f9224ae8605322b50