### PR TITLE
📝 fix outage prompt link

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -13,7 +13,7 @@ docs, see the [Codex meta prompt](/docs/prompts-codex-meta).
 
 If this prompt ever drifts, consult the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 to refresh it before use. For guidance on logging incidents, see the
-[Outage prompts](/docs/prompts-outages).
+[Outage prompts](./prompts-outages.md).
 
 > **Human setup**
 >
@@ -72,46 +72,46 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 
 > Agents: append a bullet after each successful fix.
 
--   2025-03-?? – prompt no longer requires a failing job URL; agents must inspect
-    workflows and run local checks when none is provided.
--   2025-08-09 – JSON parse failures in `generated/processes.json` and an outdated
-    generated map broke type-check and build; ensure data files stay valid and
-    regenerate artifacts.
--   2025-08-09 – `pnpm` must be installed before Node caching; place `pnpm/action-setup`
-    ahead of `actions/setup-node` to prevent missing executable errors.
--   2025-08-09 – Passing an extra `--port` to the dev server made Astro fall back to port 3000;
-    rely on the script's configured port so test waits succeed.
--   2025-08-09 – Playwright tests received `ERR_CONNECTION_REFUSED` when the workflow's dev
-    server step exited early; start a preview server with `--host 0.0.0.0` and wait on it so
-    the frontend stays reachable.
--   2025-08-09 – Installing only Chromium left Firefox and WebKit missing; install all
-    browsers with `playwright install --with-deps` and print the preview log on failure for
-    easier debugging.
--   2025-08-10 – `__dirname` in an ES module test and a nested Chip wrapper hid the
-    Cloud Sync upload button; derive paths with `import.meta.url` and use a plain container so
-    Playwright can locate the control.
--   2025-08-10 – Playwright's dev server exited between grouped runs; switching the webServer
-    command to `npm run preview` keeps a stable server for E2E tests.
--   2025-08-10 – `npm run test:ci` was undefined, breaking CI instructions; add a script
-    alias that runs `test:pr` with `SKIP_E2E` to keep checks green.
--   2025-08-10 – `listMissingImages` treated URLs with query strings as missing files; strip
-    query and hash parts before checking so coverage tests don't flag valid assets.
--   2025-08-10 – `checkPatchCoverage.cjs` assumed `origin/main`; detect the origin's HEAD branch
-    so patch coverage checks work on repositories where the default branch is `v3`.
--   2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to fix the
-    dependency audit.
--   2025-08-11 – Introduced a structured outage catalog under `/outages` so agents
-    can recall past incidents.
--   2025-08-12 – `listMissingImages` flagged remote URLs as missing assets; skip `http` and
-    `https` paths so coverage checks ignore external images.
--   2025-08-12 – `.npmrc`'s `packageManager` key made npm warn; drop the file and
-    set `packageManager` in `package.json` to keep installs quiet.
--   2025-08-12 – `listMissingImages` flagged data URIs and protocol-relative sources as missing;
-    ignore `data:` and `//` URLs so coverage checks only test local assets.
--   2025-08-14 – `new-quests.md` fell behind after new quests were added; run `npm run new-quests:update`
-    and commit the refreshed file.
--   2025-08-14 – `npm test` in `frontend` ran zero unit tests; add a minimal sanity test so CI verifies the frontend harness.
--   2025-08-14 – E2E tests failed when Playwright browsers were missing; ensure `npx --prefix frontend`
-    `playwright install --with-deps` runs before grouped tests.
--   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
-    pattern so E2E tests detect all Jest files.
+- 2025-03-?? – prompt no longer requires a failing job URL; agents must inspect
+  workflows and run local checks when none is provided.
+- 2025-08-09 – JSON parse failures in `generated/processes.json` and an outdated
+  generated map broke type-check and build; ensure data files stay valid and
+  regenerate artifacts.
+- 2025-08-09 – `pnpm` must be installed before Node caching; place `pnpm/action-setup`
+  ahead of `actions/setup-node` to prevent missing executable errors.
+- 2025-08-09 – Passing an extra `--port` to the dev server made Astro fall back to port 3000;
+  rely on the script's configured port so test waits succeed.
+- 2025-08-09 – Playwright tests received `ERR_CONNECTION_REFUSED` when the workflow's dev
+  server step exited early; start a preview server with `--host 0.0.0.0` and wait on it so
+  the frontend stays reachable.
+- 2025-08-09 – Installing only Chromium left Firefox and WebKit missing; install all
+  browsers with `playwright install --with-deps` and print the preview log on failure for
+  easier debugging.
+- 2025-08-10 – `__dirname` in an ES module test and a nested Chip wrapper hid the
+  Cloud Sync upload button; derive paths with `import.meta.url` and use a plain container so
+  Playwright can locate the control.
+- 2025-08-10 – Playwright's dev server exited between grouped runs; switching the webServer
+  command to `npm run preview` keeps a stable server for E2E tests.
+- 2025-08-10 – `npm run test:ci` was undefined, breaking CI instructions; add a script
+  alias that runs `test:pr` with `SKIP_E2E` to keep checks green.
+- 2025-08-10 – `listMissingImages` treated URLs with query strings as missing files; strip
+  query and hash parts before checking so coverage tests don't flag valid assets.
+- 2025-08-10 – `checkPatchCoverage.cjs` assumed `origin/main`; detect the origin's HEAD branch
+  so patch coverage checks work on repositories where the default branch is `v3`.
+- 2025-08-11 – `openai` v3 pulled a vulnerable `axios`; upgrade to v5 to fix the
+  dependency audit.
+- 2025-08-11 – Introduced a structured outage catalog under `/outages` so agents
+  can recall past incidents.
+- 2025-08-12 – `listMissingImages` flagged remote URLs as missing assets; skip `http` and
+  `https` paths so coverage checks ignore external images.
+- 2025-08-12 – `.npmrc`'s `packageManager` key made npm warn; drop the file and
+  set `packageManager` in `package.json` to keep installs quiet.
+- 2025-08-12 – `listMissingImages` flagged data URIs and protocol-relative sources as missing;
+  ignore `data:` and `//` URLs so coverage checks only test local assets.
+- 2025-08-14 – `new-quests.md` fell behind after new quests were added; run `npm run new-quests:update`
+  and commit the refreshed file.
+- 2025-08-14 – `npm test` in `frontend` ran zero unit tests; add a minimal sanity test so CI verifies the frontend harness.
+- 2025-08-14 – E2E tests failed when Playwright browsers were missing; ensure `npx --prefix frontend`
+  `playwright install --with-deps` runs before grouped tests.
+- 2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
+  pattern so E2E tests detect all Jest files.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -12,7 +12,7 @@ invoking Codex on DSPACE and should evolve alongside the project.
 
 For task‑specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
