### PR TITLE
🐛 : – trim whitespace in listMissingImages

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – `listMissingImages` treated paths with leading or trailing spaces as missing;
+    trim entries before checking so coverage tests skip valid assets.

--- a/outages/2025-08-25-list-missing-images-whitespace.json
+++ b/outages/2025-08-25-list-missing-images-whitespace.json
@@ -1,0 +1,12 @@
+{
+  "id": "list-missing-images-whitespace",
+  "date": "2025-08-25",
+  "component": "scripts",
+  "rootCause": "listMissingImages treated paths with surrounding spaces as missing files",
+  "resolution": "trimmed image paths before checking existence",
+  "references": [
+    "scripts/utils/fs-checks.js",
+    "scripts/tests/fsChecks.test.ts",
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md"
+  ]
+}

--- a/scripts/tests/fsChecks.test.ts
+++ b/scripts/tests/fsChecks.test.ts
@@ -41,4 +41,17 @@ describe('listMissingImages', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test('trims whitespace around paths', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'images-'));
+    try {
+      const filename = 'logo.png';
+      fs.writeFileSync(path.join(tmp, filename), '');
+      const images = [`  ${filename}  `];
+      const missing = listMissingImages(images, tmp);
+      expect(missing).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/utils/fs-checks.js
+++ b/scripts/utils/fs-checks.js
@@ -25,7 +25,7 @@ const decodeSafely = (str) => {
  */
 function listMissingImages(imagePaths, publicDir = DEFAULT_PUBLIC_DIR) {
   return imagePaths.filter((img) => {
-    const base = img.replace(/[?#].*$/, '');
+    const base = img.trim().replace(/[?#].*$/, '');
     if (!isLocalPath(base)) {
       return false;
     }


### PR DESCRIPTION
## Summary
- trim leading/trailing spaces before checking image paths
- add regression test for whitespace handling
- log outage in catalog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abac7c6410832face06ce48070bcfc