### PR TITLE
Refactor test runner and sync new quests docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -10,7 +10,7 @@ const os = require('os');
 const { hasZeroTests } = require('./scripts/utils/detect-zero-tests');
 
 // ANSI color codes for pretty output
-const colors = {
+const colors = Object.freeze({
     reset: '\x1b[0m',
     bright: '\x1b[1m',
     green: '\x1b[32m',
@@ -19,7 +19,7 @@ const colors = {
     magenta: '\x1b[35m',
     cyan: '\x1b[36m',
     red: '\x1b[31m'
-};
+});
 
 function runTests(exec = execSync, platform = os.platform()) {
     console.log(`${colors.bright}${colors.magenta}DSPACE Testing Suite${colors.reset}`);
@@ -39,22 +39,19 @@ function runTests(exec = execSync, platform = os.platform()) {
             return 1;
         }
 
-        // Determine which script to run based on OS
-        if (platform === 'win32') {
-            console.log(
-                `${colors.yellow}Detected Windows OS, running PowerShell script...${colors.reset}`
-            );
-            exec('powershell -File .\\frontend\\scripts\\prepare-pr.ps1', {
-                stdio: 'inherit'
-            });
-        } else {
-            console.log(
-                `${colors.yellow}Detected Unix-like OS, running Bash script...${colors.reset}`
-            );
-            exec('bash ./frontend/scripts/prepare-pr.sh', {
-                stdio: 'inherit'
-            });
-        }
+        const scripts = {
+            win32: {
+                message: `${colors.yellow}Detected Windows OS, running PowerShell script...${colors.reset}`,
+                command: 'powershell -File .\\frontend\\scripts\\prepare-pr.ps1'
+            },
+            default: {
+                message: `${colors.yellow}Detected Unix-like OS, running Bash script...${colors.reset}`,
+                command: 'bash ./frontend/scripts/prepare-pr.sh'
+            }
+        };
+        const { message, command } = scripts[platform] || scripts.default;
+        console.log(message);
+        exec(command, { stdio: 'inherit' });
 
         console.log(
             `\n${colors.bright}${colors.green}All tests completed successfully!${colors.reset}`


### PR DESCRIPTION
## Summary
- refactor run-tests.js with OS script map and frozen colors
- sync new-quests markdown files

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92beccc5c832fbf765a4723ba673e