### PR TITLE
Improve net-fish quest safety and process references

### DIFF
--- a/frontend/src/generated/itemQuestMap.json
+++ b/frontend/src/generated/itemQuestMap.json
@@ -434,6 +434,7 @@
       "hydroponics/temp-check",
       "geothermal/survey-ground-temperature",
       "electronics/thermometer-calibration",
+      "aquaria/water-change",
       "aquaria/thermometer",
       "aquaria/heater-install"
     ],
@@ -608,7 +609,8 @@
       "composting/start",
       "aquaria/water-change",
       "aquaria/top-off",
-      "aquaria/shrimp"
+      "aquaria/shrimp",
+      "aquaria/net-fish"
     ],
     "rewards": [
       "hydroponics/bucket_10"
@@ -995,7 +997,8 @@
   },
   "3dbf1701-5cc0-4443-b9bf-4275b33513d0": {
     "requires": [
-      "electronics/tin-soldering-iron"
+      "electronics/tin-soldering-iron",
+      "electronics/solder-wire"
     ],
     "rewards": []
   },

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2980,6 +2980,40 @@
         }
     },
     {
+        "id": "catch-fish",
+        "title": "Use an aquarium net to transfer a fish into a 19 L bucket",
+        "requireItems": [
+            {
+                "id": "ee7d437d-7426-47cd-b691-386dd20f4e47",
+                "count": 1
+            },
+            {
+                "id": "0564d441-7367-412e-b709-dad770814a39",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
+        "id": "return-fish",
+        "title": "Use an aquarium net to return a fish from a holding bucket to its tank",
+        "requireItems": [
+            {
+                "id": "ee7d437d-7426-47cd-b691-386dd20f4e47",
+                "count": 1
+            },
+            {
+                "id": "0564d441-7367-412e-b709-dad770814a39",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "print-calibration-cube",
         "title": "3D print a 20 mm calibration cube on an entry-level FDM 3D printer using 15 g of green PLA filament",
         "requireItems": [

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -2442,6 +2442,28 @@
         "duration": "30m"
     },
     {
+        "id": "catch-fish",
+        "title": "Use an aquarium net to transfer a fish into a 19 L bucket",
+        "requireItems": [
+            { "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 },
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
+        "id": "return-fish",
+        "title": "Use an aquarium net to return a fish from a holding bucket to its tank",
+        "requireItems": [
+            { "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 },
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "1m"
+    },
+    {
         "id": "print-calibration-cube",
         "title": "3D print a 20 mm calibration cube on an entry-level FDM 3D printer using 15 g of green PLA filament",
         "requireItems": [

--- a/frontend/src/pages/quests/json/aquaria/net-fish.json
+++ b/frontend/src/pages/quests/json/aquaria/net-fish.json
@@ -8,51 +8,69 @@
     "dialogue": [
         {
             "id": "start",
-            "text": "The tank needs a quick tidy. Let's move a fish to a bucket with the net first.",
+            "text": "Wash hands, fill a clean 19 L bucket with tank water, and wet the net to protect slime coat.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "catch",
-                    "text": "I'll grab the net."
+                    "text": "Bucket ready.",
+                    "requiresItems": [
+                        { "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 },
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ]
                 }
             ]
         },
         {
             "id": "catch",
-            "text": "Gently scoop the fish with the net and settle it in a nearby bucket.",
+            "text": "Guide the fish into the wet net and lift it into the bucket of tank water. Cover to stop jumps.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "release",
-                    "text": "Fish is secure in the bucket.",
+                    "text": "Fish resting in the bucket.",
                     "process": "catch-fish",
-                    "requiresItems": [{ "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 }]
+                    "requiresItems": [
+                        { "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 },
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ]
                 }
             ]
         },
         {
             "id": "release",
-            "text": "With the tank clean, return the fish to its home.",
+            "text": "After cleaning, net the fish from the bucket and return it to the tank, avoiding bucket water.",
             "options": [
                 {
                     "type": "goto",
                     "goto": "fin",
-                    "text": "Back in you go!",
-                    "process": "return-fish"
+                    "text": "Back in the tank.",
+                    "process": "return-fish",
+                    "requiresItems": [
+                        { "id": "ee7d437d-7426-47cd-b691-386dd20f4e47", "count": 1 },
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 }
+                    ]
                 }
             ]
         },
         {
             "id": "fin",
             "text": "Great job keeping the fish safe during cleanup!",
-            "options": [
-                {
-                    "type": "finish",
-                    "text": "All done."
-                }
-            ]
+            "options": [{ "type": "finish", "text": "All done." }]
         }
     ],
     "rewards": [],
-    "requiresQuests": ["aquaria/water-change"]
+    "requiresQuests": ["aquaria/water-change"],
+    "hardening": {
+        "passes": 1,
+        "score": 60,
+        "emoji": "🌀",
+        "history": [
+            {
+                "task": "codex-quest-hardening-2025-08-25",
+                "date": "2025-08-25",
+                "score": 60
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- clarify net-fish quest with bucket prep and safer wording
- add catch-fish and return-fish processes and update item map

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`


------
https://chatgpt.com/codex/tasks/task_e_68abab476c20832fae124af82151957a