### PR TITLE
🐛 clamp duration values to valid range

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -104,6 +104,9 @@ frontend/
 > Utility note: `src/utils/strings.js`'s `getDuration` now falls back to
 > `0.00%` for non-numeric input to prevent showing `NaN%`.
 
+> Utility note: `src/utils/strings.js` now clamps duration values to the 0-100% range
+> to avoid negative or overflowing percentages in the UI.
+
 ## Getting Started
 
 ### Prerequisites

--- a/frontend/__tests__/strings.test.js
+++ b/frontend/__tests__/strings.test.js
@@ -8,10 +8,20 @@ describe('getDurationString', () => {
     test('omits remaining time when duration is 100', () => {
         expect(getDurationString(100, '0s')).toBe('100.00%');
     });
+
+    test('clamps out-of-range durations', () => {
+        expect(getDurationString(-10, '3s')).toBe('0.00% - 3s');
+        expect(getDurationString(150, '3s')).toBe('100.00%');
+    });
 });
 
 describe('getDuration', () => {
     test('formats to two decimals with percent', () => {
         expect(getDuration(3)).toBe('3.00%');
+    });
+
+    test('clamps values to 0-100%', () => {
+        expect(getDuration(-5)).toBe('0.00%');
+        expect(getDuration(150)).toBe('100.00%');
     });
 });

--- a/frontend/src/utils/strings.js
+++ b/frontend/src/utils/strings.js
@@ -8,9 +8,18 @@
  *   If the duration is less than 100% and remaining time is provided, it will
  *   be included in the returned string.
  */
+const sanitizeDuration = (duration) => {
+    const num = Number(duration);
+    if (!Number.isFinite(num)) {
+        return 0;
+    }
+    return Math.min(Math.max(num, 0), 100);
+};
+
 export const getDurationString = (duration, remainingTime) => {
-    const durationStr = getDuration(duration);
-    if (duration < 100 && remainingTime) {
+    const value = sanitizeDuration(duration);
+    const durationStr = `${value.toFixed(2)}%`;
+    if (value < 100 && remainingTime) {
         return `${durationStr} - ${remainingTime}`;
     }
     return durationStr;
@@ -23,6 +32,6 @@ export const getDurationString = (duration, remainingTime) => {
  * @returns {string} The string representing the duration.
  */
 export const getDuration = (duration) => {
-    const num = Number(duration);
-    return Number.isFinite(num) ? `${num.toFixed(2)}%` : '0.00%';
+    const value = sanitizeDuration(duration);
+    return `${value.toFixed(2)}%`;
 };

--- a/outages/2025-08-25-duration-out-of-range.json
+++ b/outages/2025-08-25-duration-out-of-range.json
@@ -1,0 +1,13 @@
+{
+  "id": "duration-out-of-range",
+  "date": "2025-08-25",
+  "component": "frontend",
+  "rootCause": "getDuration allowed negative or over-100 values, producing invalid percentages",
+  "resolution": "clamp duration values to the 0-100% range and add tests",
+  "references": [
+    "frontend/src/utils/strings.js",
+    "tests/strings.test.ts",
+    "frontend/__tests__/strings.test.js",
+    "frontend/README.md"
+  ]
+}

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -16,6 +16,11 @@ describe('getDurationString', () => {
   test('handles missing remaining time gracefully', () => {
     expect(getDurationString(50, undefined)).toBe('50.00%');
   });
+
+  test('clamps out-of-range durations', () => {
+    expect(getDurationString(-10, '3s')).toBe('0.00% - 3s');
+    expect(getDurationString(150, '3s')).toBe('100.00%');
+  });
 });
 
 describe('getDuration', () => {
@@ -27,5 +32,10 @@ describe('getDuration', () => {
     expect(getDuration(NaN)).toBe('0.00%');
     // undefined should be treated as 0 at runtime
     expect(getDuration(undefined)).toBe('0.00%');
+  });
+
+  test('clamps values to 0-100%', () => {
+    expect(getDuration(-5)).toBe('0.00%');
+    expect(getDuration(150)).toBe('100.00%');
   });
 });


### PR DESCRIPTION
## Summary
- clamp duration utilities to 0-100%
- document and test duration clamping
- record duration-out-of-range outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68abac7c6410832face06ce48070bcfc