### PR TITLE
Handle missing prom-client in metrics utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ The server exposes two monitoring endpoints:
 - `GET /health` returns `{ "status": "ok" }` for basic liveness checks.
 - `GET /metrics` serves Prometheus-formatted metrics using `prom-client`. Set a
   `METRICS_TOKEN` environment variable to require
-  `Authorization: Bearer <token>` for this endpoint.
+  `Authorization: Bearer <token>` for this endpoint. When `prom-client` isn't
+  available, the endpoint returns a plain text `metrics unavailable` message.
 
 For a full Raspberry Pi setup, including k3s instructions, see [docs/RPI_DEPLOYMENT_GUIDE.md](./docs/RPI_DEPLOYMENT_GUIDE.md).
 To add Prometheus and Grafana monitoring, follow the steps in [docs/monitoring_setup.md](./docs/monitoring_setup.md).

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,6 +1,18 @@
-import { Registry, collectDefaultMetrics } from 'prom-client';
+let register;
 
-const register = new Registry();
-collectDefaultMetrics({ register });
+async function initMetrics(loader = () => import('prom-client')) {
+    try {
+        const { Registry, collectDefaultMetrics } = await loader();
+        register = new Registry();
+        collectDefaultMetrics({ register });
+    } catch {
+        register = {
+            contentType: 'text/plain',
+            metrics: async () => '# metrics unavailable\n',
+        };
+    }
+}
 
-export { register };
+await initMetrics();
+
+export { register, initMetrics };

--- a/outages/2025-08-25-metrics-prom-client-missing.json
+++ b/outages/2025-08-25-metrics-prom-client-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "metrics-prom-client-missing",
+  "date": "2025-08-25",
+  "component": "metrics endpoint",
+  "rootCause": "metrics utility crashed when prom-client dependency was absent",
+  "resolution": "load prom-client dynamically with a fallback register",
+  "references": [
+    "frontend/src/utils/metrics.js",
+    "tests/metricsFallback.test.ts"
+  ]
+}

--- a/tests/metricsFallback.test.ts
+++ b/tests/metricsFallback.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('metrics util', () => {
+    it('falls back when prom-client is missing', async () => {
+        const mod = await import('../frontend/src/utils/metrics.js');
+        await mod.initMetrics(() => {
+            throw new Error('module not found');
+        });
+        expect(mod.register.contentType).toBe('text/plain');
+        const metrics = await mod.register.metrics();
+        expect(metrics).toContain('metrics unavailable');
+    });
+});


### PR DESCRIPTION
## Summary
- load prom-client dynamically with fallback register
- document graceful metrics degradation
- capture outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: no such file)*

Refs: outages/2025-08-25-metrics-prom-client-missing.json

------
https://chatgpt.com/codex/tasks/task_e_68abac7c6410832face06ce48070bcfc