### PR TITLE
📝 docs: add audit checks to backup and monitoring prompts

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/prompts-backups.md
+++ b/frontend/src/pages/docs/md/prompts-backups.md
@@ -17,22 +17,22 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Limit changes to backup-related files or docs.
 > 2. Preserve existing backup formats and import/export paths.
 > 3. Update tests when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Modify backup-related code or docs (`frontend/src/pages/docs/md/backups.md` or backup modules).
 2. Keep game save and custom content export formats stable.
 3. Add or update tests covering backup flows.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-5. Use an emoji-prefixed commit message.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the backup improvement and passing checks.

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -8,31 +8,30 @@ slug: 'prompts-monitoring'
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
 ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when
 editing files in the [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
-stack so metrics, dashboards, and alerts stay consistent.
-To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
-these templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+stack to keep metrics, dashboards, and alerts consistent. To keep the prompt docs evolving,
+see the [Codex meta prompt](/docs/prompts-codex-meta); if these templates drift, refresh them
+with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs,
+use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
 > 2. Prefer lightweight, self-hosted tools; avoid collecting personal data.
 > 3. Add sample dashboards or alert rules when relevant.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update monitoring configs or code under `monitoring/`.
 2. Use open-source, self-hosted tools (e.g., Prometheus, Grafana) that respect user privacy.
 3. Include or update sample dashboards and alerting rules when adding metrics.
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- require `npm run audit:ci` in backup and monitoring prompts
- refresh `docs/new-quests.md` to sync quest counts

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92a9b10f8832f8d683f8441e341c2