### PR TITLE
Add item dependency map test

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/tests/generateItemDependencies.test.ts
+++ b/tests/generateItemDependencies.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import items from '../frontend/src/pages/inventory/json/items';
+import gen from '../scripts/generate-item-dependencies.js';
+
+const { buildMap } = gen as {
+  buildMap: () => Record<string, { requires: string[]; rewards: string[] }>;
+};
+
+const getId = (name: string) => items.find((i) => i.name === name)?.id;
+
+describe('generate-item-dependencies buildMap', () => {
+  it('includes quests that require items', () => {
+    const map = buildMap();
+    const telescope = getId('basic telescope');
+    expect(map[telescope!].requires).toContain('astronomy/constellations');
+  });
+
+  it('includes quests that reward items', () => {
+    const map = buildMap();
+    const solarPanel = getId('portable solar panel');
+    expect(map[solarPanel!].rewards).toContain('energy/dWatt-1e3');
+  });
+});


### PR DESCRIPTION
## Summary
- test generate-item-dependencies buildMap collects quest requirements and rewards
- sync new quests docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92bed3308832fab2fe685f9dfeb50