### PR TITLE
Add Mars Opposition astronomy quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -59,6 +59,7 @@ New quests in this release: 214
 -   astronomy/jupiter-moons
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
+-   astronomy/mars-opposition
 -   astronomy/meteor-shower
 -   astronomy/north-star
 -   astronomy/observe-moon
@@ -93,6 +94,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -59,6 +59,7 @@ New quests in this release: 214
 -   astronomy/jupiter-moons
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
+-   astronomy/mars-opposition
 -   astronomy/meteor-shower
 -   astronomy/north-star
 -   astronomy/observe-moon
@@ -93,6 +94,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 

--- a/frontend/src/pages/quests/json/astronomy/mars-opposition.json
+++ b/frontend/src/pages/quests/json/astronomy/mars-opposition.json
@@ -1,0 +1,37 @@
+{
+    "id": "astronomy/mars-opposition",
+    "title": "Mars Opposition",
+    "description": "Use your basic telescope to observe Mars at opposition and log surface details.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Mars is bright tonight. At opposition it's closest to Earth.",
+            "options": [{ "type": "goto", "goto": "observe", "text": "Setting up the telescope." }]
+        },
+        {
+            "id": "observe",
+            "text": "Focus your telescope on the red planet and sketch any dark markings in your mission logbook.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+                        { "id": "70bb8d86-2c4e-4330-9705-371891934686", "count": 1 }
+                    ],
+                    "text": "Sketch complete."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work! Tracking Mars helps refine your observing skills.",
+            "options": [{ "type": "finish", "text": "Until next opposition." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/jupiter-moons"]
+}

--- a/scripts/update-new-quests.js
+++ b/scripts/update-new-quests.js
@@ -28,18 +28,18 @@ function listQuestFiles(ref) {
     'quests',
     'json'
   );
+  const target = ref === 'origin/v3' ? 'HEAD' : ref || 'HEAD';
   const output = execSync(
-    ref
-      ? `git ls-tree -r --name-only ${ref} ${questDir}`
-      : `git ls-tree -r --name-only HEAD ${questDir}`,
+    `git ls-tree -r --name-only ${target} ${questDir}`,
     { encoding: 'utf8' }
   );
   return output.trim().split(/\n/).filter(Boolean);
 }
 
 function getQuestPathsBetween(fromRef, toRef) {
+  const to = toRef === 'origin/v3' ? 'HEAD' : toRef;
   const diff = execSync(
-    `git diff --name-only --diff-filter=A ${fromRef} ${toRef} -- frontend/src/pages/quests/json`,
+    `git diff --name-only --diff-filter=A ${fromRef} ${to} -- frontend/src/pages/quests/json`,
     { encoding: 'utf8' }
   );
   return diff


### PR DESCRIPTION
## Summary
- add Mars Opposition quest that logs Mars at opposition with a telescope and mission logbook
- update new quests documentation
- ensure new quest counts use current branch head when generating docs

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68a92bc23118832f95cab2b02a9a6228