### PR TITLE
Add binary star astronomy quest

### DIFF
--- a/frontend/src/pages/quests/json/astronomy/binary-star.json
+++ b/frontend/src/pages/quests/json/astronomy/binary-star.json
@@ -1,0 +1,59 @@
+{
+    "id": "astronomy/binary-star",
+    "title": "Split a Binary Star",
+    "description": "Use a basic telescope and planisphere to find Albireo and note its colors.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Albireo is a colorful binary in Cygnus. Ready to track it down?",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "locate",
+                    "text": "Point me to it."
+                }
+            ]
+        },
+        {
+            "id": "locate",
+            "text": "Trace Cygnus on a planisphere and aim the telescope at Albireo to split them.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "identify-constellations",
+                    "text": "Aligning with Cygnus."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        {
+                            "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5",
+                            "count": 1
+                        },
+                        {
+                            "id": "98f6252e-95c2-468a-b110-69d47604df2c",
+                            "count": 1
+                        }
+                    ],
+                    "text": "I see gold and blue!"
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great split! Jot the colors in your mission log for future observers.",
+            "options": [
+                {
+                    "type": "finish",
+                    "text": "Logged and ready for the next target."
+                }
+            ]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/constellations"]
+}


### PR DESCRIPTION
## Summary
- add Binary Star quest referencing planisphere and basic telescope
- sync new quests documentation with current counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abab2546f4832fa1e897796ad253b4