### PR TITLE
♿ : improve GrowableImage accessibility

### DIFF
--- a/frontend/__tests__/GrowableImage.test.js
+++ b/frontend/__tests__/GrowableImage.test.js
@@ -1,0 +1,19 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const componentFile = path.join(__dirname, '../src/components/GrowableImage.astro');
+
+describe('GrowableImage.astro', () => {
+    it('provides alt text for accessibility', () => {
+        const content = fs.readFileSync(componentFile, 'utf8');
+        expect(content).toMatch(/alt=\{alt \?\? ''\}/);
+    });
+
+    it('scales responsively', () => {
+        const content = fs.readFileSync(componentFile, 'utf8');
+        expect(content).toMatch(/max-width: 100%;/);
+        expect(content).toMatch(/height: auto;/);
+    });
+});

--- a/frontend/src/components/GrowableImage.astro
+++ b/frontend/src/components/GrowableImage.astro
@@ -1,14 +1,22 @@
 ---
-const { imageSrc, href } = Astro.props;
+interface Props {
+    imageSrc: string;
+    href: string;
+    alt?: string;
+}
+
+const { imageSrc, href, alt }: Props = Astro.props;
 ---
 
-<a href={href}><img class="icon" src={imageSrc} /></a>
+<a href={href}><img class="icon" src={imageSrc} alt={alt ?? ''} /></a>
 
 <style>
     .icon {
         margin-bottom: -8px;
         border-radius: 10px;
         width: 30px;
+        max-width: 100%;
+        height: auto;
         transition: 0.2s;
     }
 


### PR DESCRIPTION
## Summary
- add alt prop and responsive styles to GrowableImage
- test accessibility and responsiveness

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: ENOENT: no such file or directory, open '/workspace/dspace/tmp-backups/backup-2025-08-23T02-49-15-589Z.tar.gz')*

Label: needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68a92b2b8cbc832f885b30eeb93453cd