### PR TITLE
Add brass tip cleaner to solder quest

### DIFF
--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -600,15 +600,18 @@
     {
         "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0",
         "name": "brass tip cleaner",
-        "description": "Brass wire sponge in a holder for cleaning soldering iron tips without water.",
+        "description": "Brass wire sponge in a weighted holder scrubs oxidation from hot soldering tips without water.",
         "image": "/assets/quests/basic_circuit.svg",
         "price": "5 dUSD",
         "type": "tool",
+        "unit": "each",
         "hardening": {
-            "passes": 0,
-            "score": 0,
-            "emoji": "🛠️",
-            "history": []
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                { "task": "codex-item-hardening-2025-09-20", "date": "2025-09-20", "score": 65 }
+            ]
         }
     },
     {

--- a/frontend/src/pages/quests/json/electronics/solder-wire.json
+++ b/frontend/src/pages/quests/json/electronics/solder-wire.json
@@ -1,7 +1,7 @@
 {
     "id": "electronics/solder-wire",
     "title": "Solder a Wire Connection",
-    "description": "Join jumper wires with a soldering kit, heat-shrink tubing, and a heat gun. Ventilate and wear safety goggles.",
+    "description": "Join jumper wires with a soldering kit, heat-shrink tubing, and a heat gun. Keep a brass tip cleaner handy, ventilate, and wear safety goggles.",
     "image": "/assets/quests/basic_circuit.svg",
     "npc": "/assets/npc/orion.jpg",
     "start": "start",
@@ -13,7 +13,7 @@
         },
         {
             "id": "prep",
-            "text": "Gather the soldering iron kit, flux pen, wire stripper, needle-nose pliers, solder fume extractor, and heat gun. Add two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper, grip them with the needle-nose pliers, and slide the tubing over one lead. Heat the iron on its stand, keep cords tidy, and let the fume extractor pull smoke away. Use the heat gun to shrink the tubing after soldering.",
+            "text": "Gather the soldering iron kit, flux pen, wire stripper, needle-nose pliers, brass tip cleaner, solder fume extractor, and heat gun. Add two jumper wires, 5 cm of heat-shrink tubing, and safety goggles. Strip the wire ends with the wire stripper, grip them with the needle-nose pliers, and slide the tubing over one lead. Heat the iron on its stand, keep cords tidy, clean the tip with the brass cleaner, and let the fume extractor pull smoke away. Use the heat gun to shrink the tubing after soldering.",
             "options": [
                 {
                     "type": "process",
@@ -36,6 +36,7 @@
                         { "id": "3cd82744-d2aa-414e-9f03-80024b624066", "count": 2 },
                         { "id": "96083990-f333-4e42-ab04-7eb2a234570e", "count": 5 },
                         { "id": "dad7f853-ccc9-40be-b226-89272708db84", "count": 1 },
+                        { "id": "3dbf1701-5cc0-4443-b9bf-4275b33513d0", "count": 1 },
                         { "id": "a8f184ec-c9d0-4a4b-b6a1-c58c1c297b26", "count": 1 },
                         { "id": "593fc442-f437-4449-94e5-17b7b4625c41", "count": 1 },
                         { "id": "5029f7cb-3359-4153-b7ca-4b53988ac086", "count": 1 }
@@ -52,7 +53,7 @@
     "rewards": [{ "id": "f6bb2c1a-0001-46bd-998a-388a488b5b5c", "count": 1 }],
     "requiresQuests": [],
     "hardening": {
-        "passes": 6,
+        "passes": 7,
         "score": 94,
         "emoji": "💯",
         "history": [
@@ -61,7 +62,8 @@
             { "task": "codex-solder-wire-hardening-2025-08-12", "date": "2025-08-12", "score": 92 },
             { "task": "codex-solder-wire-hardening-2025-08-15", "date": "2025-08-15", "score": 94 },
             { "task": "codex-solder-wire-hardening-2025-08-16", "date": "2025-08-16", "score": 94 },
-            { "task": "codex-solder-wire-hardening-2025-08-22", "date": "2025-08-22", "score": 94 }
+            { "task": "codex-solder-wire-hardening-2025-08-22", "date": "2025-08-22", "score": 94 },
+            { "task": "codex-solder-wire-hardening-2025-09-20", "date": "2025-09-20", "score": 94 }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- record brass tip cleaner item details and unit
- require brass tip cleaner in "Solder a Wire Connection" quest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68aa94a7457c832fbeae5e366f30a6df