### PR TITLE
📝 docs: clarify frontend prompt checks

### DIFF
--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -7,7 +7,7 @@ slug: 'prompts-frontend'
 
 DSPACE's UI is built with Svelte and Astro. Use this guide when working on files inside
 `frontend/`, including Svelte components, pages, and styles. Changes should improve clarity,
-accessibility, or performance while keeping tests green. For deeper a11y guidance see
+accessibility, or performance while keeping tests green. For deeper accessibility guidance, see
 [Accessibility prompts](/docs/prompts-accessibility).
 
 > **TL;DR**
@@ -15,14 +15,14 @@ accessibility, or performance while keeping tests green. For deeper a11y guidanc
 > 1. Touch only the necessary files under `frontend/`.
 > 2. Keep components accessible, responsive, and idiomatic.
 > 3. Update or add tests in `frontend/__tests__` when behavior changes.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:


### PR DESCRIPTION
## Summary
- clarify accessibility mention and required checks in frontend prompt guidelines

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806ee0080832f8f22afe62c2fcf0c