### PR TITLE
♻️ refactor fs-checks default path and sync quest docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const DATA_URL_RE = /^data:/i;
 const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
+const DEFAULT_PUBLIC_DIR = path.join(__dirname, '..', '..', 'frontend', 'public');
 
 const isLocalPath = (url) => !DATA_URL_RE.test(url) && !REMOTE_URL_RE.test(url);
 
@@ -19,16 +20,15 @@ const decodeSafely = (str) => {
  * Handles query strings, hash fragments, and percent-encoded segments.
  *
  * @param {string[]} imagePaths
- * @param {string} [publicDir=path.join(__dirname, '..', '..', 'frontend', 'public')]
+ * @param {string} [publicDir=DEFAULT_PUBLIC_DIR]
  * @returns {string[]}
  */
-function listMissingImages(
-  imagePaths,
-  publicDir = path.join(__dirname, '..', '..', 'frontend', 'public'),
-) {
+function listMissingImages(imagePaths, publicDir = DEFAULT_PUBLIC_DIR) {
   return imagePaths.filter((img) => {
-    const [base] = img.split(/[?#]/);
-    if (!isLocalPath(base)) return false;
+    const base = img.replace(/[?#].*$/, '');
+    if (!isLocalPath(base)) {
+      return false;
+    }
 
     const decoded = decodeSafely(base.replace(/^\//, ''));
     return !fs.existsSync(path.join(publicDir, decoded));


### PR DESCRIPTION
## Summary
- reuse a shared public directory constant in `listMissingImages`
- refresh auto-generated new quests documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68a92beccc5c832fbf765a4723ba673e