### PR TITLE
♿️ add aria-label and responsive spacing to Button

### DIFF
--- a/frontend/__tests__/Button.test.js
+++ b/frontend/__tests__/Button.test.js
@@ -1,0 +1,19 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const buttonFile = path.join(__dirname, '../src/components/Button.astro');
+
+describe('Button.astro', () => {
+    it('supports aria-label for accessibility', () => {
+        const content = fs.readFileSync(buttonFile, 'utf8');
+        expect(content).toMatch(/aria-label={ariaLabel \?\? text}/);
+    });
+
+    it('uses responsive spacing units', () => {
+        const content = fs.readFileSync(buttonFile, 'utf8');
+        expect(content).toMatch(/padding: 0\.5rem 1rem;/);
+        expect(content).toMatch(/margin: 0\.5rem;/);
+    });
+});

--- a/frontend/src/components/Button.astro
+++ b/frontend/src/components/Button.astro
@@ -1,19 +1,38 @@
 ---
-const { text, href } = Astro.props;
+interface Props {
+    text: string;
+    href: string;
+    ariaLabel?: string;
+}
+
+const { text, href, ariaLabel }: Props = Astro.props;
 ---
 
-<a href={href}>{text}</a>
+<a
+    href={href}
+    aria-label={ariaLabel ?? text}
+    class="button"
+>
+    {text}
+</a>
 
 <style>
-	a {
-        background-color: #2f5b2f;
-		color: white;
-		border-radius: 100px;
-		text-decoration: none;
-        white-space: nowrap;
-        padding: 10px;
-        margin: 50px;
-		display: flex;
-		justify-content: center;
-	}
+        .button {
+                background-color: #2f5b2f;
+                color: white;
+                border-radius: 100px;
+                text-decoration: none;
+                white-space: nowrap;
+                padding: 0.5rem 1rem;
+                margin: 0.5rem;
+                display: inline-flex;
+                justify-content: center;
+                align-items: center;
+                width: fit-content;
+        }
+
+        .button:focus-visible {
+                outline: 2px solid #fff;
+                outline-offset: 2px;
+        }
 </style>


### PR DESCRIPTION
## Summary
- allow Button.astro to accept `ariaLabel` for accessibility
- switch Button spacing to rem units for responsiveness
- test Button for aria-label and responsive spacing

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: playwright install step aborted)*


------
https://chatgpt.com/codex/tasks/task_e_68a807c91d1c832f963c28dcdb3daf06