### PR TITLE
Add solder fume extractor tool for safer soldering

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -348,7 +348,8 @@
       "electronics/check-battery-voltage",
       "chemistry/ph-test",
       "chemistry/acid-dilution",
-      "aquaria/water-testing"
+      "aquaria/water-testing",
+      "aquaria/water-change"
     ],
     "rewards": []
   },
@@ -391,6 +392,7 @@
     "requires": [
       "programming/web-server",
       "programming/stddev-temp",
+      "programming/moving-avg-temp",
       "programming/median-temp",
       "programming/json-endpoint",
       "programming/json-api",
@@ -543,7 +545,8 @@
       "firstaid/dispose-expired",
       "chemistry/ph-test",
       "chemistry/acid-dilution",
-      "aquaria/water-testing"
+      "aquaria/water-testing",
+      "aquaria/water-change"
     ],
     "rewards": []
   },
@@ -679,7 +682,8 @@
   },
   "7a4b8892-365f-4a56-93ce-127aa989f50d": {
     "requires": [
-      "firstaid/wound-care"
+      "firstaid/wound-care",
+      "firstaid/dispose-bandages"
     ],
     "rewards": []
   },
@@ -920,6 +924,14 @@
     ],
     "rewards": []
   },
+  "5562d728-8e62-43b2-9b3d-77cebd2ab481": {
+    "requires": [
+      "electronics/test-gfci-outlet"
+    ],
+    "rewards": [
+      "electronics/continuity-test"
+    ]
+  },
   "4379a2f8-7cec-4bea-949b-ad50514d36ff": {
     "requires": [
       "electronics/tin-soldering-iron",
@@ -973,6 +985,12 @@
     "rewards": []
   },
   "a8f184ec-c9d0-4a4b-b6a1-c58c1c297b26": {
+    "requires": [
+      "electronics/solder-wire"
+    ],
+    "rewards": []
+  },
+  "593fc442-f437-4449-94e5-17b7b4625c41": {
     "requires": [
       "electronics/solder-wire"
     ],
@@ -1041,12 +1059,6 @@
       "electronics/desolder-component"
     ],
     "rewards": []
-  },
-  "5562d728-8e62-43b2-9b3d-77cebd2ab481": {
-    "requires": [],
-    "rewards": [
-      "electronics/continuity-test"
-    ]
   },
   "ce92a1a9-c817-40f0-92b1-24aff053903d": {
     "requires": [
@@ -1200,6 +1212,7 @@
   "f439b57a-9df3-4bd9-9b6e-042476ceecf5": {
     "requires": [
       "astronomy/venus-phases",
+      "astronomy/sunspot-sketch",
       "astronomy/star-trails",
       "astronomy/saturn-rings",
       "astronomy/satellite-pass",
@@ -1218,6 +1231,17 @@
     ],
     "rewards": []
   },
+  "70bb8d86-2c4e-4330-9705-371891934686": {
+    "requires": [
+      "astronomy/sunspot-sketch",
+      "astronomy/observe-moon",
+      "astronomy/meteor-shower",
+      "astronomy/light-pollution",
+      "astronomy/iss-photo",
+      "astronomy/iss-flyover"
+    ],
+    "rewards": []
+  },
   "9a72fb16-fc69-45c5-beca-f25c27028977": {
     "requires": [
       "astronomy/orion-nebula",
@@ -1226,16 +1250,6 @@
       "astronomy/light-pollution",
       "astronomy/aurora-watch",
       "astronomy/andromeda"
-    ],
-    "rewards": []
-  },
-  "70bb8d86-2c4e-4330-9705-371891934686": {
-    "requires": [
-      "astronomy/observe-moon",
-      "astronomy/meteor-shower",
-      "astronomy/light-pollution",
-      "astronomy/iss-photo",
-      "astronomy/iss-flyover"
     ],
     "rewards": []
   },

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -593,5 +593,19 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "593fc442-f437-4449-94e5-17b7b4625c41",
+        "name": "solder fume extractor",
+        "description": "120 mm fan with activated carbon filter draws solder fumes away; USB powered; 200 g.",
+        "image": "/assets/quests/basic_circuit.svg",
+        "price": "30 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -8,12 +8,12 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "A lead snapped. Ventilate, wear goggles, keep the hot iron on its stand, and clear flammables.",
+            "text": "A lead snapped. Ventilate, turn on the fume extractor, wear goggles, keep the hot iron on its stand, and clear flammables.",
             "options": [{ "type": "goto", "goto": "prep", "text": "What gear do I need?" }]
         },
         {
             "id": "prep",
-            "text": "Gather the soldering iron kit, flux pen, wire stripper, needle-nose pliers, and heat gun. Add two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper, grip them with the needle-nose pliers, and slide the tubing over one lead. Heat the iron on its stand, keep cords tidy, and avoid fumes. Use the heat gun to shrink the tubing after soldering.",
+            "text": "Gather the soldering iron kit, flux pen, wire stripper, needle-nose pliers, solder fume extractor, and heat gun. Add two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper, grip them with the needle-nose pliers, and slide the tubing over one lead. Heat the iron on its stand, keep cords tidy, and let the fume extractor pull smoke away. Use the heat gun to shrink the tubing after soldering.",
             "options": [
                 {
                     "type": "process",
@@ -37,6 +37,7 @@
                         { "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 },
                         { "id": "dad7f853-ccc9-40be-b226-89272708db84", "count": 1 },
                         { "id": "a8f184ec-c9d0-4a4b-b6a1-c58c1c297b26", "count": 1 },
+                        { "id": "593fc442-f437-4449-94e5-17b7b4625c41", "count": 1 },
                         { "id": "5029f7cb-3359-4153-b7ca-4b53988ac086", "count": 1 }
                     ]
                 }
@@ -51,7 +52,7 @@
     "rewards": [{ "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c", "count": 1 }],
     "requiresQuests": [],
     "hardening": {
-        "passes": 5,
+        "passes": 6,
         "score": 94,
         "emoji": "💯",
         "history": [
@@ -59,7 +60,8 @@
             { "task": "codex-solder-wire-polish-2025-08-07", "date": "2025-08-07", "score": 78 },
             { "task": "codex-solder-wire-hardening-2025-08-12", "date": "2025-08-12", "score": 92 },
             { "task": "codex-solder-wire-hardening-2025-08-15", "date": "2025-08-15", "score": 94 },
-            { "task": "codex-solder-wire-hardening-2025-08-16", "date": "2025-08-16", "score": 94 }
+            { "task": "codex-solder-wire-hardening-2025-08-16", "date": "2025-08-16", "score": 94 },
+            { "task": "codex-solder-wire-hardening-2025-08-22", "date": "2025-08-22", "score": 94 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- add solder fume extractor inventory item
- require fume extractor in solder-wire quest and update hardening score

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a8081630dc832faff3896a0d685eaa