### PR TITLE
🎨: enhance ItemSelector accessibility

### DIFF
--- a/frontend/__tests__/ItemSelector.test.js
+++ b/frontend/__tests__/ItemSelector.test.js
@@ -78,6 +78,23 @@ describe('ItemSelector Component', () => {
         expect(selectedId).toBe('item-1');
     });
 
+    test('should reflect selection with aria-selected', () => {
+        const component = new ItemSelector({
+            target: container,
+            props: {
+                items: mockItems,
+                selectedItemId: '',
+                label: 'Select Item',
+            },
+        });
+
+        const rows = container.querySelectorAll('.item-row');
+        expect(rows[0].getAttribute('aria-selected')).toBe('false');
+        rows[0].click();
+        expect(rows[0].getAttribute('aria-selected')).toBe('true');
+        expect(rows[1].getAttribute('aria-selected')).toBe('false');
+    });
+
     test('should emit select event on touch', () => {
         let selectedId = null;
         const component = new ItemSelector({

--- a/frontend/src/components/svelte/ItemSelector.svelte
+++ b/frontend/src/components/svelte/ItemSelector.svelte
@@ -45,7 +45,7 @@
         {#if isExpanded}
             <div class="selector-expanded" id="item-select-control">
                 <SearchBar data={items} on:search={handleSearch} />
-                <div class="items-list">
+                <div class="items-list" role="listbox">
                     {#each $filteredItems as item (item.id)}
                         <div
                             class="item-row"
@@ -58,7 +58,8 @@
                                 }
                             }}
                             tabindex="0"
-                            role="button"
+                            role="option"
+                            aria-selected={selectedItemId === item.id}
                         >
                             <div class="item-content">
                                 {#if item.image}
@@ -204,6 +205,18 @@
         padding: 8px;
         border-radius: 4px;
         border: 2px solid #007006;
+    }
+
+    @media (max-width: 480px) {
+        .item-content {
+            flex-direction: column;
+            align-items: flex-start;
+        }
+
+        .item-content img {
+            width: 100%;
+            height: auto;
+        }
     }
 
     .edit-button,


### PR DESCRIPTION
## Summary
- expose ItemSelector options as listbox options with aria-selected
- stack ItemSelector content vertically on narrow screens
- verify aria-selected on ItemSelector items

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababd9d9cc832f83862a1c2b4972da