### PR TITLE
docs: refresh Codex prompt templates with audit check

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,279 +11,280 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
--   3dprinting/bed-leveling
--   3dprinting/cable-clip
--   3dprinting/calibration-cube
--   3dprinting/filament-change
--   3dprinting/nozzle-cleaning
--   3dprinting/phone-stand
--   3dprinting/retraction-test
--   3dprinting/spool-holder
--   3dprinting/temperature-tower
--   3dprinting/x-belt-tension
+- 3dprinting/bed-leveling
+- 3dprinting/cable-clip
+- 3dprinting/calibration-cube
+- 3dprinting/filament-change
+- 3dprinting/nozzle-cleaning
+- 3dprinting/phone-stand
+- 3dprinting/retraction-test
+- 3dprinting/spool-holder
+- 3dprinting/temperature-tower
+- 3dprinting/x-belt-tension
 
 ### aquaria
 
--   aquaria/aquarium-light
--   aquaria/balance-ph
--   aquaria/breeding
--   aquaria/filter-rinse
--   aquaria/floating-plants
--   aquaria/guppy
--   aquaria/heater-install
--   aquaria/log-water-parameters
--   aquaria/net-fish
--   aquaria/ph-strip-test
--   aquaria/position-tank
--   aquaria/shrimp
--   aquaria/sponge-filter
--   aquaria/thermometer
--   aquaria/walstad
--   aquaria/water-change
--   aquaria/water-testing
+- aquaria/aquarium-light
+- aquaria/balance-ph
+- aquaria/breeding
+- aquaria/filter-rinse
+- aquaria/floating-plants
+- aquaria/guppy
+- aquaria/heater-install
+- aquaria/log-water-parameters
+- aquaria/net-fish
+- aquaria/ph-strip-test
+- aquaria/position-tank
+- aquaria/shrimp
+- aquaria/sponge-filter
+- aquaria/thermometer
+- aquaria/walstad
+- aquaria/water-change
+- aquaria/water-testing
 
 ### astronomy
 
--   astronomy/andromeda
--   astronomy/aurora-watch
--   astronomy/basic-telescope
--   astronomy/comet-tracking
--   astronomy/constellations
--   astronomy/iss-flyover
--   astronomy/iss-photo
--   astronomy/jupiter-moons
--   astronomy/light-pollution
--   astronomy/lunar-eclipse
--   astronomy/meteor-shower
--   astronomy/north-star
--   astronomy/observe-moon
--   astronomy/orion-nebula
--   astronomy/planetary-alignment
--   astronomy/satellite-pass
--   astronomy/saturn-rings
--   astronomy/star-trails
--   astronomy/sunspot-sketch
--   astronomy/venus-phases
+- astronomy/andromeda
+- astronomy/aurora-watch
+- astronomy/basic-telescope
+- astronomy/comet-tracking
+- astronomy/constellations
+- astronomy/iss-flyover
+- astronomy/iss-photo
+- astronomy/jupiter-moons
+- astronomy/light-pollution
+- astronomy/lunar-eclipse
+- astronomy/meteor-shower
+- astronomy/north-star
+- astronomy/observe-moon
+- astronomy/orion-nebula
+- astronomy/planetary-alignment
+- astronomy/satellite-pass
+- astronomy/saturn-rings
+- astronomy/star-trails
+- astronomy/sunspot-sketch
+- astronomy/venus-phases
 
 ### chemistry
 
--   chemistry/acid-dilution
--   chemistry/acid-neutralization
--   chemistry/buffer-solution
--   chemistry/ph-adjustment
--   chemistry/ph-test
--   chemistry/precipitation-reaction
--   chemistry/safe-reaction
--   chemistry/stevia-crystals
--   chemistry/stevia-extraction
--   chemistry/stevia-tasting
+- chemistry/acid-dilution
+- chemistry/acid-neutralization
+- chemistry/buffer-solution
+- chemistry/ph-adjustment
+- chemistry/ph-test
+- chemistry/precipitation-reaction
+- chemistry/safe-reaction
+- chemistry/stevia-crystals
+- chemistry/stevia-extraction
+- chemistry/stevia-tasting
 
 ### completionist
 
--   completionist/catalog
--   completionist/display
--   completionist/polish
--   completionist/reminder
+- completionist/catalog
+- completionist/display
+- completionist/polish
+- completionist/reminder
 
 ### composting
 
