### PR TITLE
♿️ Improve energy page image accessibility

### DIFF
--- a/frontend/__tests__/energyPage.test.js
+++ b/frontend/__tests__/energyPage.test.js
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const energyFile = path.join(__dirname, '../src/pages/energy/index.astro');
+
+describe('energy/index.astro', () => {
+    it('all images include descriptive alt text', () => {
+        const content = fs.readFileSync(energyFile, 'utf8');
+        const imgTags = content.match(/<img[^>]*>/g) || [];
+        expect(imgTags.length).toBeGreaterThan(0);
+        imgTags.forEach((tag) => {
+            expect(tag).toMatch(/alt="[^"]+"/);
+        });
+    });
+
+    it('uses responsive image sizing', () => {
+        const content = fs.readFileSync(energyFile, 'utf8');
+        expect(content).toMatch(/max-width: 50px/);
+        expect(content).toMatch(/width: 100%/);
+    });
+});

--- a/frontend/src/pages/energy/index.astro
+++ b/frontend/src/pages/energy/index.astro
@@ -8,7 +8,7 @@ import Chip from '../../components/Chip.astro';
         <div class="item">
             <div class="horizontal list">
                 <p>Wall outlet</p>
-                <img src="/assets/outlet.jpg" />
+                <img src="/assets/outlet.jpg" alt="Wall outlet" />
                 <p>Energy source: Coal</p>
             </div>
             <p>generate <Chip text="1000 dWatt" href={`/processes/outlet-dWatt-1e3`} />, <Chip text="1E4 dWatt" href={`/processes/outlet-dWatt-1e4`} />, or <Chip text="1E5 dWatt" href={`/processes/outlet-dWatt-1e5`} /></p>
@@ -23,7 +23,7 @@ import Chip from '../../components/Chip.astro';
         <div class="item">
             <div class="horizontal list">
                 <p>Solar Panels</p>
-                <img src="/assets/solar.jpg" />
+                <img src="/assets/solar.jpg" alt="Solar panels" />
                 <p>Energy source: the Sun</p>
             </div>
             <p>generate <Chip text="200 dWatt" href={`/processes/solar-200Wh`} /> or <Chip text="1000 dWatt" href="/processes/solar-1000Wh" /> using solar panels</p> 
@@ -32,7 +32,7 @@ import Chip from '../../components/Chip.astro';
         <div class="item">
             <div class="horizontal list">
                 <p>Convert dCarbon to dOffset</p>
-                <img src="/assets/solar.jpg" />
+                <img src="/assets/solar.jpg" alt="Solar panels" />
             </div>
             <p>convert <Chip text="1 dCarbon" href={`/processes/dCarbon-dOffset-1`} /> or <Chip text="10 dCarbon" href={`/processes/dCarbon-dOffset-10`} /> to <Chip text="dOffset" href="/inventory/item/70" /></p>
             <p>Cost per dOffset: 10 <Chip text="dUSD" href="/wallet" /></p>
@@ -42,8 +42,9 @@ import Chip from '../../components/Chip.astro';
 
 <style>
     img {
-        width: 50px;
-        height: 50px;
+        width: 100%;
+        max-width: 50px;
+        height: auto;
         margin: 10px;
         border-radius: 20px;
     }


### PR DESCRIPTION
## Summary
- add alt text to energy page images and make them scale to container width
- test energy page for descriptive alt text and responsive styles

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a807c91d1c832f963c28dcdb3daf06