### PR TITLE
Increase coverage for price table cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ console.log(approximateIrlPrice("3D-Printer")); // 350
 console.log(approximateIrlPrice("unknown")); // null
 console.log(approximateIrlPrice(undefined as any)); // null
 ```
+
+To override default prices, set `DSPACE_PRICE_TABLE_FILE` to a JSON file mapping
+item identifiers to numbers. Tests can reset cached tables with
+`__resetPriceTableCacheForTests({ keepCustom: true })` to preserve custom entries.
 ## Testing
 
 DSPACE uses a comprehensive testing suite to ensure code quality and prevent regressions.

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -48,6 +48,19 @@ describe('approximateIrlPrice', () => {
       writeFileSync(tmpFile, JSON.stringify({ custom_item: 42 }));
       expect(approximateIrlPrice('custom_item')).toBe(42);
     });
+
+    it('ignores invalid JSON files', () => {
+      writeFileSync(tmpFile, '{');
+      expect(approximateIrlPrice('custom_item')).toBeNull();
+    });
+
+    it('caches prices without rereading file', () => {
+      writeFileSync(tmpFile, JSON.stringify({ custom_item: 42 }));
+      expect(approximateIrlPrice('custom_item')).toBe(42);
+      writeFileSync(tmpFile, JSON.stringify({ custom_item: 99 }));
+      __resetPriceTableCacheForTests({ keepCustom: true });
+      expect(approximateIrlPrice('custom_item')).toBe(42);
+    });
   });
 
   describe('approximateIrlTotalPrice', () => {

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -62,8 +62,12 @@ function getPriceTable(): Record<string, number> {
   return mergedTable;
 }
 
-export function __resetPriceTableCacheForTests(): void {
-  customTable = null;
+export function __resetPriceTableCacheForTests(options?: {
+  keepCustom?: boolean;
+}): void {
+  if (!options?.keepCustom) {
+    customTable = null;
+  }
   mergedTable = null;
 }
 


### PR DESCRIPTION
## Summary
- expose reset helper option for price table caching
- test custom price table caching and invalid JSON handling
- document custom price table usage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: terminated early during e2e run)*
- `npm run coverage` *(fails: Not a valid object name origin/v3)*
- `node scripts/checkPatchCoverage.cjs` *(fails: coverage file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c3d79530832f8a67a2283eb5cfb9