### PR TITLE
fix: handle uppercase duration units

### DIFF
--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -24,7 +24,7 @@ DSPACE processes should:
 Every process requires the following properties:
 
 -   **title**: Clear, descriptive name for the process (required)
--   **duration**: Time required to complete the process in format `#h #m` (required)
+-   **duration**: Time required to complete the process in format `#h #m` (units are case-insensitive, required)
 -   **requireItems**: Items needed but not consumed (optional)
 -   **consumeItems**: Items removed from inventory when process starts (optional)
 -   **createItems**: Items added to inventory when process completes (optional)
@@ -44,7 +44,7 @@ Processes that fail validation will not be saved and the form displays helpful e
 
 ### Duration Format
 
-Duration must follow the pattern `(\d+h\s*)?(\d+m\s*)?(\d+s\s*)?`, for example:
+Duration must follow the pattern `(\d+h\s*)?(\d+m\s*)?(\d+s\s*)?` (units are case-insensitive), for example:
 
 -   "30m" (30 minutes)
 -   "2h" (2 hours)

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -41,7 +41,7 @@ These are the items produced by the process, which are added to your inventory u
 
 <img src="/assets/docs/process_duration.jpg">
 
-Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency.
+Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency. Units are case-insensitive, so `1H 30M` works as well.
 
 #### Duration Examples
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -128,7 +128,7 @@ export const durationInSeconds = (durationString) => {
         for (const component of durationComponents) {
             const number = parseFloat(component);
             if (isNaN(number)) continue;
-            const unit = component.replace(number, '');
+            const unit = component.replace(String(number), '').toLowerCase();
             let seconds = 0;
             switch (unit) {
                 case 'd':

--- a/frontend/tests/duration.test.ts
+++ b/frontend/tests/duration.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { durationInSeconds } from '../src/utils.js';
+
+describe('durationInSeconds', () => {
+    it('parses uppercase units', () => {
+        expect(durationInSeconds('1H 30M')).toBe(5400);
+        expect(durationInSeconds('45S')).toBe(45);
+    });
+});

--- a/outages/2025-08-25-duration-uppercase-units.json
+++ b/outages/2025-08-25-duration-uppercase-units.json
@@ -1,0 +1,13 @@
+{
+  "id": "duration-uppercase-units",
+  "date": "2025-08-25",
+  "component": "frontend",
+  "rootCause": "duration parser rejected uppercase time units",
+  "resolution": "normalize unit identifiers to lowercase before converting",
+  "references": [
+    "frontend/src/utils.js",
+    "frontend/tests/duration.test.ts",
+    "frontend/src/pages/docs/md/processes.md",
+    "frontend/src/pages/docs/md/process-guidelines.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- make duration parser accept uppercase time units
- document case-insensitive duration units
- record outage in outages/2025-08-25-duration-uppercase-units.json

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68abac7c6410832face06ce48070bcfc