### PR TITLE
Refine aquarium thermometer process and add hardening

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3524,7 +3524,7 @@
     },
     {
         "id": "attach-aquarium-thermometer",
-        "title": "Attach a stick-on strip thermometer to aquarium glass",
+        "title": "Dry aquarium glass and attach a stick-on strip thermometer",
         "image": "/assets/aquarium_thermometer.jpg",
         "requireItems": [
             {
@@ -3532,17 +3532,30 @@
                 "count": 1
             },
             {
-                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
-                "count": 1
-            },
-            {
                 "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07",
                 "count": 1
             }
         ],
-        "consumeItems": [],
+        "consumeItems": [
+            {
+                "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50",
+                "count": 1
+            }
+        ],
         "createItems": [],
-        "duration": "1m"
+        "duration": "1m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-attach-aquarium-thermometer-2025-08-23",
+                    "date": "2025-08-23",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "check-aquarium-temperature",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2825,16 +2825,27 @@
     },
     {
         "id": "attach-aquarium-thermometer",
-        "title": "Attach a stick-on strip thermometer to aquarium glass",
+        "title": "Dry aquarium glass and attach a stick-on strip thermometer",
         "image": "/assets/aquarium_thermometer.jpg",
         "requireItems": [
             { "id": "ca7c1069-4ba3-4339-9a10-0b690a690e60", "count": 1 },
-            { "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 },
             { "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }
         ],
-        "consumeItems": [],
+        "consumeItems": [{ "id": "b16cd6c7-dfeb-49bf-8758-0cb3563b0d50", "count": 1 }],
         "createItems": [],
-        "duration": "1m"
+        "duration": "1m",
+        "hardening": {
+            "passes": 1,
+            "score": 60,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-attach-aquarium-thermometer-2025-08-23",
+                    "date": "2025-08-23",
+                    "score": 60
+                }
+            ]
+        }
     },
     {
         "id": "check-aquarium-temperature",

--- a/frontend/src/pages/processes/hardening/attach-aquarium-thermometer.json
+++ b/frontend/src/pages/processes/hardening/attach-aquarium-thermometer.json
@@ -1,0 +1,12 @@
+{
+    "passes": 1,
+    "score": 60,
+    "emoji": "🌀",
+    "history": [
+        {
+            "task": "codex-attach-aquarium-thermometer-2025-08-23",
+            "date": "2025-08-23",
+            "score": 60
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- clarify attaching aquarium thermometer, consume paper towel
- add initial hardening metadata and record audit
- sync new quest docs after regeneration

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: new quests list markdown mismatch)*
- `npm run test:ci -- processQuality`

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68a92b92b928832f95487937a29be3e6