### PR TITLE
🔐 add security prompt guide

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -76,6 +76,9 @@ import Page from '../../components/Page.astro';
             <!-- Infra/monitoring -->
             <a href="/docs/prompts-monitoring">Monitoring prompts</a>
 
+            <!-- Security -->
+            <a href="/docs/prompts-security">Security prompts</a>
+
             <!-- Docs -->
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>
@@ -104,7 +107,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex-ci-fix">Codex CI-failure fix prompt</a>
         </nav>
     </span>
-
 </Page>
 
 <style>

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,8 @@ For task-specific templates see [Quest prompts](/docs/prompts-quests),
 [Item prompts](/docs/prompts-items), [Process prompts](/docs/prompts-processes),
 [NPC prompts](/docs/prompts-npcs), [Outage prompts](/docs/prompts-outages),
 [Backup prompts](/docs/prompts-backups), [Monitoring prompts](/docs/prompts-monitoring),
-[Docs prompts](/docs/prompts-docs), [Playwright test prompts](/docs/prompts-playwright-tests),
+[Security prompts](/docs/prompts-security), [Docs prompts](/docs/prompts-docs),
+[Playwright test prompts](/docs/prompts-playwright-tests),
 [Vitest test prompts](/docs/prompts-vitest), [Frontend prompts](/docs/prompts-frontend),
 [Backend prompts](/docs/prompts-backend), [Refactor prompts](/docs/prompts-refactors), and
 [Accessibility prompts](/docs/prompts-accessibility).
@@ -46,6 +47,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](/docs/prompts-outages)
 -   [Backup Prompts](/docs/prompts-backups)
 -   [Monitoring Prompts](/docs/prompts-monitoring)
+-   [Security Prompts](/docs/prompts-security)
 -   [Docs Prompts](/docs/prompts-docs)
 -   [Docs cross-link prompt](/docs/prompts-docs#cross-link-check-prompt)
 -   [Docs proofreading prompt](/docs/prompts-docs#proofreading-prompt)

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -8,7 +8,7 @@ slug: 'prompts-monitoring'
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
 ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex) when
 editing files in the [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
-stack so metrics, dashboards, and alerts stay consistent.
+directory so metrics, dashboards, and alerts remain consistent.
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
 these templates drift, refresh them with the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the

--- a/frontend/src/pages/docs/md/prompts-security.md
+++ b/frontend/src/pages/docs/md/prompts-security.md
@@ -1,0 +1,46 @@
+---
+title: 'Security Prompts'
+slug: 'prompts-security'
+---
+
+# Security prompts for the _dspace_ repo
+
+Codex is a sandboxed engineering agent that can open this repository, run tests,
+and submit ready-made pull requests. Use this guide alongside
+[Codex Prompts](/docs/prompts-codex) when hardening authentication,
+authorization or other security-sensitive code.
+To keep the prompt docs evolving, see the
+[Codex meta prompt](/docs/prompts-codex-meta); if these templates drift, refresh
+them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing
+GitHub Actions runs, use the [Codex CI-failure fix
+prompt](/docs/prompts-codex-ci-fix).
+
+> **TL;DR**
+>
+> 1. Scope changes to auth, encryption or input-validation code.
+> 2. Follow least privilege and avoid storing secrets in the repo.
+> 3. Add regression tests for security-sensitive paths.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build` and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 6. Commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Harden authentication, authorization or crypto routines under `backend/` or
+   `frontend/`.
+2. Follow OWASP best practices and remove dead secrets.
+3. Add regression tests for new security features.
+4. Run `npm run lint`, `npm run type-check`, `npm run build` and
+   `npm run test:ci`.
+5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+   committing.
+6. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request improving security with passing checks.
+```


### PR DESCRIPTION
## Summary
- document security-specific prompting guidelines
- link security prompts from Codex guide and docs index
- sync quest list docs to satisfy tests

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92a9b10f8832f8d683f8441e341c2