### PR TITLE
docs: clarify monitoring setup instructions and fix behavior spelling

### DIFF
--- a/docs/monitoring_setup.md
+++ b/docs/monitoring_setup.md
@@ -20,7 +20,7 @@ This guide explains how to run Prometheus and Grafana to monitor your self-hoste
 
 3. Add Prometheus as a data source in Grafana using the URL `http://prometheus:9090`.
 
-Prometheus is preconfigured to scrape the DSPACE metrics endpoint at
+By default, Prometheus is configured to scrape the DSPACE metrics endpoint at
 `http://host.docker.internal:3002/metrics`. If you run DSPACE on a different
 port or host, update `monitoring/prometheus/prometheus.yml` accordingly.
 

--- a/docs/prompts-outages.md
+++ b/docs/prompts-outages.md
@@ -33,7 +33,7 @@ CONTEXT:
 - Review existing records under [`outages`][outage-dir] for similar failures.
 - After resolving, add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
   matching [`outages/schema.json`][outage-schema].
-- Keep behaviour intact, add tests, and update documentation.
+- Keep behavior intact, add tests, and update documentation.
 
 REQUEST:
 1. Apply the fix with appropriate tests.


### PR DESCRIPTION
## Summary
- clarify Prometheus setup wording
- use American spelling in outage prompts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `detect-secrets scan --string "$(git diff --cached)"`

------
https://chatgpt.com/codex/tasks/task_e_68abac17ca58832fa9ddd51c78198661