### PR TITLE
Add trim resistor leads process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4428,5 +4428,29 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "trim-resistor-leads",
+        "title": "Trim excess leads from a soldered 220 Ω resistor using wire cutters",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+                "count": 1
+            },
+            {
+                "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3404,5 +3404,17 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "trim-resistor-leads",
+        "title": "Trim excess leads from a soldered 220 Ω resistor using wire cutters",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "ce92a1a9-c817-40f0-92b1-24aff053903d", "count": 1 },
+            { "id": "037e6065-68a7-4ad1-9b0b-7778ecfe0662", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "2m"
     }
 ]

--- a/frontend/src/pages/processes/hardening/trim-resistor-leads.json
+++ b/frontend/src/pages/processes/hardening/trim-resistor-leads.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add process for trimming soldered resistor leads with wire cutters
- include initial hardening data and regenerate processes registry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a80858f114832fb824bd9b324bf33b