### PR TITLE
🧪 Add profile page test and document avatar journey

### DIFF
--- a/frontend/e2e/backlog/profile-avatar-selection.spec.ts
+++ b/frontend/e2e/backlog/profile-avatar-selection.spec.ts
@@ -1,0 +1,8 @@
+import { test } from '@playwright/test';
+
+// Placeholder for profile avatar selection journey
+// Ensures coverage tracking for avatar updates
+
+test('Profile avatar selection', async ({ page }) => {
+    // TODO: implement profile avatar selection test
+});

--- a/frontend/e2e/backlog/profile-page.spec.ts
+++ b/frontend/e2e/backlog/profile-page.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: implement Profile page navigation test
-// This placeholder ensures a spec exists for tracking coverage.
-test('Profile page loads', async ({ page }) => {
-    await page.goto('/profile');
-});

--- a/frontend/e2e/profile-page.spec.ts
+++ b/frontend/e2e/profile-page.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Profile page', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('loads profile page', async ({ page }) => {
+        await page.goto('/profile');
+        await expect(page.getByText('Choose a default avatar')).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -22,7 +22,8 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 > 2. For journeys lacking tests, ensure a placeholder spec exists under
 >    `frontend/e2e/backlog`; create one if missing.
 > 3. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
->    implement the Playwright test; otherwise add a new test file.
+>    implement the Playwright test, asserting visible UI content rather than
+>    only checking status codes; otherwise add a new test file.
 > 4. Update `user-journeys.md` with coverage status, test file path, and any fixes,
 >    keeping the table alphabetized. Verify apparent 404s aren't missing routes;
 >    if a page should exist, add a stub instead of asserting a 404.
@@ -42,9 +43,9 @@ USER:
 1. Audit `frontend/src/pages/docs/md/user-journeys.md` for mistakes and
    propose fixes or additional journeys.
 2. Select an uncovered or newly added journey and implement a Playwright test
-   in `frontend/e2e/`. If a matching placeholder exists in
-   `frontend/e2e/backlog`, move it with `git mv` before editing; otherwise
-   create the test file.
+   in `frontend/e2e/`, asserting visible UI content. If a matching placeholder
+   exists in `frontend/e2e/backlog`, move it with `git mv` before editing;
+   otherwise create the test file.
 3. Update the coverage table in `user-journeys.md` with the new test path and
    any corrected steps, keeping it alphabetized.
 4. Improve this prompt if clearer guidance emerges.

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -33,7 +33,8 @@ sorted alphabetically by journey name.
 | Mobile quest form          | No                  | --                                                |
 | Page structure             | Yes                 | `frontend/e2e/page-structure.spec.ts`             |
 | Process creation           | Yes                 | `frontend/e2e/process-creation.spec.ts`           |
-| Profile page loads         | No                  | --                                                |
+| Profile avatar selection   | No                  | --                                                |
+| Profile page loads         | Yes                 | `frontend/e2e/profile-page.spec.ts`               |
 | Quest chat                 | Yes                 | `frontend/e2e/test-quest-chat.spec.ts`            |
 | Quest form validation      | No                  | --                                                |
 | Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |


### PR DESCRIPTION
## Summary
- cover profile page load with Playwright
- track profile avatar selection journey
- clarify Playwright test prompt about asserting UI content

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(stopped after tests due to pre-PR check hang)*

------
https://chatgpt.com/codex/tasks/task_e_68a8084ca02c832fa5232ca9b51a0cd1