### PR TITLE
📝 add unit for digital multimeter item

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -168,6 +168,7 @@
         "image": "/assets/launch_controller.jpg",
         "price": "20 dUSD",
         "type": "tool",
+        "unit": "meter",
         "hardening": {
             "passes": 1,
             "score": 65,


### PR DESCRIPTION
## Summary
- add explicit `unit` for digital multimeter inventory item

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a807cb1c04832fa15a427e9aba23d6