### PR TITLE
Add average price helper for backend items

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,21 @@ The `dev:safe` command prevents common Playwright artifact errors that can occur
 
 ### Utility Functions
 
-The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs. The lookup
-normalizes case, trims extra whitespace, and converts spaces or hyphens into underscores for
-resilient calls. It returns `null` for unknown or non-string inputs. Prices are approximate USD
-values.
+The backend exposes `approximateIrlPrice(id)` to estimate real-world item costs and
+`approximateIrlAveragePrice(ids)` to average the cost of multiple items. The lookup normalizes
+case, trims extra whitespace, and converts spaces or hyphens into underscores for resilient
+calls. It returns `null` for unknown or non-string inputs. Prices are approximate USD values.
 
 ```ts
-import { approximateIrlPrice } from "./backend/approximateIrlPrice";
+import {
+  approximateIrlPrice,
+  approximateIrlAveragePrice,
+} from "./backend/approximateIrlPrice";
 
 console.log(approximateIrlPrice("3D-Printer")); // 350
+console.log(
+  approximateIrlAveragePrice(["3d_printer", "arduino_nano"])
+); // 186
 console.log(approximateIrlPrice("unknown")); // null
 console.log(approximateIrlPrice(undefined as any)); // null
 ```

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   approximateIrlPrice,
   approximateIrlTotalPrice,
+  approximateIrlAveragePrice,
   __resetPriceTableCacheForTests,
 } from './approximateIrlPrice';
 import { writeFileSync, mkdtempSync } from 'fs';
@@ -78,6 +79,26 @@ describe('approximateIrlPrice', () => {
     it('returns null for non-array input', () => {
       expect(approximateIrlTotalPrice(null as any)).toBeNull();
       expect(approximateIrlTotalPrice(undefined as any)).toBeNull();
+    });
+  });
+
+  describe('approximateIrlAveragePrice', () => {
+    it('averages prices of known items', () => {
+      expect(
+        approximateIrlAveragePrice(['3d_printer', 'arduino_nano'])
+      ).toBe(186);
+    });
+
+    it('ignores unknown items and returns null when none are known', () => {
+      expect(
+        approximateIrlAveragePrice(['nonexistent', 'arduino_nano'])
+      ).toBe(22);
+      expect(approximateIrlAveragePrice(['foo'])).toBeNull();
+    });
+
+    it('returns null for non-array input', () => {
+      expect(approximateIrlAveragePrice(null as any)).toBeNull();
+      expect(approximateIrlAveragePrice(undefined as any)).toBeNull();
     });
   });
 });

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -114,3 +114,30 @@ export function approximateIrlTotalPrice(
 
   return found ? total : null;
 }
+
+/**
+ * Average the prices of multiple game items.
+ *
+ * Unknown or non-string identifiers are ignored. Returns `null` when no known
+ * items are provided.
+ */
+export function approximateIrlAveragePrice(
+  ids: Array<string | null | undefined> | null | undefined
+): number | null {
+  if (!Array.isArray(ids)) {
+    return null;
+  }
+
+  let total = 0;
+  let count = 0;
+
+  for (const id of ids) {
+    const price = approximateIrlPrice(id);
+    if (typeof price === 'number') {
+      total += price;
+      count++;
+    }
+  }
+
+  return count > 0 ? total / count : null;
+}


### PR DESCRIPTION
## Summary
- add approximateIrlAveragePrice to average known item costs
- document helper usage and cover with tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: Playwright browser install stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a806e3645c832f8b66ff12525dd256