### PR TITLE
docs: cross-link quest guides

### DIFF
--- a/cspell/dspace-terms.txt
+++ b/cspell/dspace-terms.txt
@@ -59,7 +59,7 @@ cooldowns
 cpus
 customcontent
 danie
-dcarbon
+dCarbon
 deburr
 deburred
 defining

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -41,7 +41,17 @@ import Page from '../../components/Page.astro';
             <a href="/docs/processes">Processes</a>
             <a href="/docs/guilds">Guilds</a>
             <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dcarbon">dCarbon</a>
+            <a href="/docs/dCarbon">dCarbon</a>
+        </nav>
+    </span>
+    <span>
+        <h2>Quests</h2>
+        <nav>
+            <a href="/docs/quest-guidelines">Quest Development Guidelines</a>
+            <a href="/docs/quest-template">Quest Template Example</a>
+            <a href="/docs/quest-schema">Quest Schema Requirements</a>
+            <a href="/docs/quest-contribution">Quest Contribution Guidelines</a>
+            <a href="/docs/quest-submission">Quest Submission Guide</a>
         </nav>
     </span>
     <span>

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -40,6 +40,10 @@ Comprehensive instructions for creating engaging, educational quests that guide 
 -   Dialogue structure and NPC interactions
 -   Technical requirements and JSON structure
 -   Submission and review process
+-   Example JSON in the [Quest Template](/docs/quest-template)
+-   Field definitions in the [Quest Schema Requirements](/docs/quest-schema)
+-   Step-by-step [Quest Submission Guide](/docs/quest-submission)
+-   Full workflow in the [Quest Contribution Guidelines](/docs/quest-contribution)
 
 ### [Item Development Guidelines](/docs/item-guidelines)
 

--- a/frontend/src/pages/docs/md/contribute.md
+++ b/frontend/src/pages/docs/md/contribute.md
@@ -21,7 +21,8 @@ DSPACE is designed as an extensible platform where community members can create 
 
 -   **[Create Custom Quests](/docs/quest-guidelines)** - Design educational missions that teach
     space-related skills. When you're ready to share your work, follow the
-    [Quest Contribution Guidelines](/docs/quest-contribution) to submit it for review.
+    [Quest Contribution Guidelines](/docs/quest-contribution) and the
+    [Quest Submission Guide](/docs/quest-submission) to submit it for review.
 -   **[Develop Custom Items](/docs/item-guidelines)** - Create virtual resources, tools, and components
 -   **[Design Custom Processes](/docs/process-guidelines)** - Build activities that transform or utilize items
 

--- a/frontend/src/pages/docs/md/dCarbon.md
+++ b/frontend/src/pages/docs/md/dCarbon.md
@@ -1,6 +1,6 @@
 ---
 title: 'dCarbon'
-slug: 'dcarbon'
+slug: 'dCarbon'
 ---
 
 dCarbon represents the amount of carbon dioxide produced by a player in the game. 1 dCarbon = 1 kg of carbon dioxide. This virtual measurement helps track environmental impact and encourages players to seek cleaner energy solutions.

--- a/frontend/src/pages/docs/md/quest-contribution.md
+++ b/frontend/src/pages/docs/md/quest-contribution.md
@@ -11,6 +11,7 @@ These guidelines outline the process for contributing your custom quests to the 
 
 -   [Quest Development Guidelines](/docs/quest-guidelines)
 -   Node.js environment with this repository cloned
+-   Review the [Quest Template Example](/docs/quest-template)
 
 ## Workflow
 
