### PR TITLE
🔗 Add cross-links for new documentation pages

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -61,6 +61,9 @@ import Page from '../../components/Page.astro';
             <a href="/docs/bounties">Bounties</a>
             <a href="/docs/user-journeys">User journeys</a>
             <a href="/docs/self-hosting">Self-hosting</a>
+            <a href="/docs/content-development">Content development</a>
+            <a href="/docs/custom-bundles">Custom content bundles</a>
+            <a href="/docs/process-guidelines">Process development guidelines</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>

--- a/frontend/src/pages/docs/md/content-development.md
+++ b/frontend/src/pages/docs/md/content-development.md
@@ -65,6 +65,10 @@ Instructions for creating processes that transform or utilize items. Topics incl
 -   Process states and lifecycle
 -   Creating process chains for progression
 
+### [Custom Content Bundles](/docs/custom-bundles)
+
+Bundle related quests, items, and processes into a single JSON file to keep submissions in sync.
+
 ## AI Assistance for Content Creation
 
 For contributors who want to leverage artificial intelligence in their content creation process, we provide [Quest Prompts](/docs/prompts-quests), [Item Prompts](/docs/prompts-items) and [Process Prompts](/docs/prompts-processes) that can be used with modern AI assistants. For automating backlog tasks, see the [Codex Implementation Prompt](/docs/prompts-codex#implementation-prompt); it walks Codex through selecting an unchecked item from the latest changelog and implementing it from start to finish. For general repository maintenance, the [Codex Upgrade Prompt](/docs/prompts-codex#upgrade-prompt) instructs Codex to scan the project for improvements and implement them automatically.

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -3,7 +3,9 @@ title: 'Processes'
 slug: 'processes'
 ---
 
-Processes are the steps that machines take to convert ingredients, raw materials, or subcomponents into other machines or objects. Think of them as blueprints or recipes.
+Processes are the steps that machines take to convert ingredients, raw materials, or subcomponents
+into other machines or objects. Think of them as blueprints or recipes. For guidance on designing
+your own, see the [Process Development Guidelines](/docs/process-guidelines).
 
 <img src="/assets/docs/process.jpg">
 


### PR DESCRIPTION
## Summary
- link to content development, custom bundles, and process guidelines in docs index
- mention custom content bundles in content development guide
- cross-link processes doc to process development guidelines

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a807b3a8d4832f9dc38fe531063ccd