### PR TITLE
Add digital caliper zeroing process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4428,5 +4428,25 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "zero-digital-calipers",
+        "title": "Zero digital calipers on a flat surface before taking measurements",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "e37c86b0-caaf-485d-b5c1-c15f7029973c",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10s",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3404,5 +3404,20 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "zero-digital-calipers",
+        "title": "Zero digital calipers on a flat surface before taking measurements",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [{ "id": "e37c86b0-caaf-485d-b5c1-c15f7029973c", "count": 1 }],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "10s",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/zero-digital-calipers.json
+++ b/frontend/src/pages/processes/hardening/zero-digital-calipers.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add process to zero digital calipers before measuring
- include hardening file and regenerate processes list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a80858f114832fb824bd9b324bf33b