### PR TITLE
feat: add compost sifter quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4022,6 +4022,20 @@
         }
     },
     {
+        "id": "sift-compost",
+        "title": "Separate finished compost using a mesh sifter",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            {
+                "id": "4796b4a9-0927-4b46-a41f-076ebaff01bb",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -593,5 +593,20 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "4796b4a9-0927-4b46-a41f-076ebaff01bb",
+        "name": "compost sifter",
+        "description": "Wooden frame with 1 cm mesh to screen finished compost; 40×40 cm, 1 kg.",
+        "image": "/assets/bucket.jpg",
+        "price": "20 dUSD",
+        "type": "tool",
+        "unit": "sifter",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3131,6 +3131,20 @@
         "duration": "1m"
     },
     {
+        "id": "sift-compost",
+        "title": "Separate finished compost using a mesh sifter",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            {
+                "id": "4796b4a9-0927-4b46-a41f-076ebaff01bb",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m"
+    },
+    {
         "id": "tin-soldering-iron-tip",
         "title": "Heat the soldering iron and melt solder on the tip while wearing safety goggles",
         "image": "/assets/quests/basic_circuit.svg",

--- a/frontend/src/pages/quests/json/composting/sift-compost.json
+++ b/frontend/src/pages/quests/json/composting/sift-compost.json
@@ -1,0 +1,35 @@
+{
+    "id": "composting/sift-compost",
+    "title": "Sift Finished Compost",
+    "description": "Screen compost to remove large chunks for a fine finished mix.",
+    "image": "/assets/bucket.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready to use your compost? Let's sift out the lumpy bits.",
+            "options": [{ "type": "goto", "goto": "sift", "text": "How do I do that?" }]
+        },
+        {
+            "id": "sift",
+            "text": "Place the sifter over a tub and shake compost through the mesh.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "process": "sift-compost",
+                    "requiresItems": [{ "id": "4796b4a9-0927-4b46-a41f-076ebaff01bb", "count": 1 }],
+                    "text": "Sift the compost"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! The fine compost is ready for your garden.",
+            "options": [{ "type": "finish", "text": "Can't wait to use it!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["composting/turn-pile"]
+}


### PR DESCRIPTION
## Summary
- add compost sifter item and sift-compost process
- introduce "Sift Finished Compost" quest after turn-pile
- update new quests docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a80860e1d0832f81b4a887fafe7be8