### PR TITLE
Refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -61,24 +61,24 @@ import Page from '../../components/Page.astro';
             <a href="/docs/bounties">Bounties</a>
             <a href="/docs/user-journeys">User journeys</a>
             <a href="/docs/self-hosting">Self-hosting</a>
-            <a href="/docs/prompts-quests">Quest prompts</a>
-            <a href="/docs/prompts-items">Item prompts</a>
-            <a href="/docs/prompts-processes">Process prompts</a>
-            <a href="/docs/prompts-backend">Backend prompts</a>
-            <a href="/docs/prompts-frontend">Frontend prompts</a>
             <a href="/docs/prompts-accessibility">Accessibility prompts</a>
+            <a href="/docs/prompts-backend">Backend prompts</a>
+            <a href="/docs/prompts-codex-ci-fix">Codex CI-failure fix prompt</a>
+            <a href="/docs/prompts-codex#implementation-prompt">Codex implementation prompt</a>
+            <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
+            <a href="/docs/prompts-codex">Codex prompts</a>
+            <a href="/docs/prompts-codex-upgrader">Codex Prompt Upgrader</a>
+            <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
+            <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
+            <a href="/docs/prompts-docs">Docs prompts</a>
+            <a href="/docs/prompts-frontend">Frontend prompts</a>
+            <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-npcs">NPC prompts</a>
             <a href="/docs/prompts-outages">Outage prompts</a>
-            <a href="/docs/prompts-docs">Docs prompts</a>
-            <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
             <a href="/docs/prompts-playwright-tests">Playwright test prompts</a>
+            <a href="/docs/prompts-processes">Process prompts</a>
+            <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-refactors">Refactor prompts</a>
-            <a href="/docs/prompts-codex">Codex prompts</a>
-            <a href="/docs/prompts-codex#implementation-prompt">Codex implementation prompt</a>
-            <a href="/docs/prompts-codex#upgrade-prompt">Codex upgrade prompt</a>
-            <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
-            <a href="/docs/prompts-codex-upgrader">Codex Prompt Upgrader</a>
-            <a href="/docs/prompts-codex-ci-fix">Codex CI-failure fix prompt</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,8 +14,8 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend),
+[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
@@ -26,8 +26,8 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`;
+>    scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
@@ -69,12 +69,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                        |
-| **Files to touch**   | Limits search space → faster & cheaper.                                                                 |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                                          |
-| **Acceptance check** | e.g. `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
+| **Files to touch**   | Limits search space → faster & cheaper.                                             |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
+| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -96,7 +96,7 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -127,7 +127,7 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`AGENTS.md` and ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
@@ -155,7 +155,7 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
@@ -180,7 +180,7 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -15,14 +15,14 @@ accessibility, or performance while keeping tests green. For deeper a11y guidanc
 > 1. Touch only the necessary files under `frontend/`.
 > 2. Keep components accessible, responsive, and idiomatic.
 > 3. Update or add tests in `frontend/__tests__` when behavior changes.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -20,7 +20,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`,
 >    `npm run itemValidation`, `npm run test:ci`, and
 >    `npm run test:ci -- itemQuality`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
@@ -40,7 +40,6 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
     -   CLI:
         ```bash
         codex exec "\
-        npm run audit:ci && \
         npm run lint && \
         npm run type-check && \
         npm run build && \
@@ -59,7 +58,6 @@ See the [OpenAI CLI docs][openai-cli] for more flags.
 -   **Files to touch**: Limits search space → faster & cheaper.
 -   **Constraints**: Coding style, a11y, item schema rules.
 -   **Acceptance check**:
-    -   `npm run audit:ci`
     -   `npm run lint`
     -   `npm run type-check`
     -   `npm run build`
@@ -84,7 +82,7 @@ REQUIREMENTS
 3. Ensure the item is referenced by at least one quest or process; update those
    files and create missing processes as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.
@@ -103,7 +101,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or
 create items under `frontend/src/pages/inventory/json/items`, choosing the
 appropriate category file. Ensure realistic details, required fields, and
-passing checks (`npm run audit:ci`, `npm run lint`, `npm run type-check`,
+passing checks (`npm run lint`, `npm run type-check`,
 `npm run build`, `npm run test:ci`, `npm run itemValidation`, and
 `npm run test:ci -- itemQuality`). Verify the item appears in at least one quest or process,
 reuse existing image assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
@@ -154,7 +152,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
+5. Run `npm run lint`, `npm run type-check`, `npm run build`,
    `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -19,13 +19,13 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Avoid mixing refactors with new features or fixes.
 > 3. Keep commits small and reversible.
 > 4. Include before-and-after benchmarks if performance could change.
-> 5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 6. Run `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
 pass before committing.
 
 USER:


### PR DESCRIPTION
## Summary
- drop audit:ci from Codex prompt templates
- sync item, frontend, and refactor prompt guides
- alphabetize prompt links on docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806f5016c832f895246356e1bad19