### PR TITLE
Refine Phoenix NPC bio and sync quest docs

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 236
-New quests in this release: 214
+Current quest count: 238
+New quests in this release: 216
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 214
 ### composting
 
 -   composting/check-temperature
+-   composting/sift-compost
 -   composting/start
 -   composting/turn-pile
 
@@ -159,6 +160,7 @@ New quests in this release: 214
 -   firstaid/change-bandage
 -   firstaid/dispose-bandages
 -   firstaid/dispose-expired
+-   firstaid/flashlight-battery
 -   firstaid/learn-cpr
 -   firstaid/remove-splinter
 -   firstaid/restock-kit

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -109,21 +109,19 @@ processes such as [Log Aquarium Test Results](/processes/log-aquarium-test-resul
 <img src="/assets/npc/phoenix.jpg" />
 
 Phoenix is a chemist focused on sustainable rocket fuel.
-They blend chemistry with conservation to push craft without scarring the planet.
+They blend propellant chemistry with conservation to push craft without scarring the planet.
 Phoenix guides recruits through quests like
 [Demonstrate a Safe Chemical Reaction](/quests/chemistry/safe-reaction) and
-[Mix an Efficient Rocket Fuel](/quests/rocketry/fuel-mixture),
+[Extract Stevia Sweetener](/quests/chemistry/stevia-extraction),
 showing how green chemistry powers missions.
 
 ### Sample Dialogue
 
 -   "Hey, I'm Phoenix—chemistry without pollution is my specialty."
 -   "Safety goggles on; propellant fumes bite harder than dragons."
--   "We test in micro batches so a bad mix only scorches a spoon."
+-   "Micro batches keep mishaps small; a spoonful test is plenty."
 -   "Keep the oxidizer chilled; warm tanks turn engines into fireworks."
--   "When the exhaust runs clear, you know we've done it right."
--   "Next up, we'll brew propellant that pushes rockets without scorching the skies."
--   "Spent fuel? We'll distill what's usable and neutralize the rest."
+-   "Spent fuel? We distill what's usable and neutralize the rest."
 
 ## Atlas
 


### PR DESCRIPTION
## Summary
- polish Phoenix NPC voice and link chemistry quests
- sync new quests documentation after updating quest counts

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a92b561e3c832f8f553a21b87245d1