### PR TITLE
♿ Add alt text to card images

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/__tests__/CardAccessibility.test.js
+++ b/frontend/__tests__/CardAccessibility.test.js
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const compactCardFile = path.join(__dirname, '../src/components/CompactCard.astro');
+const cardFile = path.join(__dirname, '../src/components/Card.astro');
+
+describe('Card components accessibility', () => {
+    it('CompactCard image includes alt text and responsive sizing', () => {
+        const content = fs.readFileSync(compactCardFile, 'utf8');
+        expect(content).toMatch(/<img src={image} alt={title} class="item-image" \/>/);
+        expect(content).toMatch(/max-width: 100px;/);
+        expect(content).toMatch(/height: auto;/);
+    });
+
+    it('Card image includes alt text and responsive sizing', () => {
+        const content = fs.readFileSync(cardFile, 'utf8');
+        expect(content).toMatch(/<img src={image} alt={title} class="img" \/>/);
+        expect(content).toMatch(/\.img {\n\s+width: 100%;\n\s+height: auto;/);
+    });
+});

--- a/frontend/src/components/Card.astro
+++ b/frontend/src/components/Card.astro
@@ -12,7 +12,7 @@ disabled
 		<li class="link-card disabled">
 			<span>
 				<Editable  title="" href="" body="" editable={false} />
-				<img src={image} class="img" />
+                                <img src={image} alt={title} class="img" />
 				<h2>
 					{title}
 				</h2>
@@ -29,7 +29,7 @@ disabled
 		<li class="link-card">
 			<a href={href}>
 				<Editable  title="" href="" body="" editable={false} />
-				<img src={image} class="img" />
+                                <img src={image} alt={title} class="img" />
 				<h2>
 					{title}
 				</h2>
@@ -49,9 +49,10 @@ disabled
 		border-color: red;
 	}
 
-	.img {
-		width: 100%;
-	}
+        .img {
+                width: 100%;
+                height: auto;
+        }
 
 	.link-card {
 		list-style: none;

--- a/frontend/src/components/CompactCard.astro
+++ b/frontend/src/components/CompactCard.astro
@@ -8,7 +8,7 @@ const { title, text, href, image } = Astro.props;
     <div class="item">
         <h3>{title}</h3>
         <div class="section horizontal">
-            <img src={image} />
+            <img src={image} alt={title} class="item-image" />
             <div class="section vertical">
                 <p class="nobackground">{text}</p>
                 <div class="section horizontal">
@@ -52,9 +52,10 @@ const { title, text, href, image } = Astro.props;
         text-align: center;
     }
     
-    img {
-        width: 100px;
-        height: 100px;
+    .item-image {
+        width: 100%;
+        max-width: 100px;
+        height: auto;
         border-radius: 20px;
         margin-right: 5px;
     }
@@ -73,7 +74,4 @@ const { title, text, href, image } = Astro.props;
         color: white;
     }
     
-    button {
-
-    }
 </style>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 


### PR DESCRIPTION
## Summary
- add alt text and responsive sizing to Card and CompactCard images
- refresh new quests list for test sync

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92b2b8cbc832f885b30eeb93453cd