### PR TITLE
Add about page journey test and doc updates

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/e2e/about-page.spec.ts
+++ b/frontend/e2e/about-page.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+
+test('About page loads', async ({ page }) => {
+    await page.goto('/docs/about');
+    await expect(page.getByRole('heading', { name: 'About DSPACE' })).toBeVisible();
+});

--- a/frontend/e2e/backlog/about-page.spec.ts
+++ b/frontend/e2e/backlog/about-page.spec.ts
@@ -1,6 +1,0 @@
-import { test } from '@playwright/test';
-
-// Placeholder for about page journey
-test('About page loads', async ({ page }) => {
-    // TODO: implement about page test
-});

--- a/frontend/e2e/backlog/dark-mode-toggle.spec.ts
+++ b/frontend/e2e/backlog/dark-mode-toggle.spec.ts
@@ -1,0 +1,6 @@
+import { test } from '@playwright/test';
+
+// Placeholder for dark mode toggle journey
+test('Dark mode toggle', async ({ page }) => {
+    // TODO: implement dark mode toggle test
+});

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -30,8 +30,8 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 >    fixes, keeping the table alphabetized. Verify apparent 404s aren't missing
 >    routes; if a page should exist, add a stub instead of asserting a 404.
 > 6. Run `npx playwright install chromium` if browsers are missing.
-> 7. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`.
+> 7. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
 > 8. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >    and commit with an emoji.
 

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -11,7 +11,7 @@ sorted alphabetically by journey name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
-| About page loads           | No                  | --                                                |
+| About page loads           | Yes                 | `frontend/e2e/about-page.spec.ts`                 |
 | Authentication flow        | Yes                 | `frontend/e2e/authentication-flow.spec.ts`        |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
@@ -19,6 +19,7 @@ sorted alphabetically by journey name.
 | Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |
 | Custom backup              | Yes                 | `frontend/e2e/custom-backup.spec.ts`              |
 | Custom content integration | Yes                 | `frontend/e2e/custom-content.spec.ts`             |
+| Dark mode toggle           | No                  | --                                                |
 | Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
 | Failover status page       | Yes                 | `frontend/e2e/failover-status.spec.ts`            |


### PR DESCRIPTION
## Summary
- add Playwright test for About page journey
- document dark mode toggle journey placeholder
- refresh new quest stats and prompts guidance

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92b70116c832fb40f444c6efdd479