### PR TITLE
docs: refine backup and failover guides

### DIFF
--- a/docs/backup_system.md
+++ b/docs/backup_system.md
@@ -1,9 +1,9 @@
 # Backup System
 
 DSPACE nodes perform nightly backups to preserve player progress and custom content.
-Backups run as a cron job on the host and create a timestamped `tar.gz` archive of the
-`backend` and `frontend` workspaces. Archives are stored in the `backups/` directory and
-can be copied off‑device for redundancy.
+A cron job on the host creates a timestamped `tar.gz` archive of the `backend` and
+`frontend` workspaces each night. Archives live in the `backups/` directory and can be
+copied off-device for redundancy.
 
 ## Usage
 
@@ -13,13 +13,13 @@ Run the backup script manually when needed:
 node scripts/backup.mjs
 ```
 
-To back up specific paths pass them as arguments:
+To back up specific paths, pass them as arguments:
 
 ```bash
 node scripts/backup.mjs package.json docs
 ```
 
-To change the output directory, use `--out`:
+To change the output directory, pass `--out`:
 
 ```bash
 node scripts/backup.mjs --out my-backups package.json docs
@@ -27,7 +27,7 @@ node scripts/backup.mjs --out my-backups package.json docs
 
 ## Restore
 
-Extract the desired archive and replace the existing directories:
+Extract the desired archive, then replace the existing directories:
 
 ```bash
 tar -xzf backups/backup-<timestamp>.tar.gz

--- a/docs/failover_procedures.md
+++ b/docs/failover_procedures.md
@@ -1,11 +1,11 @@
 # Failover Procedures
 
-This guide outlines how to handle downtime when running multiple DSPACE instances with Cloudflare Load Balancing.
+This guide outlines how to handle downtime when running multiple DSPACE instances behind Cloudflare Load Balancing.
 
 ## Overview
 
 If an instance becomes unreachable, Cloudflare automatically routes traffic to a healthy node.
-However, you should still investigate the failed instance and restore it as soon as possible.
+However, you should still investigate the failed instance and restore it promptly.
 
 ## Steps
 
@@ -18,17 +18,17 @@ However, you should still investigate the failed instance and restore it as soon
      ```bash
      docker compose restart app
      ```
-   - Wait a few seconds and verify that `curl http://localhost:3002/health` returns `{ "status": "ok" }`.
+   - Wait a few seconds, then verify that `curl http://localhost:3002/health` returns `{ "status": "ok" }`.
 
 3. **Check Prometheus metrics**
-    - Navigate to your Grafana dashboard (default `http://localhost:3001`) and ensure the
+    - Navigate to your Grafana dashboard (default `http://localhost:3001`) and confirm the
       `up` metric shows `1` for all instances.
 
 4. **Fallback option**
-    - If a node is corrupted or unreachable, spin up a new instance using the same deployment steps from
+    - If a node becomes corrupted or unreachable, spin up a new instance using the deployment steps from the
       [Raspberry Pi Deployment Guide](./RPI_DEPLOYMENT_GUIDE.md).
     - Once the new node is running, add it to your [Cloudflare load balancer](./cloudflare_load_balancing.md)
       as an origin.
 
-Cloudflare will automatically bring the restored instance back into rotation once it reports healthy.
+Cloudflare automatically returns the restored instance to rotation once it reports healthy.
 

--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/docs/prompts-outages.md
+++ b/docs/prompts-outages.md
@@ -3,12 +3,12 @@ title: 'Outage Prompts'
 slug: 'prompts-outages'
 ---
 
-# Outage prompts for the _dspace_ repo
+# Outage prompts for the DSPACE repo
 
-Codex is a sandboxed engineering agent that can open this repository and run its own tests.
+Codex is a sandboxed engineering agent that can open this repository and run tests.
 Use this guide alongside [Codex Prompts](/docs/prompts-codex) so every fix ships with a matching
 record in the outage catalog.
-To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta);
+To keep these prompt docs evolving, consult the [Codex meta prompt](/docs/prompts-codex-meta);
 if templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 
 > **TL;DR**

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 


### PR DESCRIPTION
## Summary
- polish backup and failover docs for clarity
- refresh outage prompt wording and sync quest list counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: ENOENT tmp-backups/backup-<timestamp>.tar.gz)*


------
https://chatgpt.com/codex/tasks/task_e_68a92ad2d354832fb90edbd1ee3cac6b