### PR TITLE
feat: add mechanical outlet timer for grow-light quest

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -546,7 +546,8 @@
       "chemistry/ph-test",
       "chemistry/acid-dilution",
       "aquaria/water-testing",
-      "aquaria/water-change"
+      "aquaria/water-change",
+      "aquaria/log-water-parameters"
     ],
     "rewards": []
   },
@@ -589,6 +590,12 @@
     ],
     "rewards": []
   },
+  "8f7c2e83-285a-4b29-9a3a-312f0dce2745": {
+    "requires": [
+      "hydroponics/grow-light"
+    ],
+    "rewards": []
+  },
   "978ce094-f4fa-4b55-9e1a-2ea76531989d": {
     "requires": [],
     "rewards": [
@@ -600,6 +607,7 @@
       "composting/turn-pile",
       "composting/start",
       "aquaria/water-change",
+      "aquaria/top-off",
       "aquaria/shrimp"
     ],
     "rewards": [
@@ -645,6 +653,12 @@
   "29190faf-8581-4769-b871-f0ee283840e1": {
     "requires": [
       "hydroponics/basil"
+    ],
+    "rewards": []
+  },
+  "9f91173d-2609-4127-896d-7578078135db": {
+    "requires": [
+      "hydroponics/air-stone-soak"
     ],
     "rewards": []
   },
@@ -727,6 +741,38 @@
   "b397aa70-3503-4e40-b84a-4d5609578d2b": {
     "requires": [
       "firstaid/learn-cpr"
+    ],
+    "rewards": []
+  },
+  "9a72fb16-fc69-45c5-beca-f25c27028977": {
+    "requires": [
+      "firstaid/flashlight-battery",
+      "astronomy/orion-nebula",
+      "astronomy/observe-moon",
+      "astronomy/meteor-shower",
+      "astronomy/light-pollution",
+      "astronomy/aurora-watch",
+      "astronomy/andromeda"
+    ],
+    "rewards": []
+  },
+  "5127e156-3009-4db4-85ac-e3ea070b68f2": {
+    "requires": [
+      "firstaid/flashlight-battery",
+      "electronics/voltage-divider",
+      "electronics/measure-resistance",
+      "electronics/measure-led-current",
+      "electronics/measure-arduino-5v",
+      "electronics/light-sensor",
+      "electronics/led-polarity",
+      "electronics/continuity-test",
+      "electronics/check-battery-voltage"
+    ],
+    "rewards": []
+  },
+  "80d30825-a42b-4add-b715-322e1713952c": {
+    "requires": [
+      "firstaid/flashlight-battery"
     ],
     "rewards": []
   },
@@ -906,19 +952,6 @@
     ],
     "rewards": []
   },
-  "5127e156-3009-4db4-85ac-e3ea070b68f2": {
-    "requires": [
-      "electronics/voltage-divider",
-      "electronics/measure-resistance",
-      "electronics/measure-led-current",
-      "electronics/measure-arduino-5v",
-      "electronics/light-sensor",
-      "electronics/led-polarity",
-      "electronics/continuity-test",
-      "electronics/check-battery-voltage"
-    ],
-    "rewards": []
-  },
   "b6fc1ed6-f399-4fdb-9f9d-3913f893f43d": {
     "requires": [
       "electronics/thermistor-reading",
@@ -926,7 +959,8 @@
       "electronics/measure-arduino-5v",
       "electronics/light-sensor",
       "electronics/arduino-blink",
-      "devops/ssh-hardening"
+      "devops/ssh-hardening",
+      "devops/firewall-rules"
     ],
     "rewards": []
   },
@@ -1066,10 +1100,16 @@
     ],
     "rewards": []
   },
+  "06146006-5615-4c1a-98dd-ff1b107ec893": {
+    "requires": [
+      "electronics/desolder-component"
+    ],
+    "rewards": []
+  },
   "ce92a1a9-c817-40f0-92b1-24aff053903d": {
     "requires": [
-      "3dprinting/filament-change",
-      "electronics/continuity-test"
+      "electronics/continuity-test",
+      "3dprinting/filament-change"
     ],
     "rewards": []
   },
