### PR TITLE
Refine brass tip cleaning process hardening

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4474,7 +4474,7 @@
     },
     {
         "id": "use-brass-tip-cleaner",
-        "title": "Clean soldering iron tip using a brass wire sponge",
+        "title": "Wipe hot soldering iron tip on a brass wire sponge to remove residue",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             {
@@ -4488,12 +4488,18 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "1m",
+        "duration": "30s",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-use-brass-tip-cleaner-2025-08-23",
+                    "date": "2025-08-23",
+                    "score": 60
+                }
+            ]
         }
     },
     {

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3450,7 +3450,7 @@
     },
     {
         "id": "use-brass-tip-cleaner",
-        "title": "Clean soldering iron tip using a brass wire sponge",
+        "title": "Wipe hot soldering iron tip on a brass wire sponge to remove residue",
         "image": "/assets/quests/basic_circuit.svg",
         "requireItems": [
             { "id": "4379a2f8-7cec-4bea-949b-ad50514d36ff", "count": 1 },
@@ -3458,12 +3458,18 @@
         ],
         "consumeItems": [],
         "createItems": [],
-        "duration": "1m",
+        "duration": "30s",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-use-brass-tip-cleaner-2025-08-23",
+                    "date": "2025-08-23",
+                    "score": 60
+                }
+            ]
         }
     },
     {

--- a/frontend/src/pages/processes/hardening/use-brass-tip-cleaner.json
+++ b/frontend/src/pages/processes/hardening/use-brass-tip-cleaner.json
@@ -1,6 +1,12 @@
 {
-    "passes": 0,
-    "score": 0,
-    "emoji": "🛠️",
-    "history": []
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-use-brass-tip-cleaner-2025-08-23",
+            "date": "2025-08-23",
+            "score": 60
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- clarify brass tip cleaning process, shorten duration, and record first hardening pass
- sync new quest counts to satisfy tests

## Testing
- `npm run audit:ci` *(fails: undici vulnerabilities)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a92b92b928832f95487937a29be3e6