### PR TITLE
Add item/process preview test and update user journeys

### DIFF
--- a/frontend/e2e/item-process-preview.spec.ts
+++ b/frontend/e2e/item-process-preview.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData } from './test-helpers';
+import { clearUserData, ItemSelectorHelper } from './test-helpers';
 
 test.describe('Custom content preview', () => {
     test.beforeEach(async ({ page }) => {
@@ -35,6 +35,11 @@ test.describe('Custom content preview', () => {
 
         await page.fill('#title', 'Preview Process');
         await page.fill('#duration', '1h');
+
+        await page.getByRole('button', { name: 'Add Required Item' }).click();
+        const row = page.locator('#required-items-section .item-row').first();
+        const selector = new ItemSelectorHelper(page, row);
+        await selector.selectItem();
 
         const btn = page.locator('button.preview-button');
         await btn.click();

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -6,8 +6,9 @@ slug: 'user-journeys'
 # User journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
-Tests under `frontend/e2e/backlog` are placeholders for journeys without automation. Entries are
-sorted alphabetically by journey name.
+Tests under `frontend/e2e/backlog` are placeholders for journeys without automation. When adding
+coverage, move the placeholder with `git mv` to `frontend/e2e` and ensure the test asserts visible
+UI content. Entries are sorted alphabetically by journey name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
@@ -23,8 +24,10 @@ sorted alphabetically by journey name.
 | Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
 | Failover status page       | Yes                 | `frontend/e2e/failover-status.spec.ts`            |
+| FAQ page loads             | No                  | --                                                |
+| Glossary page loads        | No                  | --                                                |
 | Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
-| Item/process preview       | No                  | --                                                |
+| Item/process preview       | Yes                 | `frontend/e2e/item-process-preview.spec.ts`       |
 | Legacy data import         | No                  | --                                                |
 | Manage items               | No                  | --                                                |
 | Manage processes           | No                  | --                                                |


### PR DESCRIPTION
## Summary
- document new FAQ and Glossary journeys and note how to promote tests from backlog
- cover item and process preview flows with a Playwright test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run test:e2e item-process-preview.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68abac934938832f800db41a0458db6e