### PR TITLE
📝 Refresh docs links

### DIFF
--- a/frontend/src/pages/docs/md/cloud-sync.md
+++ b/frontend/src/pages/docs/md/cloud-sync.md
@@ -4,7 +4,7 @@ title: 'Cloud Sync'
 
 You can now back up your game progress to a private GitHub gist. On the **Cloud Sync** page you can upload your current save or download it to another device.
 
-1. Generate a GitHub personal access token with the `gist` scope.
+1. Generate a GitHub personal access token with the `gist` scope (see [GitHub's token guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)).
 2. Enter the token in the form and click **Save**.
 3. Click **Upload** to create/update the gist and store your save data.
 4. Copy the resulting Gist ID to use on other devices.

--- a/frontend/src/pages/docs/md/prs.md
+++ b/frontend/src/pages/docs/md/prs.md
@@ -3,7 +3,7 @@ title: 'Pull Requests'
 slug: 'prs'
 ---
 
-Pull requests are welcome! See our [Contribution Guide](/CONTRIBUTING.md) for details on how to get started.
+Pull requests are welcome! See our [Contribution Guide](/docs/contribute) for details on how to get started.
 
 Before opening a pull request:
 


### PR DESCRIPTION
## Summary
- clarify PR docs to link to internal contribution guide
- add GitHub token guide link in cloud sync doc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababf43bc8832f8f1711df93e50d0f