### PR TITLE
docs: fix Cloud Sync link and sync quest list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -189,7 +189,8 @@ A few technical details that might interest you:
 -   Your v2 progress will automatically migrate to v3
 -   All custom content includes rollback functionality (in case something goes wrong)
 
-The new **Cloud Sync** feature lets you back up your progress across devices using a private GitHub gist. Visit the [Cloud Sync](/cloudsync) page to enable it.
+The new **Cloud Sync** feature lets you back up your progress across devices using a private
+GitHub gist. Visit the [Cloud Sync](/docs/cloud-sync) page to enable it. 💯
 
 ## Refined Virtual Economy
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 


### PR DESCRIPTION
## Summary
- fix Cloud Sync link in 2025 changelog
- regenerate new quest list docs for accurate counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68a92aa83f90832f8e63802232689d15