-[NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
+[NPC prompts](/docs/prompts-npcs), [Outage prompts](./prompts-outages.md),
 [Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
 [Frontend prompts](/docs/prompts-frontend), [Backend prompts](/docs/prompts-backend), and
 [Refactor prompts](/docs/prompts-refactors), and [Accessibility prompts](/docs/prompts-accessibility)
@@ -37,21 +37,21 @@ For failing GitHub Actions runs, use the dedicated
 
 ## Related prompt guides
 
--   [Item Prompts](/docs/prompts-items)
--   [Process Prompts](/docs/prompts-processes)
--   [Quest Prompts](/docs/prompts-quests)
--   [NPC Prompts](/docs/prompts-npcs)
--   [Outage Prompts](/docs/prompts-outages)
--   [Docs Prompts](/docs/prompts-docs)
--   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
--   [Backend Prompts](/docs/prompts-backend)
--   [Frontend Prompts](/docs/prompts-frontend)
--   [Accessibility Prompts](/docs/prompts-accessibility)
--   [Playwright Test Prompts](/docs/prompts-playwright-tests)
--   [Refactor Prompts](/docs/prompts-refactors)
--   [Codex CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
--   [Codex Meta Prompt](/docs/prompts-codex-meta)
--   [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
+- [Item Prompts](/docs/prompts-items)
+- [Process Prompts](/docs/prompts-processes)
+- [Quest Prompts](/docs/prompts-quests)
+- [NPC Prompts](/docs/prompts-npcs)
+- [Outage Prompts](./prompts-outages.md)
+- [Docs Prompts](/docs/prompts-docs)
+- [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
+- [Backend Prompts](/docs/prompts-backend)
+- [Frontend Prompts](/docs/prompts-frontend)
+- [Accessibility Prompts](/docs/prompts-accessibility)
+- [Playwright Test Prompts](/docs/prompts-playwright-tests)
+- [Refactor Prompts](/docs/prompts-refactors)
+- [Codex CI-Failure Fix Prompt](/docs/prompts-codex-ci-fix)
+- [Codex Meta Prompt](/docs/prompts-codex-meta)
+- [Codex Prompt Upgrader](/docs/prompts-codex-upgrader)
 
 ---
 
@@ -110,10 +110,10 @@ Use this template when you want Codex to automatically clear items from the
 [September&nbsp;1,&nbsp;2025 changelog](/docs/changelog/20250901). Tasks are
 tracked with Markdown checkboxes and an emoji status:
 
--   `- [ ]` – work not started
--   `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
--   `- [x] ✅` – implemented before robustness checks; replace with `💯` once verified
--   `- [x] 💯` – thoroughly tested and reviewed
+- `- [ ]` – work not started
+- `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
+- `- [x] ✅` – implemented before robustness checks; replace with `💯` once verified
+- `- [x] 💯` – thoroughly tested and reviewed
 
 Codex should pick a single entry that is either unchecked or checked without a
 💯 (for example, entries marked with ✅) and implement it completely. After all
@@ -195,9 +195,5 @@ USER:
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
-
-## Outage prompts
-
-See [Outage prompts](/docs/prompts-outages) for guidance on logging incidents and fixes.
 
 [openai-cli]: https://github.com/openai/openai-cli

--- a/outages/2025-08-22-prompts-outages-link-404.json
+++ b/outages/2025-08-22-prompts-outages-link-404.json
@@ -1,0 +1,11 @@
+{
+  "id": "prompts-outages-link-404",
+  "date": "2025-08-22",
+  "component": "docs",
+  "rootCause": "Absolute link used '/docs/prompts-outages', which GitHub interpreted as an external path and returned 404.",
+  "resolution": "Updated cross references to use a relative path and removed redundant section.",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex.md",
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- fix broken outage prompt links and trim redundant section
- cross-link CI fix prompt to outage doc
- log the outage in repository catalog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a8076754a0832fa95e6cefd8a8c462