### PR TITLE
📈 Add sample Grafana dashboard and Prometheus alerts

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 237
+New quests in this release: 215
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,18 @@
+# Monitoring
+
+This stack runs [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/)
+locally to collect and visualize metrics without sending data to third parties.
+
+## Usage
+
+```bash
+docker-compose up
+```
+
+## Features
+
+- Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
+- Grafana provisions a Prometheus data source and a sample dashboard.
+- Alerts include `DspaceDown`, which fires when the `dspace` job stops reporting `up`.
+
+All services are self-hosted to respect user privacy.

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -5,19 +5,22 @@ services:
     container_name: prometheus
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml
     ports:
-      - "127.0.0.1:9090:9090"
+      - '127.0.0.1:9090:9090'
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
     depends_on:
       - prometheus
     ports:
-      - "127.0.0.1:3001:3000"
+      - '127.0.0.1:3001:3000'
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
 volumes:
   grafana-data:

--- a/monitoring/grafana/dashboards/dspace-overview.json
+++ b/monitoring/grafana/dashboards/dspace-overview.json
@@ -1,0 +1,20 @@
+{
+  "id": null,
+  "title": "DSpace Overview",
+  "timezone": "browser",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Service Up",
+      "targets": [
+        {
+          "expr": "up{job=\"dspace\"}",
+          "legendFormat": "dspace"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "5s"
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+providers:
+  - name: dspace
+    orgId: 1
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,0 +1,10 @@
+groups:
+  - name: dspace
+    rules:
+      - alert: DspaceDown
+        expr: up{job="dspace"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: DSpace service is down

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,6 +1,9 @@
 global:
   scrape_interval: 15s
 
+rule_files:
+  - alerts.yml
+
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:


### PR DESCRIPTION
## Summary
- wire Grafana and Prometheus provisioning for self-hosted monitoring
- add sample dashboard and `DspaceDown` alert rule
- regenerate new quest lists to satisfy tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92b4ce694832fbdc1f6c34ac4857a