@@ -1153,6 +1193,12 @@
   "2b57a38d-0486-40e8-a50d-d893541b50e9": {
     "requires": [
       "composting/turn-pile"
+    ],
+    "rewards": []
+  },
+  "4796b4a9-0927-4b46-a41f-076ebaff01bb": {
+    "requires": [
+      "composting/sift-compost"
     ],
     "rewards": []
   },
@@ -1249,17 +1295,6 @@
     ],
     "rewards": []
   },
-  "9a72fb16-fc69-45c5-beca-f25c27028977": {
-    "requires": [
-      "astronomy/orion-nebula",
-      "astronomy/observe-moon",
-      "astronomy/meteor-shower",
-      "astronomy/light-pollution",
-      "astronomy/aurora-watch",
-      "astronomy/andromeda"
-    ],
-    "rewards": []
-  },
   "aa82b02f-2617-4474-a91b-29647e4a9780": {
     "requires": [
       "astronomy/observe-moon"
@@ -1334,7 +1369,8 @@
   },
   "97317bc3-507a-4e2c-912b-507d586cee87": {
     "requires": [
-      "aquaria/water-change"
+      "aquaria/water-change",
+      "aquaria/top-off"
     ],
     "rewards": []
   },

--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -418,5 +418,26 @@
             "emoji": "🛠️",
             "history": []
         }
+    },
+    {
+        "id": "8f7c2e83-285a-4b29-9a3a-312f0dce2745",
+        "name": "mechanical outlet timer",
+        "description": "24 h analog timer with 15 min segments; rated 120 V AC, 15 A. Controls grow lights offline.",
+        "image": "/assets/aquarium_light.jpg",
+        "price": "10 dUSD",
+        "unit": "each",
+        "type": "tool",
+        "hardening": {
+            "passes": 1,
+            "score": 65,
+            "emoji": "🌀",
+            "history": [
+                {
+                    "task": "codex-item-hardening-2025-08-24",
+                    "date": "2025-08-24",
+                    "score": 65
+                }
+            ]
+        }
     }
 ]

--- a/frontend/src/pages/quests/json/hydroponics/grow-light.json
+++ b/frontend/src/pages/quests/json/hydroponics/grow-light.json
@@ -1,9 +1,9 @@
 {
     "id": "hydroponics/grow-light",
     "title": "Install a Grow Light",
-    "description": "Mount a full-spectrum LED grow lamp and automate a 12 h light cycle with a smart plug.",
+    "description": "Mount a full-spectrum LED grow lamp and automate a 12 h light cycle with a smart plug and timer.",
     "hardening": {
-        "passes": 3,
+        "passes": 4,
         "score": 92,
         "emoji": "💯",
         "history": [
@@ -20,6 +20,11 @@
             {
                 "task": "codex-quest-refinement-2025-08-06-3",
                 "date": "2025-08-06",
+                "score": 92
+            },
+            {
+                "task": "codex-quest-hardening-2025-08-24",
+                "date": "2025-08-24",
                 "score": 92
             }
         ]
@@ -41,7 +46,7 @@
         },
         {
             "id": "install",
-            "text": "Hang the LED panel 25–30 cm above plants with the included hanger. Route the cord downward to form a drip loop so any moisture falls away from the outlet. Plug the lamp into the smart plug and use its app to set a 12 h on/off cycle.",
+            "text": "Hang the LED panel 25–30 cm above plants with the included hanger. Route the cord downward to form a drip loop so moisture falls away from the outlet. Plug the lamp into the smart plug, then a mechanical timer, and set both for a 12 h cycle.",
             "options": [
                 {
                     "type": "goto",
@@ -55,6 +60,10 @@
                         },
                         {
                             "id": "a5395e29-1862-4eb7-8517-5d161635e032",
+                            "count": 1
+                        },
+                        {
+                            "id": "8f7c2e83-285a-4b29-9a3a-312f0dce2745",
                             "count": 1
                         }
                     ]


### PR DESCRIPTION
## Summary
- add mechanical outlet timer item and inventory mapping
- require timer in grow-light quest and refresh hardening

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run itemValidation`
- `npm run test:ci -- itemQuality`
- `npm run test:ci -- questQuality`
- `detect-secrets scan frontend/src/pages/inventory/json/items/hydroponics.json frontend/src/pages/quests/json/hydroponics/grow-light.json frontend/src/generated/itemQuestMap.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa94a7457c832fbeae5e366f30a6df