### PR TITLE
🔧 ensure CI fetches full history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
           version: 9

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
+    `fetch-depth: 0` so scripts can compare against the default branch.

--- a/outages/2025-08-25-shallow-checkout.json
+++ b/outages/2025-08-25-shallow-checkout.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-25-shallow-checkout",
+  "date": "2025-08-25",
+  "component": "ci",
+  "rootCause": "actions/checkout fetched depth 1, leaving origin/v3 unavailable for tests",
+  "resolution": "set fetch-depth: 0 in ci.yml so scripts can access origin/v3",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md#lessons-learned"
+  ]
+}

--- a/tests/checkoutFetchDepth.test.ts
+++ b/tests/checkoutFetchDepth.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('CI workflow checkout', () => {
+  it('fetches full history for origin/v3', () => {
+    const ciPath = join(__dirname, '..', '.github', 'workflows', 'ci.yml');
+    const contents = readFileSync(ciPath, 'utf8');
+    expect(contents).toMatch(/fetch-depth:\s*0/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure CI workflow fetches full history so coverage scripts can access origin/v3
- document the fix and record the incident
- add regression test for checkout depth

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababa957ec832fb4bb7e5254510939