### PR TITLE
Add launch controller battery swap process

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -4527,5 +4527,30 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "replace-launch-controller-battery",
+        "title": "Replace the 9 V battery in a model rocket launch controller",
+        "image": "/assets/launch_controller.jpg",
+        "requireItems": [
+            {
+                "id": "ae343640-c7c0-4f7e-907b-17bd87574d9b",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "80d30825-a42b-4add-b715-322e1713952c",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3494,5 +3494,20 @@
         "consumeItems": [],
         "createItems": [],
         "duration": "2m"
+    },
+    {
+        "id": "replace-launch-controller-battery",
+        "title": "Replace the 9 V battery in a model rocket launch controller",
+        "image": "/assets/launch_controller.jpg",
+        "requireItems": [{ "id": "ae343640-c7c0-4f7e-907b-17bd87574d9b", "count": 1 }],
+        "consumeItems": [{ "id": "80d30825-a42b-4add-b715-322e1713952c", "count": 1 }],
+        "createItems": [],
+        "duration": "1m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
     }
 ]

--- a/frontend/src/pages/processes/hardening/replace-launch-controller-battery.json
+++ b/frontend/src/pages/processes/hardening/replace-launch-controller-battery.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}


### PR DESCRIPTION
## Summary
- add process to replace a 9 V battery in a model rocket launch controller
- track hardening for the new process

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:ci -- processQuality`


------
https://chatgpt.com/codex/tasks/task_e_68aa9524cef4832f96a9713b975bf728