### PR TITLE
feat: add service restart sysadmin quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -258,6 +258,7 @@ New quests in this release: 214
 -   sysadmin/basic-commands
 -   sysadmin/log-analysis
 -   sysadmin/resource-monitoring
+-   sysadmin/service-restart
 
 ### ubi
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -258,6 +258,7 @@ New quests in this release: 214
 -   sysadmin/basic-commands
 -   sysadmin/log-analysis
 -   sysadmin/resource-monitoring
+-   sysadmin/service-restart
 
 ### ubi
 

--- a/frontend/src/pages/quests/json/sysadmin/service-restart.json
+++ b/frontend/src/pages/quests/json/sysadmin/service-restart.json
@@ -1,0 +1,50 @@
+{
+    "id": "sysadmin/service-restart",
+    "title": "Restart a Service",
+    "description": "Use systemctl to restart a stuck service on Ubuntu 24.04 LTS Minimal.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "One node froze. Want to breathe life into its service?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "restart",
+                    "text": "Give it a restart"
+                }
+            ]
+        },
+        {
+            "id": "restart",
+            "text": "Run systemctl restart apache2 && systemctl status apache2 to confirm.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Service revived",
+                    "requiresItems": [
+                        {
+                            "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Back online. Uptime preserved and users none the wiser.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Onward"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": []
+}


### PR DESCRIPTION
## Summary
- add service restart quest for sysadmins
- document new quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a8086a314c832fb562c0a14b6d1627