--   composting/check-temperature
--   composting/start
--   composting/turn-pile
+- composting/check-temperature
+- composting/sift-compost
+- composting/start
+- composting/turn-pile
 
 ### devops
 
--   devops/auto-updates
--   devops/ci-pipeline
--   devops/daily-backups
--   devops/docker-compose
--   devops/enable-https
--   devops/fail2ban
--   devops/firewall-rules
--   devops/k3s-deploy
--   devops/log-maintenance
--   devops/monitoring
--   devops/pi-cluster-hardware
--   devops/prepare-first-node
--   devops/private-registry
--   devops/ssd-boot
--   devops/ssh-hardening
+- devops/auto-updates
+- devops/ci-pipeline
+- devops/daily-backups
+- devops/docker-compose
+- devops/enable-https
+- devops/fail2ban
+- devops/firewall-rules
+- devops/k3s-deploy
+- devops/log-maintenance
+- devops/monitoring
+- devops/pi-cluster-hardware
+- devops/prepare-first-node
+- devops/private-registry
+- devops/ssd-boot
+- devops/ssh-hardening
 
 ### electronics
 
--   electronics/arduino-blink
--   electronics/basic-circuit
--   electronics/check-battery-voltage
--   electronics/continuity-test
--   electronics/data-logger
--   electronics/desolder-component
--   electronics/led-polarity
--   electronics/light-sensor
--   electronics/measure-arduino-5v
--   electronics/measure-led-current
--   electronics/measure-resistance
--   electronics/potentiometer-dimmer
--   electronics/resistor-color-check
--   electronics/servo-sweep
--   electronics/solder-led-harness
--   electronics/solder-wire
--   electronics/soldering-intro
--   electronics/temperature-plot
--   electronics/test-gfci-outlet
--   electronics/thermistor-reading
--   electronics/thermometer-calibration
--   electronics/voltage-divider
+- electronics/arduino-blink
+- electronics/basic-circuit
+- electronics/check-battery-voltage
+- electronics/continuity-test
+- electronics/data-logger
+- electronics/desolder-component
+- electronics/led-polarity
+- electronics/light-sensor
+- electronics/measure-arduino-5v
+- electronics/measure-led-current
+- electronics/measure-resistance
+- electronics/potentiometer-dimmer
+- electronics/resistor-color-check
+- electronics/servo-sweep
+- electronics/solder-led-harness
+- electronics/solder-wire
+- electronics/soldering-intro
+- electronics/temperature-plot
+- electronics/test-gfci-outlet
+- electronics/thermistor-reading
+- electronics/thermometer-calibration
+- electronics/voltage-divider
 
 ### energy
 
--   energy/battery-maintenance
--   energy/battery-upgrade
--   energy/biogas-digester
--   energy/charge-controller-setup
--   energy/dWatt-1e8
--   energy/hand-crank-generator
--   energy/offgrid-charger
--   energy/portable-solar-panel
--   energy/power-inverter
--   energy/solar-tracker
--   energy/wind-turbine
+- energy/battery-maintenance
+- energy/battery-upgrade
+- energy/biogas-digester
+- energy/charge-controller-setup
+- energy/dWatt-1e8
+- energy/hand-crank-generator
+- energy/offgrid-charger
+- energy/portable-solar-panel
+- energy/power-inverter
+- energy/solar-tracker
+- energy/wind-turbine
 
 ### firstaid
 
--   firstaid/assemble-kit
--   firstaid/change-bandage
--   firstaid/dispose-bandages
--   firstaid/dispose-expired
--   firstaid/learn-cpr
--   firstaid/remove-splinter
--   firstaid/restock-kit
--   firstaid/sanitize-pocket-mask
--   firstaid/splint-limb
--   firstaid/stop-nosebleed
--   firstaid/treat-burn
--   firstaid/wound-care
+- firstaid/assemble-kit
+- firstaid/change-bandage
+- firstaid/dispose-bandages
+- firstaid/dispose-expired
+- firstaid/learn-cpr
+- firstaid/remove-splinter
+- firstaid/restock-kit
+- firstaid/sanitize-pocket-mask
+- firstaid/splint-limb
+- firstaid/stop-nosebleed
+- firstaid/treat-burn
+- firstaid/wound-care
 
 ### geothermal
 
