### PR TITLE
Add completionist journal quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -88,6 +88,7 @@ New quests in this release: 217
 
 -   completionist/catalog
 -   completionist/display
+-   completionist/journal
 -   completionist/polish
 -   completionist/reminder
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -88,6 +88,7 @@ New quests in this release: 217
 
 -   completionist/catalog
 -   completionist/display
+-   completionist/journal
 -   completionist/polish
 -   completionist/reminder
 

--- a/frontend/src/pages/quests/json/completionist/journal.json
+++ b/frontend/src/pages/quests/json/completionist/journal.json
@@ -1,0 +1,55 @@
+{
+    "id": "completionist/journal",
+    "title": "Journal the Journey",
+    "description": "Record how you earned the Completionist Award II.",
+    "image": "/assets/quests/completionist.jpg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Want to capture your trophy tale in the mission log?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "log",
+                    "text": "Definitely, let's document it"
+                }
+            ]
+        },
+        {
+            "id": "log",
+            "text": "Write a brief entry and give the award a quick dust while you're at it.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "write-mission-log-entry",
+                    "text": "Draft the mission log entry"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Entry saved and award dusted",
+                    "requiresItems": [
+                        {
+                            "id": "c01676ec-27e5-4a53-9a47-24bf6c5a56a9",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Your story is recorded, and the trophy looks sharp.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Another memory secured!"
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["completionist/v2"]
+}


### PR DESCRIPTION
## Summary
- add quest to log Completionist Award in mission log
- update new quests documentation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68aa9553bc74832f951a8800dc369f74