### PR TITLE
📝 docs: add backup prompt guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -69,6 +69,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-accessibility">Accessibility prompts</a>
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
+            <a href="/docs/prompts-backups">Backup prompts</a>
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>

--- a/frontend/src/pages/docs/md/prompts-backups.md
+++ b/frontend/src/pages/docs/md/prompts-backups.md
@@ -1,0 +1,39 @@
+---
+title: 'Backup Prompts'
+slug: 'prompts-backups'
+---
+
+# Backup prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
+ready-made PR — but only if given a clear, file-scoped prompt. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when working on [Backups](/docs/backups) features or docs. To
+keep these templates evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If they drift,
+refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub
+Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+
+> **TL;DR**
+>
+> 1. Limit changes to backup-related files or docs.
+> 2. Preserve existing backup formats and import/export paths.
+> 3. Update tests when behavior changes.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 6. Commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
+committing.
+
+USER:
+1. Modify backup-related code or docs (`frontend/src/pages/docs/md/backups.md` or backup modules).
+2. Keep game save and custom content export formats stable.
+3. Add or update tests covering backup flows.
+4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with the backup improvement and passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -13,9 +13,10 @@ invoking Codex on DSPACE and should evolve alongside the project.
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
-[Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Backup prompts](/docs/prompts-backups), [Docs prompts](/docs/prompts-docs),
+[Playwright test prompts](/docs/prompts-playwright-tests), [Frontend prompts](/docs/prompts-frontend),
+[Backend prompts](/docs/prompts-backend), [Refactor prompts](/docs/prompts-refactors), and
+[Accessibility prompts](/docs/prompts-accessibility)
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -42,6 +43,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Quest Prompts](/docs/prompts-quests)
 -   [NPC Prompts](/docs/prompts-npcs)
 -   [Outage Prompts](/docs/prompts-outages)
+-   [Backup Prompts](/docs/prompts-backups)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
 -   [Backend Prompts](/docs/prompts-backend)

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -17,7 +17,8 @@ current and consistent. To keep these templates evolving, see the
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Link new prompt docs from `prompts-codex.md` and the docs index.
+> 3. Link new prompt docs from [`prompts-codex.md`](/docs/prompts-codex) and
+>    `frontend/src/pages/docs/index.astro`.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.


### PR DESCRIPTION
## Summary
- add backup prompt doc and link from codex guide
- clarify docs prompt linking rule
- surface backup prompt in docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806f16288832f9d7d9aefc7cf36ec