--   geothermal/backflush-loop-filter
--   geothermal/calibrate-ground-sensor
--   geothermal/check-loop-inlet-temp
--   geothermal/check-loop-outlet-temp
--   geothermal/check-loop-temp-delta
--   geothermal/compare-depth-ground-temps
--   geothermal/compare-seasonal-ground-temps
--   geothermal/install-backup-thermistor
--   geothermal/log-ground-temperature
--   geothermal/log-heat-pump-warmup
--   geothermal/monitor-heat-pump-energy
--   geothermal/purge-loop-air
--   geothermal/replace-faulty-thermistor
--   geothermal/survey-ground-temperature
+- geothermal/backflush-loop-filter
+- geothermal/calibrate-ground-sensor
+- geothermal/check-loop-inlet-temp
+- geothermal/check-loop-outlet-temp
+- geothermal/check-loop-temp-delta
+- geothermal/compare-depth-ground-temps
+- geothermal/compare-seasonal-ground-temps
+- geothermal/install-backup-thermistor
+- geothermal/log-ground-temperature
+- geothermal/log-heat-pump-warmup
+- geothermal/monitor-heat-pump-energy
+- geothermal/purge-loop-air
+- geothermal/replace-faulty-thermistor
+- geothermal/survey-ground-temperature
 
 ### hydroponics
 
--   hydroponics/air-stone-soak
--   hydroponics/ec-check
--   hydroponics/filter-clean
--   hydroponics/grow-light
--   hydroponics/lettuce
--   hydroponics/mint-cutting
--   hydroponics/netcup-clean
--   hydroponics/nutrient-check
--   hydroponics/ph-check
--   hydroponics/ph-test
--   hydroponics/plug-soak
--   hydroponics/pump-install
--   hydroponics/pump-prime
--   hydroponics/regrow-stevia
--   hydroponics/reservoir-refresh
--   hydroponics/root-rinse
--   hydroponics/stevia
--   hydroponics/temp-check
--   hydroponics/top-off
--   hydroponics/tub-scrub
+- hydroponics/air-stone-soak
+- hydroponics/ec-check
+- hydroponics/filter-clean
+- hydroponics/grow-light
+- hydroponics/lettuce
+- hydroponics/mint-cutting
+- hydroponics/netcup-clean
+- hydroponics/nutrient-check
+- hydroponics/ph-check
+- hydroponics/ph-test
+- hydroponics/plug-soak
+- hydroponics/pump-install
+- hydroponics/pump-prime
+- hydroponics/regrow-stevia
+- hydroponics/reservoir-refresh
+- hydroponics/root-rinse
+- hydroponics/stevia
+- hydroponics/temp-check
+- hydroponics/top-off
+- hydroponics/tub-scrub
 
 ### programming
 
--   programming/avg-temp
--   programming/graph-temp
--   programming/graph-temp-data
--   programming/hello-sensor
--   programming/http-post
--   programming/json-api
--   programming/json-endpoint
--   programming/median-temp
--   programming/moving-avg-temp
--   programming/plot-temp-cli
--   programming/stddev-temp
--   programming/temp-alert
--   programming/temp-email
--   programming/temp-graph
--   programming/temp-json-api
--   programming/temp-logger
--   programming/thermistor-calibration
--   programming/web-server
+- programming/avg-temp
+- programming/graph-temp
+- programming/graph-temp-data
+- programming/hello-sensor
+- programming/http-post
+- programming/json-api
+- programming/json-endpoint
+- programming/median-temp
+- programming/moving-avg-temp
+- programming/plot-temp-cli
+- programming/stddev-temp
+- programming/temp-alert
+- programming/temp-email
+- programming/temp-graph
+- programming/temp-json-api
+- programming/temp-logger
+- programming/thermistor-calibration
+- programming/web-server
 
 ### robotics
 
--   robotics/gyro-balance
--   robotics/line-follower
--   robotics/maze-navigation
--   robotics/obstacle-avoidance
--   robotics/odometry-basics
--   robotics/pan-tilt
--   robotics/servo-arm
--   robotics/servo-control
--   robotics/servo-gripper
--   robotics/servo-radar
--   robotics/ultrasonic-rangefinder
--   robotics/wheel-encoders
+- robotics/gyro-balance
+- robotics/line-follower
+- robotics/maze-navigation
+- robotics/obstacle-avoidance
+- robotics/odometry-basics
+- robotics/pan-tilt
+- robotics/servo-arm
+- robotics/servo-control
+- robotics/servo-gripper
+- robotics/servo-radar
+- robotics/ultrasonic-rangefinder
+- robotics/wheel-encoders
 
 ### rocketry
 
