### PR TITLE
docs: refine guides and quest list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,23 +12,23 @@ The project is licensed under the MIT License, which is permissive and business-
 
 You're invited to contribute in several ways:
 
-1. **Bug Reports:** If you encounter any bugs or issues while playing the game, please report them in the **[Issues](https://github.com/democratizedspace/dspace/issues)** section of our GitHub repository. Before creating a new issue, make sure to check if a similar issue hasn't been reported already. 
+1. **Bug Reports:** If you encounter any bugs or issues while playing the game, please report them in the **[Issues](https://github.com/democratizedspace/dspace/issues)** section of our GitHub repository. Before creating a new issue, check whether a similar one has already been reported.
 
-2. **Feature Requests:** If you have an idea for a new feature or an improvement for our game, please also submit this to the **Issues** section. Be as detailed as possible to help us understand your suggestion. 
+2. **Feature Requests:** If you have an idea for a new feature or an improvement for our game, please also submit this to the **Issues** section. Be as detailed as possible to help us understand your suggestion.
 
-3. **Code Contributions:** If you'd like to write code to fix issues or add new features, we encourage you to do so. 
+3. **Code Contributions:** If you'd like to write code to fix issues or add new features, we encourage you to do so.
 
 ### 3. Good First Issues & Help Wanted
 
 If you are new to the project, you may start with issues labelled as "Good First Issue". These issues are typically simpler and easier to resolve, and are a great way for new contributors to get involved with the project.
 
-More experienced contributors can look for the "Help Wanted" label. These are issues or enhancements that are somewhat more involved than "Good First Issues".
+More experienced contributors can look for the "Help Wanted" label on issues that are more involved than "Good First Issues".
 
 ### 4. Pull Requests
 
-Once you're ready to submit your code, create a pull request on GitHub. This will initiate a review process of your code. Please provide as much detail as possible in your pull request description.
+When you're ready to submit your code, create a pull request on GitHub to start the review process. Provide as much detail as possible in your pull request description.
 
-Make sure all the tests passed, and feel free to improve test coverage along with your pull requests if you're able to.
+Make sure all tests pass, and feel free to improve test coverage alongside your pull request if possible.
 
 In order to run the tests, simply run the following command:
 
@@ -36,7 +36,7 @@ In order to run the tests, simply run the following command:
 npm test
 ```
 
-to see test coverage, use
+To view test coverage, run
 
 ```sh
 npm run coverage
@@ -44,11 +44,11 @@ npm run coverage
 
 ### 5. Coding Guidelines
 
-We don't have a strict coding style guide (yet?), but we do ask that you keep your code clean and well-commented. Additionally, if you're able to add unit tests for your code, that would be great, but it's not required unless otherwise stated.
+We don't yet have a strict coding style guide, but please keep your code clean and well commented. Additionally, if you're able to add unit tests for your code, that would be great, but it's not required unless otherwise stated.
 
 ### 6. Contact
 
-If you have any questions or need further clarification on anything, feel free to contact us through [Discord](https://discord.gg/A3UAfYvnxM). 
+If you have any questions or need further clarification on anything, feel free to contact us through [Discord](https://discord.gg/A3UAfYvnxM).
 
 ### 7. Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 You can find the game at [democratized.space](https://democratized.space).
-The production instance is now self-hosted; see
-[Netlify Migration](docs/netlify-migration.md) for background.
+The production instance is self-hosted; see [Netlify Migration](docs/netlify-migration.md)
+for background.
 
 Check out the [docs](https://democratized.space/docs)!
 
@@ -49,11 +49,11 @@ Start the development server:
 # Standard development server
 npm run dev
 
-# Development server with Playwright artifact error prevention
+# Development server that avoids Playwright artifact errors
 cd frontend && npm run dev:safe
 ```
 
-The `dev:safe` command prevents common Playwright artifact errors that can occur after running tests.
+The `dev:safe` command prevents common Playwright artifact errors that occur after running tests.
 
 ### Utility Functions
 
@@ -66,19 +66,18 @@ calls. It returns `null` for unknown or non-string inputs. Prices are approximat
 import {
   approximateIrlPrice,
   approximateIrlAveragePrice,
-} from "./backend/approximateIrlPrice";
+} from './backend/approximateIrlPrice';
 
-console.log(approximateIrlPrice("3D-Printer")); // 350
-console.log(
-  approximateIrlAveragePrice(["3d_printer", "arduino_nano"])
-); // 186
-console.log(approximateIrlPrice("unknown")); // null
+console.log(approximateIrlPrice('3D-Printer')); // 350
+console.log(approximateIrlAveragePrice(['3d_printer', 'arduino_nano'])); // 186
+console.log(approximateIrlPrice('unknown')); // null
 console.log(approximateIrlPrice(undefined as any)); // null
 ```
 
 To override default prices, set `DSPACE_PRICE_TABLE_FILE` to a JSON file mapping
 item identifiers to numbers. Tests can reset cached tables with
 `__resetPriceTableCacheForTests({ keepCustom: true })` to preserve custom entries.
+
 ## Testing
 
 DSPACE uses a comprehensive testing suite to ensure code quality and prevent regressions.
@@ -246,7 +245,7 @@ Looking for a concrete walkthrough? The Playwright test `constellations-quest.sp
 
 Aquarium quests progress through a gentle learning curve: set up a Walstad tank, test the water, install a sponge filter, ask Atlas to position the tank, add dwarf shrimp, introduce guppies, perform regular water changes, practice breeding, and finally keep a goldfish in a large tank.
 Electronics quests now begin with a simple LED circuit to teach basic wiring before moving on to sensors and automation. Each tree has been extended with follow-up tasks, such as tuning 3D printer retraction and refreshing hydroponic nutrients.
-The DevOps chain now covers deploying DSPACE on a Raspberry Pi cluster with Docker and k3s, setting up monitoring with Prometheus and Grafana, and scheduling nightly backups. Recent updates shortened several prerequisite chains so energy and DevOps milestones align more closely with other categories.
+The DevOps chain now covers deploying DSPACE on a Raspberry Pi cluster with Docker and k3s, setting up monitoring with Prometheus and Grafana, and scheduling nightly backups. Recent updates shortened several prerequisite chains, aligning energy and DevOps milestones more closely with other categories.
 
 To validate that quests use a canonical structure with clear start and finish
 steps, run the dedicated test:
@@ -347,15 +346,18 @@ files help prevent accidental removals.
 ## FAQ
 
 ### Which Node.js versions are supported?
+
 We test against active Node.js LTS releases (currently 18 and 20). Run
 `node --version` to confirm your environment, and let us know if newer LTS
 versions behave unexpectedly.
 
 ### Do I need to use pnpm to install dependencies?
+
 Yes. Run `pnpm install` in the repository root. The `pnpmfile.cjs` pre-approves
 native builds so no interactive prompts appear.
 
 ### How do I install Playwright browsers for end-to-end tests?
+
 Use `npx playwright install chromium` to download the required browser before
 running `npm test`.
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -2,11 +2,12 @@
 
 DSPACE avoids traditional user accounts. The only time authentication occurs is when you submit a custom quest to GitHub.
 
-1. Generate a personal access token with `repo` scope on GitHub.
+1. Generate a personal access token with the `repo` scope on GitHub.
 2. Enter the token in the Quest Submission form at `/quests/submit`.
 3. The token is stored in your browser's `localStorage` so you don't need to re-enter it.
 4. The token is sent directly to the GitHub API to create a branch and pull request.
 5. You can clear the saved token using the **Clear Token** button or by removing it from your GitHub settings.
 
-Tokens are never sent to any server other than GitHub. Remember to revoke the token from GitHub whenever you no longer need it.
+Tokens are never sent to servers other than GitHub. Remember to revoke the token when you no longer need it.
+
 User-generated markdown is sanitized with DOMPurify before rendering to prevent cross-site scripting (XSS).

--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 


### PR DESCRIPTION
## Summary
- clarify self-hosting, dev server tips, and DevOps notes in README
- tighten contributor instructions and authentication flow
- refresh new quest counts to match current data

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92ad2d354832fb90edbd1ee3cac6b