### PR TITLE
Add safety goggles process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4428,5 +4428,25 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "wear-safety-goggles",
+        "title": "Put on safety goggles before operating power tools",
+        "image": "/assets/rescue.jpg",
+        "requireItems": [
+            {
+                "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3404,5 +3404,20 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "wear-safety-goggles",
+        "title": "Put on safety goggles before operating power tools",
+        "image": "/assets/rescue.jpg",
+        "requireItems": [{ "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/wear-safety-goggles.json
+++ b/frontend/src/pages/processes/hardening/wear-safety-goggles.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add wear-safety-goggles process referencing existing safety goggles item
- include default hardening metadata and regenerate processes registry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a80858f114832fb824bd9b324bf33b