### PR TITLE
📊 Add error rate alert and dashboard

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -14,5 +14,7 @@ docker-compose up
 - Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
 - Grafana provisions a Prometheus data source and a sample dashboard.
 - Alerts include `DspaceDown`, which fires when the `dspace` job stops reporting `up`.
+- Alerts also include `DspaceHighErrorRate`, which triggers when over 5% of requests fail.
+- The dashboard shows service availability and HTTP 5xx error rate over time.
 
 All services are self-hosted to respect user privacy.

--- a/monitoring/grafana/dashboards/dspace-overview.json
+++ b/monitoring/grafana/dashboards/dspace-overview.json
@@ -12,6 +12,16 @@
           "legendFormat": "dspace"
         }
       ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total{job=\"dspace\",status=~\"5..\"}[5m])/rate(http_requests_total{job=\"dspace\"}[5m])",
+          "legendFormat": "5xx rate"
+        }
+      ]
     }
   ],
   "schemaVersion": 36,

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -8,3 +8,13 @@ groups:
           severity: critical
         annotations:
           summary: DSpace service is down
+      - alert: DspaceHighErrorRate
+        expr: |
+          rate(http_requests_total{job="dspace",status=~"5.."}[5m]) /
+          rate(http_requests_total{job="dspace"}[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High error rate on DSpace
+          description: More than 5% of HTTP requests returned 5xx status codes


### PR DESCRIPTION
## Summary
- add DspaceHighErrorRate alert in Prometheus
- show error rate panel in Grafana dashboard
- document new alert and panel in monitoring README

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68abac778bdc832faa57081e0fbc4a17