### PR TITLE
Add compost moisture check quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 217
 
 ### composting
 
+-   composting/check-moisture
 -   composting/check-temperature
 -   composting/sift-compost
 -   composting/start

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -93,6 +93,7 @@ New quests in this release: 217
 
 ### composting
 
+-   composting/check-moisture
 -   composting/check-temperature
 -   composting/sift-compost
 -   composting/start

--- a/frontend/src/pages/quests/json/composting/check-moisture.json
+++ b/frontend/src/pages/quests/json/composting/check-moisture.json
@@ -1,0 +1,48 @@
+{
+  "id": "composting/check-moisture",
+  "title": "Check Compost Moisture",
+  "description": "Use a compost moisture meter to keep your bucket damp but not soggy.",
+  "image": "/assets/bucket.jpg",
+  "npc": "/assets/npc/nova.jpg",
+  "start": "start",
+  "dialogue": [
+    {
+      "id": "start",
+      "text": "Moisture fuels microbes. Want to see if your bucket needs water?",
+      "options": [
+        { "type": "goto", "goto": "probe", "text": "Sure, let's check." }
+      ]
+    },
+    {
+      "id": "probe",
+      "text": "Insert the moisture meter deep into the compost and note the reading.",
+      "options": [
+        {
+          "type": "goto",
+          "goto": "reading",
+          "process": "measure-compost-moisture",
+          "requiresItems": [
+            { "id": "2b57a38d-0486-40e8-a50d-d893541b50e9", "count": 1 }
+          ],
+          "text": "Meter is in."
+        }
+      ]
+    },
+    {
+      "id": "reading",
+      "text": "It shows about 55%—perfectly damp.",
+      "options": [
+        { "type": "goto", "goto": "finish", "text": "Nice!" }
+      ]
+    },
+    {
+      "id": "finish",
+      "text": "Great! Keep moisture between 40–60% and add water or dry leaves as needed.",
+      "options": [
+        { "type": "finish", "text": "Will do." }
+      ]
+    }
+  ],
+  "rewards": [],
+  "requiresQuests": ["composting/turn-pile"]
+}


### PR DESCRIPTION
## Summary
- add compost moisture meter quest
- sync new quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68aa9548bd80832f89005aab0a9f5a0e