### PR TITLE
docs: clarify Helio solar quests

### DIFF
--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -189,18 +189,19 @@ She steers launches through debris fields and teaches patience in stargazing.
 
 <img src="/assets/npc/sydney.jpg" />
 
-Helio is a cheerful solar technician who can't resist chasing daylight.
-They design compact arrays that keep the metaguild's gear humming far from any outlet.
-Helio can eyeball solar angles to within a degree and keeps meticulous charge logs.
+Helio is a cheerful solar tech who chases daylight for off-grid power.
+They design compact arrays for the guild's remote ops and eyeball solar angles within a degree.
+Helio guides recruits through quests like
+[Test a Portable Solar Panel](/quests/energy/portable-solar-panel) and
+[Assemble an Off-grid Charger](/quests/energy/offgrid-charger).
 
 ### Sample Dialogue
 
--   "Sun's up! I'm Helio. Let's put that star to work for you."
--   "Start by unfolding the panel and angling it toward the brightest patch of sky."
--   "See that meter? If it's in the green, you're charging at peak efficiency."
--   "A cloud rolled in—no worries, the battery will bridge the gap."
--   "Shade from a single leaf can tank output, so keep the array clear."
--   "Keep the cells clean and they'll power your adventures for years."
+-   "Sun's up! I'm Helio—let's catch some photons."
+-   "Unfold the panel and tilt it toward the brightest patch."
+-   "Green on the meter means maximum juice."
+-   "Clouds drift? The battery smooths it out."
+-   "Even a leaf's shadow kills output—keep it spotless."
 
 ## Quill
 


### PR DESCRIPTION
## Summary
- refine Helio's bio
- link solar quests and tighten dialogue

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: new quests list out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_68a92b561e3c832f8f553a21b87245d1