### PR TITLE
Verify quest count growth and finalize changelog entry

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -29,7 +29,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Document quest schema requirements 💯
         -   [x] Create example quest templates 💯
 
--   [x] 10x More Quests
+-   [x] 10x More Quests 💯
 
     -   [x] Create new official quests using the custom quest system 💯
     -   [x] Balance progression curve across all quests 💯
@@ -149,14 +149,14 @@ Thanks to the new custom quest system, I managed to make all the new quests in�
 
 Astronomy now includes a meteor shower quest, bringing us closer to the full expansion.
 
-As of this release, DSPACE includes **73 official quests**. For reference, v2.1 contained only 22 quests. Here's how the totals compare:
+As of this release, DSPACE includes **236 official quests**. For reference, v2.1 contained only 22 quests. Here's how the totals compare:
 
 | Release   | Quest Count |
 | --------- | ----------- |
 | v2.1      | 22          |
-| v3 (HEAD) | 73          |
+| v3 (HEAD) | 236         |
 
-We're still working toward that 10x increase, but the new quest system makes adding content much faster.
+We've surpassed that 10x increase, and the new quest system makes adding content much faster.
 
 ## Custom Quests
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 232
-New quests in this release: 210
+Current quest count: 236
+New quests in this release: 214
 
 ### 3dprinting
 
@@ -67,6 +67,7 @@ New quests in this release: 210
 -   astronomy/satellite-pass
 -   astronomy/saturn-rings
 -   astronomy/star-trails
+-   astronomy/sunspot-sketch
 -   astronomy/venus-phases
 
 ### chemistry
@@ -133,6 +134,7 @@ New quests in this release: 210
 -   electronics/solder-wire
 -   electronics/soldering-intro
 -   electronics/temperature-plot
+-   electronics/test-gfci-outlet
 -   electronics/thermistor-reading
 -   electronics/thermometer-calibration
 -   electronics/voltage-divider
@@ -155,6 +157,7 @@ New quests in this release: 210
 
 -   firstaid/assemble-kit
 -   firstaid/change-bandage
+-   firstaid/dispose-bandages
 -   firstaid/dispose-expired
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
@@ -215,6 +218,7 @@ New quests in this release: 210
 -   programming/json-api
 -   programming/json-endpoint
 -   programming/median-temp
+-   programming/moving-avg-temp
 -   programming/plot-temp-cli
 -   programming/stddev-temp
 -   programming/temp-alert

--- a/frontend/src/pages/quests/json/astronomy/sunspot-sketch.json
+++ b/frontend/src/pages/quests/json/astronomy/sunspot-sketch.json
@@ -1,0 +1,43 @@
+{
+    "id": "astronomy/sunspot-sketch",
+    "title": "Sketch Sunspots",
+    "description": "Project the Sun onto paper with a basic telescope and sketch sunspots in your mission logbook without looking through the eyepiece.",
+    "image": "/assets/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Sunspots show the Sun's activity. We'll use projection for safety.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "project",
+                    "text": "Set up the projection."
+                }
+            ]
+        },
+        {
+            "id": "project",
+            "text": "Aim your basic telescope at the Sun and project the image onto a white card. Never look through the eyepiece.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+                        { "id": "70bb8d86-2c4e-4330-9705-371891934686", "count": 1 }
+                    ],
+                    "text": "Sunspots sketched in my logbook."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Sunspot sketches help track solar cycles. Store your telescope and logbook safely.",
+            "options": [{ "type": "finish", "text": "Solar sketch complete." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/basic-telescope"]
+}

--- a/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
+++ b/frontend/src/pages/quests/json/electronics/test-gfci-outlet.json
@@ -1,0 +1,45 @@
+{
+    "id": "electronics/test-gfci-outlet",
+    "title": "Test a GFCI Outlet",
+    "description": "Verify a ground-fault circuit interrupter outlet with a plug-in tester.",
+    "image": "/assets/outlet.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "GFCI outlets guard against shocks. Make sure your hands are dry and the wall plate is intact before we start.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "plug",
+                    "text": "Tester ready."
+                }
+            ]
+        },
+        {
+            "id": "plug",
+            "text": "Insert the GFCI tester fully into the outlet. Check the light pattern against the chart. Press the test button; the outlet should trip. Use the reset button to restore power and confirm the lights return to normal.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "test-gfci-outlet",
+                    "text": "Run the GFCI test."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Outlet passed.",
+                    "requiresItems": [{ "id": "5562d728-8e62-43b2-9b3d-77cebd2ab481", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! The GFCI is wired correctly and trips as expected. Test it monthly and replace damaged outlets.",
+            "options": [{ "type": "finish", "text": "Safety confirmed." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/continuity-test"]
+}

--- a/frontend/src/pages/quests/json/firstaid/dispose-bandages.json
+++ b/frontend/src/pages/quests/json/firstaid/dispose-bandages.json
@@ -1,0 +1,56 @@
+{
+    "id": "firstaid/dispose-bandages",
+    "title": "Bag Used Bandages",
+    "description": "Use a biohazard bag to discard used bandages and wash up.",
+    "image": "/assets/rescue.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Used bandages can spread germs. Let's bag them properly.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "bag",
+                    "text": "Show me how."
+                }
+            ]
+        },
+        {
+            "id": "bag",
+            "text": "Place the used bandage and wipes in a biohazard bag, seal it, then wash your hands.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "wash-hands",
+                    "text": "Wash hands",
+                    "goto": "bag"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Supplies bagged",
+                    "requiresItems": [
+                        {
+                            "id": "7a4b8892-365f-4a56-93ce-127aa989f50d",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work. Dispose of the sealed bag with your regular trash.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "All clean!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/change-bandage"]
+}

--- a/frontend/src/pages/quests/json/programming/moving-avg-temp.json
+++ b/frontend/src/pages/quests/json/programming/moving-avg-temp.json
@@ -1,0 +1,50 @@
+{
+    "id": "programming/moving-avg-temp",
+    "title": "Compute Moving Average Temperature",
+    "description": "Add a moving average to your temperature analysis script.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your average gives a big picture. Let's watch trends with a moving window.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "code",
+                    "text": "Let's smooth it out."
+                }
+            ]
+        },
+        {
+            "id": "code",
+            "text": "Calculate a moving average over the last N readings in your log.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Moving average computed!",
+                    "requiresItems": [
+                        {
+                            "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! The moving average reveals trends in real time.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Data looks smoother."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/avg-temp"]
+}

--- a/tests/questCount.test.ts
+++ b/tests/questCount.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const QUEST_DIR = path.join(__dirname, '../frontend/src/pages/quests/json');
+const BASE_COMMIT = 'd956e807d49114da2d0ff28aacef91341813bf82'; // v2.1
+
+function listQuestFiles(commit?: string): string[] {
+  if (commit) {
+    const output = execSync(
+      `git ls-tree -r --name-only ${commit} ${QUEST_DIR}`,
+      { encoding: 'utf8' }
+    );
+    return output.trim().split(/\n/).filter(Boolean);
+  }
+  const files: string[] = [];
+  function walk(dir: string) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.json')) files.push(full);
+    }
+  }
+  walk(QUEST_DIR);
+  return files;
+}
+
+describe('quest count', () => {
+  it('has increased at least 10x since v2.1', () => {
+    const prev = listQuestFiles(BASE_COMMIT).length;
+    const current = listQuestFiles().length;
+    const ratio = current / prev;
+    expect(ratio).toBeGreaterThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
## Summary
- sync new-quests docs with latest quest list and counts
- adjust changelog totals to 236 quests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57adfe374832f9d1ae3527c6b59e1