### PR TITLE
🌔 : log moon phases quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -60,6 +60,7 @@ New quests in this release: 214
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
 -   astronomy/meteor-shower
+-   astronomy/moon-phase-log
 -   astronomy/north-star
 -   astronomy/observe-moon
 -   astronomy/orion-nebula

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -60,6 +60,7 @@ New quests in this release: 214
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
 -   astronomy/meteor-shower
+-   astronomy/moon-phase-log
 -   astronomy/north-star
 -   astronomy/observe-moon
 -   astronomy/orion-nebula

--- a/frontend/src/pages/quests/json/astronomy/lunar-eclipse.json
+++ b/frontend/src/pages/quests/json/astronomy/lunar-eclipse.json
@@ -51,5 +51,5 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["astronomy/observe-moon"]
+    "requiresQuests": ["astronomy/moon-phase-log"]
 }

--- a/frontend/src/pages/quests/json/astronomy/moon-phase-log.json
+++ b/frontend/src/pages/quests/json/astronomy/moon-phase-log.json
@@ -1,0 +1,43 @@
+{
+    "id": "astronomy/moon-phase-log",
+    "title": "Log Moon Phases",
+    "description": "Track the Moon's phase each night for a week in your mission logbook.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Nova here! After sunset, note today's lunar phase in your log.",
+            "options": [{ "type": "goto", "goto": "record", "text": "Moon's up" }]
+        },
+        {
+            "id": "record",
+            "text": "Sketch the Moon and label the date in your mission logbook.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "write-mission-log-entry",
+                    "text": "Log the phase"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Entry done",
+                    "requiresItems": [
+                        { "id": "70bb8d86-2c4e-4330-9705-371891934686", "count": 1 },
+                        { "id": "aa82b02f-2617-4474-a91b-29647e4a9780", "count": 1 },
+                        { "id": "4729b96d-5057-40d8-83a4-25a4fa122d98", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! Repeat nightly to map the full lunar cycle.",
+            "options": [{ "type": "finish", "text": "Onward" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/observe-moon"]
+}


### PR DESCRIPTION
## Summary
- add moon-phase-log quest referencing logbook items
- require moon-phase-log before lunar-eclipse

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `npm run new-quests:update`


------
https://chatgpt.com/codex/tasks/task_e_68a80860e1d0832f81b4a887fafe7be8