### PR TITLE
Refine pH measurement process with hardening metadata

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -1863,16 +1863,34 @@
     },
     {
         "id": "measure-ph",
-        "title": "Measure solution pH",
+        "title": "Measure hydroponic nutrient solution pH with a test strip",
+        "image": "/assets/pH_strip.jpg",
         "requireItems": [
+            {
+                "id": "fc2bb989-f192-4891-8bde-78ae631dae78",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
             {
                 "id": "13167d6a-5617-4931-8a6e-6f463c6b8835",
                 "count": 1
             }
         ],
-        "consumeItems": [],
         "createItems": [],
-        "duration": "1m"
+        "duration": "2m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-22",
+                    "date": "2025-08-22",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "measure-ec",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1630,16 +1630,34 @@
     },
     {
         "id": "measure-ph",
-        "title": "Measure solution pH",
+        "title": "Measure hydroponic nutrient solution pH with a test strip",
+        "image": "/assets/pH_strip.jpg",
         "requireItems": [
+            {
+                "id": "fc2bb989-f192-4891-8bde-78ae631dae78",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
             {
                 "id": "13167d6a-5617-4931-8a6e-6f463c6b8835",
                 "count": 1
             }
         ],
-        "consumeItems": [],
         "createItems": [],
-        "duration": "1m"
+        "duration": "2m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-process-hardening-2025-08-22",
+                    "date": "2025-08-22",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "measure-ec",

--- a/frontend/src/pages/processes/hardening/measure-ph.json
+++ b/frontend/src/pages/processes/hardening/measure-ph.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-process-hardening-2025-08-22",
+            "date": "2025-08-22",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- clarify "measure-ph" workflow with realistic item usage, duration, and image
- add and track initial hardening pass for the process
- record hardening metadata for consistency tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a8085f83fc832faeb26ab70cc288f2