### PR TITLE
docs: refresh Codex prompt templates

### DIFF
--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -13,6 +13,7 @@ ARIA attributes, keyboard navigation, and sufficient color contrast.
 > 1. Limit changes to files that impact user accessibility.
 > 2. Follow WCAG 2.1 AA: provide focus states, semantic elements, and ARIA labels.
 > 3. Validate with tooling like `npm run lint` and screen‑reader checks when possible.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.

--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -22,7 +22,7 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 2. Minimize data collection and obtain explicit user consent before storing or
 >    transmitting information.
 > 3. Add or update tests in `backend/__tests__` when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
@@ -30,8 +30,8 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update backend files under `backend/`.

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -36,7 +36,7 @@ CONTEXT:
   error.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-  * Run `npm run lint`, `npm run type-check`, `npm run build`, and
+  * Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
     `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -14,8 +14,8 @@ see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Select one or more `prompts-*.md` files under `frontend/src/pages/docs/md/`.

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -15,8 +15,8 @@ workflows.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and
-`README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` all pass before committing.
+`README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` all pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,8 +14,8 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend),
+[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -18,14 +18,14 @@ current and consistent. To keep these templates evolving, see the
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
 > 3. Link new prompt docs from `prompts-codex.md` and the docs index.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci` pass before committing.
 
 USER:
@@ -33,7 +33,7 @@ USER:
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
@@ -49,8 +49,8 @@ Use this when adding or renaming docs to keep internal links current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+pass before committing.
 
 USER:
 1. Audit the documentation for missing or broken cross-links.

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -19,7 +19,7 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Scope changes to a single NPC.
 > 2. Specify the expected output (tests, docs).
 > 3. Stop when the spec is complete; remaining text becomes mandatory.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
@@ -37,11 +37,12 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "\
-        npm run lint && \
-        npm run type-check && \
-        npm run build && \
-        npm run test:ci"
+          codex exec "\
+          npm run audit:ci && \
+          npm run lint && \
+          npm run type-check && \
+          npm run build && \
+          npm run test:ci"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -75,8 +76,8 @@ FILES OF INTEREST
 REQUIREMENTS
 1. Preserve established character voice and lore.
 2. Keep sample dialogue short and approachable.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:ci`.
+ 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+    `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Update related docs if needed.
 
@@ -93,7 +94,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit
 `frontend/src/pages/docs/md/npcs.md`, adding or refining NPC sections.
 Maintain each character’s voice, keep sample dialogue realistic, and ensure
-`npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+`npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
 pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 before committing.
 
@@ -119,7 +120,7 @@ USER:
 2. Improve characterization and ensure dialogue stays concise and in-universe.
 3. Reuse existing image assets; do not add new images.
 4. Cross-reference related quests or processes and update them if needed.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 7. Use an emoji-prefixed commit message like `📝 : – refine NPC bio`.

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -17,7 +17,7 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 1. Investigate the failure and implement a fix.
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
 > 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Use an emoji-prefixed commit message.
@@ -38,7 +38,7 @@ CONTEXT:
 REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Use an emoji-prefixed commit message.

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -27,7 +27,7 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 >    keeping the table alphabetized. Verify apparent 404s aren't missing routes;
 >    if a page should exist, add a stub instead of asserting a 404.
 > 5. Run `npx playwright install chromium` if browsers are missing.
-> 6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
 > 7. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >    and commit with an emoji.
@@ -35,7 +35,7 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -21,7 +21,7 @@ For fundamental design tips see the
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
@@ -39,7 +39,7 @@ For fundamental design tips see the
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
+        codex exec "npm run audit:ci && npm run lint && npm run type-check && npm run build && \
         npm run test:ci && \
         npm run test:ci -- processQuality && \
         git diff --cached | ./scripts/scan-secrets.py"
@@ -51,12 +51,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                          |
-| -------------------- | ----------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add lettuce seed input to hydroponics”). |
-| **Files to touch**   | Limits search space → faster & cheaper.                                 |
-| **Constraints**      | Coding style, a11y, process schema rules.                               |
-| **Acceptance check** | e.g. “`npm run test:ci` and `npm run test:ci -- processQuality` pass”.  |
+| Ingredient           | Why it matters                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add lettuce seed input to hydroponics”).                     |
+| **Files to touch**   | Limits search space → faster & cheaper.                                                     |
+| **Constraints**      | Coding style, a11y, process schema rules.                                                   |
+| **Acceptance check** | e.g. “`npm run audit:ci`, `npm run test:ci`, and `npm run test:ci -- processQuality` pass”. |
 
 Codex merges these instructions with any `AGENTS.md` files in scope, so keep
 prompt‑level rules short and concrete.
@@ -80,7 +80,7 @@ REQUIREMENTS
 3. Ensure the process is referenced by at least one quest or item; create
    missing items or quest hooks as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
@@ -99,8 +99,8 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 processes under `frontend/src/pages/processes/base.json` with corresponding
 hardening files in `frontend/src/pages/processes/hardening`. Ensure realistic
-steps, durations, item references, and passing checks (`npm run lint`,
-`npm run type-check`, `npm run build`, `npm run test:ci`, and
+steps, durations, item references, and passing checks (`npm run audit:ci`,
+`npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci`, and
 `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
@@ -148,7 +148,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality`. Update docs or items if needed.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -23,7 +23,7 @@ which covers quests, items and processes in detail.
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
@@ -41,8 +41,8 @@ which covers quests, items and processes in detail.
     -   Web: not supported yet.
     -   CLI:
         ```bash
-        codex exec "npm run lint && npm run type-check && npm run build && \
-        npm run test:ci -- questCanonical questQuality"
+          codex exec "npm run audit:ci && npm run lint && npm run type-check && npm run build && \
+          npm run test:ci -- questCanonical questQuality"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -56,7 +56,7 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
-| **Acceptance check** | e.g. “`npm run test:ci -- questCanonical questQuality` passes”.     |
+| **Acceptance check** | e.g. “`npm run audit:ci` and `npm run test:ci -- questCanonical questQuality` pass”.     |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -80,7 +80,7 @@ REQUIREMENTS
 3. Find the most natural predecessor quest and update the `requiresQuests`
    chain so progression flows logically.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check` and `npm run build`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, and `npm run build`.
 6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
@@ -99,7 +99,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or create
 quests under `frontend/src/pages/quests/json`. Ensure start, middle and
 completion nodes, at least one item or process reference, and passing checks
-(`npm run lint`, `npm run type-check`, `npm run build`, and
+(`npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
@@ -131,7 +131,7 @@ existing quests in that tree as examples for tone and structure.
 USER:
 1. Create a new quest JSON in the chosen tree following the quest schema.
 2. Reference at least one inventory item or process.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+ 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci -- questCanonical questQuality`. Fix any failures.
 4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -180,7 +180,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+ 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
     `npm run test:ci -- questCanonical questQuality`. Update docs if needed.
    7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
    8. Use an emoji-prefixed commit message.


### PR DESCRIPTION
## Summary
- require npm run audit:ci across all prompt docs
- fix Codex prompt cross-link list

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a8071f9b00832f8c5893b63b70d7f3