### PR TITLE
docs: add secret scanning prompt guide

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -25,7 +25,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/solar">Solar power</a>
             <a href="/docs/electricity">Electricity</a>
             <a href="/docs/hydroponics">Hydroponics</a>
-            <a href="/docs/electricity">Electricity</a>
             <a href="/docs/chemistry-lab">Chemistry Lab Basics</a>
             <a href="/docs/rockets">Rockets</a>
         </nav>
@@ -47,9 +46,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/dusd">dUSD</a>
             <a href="/docs/amazing">Amazing</a>
             <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dusd">dUSD</a>
             <a href="/docs/dCarbon">dCarbon</a>
-            <a href="/docs/dusd">dUSD</a>
         </nav>
     </span>
     <span>
@@ -63,7 +60,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-quest-system">Custom Quest System</a>
             <a href="/docs/quest-trees">Quest trees</a>
             <a href="/docs/new-quests">New quests list</a>
-            <a href="/docs/quest-trees">Quest Trees</a>
         </nav>
     </span>
     <span>
@@ -84,8 +80,6 @@ import Page from '../../components/Page.astro';
             <a href="/docs/custom-bundles">Custom content bundles</a>
             <a href="/docs/process-guidelines">Process development guidelines</a>
             <a href="/docs/item-guidelines">Item development guidelines</a>
-            <a href="/docs/token-place">token.place integration</a>
-            <a href="/docs/db-benchmark">Database benchmark</a>
             <a href="/docs/prompts-quests">Quest prompts</a>
             <a href="/docs/prompts-items">Item prompts</a>
             <a href="/docs/prompts-processes">Process prompts</a>
@@ -98,6 +92,7 @@ import Page from '../../components/Page.astro';
 
             <!-- Security -->
             <a href="/docs/prompts-audit">Dependency audit prompts</a>
+            <a href="/docs/prompts-secrets">Secret scanning prompts</a>
             <!-- Docs -->
             <a href="/docs/prompts-docs">Docs prompts</a>
             <a href="/docs/prompts-docs#cross-link-check-prompt">Docs cross-link prompt</a>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,8 @@ For task-specific templates see [Quest prompts](prompts-quests.md),
 [Item prompts](prompts-items.md), [Process prompts](prompts-processes.md),
 [NPC prompts](prompts-npcs.md), [Outage prompts](prompts-outages.md),
 [Backup prompts](prompts-backups.md), [Monitoring prompts](prompts-monitoring.md),
-[Audit prompts](prompts-audit.md), [Docs prompts](prompts-docs.md),
+[Audit prompts](prompts-audit.md), [Secret scanning prompts](prompts-secrets.md),
+[Docs prompts](prompts-docs.md),
 [Playwright test prompts](prompts-playwright-tests.md),
 [Vitest test prompts](prompts-vitest.md), [Frontend prompts](prompts-frontend.md),
 [Backend prompts](prompts-backend.md), [Refactor prompts](prompts-refactors.md), and
@@ -48,6 +49,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Backup Prompts](prompts-backups.md)
 -   [Monitoring Prompts](prompts-monitoring.md)
 -   [Audit Prompts](prompts-audit.md)
+-   [Secret Scanning Prompts](prompts-secrets.md)
 -   [Docs Prompts](prompts-docs.md)
 -   [Docs cross-link prompt](prompts-docs.md#cross-link-check-prompt)
 -   [Docs proofreading prompt](prompts-docs.md#proofreading-prompt)

--- a/frontend/src/pages/docs/md/prompts-secrets.md
+++ b/frontend/src/pages/docs/md/prompts-secrets.md
@@ -1,0 +1,31 @@
+---
+title: 'Secret Scanning Prompts'
+slug: 'prompts-secrets'
+---
+
+# Secret scanning prompts for the _dspace_ repo
+
+Use this template to prevent leaking credentials or other sensitive data. Combine it with
+other prompt guides to keep the repository secure.
+
+> **TL;DR**
+>
+> 1. Run `git diff --cached | ./scripts/scan-secrets.py` before every commit.
+> 2. Investigate any findings and remove credentials.
+> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Commit with an emoji prefix.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+
+USER:
+1. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+2. Investigate any findings and remove credentials.
+3. Run the checks above.
+4. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request with no exposed secrets and all checks passing.
+```


### PR DESCRIPTION
## Summary
- add secret scanning prompt doc
- link from codex and docs index, remove duplicate links

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababf43bc8832f8f1711df93e50d0f