### PR TITLE
Add test for markdown image path fixer and sync quest docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/scripts/fix-markdown-image-paths.js
+++ b/scripts/fix-markdown-image-paths.js
@@ -1,7 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
-const dir = path.join(__dirname, '..', 'frontend', 'src', 'pages', 'docs', 'md', 'changelog');
+const dir = path.join(
+  __dirname,
+  '..',
+  'frontend',
+  'src',
+  'pages',
+  'docs',
+  'md',
+  'changelog'
+);
 const changed = [];
 
 function walk(folder) {
@@ -17,13 +26,17 @@ function fixFile(file) {
   let data = fs.readFileSync(file, 'utf8');
   const orig = data;
 
-  data = data.replace(/!\[([^\]]*)\]\(\/assets\/([^\)]+)\)/g, (m, alt, rest) =>
-    `![${alt}](../../../../../public/assets/${rest})`);
+  data = data.replace(
+    /!\[([^\]]*)\]\(\/assets\/([^\)]+)\)/g,
+    (_m, alt, rest) => `![${alt}](../../../../../public/assets/${rest})`
+  );
 
   data = data.replace(/【\d+†Image: ([^】]+)】/g, '<!-- image removed: $1 -->');
 
-  data = data.replace(/^---\r?\n([\s\S]*?)\r?\n---[\r\n]*/, (_m, body) =>
-    `---\n${body}\n---\n\n`);
+  data = data.replace(
+    /^---\r?\n([\s\S]*?)\r?\n---[\r\n]*/,
+    (_m, body) => `---\n${body}\n---\n\n`
+  );
 
   if (data !== orig) {
     fs.writeFileSync(file, data);
@@ -31,10 +44,18 @@ function fixFile(file) {
   }
 }
 
-walk(dir);
-if (changed.length) {
-  console.log('Updated files:');
-  for (const f of changed) console.log(' - ' + f);
-} else {
-  console.log('No changes found.');
+function main() {
+  walk(dir);
+  if (changed.length) {
+    console.log('Updated files:');
+    for (const f of changed) console.log(' - ' + f);
+  } else {
+    console.log('No changes found.');
+  }
 }
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { fixFile, walk, main };

--- a/tests/fixMarkdownImagePaths.test.ts
+++ b/tests/fixMarkdownImagePaths.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { expect, test } from 'vitest';
+import { fixFile } from '../scripts/fix-markdown-image-paths.js';
+
+test('fixFile rewrites markdown image paths and front matter', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'md-'));
+  const file = path.join(dir, 'example.md');
+  const input = [
+    '---',
+    'title: Example',
+    '---',
+    '![alt](/assets/foo.png)',
+    'Text',
+    '【1†Image: secret.png】'
+  ].join('\n');
+  writeFileSync(file, input);
+
+  fixFile(file);
+
+  const output = readFileSync(file, 'utf8');
+  expect(output).toBe([
+    '---',
+    'title: Example',
+    '---',
+    '',
+    '![alt](../../../../../public/assets/foo.png)',
+    'Text',
+    '<!-- image removed: secret.png -->'
+  ].join('\n'));
+
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- export functions from `fix-markdown-image-paths` and guard CLI execution
- add unit test covering markdown image path fixes
- sync `new-quests` docs with latest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs` *(fails: Coverage file not found at /workspace/dspace/frontend/coverage/coverage-summary.json)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92bed3308832fab2fe685f9dfeb50