### PR TITLE
Add cron automation quest to sysadmin tree

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -256,6 +256,7 @@ New quests in this release: 214
 ### sysadmin
 
 -   sysadmin/basic-commands
+-   sysadmin/cron-automation
 -   sysadmin/log-analysis
 -   sysadmin/resource-monitoring
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -256,6 +256,7 @@ New quests in this release: 214
 ### sysadmin
 
 -   sysadmin/basic-commands
+-   sysadmin/cron-automation
 -   sysadmin/log-analysis
 -   sysadmin/resource-monitoring
 

--- a/frontend/src/pages/quests/json/sysadmin/cron-automation.json
+++ b/frontend/src/pages/quests/json/sysadmin/cron-automation.json
@@ -1,0 +1,50 @@
+{
+    "id": "sysadmin/cron-automation",
+    "title": "Schedule Cron Jobs",
+    "description": "Use cron to automate tasks on an Ubuntu 24.04 LTS Minimal server.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Servers never sleep. Ready to make cron do the night shift?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "cron",
+                    "text": "Let's schedule a task"
+                }
+            ]
+        },
+        {
+            "id": "cron",
+            "text": "Edit crontab to run your backup script at 02:00 every day.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Cron job saved",
+                    "requiresItems": [
+                        {
+                            "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice. Your backups will run while you sleep.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Mission accomplished"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["sysadmin/basic-commands"]
+}


### PR DESCRIPTION
## Summary
- add sysadmin quest for scheduling cron jobs
- update new quests catalog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`

## Security
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script)*
- `detect-secrets scan /tmp/diff.patch`

------
https://chatgpt.com/codex/tasks/task_e_68a8086a314c832fb562c0a14b6d1627