### PR TITLE
docs: add proofreading prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -71,6 +71,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-outages">Outage prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
+            <a href="/docs/prompts-docs#proofreading-prompt">Docs proofreading prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -44,6 +44,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
+-   [Docs proofreading prompt](/docs/prompts-docs#proofreading-prompt)
 -   [Backend Prompts](/docs/prompts-backend)
 -   [Frontend Prompts](/docs/prompts-frontend)
 -   [Accessibility Prompts](/docs/prompts-accessibility)

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -42,6 +42,26 @@ OUTPUT:
 A pull request with refreshed documentation and passing checks.
 ```
 
+## Proofreading prompt
+
+Use this to polish grammar and style without changing technical meaning.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
+committing.
+
+USER:
+1. Proofread the selected docs for typos, grammar, and clarity.
+2. Preserve the original intent and technical accuracy.
+3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with polished documentation and passing checks.
+```
+
 ## Cross-link check prompt
 
 Use this when adding or renaming docs to keep internal links current.


### PR DESCRIPTION
## Summary
- add docs proofreading prompt
- link from codex and docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806ee0080832f8f22afe62c2fcf0c