### PR TITLE
📝 refine filament-change quest safety and tools

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -1050,6 +1050,7 @@
   },
   "ce92a1a9-c817-40f0-92b1-24aff053903d": {
     "requires": [
+      "3dprinting/filament-change",
       "electronics/continuity-test"
     ],
     "rewards": []

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3023,6 +3023,10 @@
             {
                 "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
                 "count": 1
+            },
+            {
+                "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+                "count": 1
             }
         ],
         "consumeItems": [

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2476,6 +2476,10 @@
             {
                 "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4",
                 "count": 1
+            },
+            {
+                "id": "ce92a1a9-c817-40f0-92b1-24aff053903d",
+                "count": 1
             }
         ],
         "consumeItems": [

--- a/frontend/src/pages/quests/json/3dprinting/filament-change.json
+++ b/frontend/src/pages/quests/json/3dprinting/filament-change.json
@@ -1,14 +1,14 @@
 {
     "id": "3dprinting/filament-change",
     "title": "Swap Filament",
-    "description": "Safely swap your entry-level FDM printer to green PLA by unloading the old spool and purging 10 g.",
+    "description": "Swap to green PLA on your entry-level FDM printer with goggles, wire cutters, and a 10 g purge.",
     "image": "/assets/quests/benchy_25.jpg",
     "npc": "/assets/npc/sydney.jpg",
     "start": "start",
     "dialogue": [
         {
             "id": "start",
-            "text": "Ready to swap colors? We'll unload the old spool, purge 10 g, and load green PLA on your entry-level FDM printer.",
+            "text": "Ready to swap colors? We'll unload the old spool, purge 10 g, and load green PLA—grab goggles and wire cutters.",
             "options": [
                 {
                     "type": "goto",
@@ -19,7 +19,7 @@
         },
         {
             "id": "swap",
-            "text": "Put on safety goggles and preheat the hotend to 200 °C. Release the extruder lever to retract the old filament while keeping fingers clear of gears. Cut the tip of the green PLA at an angle, feed it until only green extrudes, and avoid touching the hot nozzle or molten plastic.",
+            "text": "Wear safety goggles and preheat the hotend to 200 °C. Press the extruder lever and pull out the old filament, keeping fingers clear of gears. Clip the green PLA at a 45° angle with wire cutters, feed until only green extrudes, and avoid touching the hot nozzle or molten plastic.",
             "options": [
                 {
                     "type": "process",
@@ -33,7 +33,8 @@
                     "requiresItems": [
                         { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
                         { "id": "d3590107-25ff-4de5-af3a-46e2497bfc52", "count": 10 },
-                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 }
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 },
+                        { "id": "ce92a1a9-c817-40f0-92b1-24aff053903d", "count": 1 }
                     ]
                 }
             ]
@@ -52,13 +53,14 @@
     "rewards": [],
     "requiresQuests": ["3dprinter/start"],
     "hardening": {
-        "passes": 3,
-        "score": 90,
+        "passes": 4,
+        "score": 95,
         "emoji": "💯",
         "history": [
             { "task": "codex-quest-hardening-2025-08-12", "date": "2025-08-12", "score": 60 },
             { "task": "codex-quest-refinement-2025-08-17", "date": "2025-08-17", "score": 80 },
-            { "task": "codex-quest-clarity-2025-08-19", "date": "2025-08-19", "score": 90 }
+            { "task": "codex-quest-clarity-2025-08-19", "date": "2025-08-19", "score": 90 },
+            { "task": "codex-quest-polish-2025-08-22", "date": "2025-08-22", "score": 95 }
         ]
     }
 }


### PR DESCRIPTION
what: add wire cutter requirement and clearer safety guidance
why: keep quests reproducible and track updated hardening pass
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci -- questCanonical questQuality
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a80872b16c832f9165cf1be1158c94