### PR TITLE
📝 : tidy prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/contribute.md
+++ b/frontend/src/pages/docs/md/contribute.md
@@ -38,9 +38,11 @@ creation process.
 -   Fix bugs or implement new features
 -   Improve documentation
 -   Enhance the user interface
-    Install dependencies with `pnpm install` and use Node.js 20 LTS (`.nvmrc`) before running tests.
-    For technical contributions, please review our
-    [Developer Guide](https://github.com/democratizedspace/dspace/blob/main/DEVELOPER_GUIDE.md) first.
+
+Install dependencies with `pnpm install` and use Node.js 20 LTS (`.nvmrc`) before running
+tests. For technical contributions, please review our
+[Developer Guide](https://github.com/democratizedspace/dspace/blob/main/DEVELOPER_GUIDE.md)
+first.
 
 ## Testing and Feedback
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,8 +14,8 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend),
+[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).


### PR DESCRIPTION
## Summary
- remove duplicate "and" and add period in prompts-codex
- fix bullet formatting in contribute guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(SKIP_E2E set; playwright browsers unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_68a80795675c832f89602e7f001df19b