### PR TITLE
docs: cross-link Codex prompt templates

### DIFF
--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -5,14 +5,20 @@ slug: 'prompts-accessibility'
 
 # Accessibility prompts for the _dspace_ repo
 
-Use this guide when enhancing the project's accessibility. The focus is on semantic HTML,
-ARIA attributes, keyboard navigation, and sufficient color contrast.
+Codex can open this repository and run its own tests. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when improving accessibility so instructions stay
+consistent. To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta). If templates drift, refresh them with the
+[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use
+the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix). The focus here is on semantic
+HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
 
 > **TL;DR**
 >
 > 1. Limit changes to files that impact user accessibility.
 > 2. Follow WCAG 2.1 AA: provide focus states, semantic elements, and ARIA labels.
 > 3. Validate with tooling like `npm run lint` and screen‑reader checks when possible.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,8 +14,9 @@ For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
-[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
-[Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
+[Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend),
+[Refactor prompts](/docs/prompts-refactors), and
+[Accessibility prompts](/docs/prompts-accessibility).
 For specialized workflows use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix),
 the [Codex meta prompt](/docs/prompts-codex-meta), and the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -5,10 +5,14 @@ slug: 'prompts-frontend'
 
 # Frontend prompts for the _dspace_ repo
 
-DSPACE's UI is built with Svelte and Astro. Use this guide when working on files inside
-`frontend/`, including Svelte components, pages, and styles. Changes should improve clarity,
-accessibility, or performance while keeping tests green. For deeper a11y guidance see
-[Accessibility prompts](/docs/prompts-accessibility).
+DSPACE's UI is built with Svelte and Astro. Codex can open this repository and run its own
+tests. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when working on files
+inside `frontend/`, including Svelte components, pages, and styles. Changes should improve
+clarity, accessibility, or performance while keeping tests green. For deeper a11y guidance
+see [Accessibility prompts](/docs/prompts-accessibility). To keep the prompt docs evolving,
+see the [Codex meta prompt](/docs/prompts-codex-meta). If templates drift, refresh them
+with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions
+runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- cross-link accessibility and frontend prompt docs to Codex templates
- tidy Codex prompt guide link list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806f5016c832f895246356e1bad19