### PR TITLE
📝 docs: add monitoring prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -69,6 +69,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-accessibility">Accessibility prompts</a>
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
+            <a href="/docs/prompts-monitoring">Monitoring prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>

--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -5,8 +5,8 @@ slug: 'prompts-backend'
 
 # Backend prompts for the _dspace_ repo
 
-DSPACE is mostly frontend code, but some backend pieces support self-hosting via
-[Sugarkube's RasPi cluster](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md).
+DSPACE is mostly frontend code, but a few backend pieces support self-hosting via
+[Sugarkube's Raspberry Pi cluster](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md).
 Use this guide alongside [Codex Prompts](/docs/prompts-codex) when editing
 `backend/` modules. Contributions must deliver clear user value and honor
 end-user privacy, dignity, and agency as outlined in
@@ -19,8 +19,8 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 >
 > 1. Scope changes to specific `backend/` modules that enable self-hosting or other
 >    substantial improvements.
-> 2. Minimize data collection and obtain explicit user consent before storing or
->    transmitting information.
+> 2. Favor open-source, self-hosted services and minimize data collection;
+>    obtain explicit user consent before storing or transmitting information.
 > 3. Add or update tests in `backend/__tests__` when behavior changes.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,9 +13,10 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Monitoring prompts](/docs/prompts-monitoring), [Docs prompts](/docs/prompts-docs),
+[Playwright test prompts](/docs/prompts-playwright-tests), [Frontend prompts](/docs/prompts-frontend),
+[Backend prompts](/docs/prompts-backend), [Refactor prompts](/docs/prompts-refactors), and
+[Accessibility prompts](/docs/prompts-accessibility).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -42,6 +43,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Quest Prompts](/docs/prompts-quests)
 -   [NPC Prompts](/docs/prompts-npcs)
 -   [Outage Prompts](/docs/prompts-outages)
+-   [Monitoring Prompts](/docs/prompts-monitoring)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
 -   [Backend Prompts](/docs/prompts-backend)

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -1,0 +1,41 @@
+---
+title: 'Monitoring Prompts'
+slug: 'prompts-monitoring'
+---
+
+# Monitoring prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
+ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when
+editing files in the [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
+stack so metrics, dashboards, and alerts stay consistent.
+To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
+these templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+
+> **TL;DR**
+>
+> 1. Scope changes to `monitoring/` configs or supporting scripts.
+> 2. Prefer lightweight, self-hosted tools; avoid collecting personal data.
+> 3. Add sample dashboards or alert rules when relevant.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 6. Commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+
+USER:
+1. Update monitoring configs or code under `monitoring/`.
+2. Use open-source, self-hosted tools (e.g., Prometheus, Grafana) that respect user privacy.
+3. Include or update sample dashboards and alerting rules when adding metrics.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with improved monitoring docs or configs and passing checks.
+```


### PR DESCRIPTION
## Summary
- add monitoring prompt guide
- link guide from codex docs and docs index
- clarify backend prompt around self-hosted services

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a806ee0080832f8f22afe62c2fcf0c