### PR TITLE
📝 docs: – standardize accessibility prompt file

### DIFF
--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -16,3 +16,20 @@ ARIA attributes, keyboard navigation, and sufficient color contrast.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Update files that affect user accessibility.
+2. Follow WCAG 2.1 AA with semantic HTML, visible focus states, and ARIA labels.
+3. Validate with linting and, when possible, screen-reader or keyboard checks.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request improving accessibility with passing checks.
+```


### PR DESCRIPTION
## Summary
- add SYSTEM/USER/OUTPUT block to prompts-accessibility.md

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(stalled installing Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a806d1cc00832fab57879bd9b5c60e