### PR TITLE
Add carbon offset quest to energy progression

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/quests/json/energy/dOffset-1.json
+++ b/frontend/src/pages/quests/json/energy/dOffset-1.json
@@ -1,0 +1,60 @@
+{
+    "id": "energy/dOffset-1",
+    "title": "Offset 1 kg of carbon",
+    "description": "Convert 1 dCarbon into 1 dOffset to balance your emissions.",
+    "image": "/assets/dOffset.jpg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your dCarbon is piling up. Want to offset 1 kg by converting it into a dOffset token?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "offset",
+                    "text": "Absolutely, let's do it."
+                }
+            ]
+        },
+        {
+            "id": "offset",
+            "text": "Run the conversion process to burn dCarbon with dUSD.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "dCarbon-dOffset-1",
+                    "text": "Convert 1 dCarbon to 1 dOffset"
+                },
+                {
+                    "type": "goto",
+                    "goto": "check",
+                    "text": "I already have my dOffset.",
+                    "requiresItems": [
+                        {
+                            "id": "b0ac46e6-6c60-48f0-b753-d9b6ad9935a6",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "check",
+            "text": "Nice work! You've offset some emissions.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Feels good to breathe easier."
+                }
+            ]
+        }
+    ],
+    "rewards": [
+        {
+            "id": "02b32152-a7b2-458e-9643-7b754c722165",
+            "count": 1
+        }
+    ],
+    "requiresQuests": ["energy/dWatt-1e3"]
+}

--- a/frontend/src/pages/quests/json/energy/dWatt-1e4.json
+++ b/frontend/src/pages/quests/json/energy/dWatt-1e4.json
@@ -51,5 +51,5 @@
             "count": 3
         }
     ],
-    "requiresQuests": ["energy/dWatt-1e3"]
+    "requiresQuests": ["energy/dOffset-1"]
 }


### PR DESCRIPTION
## Summary
- add `energy/dOffset-1` quest to convert dCarbon into dOffset
- link quest after dWatt milestone for smoother energy progression

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a92ba4dd64832f819386d4adc54dbf