### PR TITLE
docs: clarify quest submission testing and tidy index

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -25,7 +25,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/solar">Solar power</a>
             <a href="/docs/electricity">Electricity</a>
             <a href="/docs/hydroponics">Hydroponics</a>
-            <a href="/docs/electricity">Electricity</a>
             <a href="/docs/chemistry-lab">Chemistry Lab Basics</a>
             <a href="/docs/rockets">Rockets</a>
         </nav>
@@ -47,9 +46,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/dusd">dUSD</a>
             <a href="/docs/amazing">Amazing</a>
             <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dusd">dUSD</a>
             <a href="/docs/dCarbon">dCarbon</a>
-            <a href="/docs/dusd">dUSD</a>
         </nav>
     </span>
     <span>
@@ -63,7 +60,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-quest-system">Custom Quest System</a>
             <a href="/docs/quest-trees">Quest trees</a>
             <a href="/docs/new-quests">New quests list</a>
-            <a href="/docs/quest-trees">Quest Trees</a>
         </nav>
     </span>
     <span>
@@ -84,8 +80,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-bundles">Custom content bundles</a>
             <a href="/docs/process-guidelines">Process development guidelines</a>
             <a href="/docs/item-guidelines">Item development guidelines</a>
-            <a href="/docs/token-place">token.place integration</a>
-            <a href="/docs/db-benchmark">Database benchmark</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -20,18 +20,18 @@ This guide describes how to submit your custom quests to become part of the offi
 2. **Bundle related items and processes** using `scripts/create-content-bundle.js`. This script collects quests, items, and processes into a single JSON file under `submissions/bundles`.
 3. **Validate** the quest structure by running:
     ```bash
-    npm test -- questValidation
+    npm run test:ci -- questValidation
     ```
     Ensure your quest file passes all schema checks. See the [Quest Schema Requirements](/docs/quest-schema) for field definitions.
     Quest titles and descriptions must be plain text with no HTML tags.
 4. **Check quest quality** with:
     ```bash
-    npm test -- questQuality
+    npm run test:ci -- questQuality
     ```
     Fix any reported errors until the test passes.
 5. **Simulate your quest** to ensure it can be completed:
     ```bash
-    npm test -- questSimulation
+    npm run test:ci -- questSimulation
     ```
     This validates that at least one path leads to a `finish` option.
 6. **Open the Quest Submission form** at `/quests/submit`.


### PR DESCRIPTION
## Summary
- use `npm run test:ci` in quest submission guide
- remove duplicate links from docs index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababf43bc8832f8f1711df93e50d0f