### PR TITLE
🔗: add target and rel props to Button

### DIFF
--- a/frontend/__tests__/Button.test.js
+++ b/frontend/__tests__/Button.test.js
@@ -16,4 +16,10 @@ describe('Button.astro', () => {
         expect(content).toMatch(/padding: 0\.5rem 1rem;/);
         expect(content).toMatch(/margin: 0\.5rem;/);
     });
+
+    it('supports target blank with security rel', () => {
+        const content = fs.readFileSync(buttonFile, 'utf8');
+        expect(content).toMatch(/target={target}/);
+        expect(content).toMatch(/rel={target === "_blank" \? "noopener noreferrer" : undefined}/);
+    });
 });

--- a/frontend/src/components/Button.astro
+++ b/frontend/src/components/Button.astro
@@ -3,15 +3,18 @@ interface Props {
     text: string;
     href: string;
     ariaLabel?: string;
+    target?: string;
 }
 
-const { text, href, ariaLabel }: Props = Astro.props;
+const { text, href, ariaLabel, target }: Props = Astro.props;
 ---
 
 <a
     href={href}
     aria-label={ariaLabel ?? text}
     class="button"
+    target={target}
+    rel={target === "_blank" ? "noopener noreferrer" : undefined}
 >
     {text}
 </a>


### PR DESCRIPTION
## Summary
- allow Button component to open links in a new tab with a secure rel
- cover new target/rel behavior with tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: running pre-PR checks stalled after Playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68ababd9d9cc832f83862a1c2b4972da