### PR TITLE
ci: document ESLint plugin requirement

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+
+-   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.

--- a/outages/2025-08-25-eslint-plugin-missing.json
+++ b/outages/2025-08-25-eslint-plugin-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "eslint-plugin-missing",
+  "date": "2025-08-25",
+  "component": "frontend lint",
+  "rootCause": "ESLint failed to load @typescript-eslint plugins because frontend dev dependencies were not installed.",
+  "resolution": "Install frontend packages before running lint to provide @typescript-eslint plugins.",
+  "references": [
+    "frontend/package.json",
+    "tests/eslintPluginPresence.test.ts"
+  ]
+}

--- a/tests/eslintPluginPresence.test.ts
+++ b/tests/eslintPluginPresence.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'path';
+
+describe('@typescript-eslint/eslint-plugin', () => {
+  it('is installed', () => {
+    const resolveFn = () =>
+      require.resolve('@typescript-eslint/eslint-plugin', {
+        paths: [join(__dirname, '..', 'frontend', 'node_modules')],
+      });
+    expect(resolveFn).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring @typescript-eslint plugin is installed
- record outage and document the need to install frontend dependencies before linting

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababa957ec832fb4bb7e5254510939