### PR TITLE
Add Fail2ban install process and quest reference

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4443,6 +4443,30 @@
         }
     },
     {
+        "id": "install-fail2ban",
+        "title": "Install Fail2ban on a Pi node and enable the sshd jail",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            {
+                "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d",
+                "count": 1
+            },
+            {
+                "id": "df7e94e2-76b9-4865-b843-2ec21feb258e",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "measure-filament-diameter",
         "title": "Measure 1.75 mm PLA filament at three points with digital calipers",
         "image": "/assets/pla_white.jpg",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3437,6 +3437,24 @@
         }
     },
     {
+        "id": "install-fail2ban",
+        "title": "Install Fail2ban on a Pi node and enable the sshd jail",
+        "image": "/assets/quests/basic_circuit.svg",
+        "requireItems": [
+            { "id": "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d", "count": 1 },
+            { "id": "df7e94e2-76b9-4865-b843-2ec21feb258e", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "5m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "measure-filament-diameter",
         "title": "Measure 1.75 mm PLA filament at three points with digital calipers",
         "image": "/assets/pla_white.jpg",

--- a/frontend/src/pages/processes/hardening/install-fail2ban.json
+++ b/frontend/src/pages/processes/hardening/install-fail2ban.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/quests/json/devops/fail2ban.json
+++ b/frontend/src/pages/quests/json/devops/fail2ban.json
@@ -22,6 +22,11 @@
             "text": "Install Fail2ban and configure a jail for the SSH service.",
             "options": [
                 {
+                    "type": "process",
+                    "process": "install-fail2ban",
+                    "text": "Install and enable Fail2ban"
+                },
+                {
                     "type": "goto",
                     "goto": "finish",
                     "text": "Bans configured",


### PR DESCRIPTION
## Summary
- add install-fail2ban process with hardening metadata
- hook process into devops Fail2ban quest
- regenerate new-quests docs and process map

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: missing origin/v3 remote and missing backup file)*
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a92b80e58c832f95dfbb16c08297a6