### PR TITLE
🔧: refine SSH key generation process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4333,7 +4333,7 @@
     },
     {
         "id": "generate-ssh-key",
-        "title": "Generate an SSH key pair and copy it to a node",
+        "title": "Generate an ed25519 SSH key pair on a laptop and copy it to a Pi cluster node",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             {
@@ -4347,7 +4347,7 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "2m",
         "hardening": {
             "passes": 0,
             "score": 0,

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3344,7 +3344,7 @@
     },
     {
         "id": "generate-ssh-key",
-        "title": "Generate an SSH key pair and copy it to a node",
+        "title": "Generate an ed25519 SSH key pair on a laptop and copy it to a Pi cluster node",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             { "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d", "count": 1 },
@@ -3352,7 +3352,7 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "5m",
+        "duration": "2m",
         "hardening": {
             "passes": 0,
             "score": 0,


### PR DESCRIPTION
what: clarify ed25519 key pair steps and shorter duration
why: better reflect typical SSH workflow
how to test: npm run lint && npm run type-check && npm run build &&
  npm run test:ci && npm run test:ci -- processQuality
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a808556630832fb2aa570edded8709