@@ -31,7 +32,8 @@ These guidelines outline the process for contributing your custom quests to the 
     node scripts/create-content-bundle.js
     ```
     This creates a JSON bundle in `submissions/bundles`.
-5. **Submit via the in-game form** at `/quests/submit`.
+5. **Submit via the in-game form** at `/quests/submit` (see the
+   [Quest Submission Guide](/docs/quest-submission)).
 6. **Authorize GitHub** with a personal access token and create a pull request.
 7. **Respond to feedback** until the quest meets project standards.
 

--- a/frontend/src/pages/docs/md/quest-guidelines.md
+++ b/frontend/src/pages/docs/md/quest-guidelines.md
@@ -5,7 +5,13 @@ slug: 'quest-guidelines'
 
 # Quest Development Guidelines
 
-This guide provides structured instructions for creating engaging, educational quests that align with DSPACE's mission to democratize space exploration through practical, hands-on learning experiences.
+This guide provides structured instructions for creating engaging, educational quests that align
+with DSPACE's mission to democratize space exploration through practical, hands-on learning
+experiences. Start with the
+[Quest Template Example](/docs/quest-template) and consult the
+[Quest Schema Requirements](/docs/quest-schema) for field definitions. When your quest is ready,
+follow the [Quest Contribution Guidelines](/docs/quest-contribution) and the
+[Quest Submission Guide](/docs/quest-submission) to share it with the community.
 
 ## Quest Philosophy
 

--- a/frontend/src/pages/docs/md/quest-schema.md
+++ b/frontend/src/pages/docs/md/quest-schema.md
@@ -5,7 +5,10 @@ slug: 'quest-schema'
 
 # Quest Schema Requirements
 
-Every quest JSON file must conform to the [quest schema](../quests/jsonSchemas/quest.json) to be loaded by DSPACE. This page summarizes the required structure.
+Every quest JSON file must conform to the [quest schema](../quests/jsonSchemas/quest.json) to be
+loaded by DSPACE. Review the [Quest Development Guidelines](/docs/quest-guidelines) for design tips
+and the [Quest Submission Guide](/docs/quest-submission) when you're ready to publish. This page
+summarizes the required structure.
 
 ## Top-level properties
 

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -11,6 +11,8 @@ This guide describes how to submit your custom quests to become part of the offi
 
 -   Familiarity with the [Quest Development Guidelines](/docs/quest-guidelines)
 -   A local copy of this repository with all dependencies installed
+-   Optional: start from the [Quest Template Example](/docs/quest-template) for a minimal JSON
+    structure
 
 ## Steps
 
@@ -42,6 +44,8 @@ Maintainers can review submitted quests at `/quests/review`, approving or reject
 If something goes wrong, the submission form will display an error message so you can adjust and try again.
 
 Once merged, your quest will be included in the next game update!
+
+For the full workflow, see the [Quest Contribution Guidelines](/docs/quest-contribution).
 
 ### GitHub Token Setup
 

--- a/frontend/src/pages/docs/md/quest-template.md
+++ b/frontend/src/pages/docs/md/quest-template.md
@@ -5,7 +5,12 @@ slug: 'quest-template'
 
 # Quest Template Example
 
-This page provides a minimal quest JSON structure that you can use as a starting point for your own quests. Quests created with this format are compatible with the [token.place](https://token.place) project and can be shared across repos. Feel free to copy this snippet into your editor to speed up the process.
+This page provides a minimal quest JSON structure that you can use as a starting point for your
+own quests. Quests created with this format are compatible with the
+[token.place](https://token.place) project and can be shared across repos. For field details see
+the [Quest Schema Requirements](/docs/quest-schema), and when you're ready to publish, follow the
+[Quest Submission Guide](/docs/quest-submission). Feel free to copy this snippet into your editor
+to speed up the process.
 
 Ready-to-use JSON templates live in `frontend/src/pages/quests/templates`. Copy `basic.json` for a linear quest or `branching.json` to experiment with multiple paths. You can also run `npm run generate-quest --template basic` (or `branching`) to copy one automatically.
 

--- a/frontend/src/pages/energy/index.astro
+++ b/frontend/src/pages/energy/index.astro
@@ -12,7 +12,11 @@ import Chip from '../../components/Chip.astro';
                 <p>Energy source: Coal</p>
             </div>
             <p>generate <Chip text="1000 dWatt" href={`/processes/outlet-dWatt-1e3`} />, <Chip text="1E4 dWatt" href={`/processes/outlet-dWatt-1e4`} />, or <Chip text="1E5 dWatt" href={`/processes/outlet-dWatt-1e5`} /></p>
-            <p>Generating energy from a wall outlet assumes the outlet uses coal, which causes <Chip text="dCarbon" href={`/docs/dCarbon`} /> to accrue. Use an alternate energy source, like <Chip text="solar" href={`/docs/solar`} />, to avoid accruing dCarbon.</p>
+            <p>
+                Generating energy from a wall outlet assumes the outlet uses coal, which causes
+                <Chip text="dCarbon" href={`/docs/dCarbon`} /> to accrue. Use an alternate energy
+                source, like <Chip text="solar" href={`/docs/solar`} />, to avoid accruing dCarbon.
+            </p>
             <p>dCarbon per dWatt: {.4325943029.toFixed(10)}</p>
             <p>price per kWh: 0.18 dUSD</p>
         </div>
@@ -30,7 +34,7 @@ import Chip from '../../components/Chip.astro';
                 <p>Convert dCarbon to dOffset</p>
                 <img src="/assets/solar.jpg" />
             </div>
-            <p>convert <Chip text="1 dCarbon" href={`/processes/dCarbon-dOffset-1`} /> or <Chip text="10 dCarbon" href={`/processes/dCarbon-dOffset-10`} /> to <Chip text="dOffset" href="/inventory/item/70" /></p> 
+            <p>convert <Chip text="1 dCarbon" href={`/processes/dCarbon-dOffset-1`} /> or <Chip text="10 dCarbon" href={`/processes/dCarbon-dOffset-10`} /> to <Chip text="dOffset" href="/inventory/item/70" /></p>
             <p>Cost per dOffset: 10 <Chip text="dUSD" href="/wallet" /></p>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- link quest documentation pages from index
- cross-reference quest guides and fix dCarbon links

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a57b023d94832fbbb661e829990ecd