### PR TITLE
Handle missing origin in patch coverage check

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – `checkPatchCoverage.cjs` assumed an `origin` remote; detect the local HEAD and skip
+    `origin` when it is absent.

--- a/outages/2025-08-25-check-patch-coverage-no-remote.json
+++ b/outages/2025-08-25-check-patch-coverage-no-remote.json
@@ -1,0 +1,12 @@
+{
+  "id": "check-patch-coverage-no-remote",
+  "date": "2025-08-25",
+  "component": "scripts/checkPatchCoverage.cjs",
+  "rootCause": "checkPatchCoverage attempted to diff against origin/v3 when no origin remote existed, causing coverage checks to fail.",
+  "resolution": "Fall back to the local HEAD branch and skip origin lookups when origin remote is missing.",
+  "references": [
+    "scripts/checkPatchCoverage.cjs",
+    "scripts/tests/checkPatchCoverageBranch.test.ts",
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md"
+  ]
+}

--- a/scripts/checkPatchCoverage.cjs
+++ b/scripts/checkPatchCoverage.cjs
@@ -1,12 +1,21 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const cp = require('child_process');
 
 function getDefaultBranch() {
   try {
-    const info = execSync('git remote show origin', { stdio: ['pipe', 'pipe', 'ignore'] }).toString();
+    const info = cp.execSync('git remote show origin', {
+      stdio: ['pipe', 'pipe', 'ignore']
+    }).toString();
     const match = info.match(/HEAD branch: (.+)/);
     if (match) return match[1].trim();
+  } catch {}
+  try {
+    return cp.execSync('git symbolic-ref --short HEAD', {
+      stdio: ['pipe', 'pipe', 'ignore']
+    })
+      .toString()
+      .trim();
   } catch {}
   return 'main';
 }
@@ -14,19 +23,26 @@ function getDefaultBranch() {
 function getChangedFiles() {
   const branch = getDefaultBranch();
   let base = '';
-  try {
-    base = execSync(`git merge-base origin/${branch} HEAD`, {
-      stdio: ['pipe', 'pipe', 'ignore']
-    }).toString().trim();
-  } catch {
+  const hasOrigin = (() => {
     try {
-      base = execSync(`git merge-base ${branch} HEAD`, {
+      cp.execSync('git remote get-url origin', {
         stdio: ['pipe', 'pipe', 'ignore']
-      }).toString().trim();
-    } catch {}
-  }
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  try {
+    const target = hasOrigin ? `origin/${branch}` : branch;
+    base = cp.execSync(`git merge-base ${target} HEAD`, {
+      stdio: ['pipe', 'pipe', 'ignore']
+    })
+      .toString()
+      .trim();
+  } catch {}
   if (!base) return [];
-  const diff = execSync(`git diff --name-only ${base}`).toString();
+  const diff = cp.execSync(`git diff --name-only ${base}`).toString();
   return diff.split('\n').filter(Boolean);
 }
 
@@ -66,4 +82,4 @@ if (require.main === module) {
   checkCoverage();
 }
 
-module.exports = { getDefaultBranch };
+module.exports = { getDefaultBranch, getChangedFiles };

--- a/scripts/tests/checkPatchCoverageBranch.test.ts
+++ b/scripts/tests/checkPatchCoverageBranch.test.ts
@@ -1,23 +1,44 @@
 import { expect, test, vi } from 'vitest';
 
-vi.mock('child_process', () => {
-  return {
-    execSync: vi.fn((cmd: string) => {
-      if (cmd === 'git remote show origin') {
-        return Buffer.from('HEAD branch: v3\n');
-      }
-      if (cmd.startsWith('git merge-base')) {
-        expect(cmd.includes('origin/v3')).toBe(true);
-        return Buffer.from('');
-      }
-      if (cmd.startsWith('git diff --name-only')) {
-        return Buffer.from('');
-      }
-      return Buffer.from('');
-    })
-  };
-});
+const execSync = vi.fn();
+vi.mock('child_process', () => ({ execSync }));
 
 test('checkPatchCoverage uses origin HEAD branch', () => {
+  execSync.mockImplementation(cmd => {
+    if (cmd === 'git remote show origin') {
+      return Buffer.from('HEAD branch: v3\n');
+    }
+    if (cmd.startsWith('git merge-base')) {
+      expect(cmd.includes('origin/v3')).toBe(true);
+      return Buffer.from('');
+    }
+    if (cmd.startsWith('git diff --name-only')) {
+      return Buffer.from('');
+    }
+    return Buffer.from('');
+  });
+  delete require.cache[require.resolve('../checkPatchCoverage.cjs')];
   require('../checkPatchCoverage.cjs');
+});
+
+test('checkPatchCoverage handles missing origin remote', () => {
+  execSync.mockReset();
+  execSync.mockImplementation(cmd => {
+    if (cmd === 'git remote show origin' || cmd === 'git remote get-url origin') {
+      throw new Error('no origin');
+    }
+    if (cmd.startsWith('git merge-base v3') || cmd.startsWith('git diff --name-only')) {
+      return Buffer.from('');
+    }
+    if (cmd === 'git symbolic-ref --short HEAD') {
+      return Buffer.from('work\n');
+    }
+    return Buffer.from('');
+  });
+  delete require.cache[require.resolve('../checkPatchCoverage.cjs')];
+  const { getDefaultBranch, getChangedFiles } = require('../checkPatchCoverage.cjs');
+  expect(() => {
+    getDefaultBranch();
+    getChangedFiles();
+  }).not.toThrow();
 });


### PR DESCRIPTION
## Summary
- avoid failing `checkPatchCoverage.cjs` when repository has no `origin` remote
- cover fallback logic with tests and document the lesson
- record outage for missing-origin patch coverage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68ababa957ec832fb4bb7e5254510939