### PR TITLE
Add MQTT temperature quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -229,6 +229,7 @@ New quests in this release: 217
 -   programming/temp-graph
 -   programming/temp-json-api
 -   programming/temp-logger
+-   programming/temp-mqtt
 -   programming/thermistor-calibration
 -   programming/web-server
 

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 239
-New quests in this release: 217
+Current quest count: 240
+New quests in this release: 218
 
 ### 3dprinting
 
@@ -229,6 +229,7 @@ New quests in this release: 217
 -   programming/temp-graph
 -   programming/temp-json-api
 -   programming/temp-logger
+-   programming/temp-mqtt
 -   programming/thermistor-calibration
 -   programming/web-server
 

--- a/frontend/src/pages/quests/json/programming/temp-mqtt.json
+++ b/frontend/src/pages/quests/json/programming/temp-mqtt.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/temp-mqtt",
+    "title": "Publish Temperature via MQTT",
+    "description": "Send sensor readings to an MQTT broker with a simple script.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/orion.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Ready to share your data? Let's publish temperature readings to an MQTT topic.",
+            "options": [{ "type": "goto", "goto": "script", "text": "I'm ready." }]
+        },
+        {
+            "id": "script",
+            "text": "Write a short program that reads the thermistor and publishes the value to a topic like `sensors/temperature`.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Message sent!",
+                    "requiresItems": [{ "id": "8e81b5e5-4aee-402c-bd04-fed9188f8c07", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice! Remote systems can now subscribe to your data stream.",
+            "options": [{ "type": "finish", "text": "Neat!" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/temp-logger"]
+}


### PR DESCRIPTION
## Summary
- add programming quest to publish temperature via MQTT
- sync new-quests docs with updated quest count

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68aa9553bc74832f951a8800dc369f74