### PR TITLE
docs: fix internal prompt links and clean docs index

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -25,7 +25,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/solar">Solar power</a>
             <a href="/docs/electricity">Electricity</a>
             <a href="/docs/hydroponics">Hydroponics</a>
-            <a href="/docs/electricity">Electricity</a>
             <a href="/docs/chemistry-lab">Chemistry Lab Basics</a>
             <a href="/docs/rockets">Rockets</a>
         </nav>
@@ -44,10 +43,8 @@ import Page from '../../components/Page.astro';
             <a href="/docs/titles">Titles</a>
             <a href="/docs/processes">Processes</a>
             <a href="/docs/guilds">Guilds</a>
-            <a href="/docs/dusd">dUSD</a>
             <a href="/docs/amazing">Amazing</a>
             <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dusd">dUSD</a>
             <a href="/docs/dCarbon">dCarbon</a>
             <a href="/docs/dusd">dUSD</a>
         </nav>
@@ -63,7 +60,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-quest-system">Custom Quest System</a>
             <a href="/docs/quest-trees">Quest trees</a>
             <a href="/docs/new-quests">New quests list</a>
-            <a href="/docs/quest-trees">Quest Trees</a>
         </nav>
     </span>
     <span>
@@ -84,8 +80,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-bundles">Custom content bundles</a>
             <a href="/docs/process-guidelines">Process development guidelines</a>
             <a href="/docs/item-guidelines">Item development guidelines</a>
-            <a href="/docs/token-place">token.place integration</a>
-            <a href="/docs/db-benchmark">Database benchmark</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -7,17 +7,17 @@ slug: 'prompts-docs'
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
 ready-made PR — but only if given a clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when updating Markdown or JSDoc so instructions stay
+[Codex Prompts](prompts-codex.md) when updating Markdown or JSDoc so instructions stay
 current and consistent. To keep these templates evolving, see the
-[Codex meta prompt](/docs/prompts-codex-meta). If they drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+[Codex meta prompt](prompts-codex-meta.md). If they drift, refresh them with the
+[Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Link new prompt docs from [`prompts-codex.md`](/docs/prompts-codex) and
+> 3. Link new prompt docs from [`prompts-codex.md`](prompts-codex.md) and
 >    `frontend/src/pages/docs/index.astro`.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`


### PR DESCRIPTION
## Summary
- Switch internal doc references to relative paths in prompts-docs
- Remove duplicate links in docs index (Electricity, dUSD, Quest trees, db benchmark)

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababf43bc8832f8f1711df93e50d0f