### PR TITLE
Verify quest count expansion

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -29,7 +29,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Document quest schema requirements 💯
         -   [x] Create example quest templates 💯
 
--   [x] 10x More Quests
+-   [x] 10x More Quests 💯
 
     -   [x] Create new official quests using the custom quest system 💯
     -   [x] Balance progression curve across all quests 💯

--- a/scripts/compareQuestCount.js
+++ b/scripts/compareQuestCount.js
@@ -27,6 +27,11 @@ function listQuestFiles(commit) {
   return files;
 }
 
+module.exports = {
+  listQuestFiles,
+  BASE_COMMIT,
+};
+
 function main() {
   const v21Files = listQuestFiles(BASE_COMMIT);
   const headFiles = listQuestFiles();

--- a/tests/questCountIncrease.test.ts
+++ b/tests/questCountIncrease.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import compare from '../scripts/compareQuestCount.js';
+
+const { listQuestFiles, BASE_COMMIT } = compare as {
+  listQuestFiles: (ref?: string) => string[];
+  BASE_COMMIT: string;
+};
+
+describe('quest count increase', () => {
+  it('has at least 10x more quests than v2.1', () => {
+    const base = listQuestFiles(BASE_COMMIT).length;
+    const current = listQuestFiles().length;
+    expect(current).toBeGreaterThanOrEqual(base * 10);
+  });
+});


### PR DESCRIPTION
## Summary
- export quest counter for reuse
- test quest counts grew 10x since v2.1
- mark quest expansion as complete

## Testing
- `npm run audit:ci` *(fails: vulnerabilities remain)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a806fc41ec832f9dc6d256fe6df604