### PR TITLE
Add aquaria top-off quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/frontend/src/pages/quests/json/aquaria/top-off.json
+++ b/frontend/src/pages/quests/json/aquaria/top-off.json
@@ -1,0 +1,55 @@
+{
+    "id": "aquaria/top-off",
+    "title": "Top Off Evaporated Water",
+    "description": "Use a hand pump siphon and aged water to restore aquarium levels.",
+    "image": "/assets/walstad.jpg",
+    "npc": "/assets/npc/vega.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "The waterline dropped. Raise two 5 gal buckets above the tank and prime the gravel vacuum.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "topoff",
+                    "text": "Setup done.",
+                    "requiresItems": [
+                        { "id": "97317bc3-507a-4e2c-912b-507d586cee87", "count": 1 },
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 2 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "topoff",
+            "text": "Hand-pump water from the buckets until the tank's level is restored.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "refill",
+                    "text": "Waterline topped off."
+                }
+            ]
+        },
+        {
+            "id": "refill",
+            "text": "Refill both buckets with a hose. Let them sit 24–48 h or condition before the next top-off.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Buckets refilled and aging.",
+                    "process": "bucket-water-dechlorinated"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! You've got water aging for the next evaporation top-off.",
+            "options": [{ "type": "finish", "text": "Job done." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["aquaria/water-change"]
+}

--- a/frontend/src/pages/quests/json/firstaid/flashlight-battery.json
+++ b/frontend/src/pages/quests/json/firstaid/flashlight-battery.json
@@ -1,0 +1,45 @@
+{
+    "id": "firstaid/flashlight-battery",
+    "title": "Check Flashlight Battery",
+    "description": "Measure your emergency flashlight's 9 V battery with a digital multimeter.",
+    "image": "/assets/battery.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Power failures happen. Let's make sure your red flashlight still has juice.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "measure",
+                    "text": "Grab the multimeter."
+                }
+            ]
+        },
+        {
+            "id": "measure",
+            "text": "Set the meter to 20 V DC and measure across the 9 V battery terminals.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Battery reads 9 V",
+                    "process": "check-flashlight-battery",
+                    "requiresItems": [
+                        { "id": "9a72fb16-fc69-45c5-beca-f25c27028977", "count": 1 },
+                        { "id": "5127e156-3009-4db4-85ac-e3ea070b68f2", "count": 1 },
+                        { "id": "80d30825-a42b-4add-b715-322e1713952c", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Replace the battery if it drops below 7.5 V.",
+            "options": [{ "type": "finish", "text": "Will do." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["firstaid/assemble-kit"]
+}


### PR DESCRIPTION
## Summary
- add "Top Off Evaporated Water" quest under aquaria
- restore missing first aid flashlight battery quest and sync new-quests docs

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92bc2cb98832fb5747f6088a3d32e