### PR TITLE
✨: add soldering mat quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -137,6 +137,7 @@ New quests in this release: 214
 -   electronics/test-gfci-outlet
 -   electronics/thermistor-reading
 -   electronics/thermometer-calibration
+-   electronics/use-soldering-mat
 -   electronics/voltage-divider
 
 ### energy

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -137,6 +137,7 @@ New quests in this release: 214
 -   electronics/test-gfci-outlet
 -   electronics/thermistor-reading
 -   electronics/thermometer-calibration
+-   electronics/use-soldering-mat
 -   electronics/voltage-divider
 
 ### energy

--- a/frontend/src/pages/quests/json/electronics/soldering-intro.json
+++ b/frontend/src/pages/quests/json/electronics/soldering-intro.json
@@ -58,7 +58,7 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["electronics/basic-circuit"],
+    "requiresQuests": ["electronics/use-soldering-mat"],
     "hardening": {
         "passes": 3,
         "score": 60,

--- a/frontend/src/pages/quests/json/electronics/use-soldering-mat.json
+++ b/frontend/src/pages/quests/json/electronics/use-soldering-mat.json
@@ -1,0 +1,38 @@
+{
+    "id": "electronics/use-soldering-mat",
+    "title": "Use a Soldering Mat",
+    "description": "Lay a heat-resistant silicone mat before powering the iron.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "A safe workspace starts with the right surface. Ready to roll out the silicone mat?",
+            "options": [{ "type": "goto", "goto": "place", "text": "Yes, clear the bench." }]
+        },
+        {
+            "id": "place",
+            "text": "Unfold the mat and keep cords away from the edges before heating the iron.",
+            "options": [
+                { "type": "process", "process": "use-soldering-mat", "text": "Mat positioned" },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Mat down and iron ready",
+                    "requiresItems": [
+                        { "id": "cd0e1512-9b4e-4450-92ab-b298852ca5e7", "count": 1 },
+                        { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great. The mat protects the bench from heat and solder splashes.",
+            "options": [{ "type": "finish", "text": "All set." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["electronics/basic-circuit"]
+}


### PR DESCRIPTION
## Summary
- add use-soldering-mat quest in electronics
- chain tin-soldering-iron after the new mat step
- refresh new-quests documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a80860e1d0832f81b4a887fafe7be8