--   rocketry/fuel-mixture
--   rocketry/night-launch
--   rocketry/preflight-check
--   rocketry/recovery-run
--   rocketry/static-test
--   rocketry/wind-check
+- rocketry/fuel-mixture
+- rocketry/night-launch
+- rocketry/preflight-check
+- rocketry/recovery-run
+- rocketry/static-test
+- rocketry/wind-check
 
 ### sysadmin
 
--   sysadmin/basic-commands
--   sysadmin/log-analysis
--   sysadmin/resource-monitoring
+- sysadmin/basic-commands
+- sysadmin/log-analysis
+- sysadmin/resource-monitoring
 
 ### ubi
 
--   ubi/first-payment
--   ubi/reminder
--   ubi/savings-goal
+- ubi/first-payment
+- ubi/reminder
+- ubi/savings-goal
 
 ### welcome
 
--   welcome/connect-github
--   welcome/intro-inventory
--   welcome/run-tests
--   welcome/smart-plug-test
+- welcome/connect-github
+- welcome/intro-inventory
+- welcome/run-tests
+- welcome/smart-plug-test
 
 ### woodworking
 
--   woodworking/apply-finish
--   woodworking/birdhouse
--   woodworking/bookshelf
--   woodworking/coffee-table
--   woodworking/finish-sanding
--   woodworking/picture-frame
--   woodworking/planter-box
--   woodworking/step-stool
--   woodworking/tool-rack
--   woodworking/workbench
+- woodworking/apply-finish
+- woodworking/birdhouse
+- woodworking/bookshelf
+- woodworking/coffee-table
+- woodworking/finish-sanding
+- woodworking/picture-frame
+- woodworking/planter-box
+- woodworking/step-stool
+- woodworking/tool-rack
+- woodworking/workbench
 
 ## Quests added in v2.1
 
@@ -293,24 +294,24 @@ New quests in this release: 12
 
 ### 3dprinting
 
--   3dprinting/benchy_10
--   3dprinting/benchy_100
--   3dprinting/benchy_25
+- 3dprinting/benchy_10
+- 3dprinting/benchy_100
+- 3dprinting/benchy_25
 
 ### energy
 
--   energy/dSolar-100kW
--   energy/dSolar-10kW
--   energy/dSolar-1kW
--   energy/dWatt-1e3
--   energy/dWatt-1e4
--   energy/dWatt-1e5
--   energy/dWatt-1e6
--   energy/dWatt-1e7
+- energy/dSolar-100kW
+- energy/dSolar-10kW
+- energy/dSolar-1kW
+- energy/dWatt-1e3
+- energy/dWatt-1e4
+- energy/dWatt-1e5
+- energy/dWatt-1e6
+- energy/dWatt-1e7
 
 ### hydroponics
 
--   hydroponics/bucket_10
+- hydroponics/bucket_10
 
 ## Quests added in v2
 
@@ -320,30 +321,30 @@ New quests in this release: 9
 
 ### aquaria
 
--   aquaria/goldfish
+- aquaria/goldfish
 
 ### completionist
 
--   completionist/v2
+- completionist/v2
 
 ### energy
 
--   energy/solar
--   energy/solar-1kWh
+- energy/solar
+- energy/solar-1kWh
 
 ### hydroponics
 
--   hydroponics/basil
+- hydroponics/basil
 
 ### rocketry
 
--   rocketry/firstlaunch
--   rocketry/parachute
+- rocketry/firstlaunch
+- rocketry/parachute
 
 ### ubi
 
--   ubi/basicincome
+- ubi/basicincome
 
 ### welcome
 
--   welcome/howtodoquests
+- welcome/howtodoquests

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/prompts-backups.md
+++ b/frontend/src/pages/docs/md/prompts-backups.md
@@ -17,15 +17,15 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Limit changes to backup-related files or docs.
 > 2. Preserve existing backup formats and import/export paths.
 > 3. Update tests when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
