### PR TITLE
🚀 Enhance logo responsiveness and tests

### DIFF
--- a/frontend/__tests__/Logo.test.js
+++ b/frontend/__tests__/Logo.test.js
@@ -1,0 +1,19 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const logoFile = path.join(__dirname, '../src/components/Logo.astro');
+
+describe('Logo.astro', () => {
+    it('includes descriptive alt text', () => {
+        const content = fs.readFileSync(logoFile, 'utf8');
+        expect(content).toMatch(/alt="[^"]*rocket[^"]*"/i);
+    });
+
+    it('uses clamp for responsive sizing', () => {
+        const content = fs.readFileSync(logoFile, 'utf8');
+        expect(content).toMatch(/width: clamp\(4rem, 20vw, 8rem\);/);
+        expect(content).toMatch(/height: auto;/);
+    });
+});

--- a/frontend/src/components/Logo.astro
+++ b/frontend/src/components/Logo.astro
@@ -1,14 +1,18 @@
 ---
-const { href, title, body } = Astro.props as Props;
 ---
 
-<div></div><img src="/assets/logo.png" alt="A logo of a rocket lifting off from Mars, minimalistic. Made with DALL-E 2." class="logo" />
+<img
+    src="/assets/logo.png"
+    alt="Minimal rocket launching from Mars"
+    class="logo"
+    loading="lazy"
+/> 
 
 <style>
-	.logo {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  width: 20%;
-	}
+    .logo {
+        display: block;
+        margin-inline: auto;
+        width: clamp(4rem, 20vw, 8rem);
+        height: auto;
+    }
 </style>


### PR DESCRIPTION
what: make logo responsive with lazy loading and tests
why: improve accessibility and layout
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ababd9d9cc832f83862a1c2b4972da