### PR TITLE
docs: add Vitest test prompt and clarify Playwright guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -72,6 +72,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
+            <a href="/docs/prompts-vitest">Vitest test prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
             <a href="/docs/prompts-codex">Codex prompts</a>
             <a href="/docs/prompts-codex#implementation-prompt">Codex implementation prompt</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,8 +14,9 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Vitest test prompts](/docs/prompts-vitest), [Frontend prompts](/docs/prompts-frontend),
+[Backend prompts](/docs/prompts-backend), [Refactor prompts](/docs/prompts-refactors), and
+[Accessibility prompts](/docs/prompts-accessibility)
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -48,6 +49,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Frontend Prompts](/docs/prompts-frontend)
 -   [Accessibility Prompts](/docs/prompts-accessibility)
 -   [Playwright Test Prompts](/docs/prompts-playwright-tests)
+-   [Vitest Test Prompts](/docs/prompts-vitest)
 -   [Refactor Prompts](/docs/prompts-refactors)
 -   [Codex CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
 -   [Codex Meta Prompt](/docs/prompts-codex-meta)

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -7,7 +7,7 @@ slug: 'prompts-playwright-tests'
 
 Use this template to add end-to-end coverage for journeys listed in
 [User journeys](/docs/user-journeys). While working, review the existing
-journeys for inaccuracies or misunderstandings and expand the list as new
+journeys for inaccuracies or gaps and expand the list as new
 features land. Treat this prompt as living documentation—periodically refine
 it using other `prompts-*.md` files for inspiration. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
@@ -17,8 +17,8 @@ GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-c
 
 > **TL;DR**
 >
-> 1. Review `user-journeys.md`, correcting mistakes and keeping the coverage
->    table sorted alphabetically.
+> 1. Review `frontend/src/pages/docs/md/user-journeys.md`, correcting mistakes
+>    and keeping the coverage table sorted alphabetically.
 > 2. For journeys lacking tests, ensure a placeholder spec exists under
 >    `frontend/e2e/backlog`; create one if missing.
 > 3. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
@@ -45,8 +45,8 @@ USER:
    in `frontend/e2e/`. If a matching placeholder exists in
    `frontend/e2e/backlog`, move it with `git mv` before editing; otherwise
    create the test file.
-3. Update the coverage table in `user-journeys.md` with the new test path and
-   any corrected steps, keeping it alphabetized.
+3. Update the coverage table in `frontend/src/pages/docs/md/user-journeys.md`
+   with the new test path and any corrected steps, keeping it alphabetized.
 4. Improve this prompt if clearer guidance emerges.
 5. Run `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.

--- a/frontend/src/pages/docs/md/prompts-vitest.md
+++ b/frontend/src/pages/docs/md/prompts-vitest.md
@@ -1,0 +1,37 @@
+---
+title: 'Vitest Test Prompts'
+slug: 'prompts-vitest'
+---
+
+# Vitest test prompts for the _dspace_ repo
+
+Use this template to add unit tests with [Vitest](https://vitest.dev). Lean on it when
+new features or bug fixes need coverage. Treat the prompt as living documentation and
+refresh it using other `prompts-*.md` files for inspiration. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta); if templates drift, refresh them with
+the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs,
+use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+
+> **TL;DR**
+>
+> 1. Choose a module or component that lacks unit tests or needs better coverage.
+> 2. Add or update a Vitest spec under `frontend/__tests__/` or `tests/`.
+> 3. Keep tests deterministic and focused on behavior.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+
+USER:
+1. Identify an untested or under-tested module.
+2. Write or refine a Vitest unit test in `frontend/__tests__/` or `tests/`.
+3. Run the commands above and `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request adding the tests with all checks green.
+```


### PR DESCRIPTION
## Summary
- document Vitest test workflow for unit testing
- link new guide from Codex prompts and docs index
- clarify Playwright prompt wording around user-journeys

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806f16288832f9d7d9aefc7cf36ec