+pass before committing.
 
 USER:
 1. Modify backup-related code or docs (`frontend/src/pages/docs/md/backups.md` or backup modules).

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -28,8 +28,8 @@ the [Codex meta prompt](/docs/prompts-codex-meta), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
->    `npm run test:ci`; scan staged changes with
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`; scan staged changes with
 >    `git diff --cached | ./scripts/scan-secrets.py`; commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
@@ -75,12 +75,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
-| **Files to touch**   | Limits search space → faster & cheaper.                                             |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
-| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                        |
+| **Files to touch**   | Limits search space → faster & cheaper.                                                                 |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                                          |
+| **Acceptance check** | e.g. `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -102,7 +102,7 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -133,7 +133,7 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run lint`, `npm run type-check`,
+`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
@@ -161,7 +161,7 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
@@ -186,7 +186,7 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -19,15 +19,15 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Touch only the necessary files under `frontend/`.
 > 2. Keep components accessible, responsive, and idiomatic.
 > 3. Update or add tests in `frontend/__tests__` when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update UI code under `frontend/`.

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -20,8 +20,8 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
 > 2. Say exactly what output you expect (tests, docs).
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`,
->    `npm run itemValidation`, `npm run test:ci`, and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, `npm run itemValidation`, `npm run test:ci`, and
 >    `npm run test:ci -- itemQuality`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`;
 >    commit with an emoji prefix.
@@ -41,6 +41,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
     -   CLI:
         ```bash
         codex exec "\
+        npm run audit:ci && \
         npm run lint && \
         npm run type-check && \
         npm run build && \
@@ -60,6 +61,7 @@ See the [OpenAI CLI docs][openai-cli] for more flags.
 -   **Files to touch**: Limits search space → faster & cheaper.
 -   **Constraints**: Coding style, a11y, item schema rules.
 -   **Acceptance check**:
+    -   `npm run audit:ci`
     -   `npm run lint`
     -   `npm run type-check`
     -   `npm run build`
@@ -84,7 +86,7 @@ REQUIREMENTS
 3. Ensure the item is referenced by at least one quest or process; update those
    files and create missing processes as needed.
 4. Use only existing image assets; do not add new image files.
-5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
 7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.
@@ -103,7 +105,7 @@ SYSTEM:
 You are an automated contributor for the DSPACE repository. Edit or
 create items under `frontend/src/pages/inventory/json/items`, choosing the
 appropriate category file. Ensure realistic details, required fields, and
-passing checks (`npm run lint`, `npm run type-check`,
+passing checks (`npm run audit:ci`, `npm run lint`, `npm run type-check`,
 `npm run build`, `npm run test:ci`, `npm run itemValidation`, and
 `npm run test:ci -- itemQuality`). Verify the item appears in at least one quest or process,
 reuse existing image assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
@@ -154,7 +156,7 @@ USER:
        { "task": "codex-upgrade-2025-09-01", "date": "2025-09-01", "score": 60 }
      ]
    }
-5. Run `npm run lint`, `npm run type-check`, `npm run build`,
+5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
    `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
 6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -19,20 +19,20 @@ these templates drift, refresh them with the
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
 > 2. Prefer lightweight, self-hosted tools; avoid collecting personal data.
 > 3. Add sample dashboards or alert rules when relevant.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update monitoring configs or code under `monitoring/`.
 2. Use open-source, self-hosted tools (e.g., Prometheus, Grafana) that respect user privacy.
 3. Include or update sample dashboards and alerting rules when adding metrics.
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -19,13 +19,13 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Avoid mixing refactors with new features or fixes.
 > 3. Keep commits small and reversible.
 > 4. Include before-and-after benchmarks if performance could change.
-> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 6. Run `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Refactor code in the specified files without changing behavior.

--- a/frontend/src/pages/docs/md/prompts-vitest.md
+++ b/frontend/src/pages/docs/md/prompts-vitest.md
@@ -18,13 +18,13 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 1. Choose a module or component that lacks unit tests or needs better coverage.
 > 2. Add or update a Vitest spec under `frontend/__tests__/` or `tests/`.
 > 3. Keep tests deterministic and focused on behavior.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Identify an untested or under-tested module.


### PR DESCRIPTION
## Summary
- add `npm run audit:ci` to Codex prompt templates (backups, frontend, items, monitoring, refactors, vitest, Codex)
- sync `new-quests.md` to satisfy tests

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a92aa223bc832f880b037c4cb2bdcd