### PR TITLE
feat: add Mars opposition quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -60,6 +60,7 @@ New quests in this release: 218
 -   astronomy/jupiter-moons
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
+-   astronomy/mars-opposition
 -   astronomy/meteor-shower
 -   astronomy/north-star
 -   astronomy/observe-moon

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -60,6 +60,7 @@ New quests in this release: 218
 -   astronomy/jupiter-moons
 -   astronomy/light-pollution
 -   astronomy/lunar-eclipse
+-   astronomy/mars-opposition
 -   astronomy/meteor-shower
 -   astronomy/north-star
 -   astronomy/observe-moon

--- a/frontend/src/pages/quests/json/astronomy/mars-opposition.json
+++ b/frontend/src/pages/quests/json/astronomy/mars-opposition.json
@@ -1,0 +1,44 @@
+{
+    "id": "astronomy/mars-opposition",
+    "title": "Capture Mars at Opposition",
+    "description": "Photograph Mars during its close approach using a basic telescope and digital camera.",
+    "image": "/assets/quests/solar.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Mars is bright tonight. Set up your basic telescope and attach the digital camera to capture its details.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "capture",
+                    "text": "I'm ready to focus."
+                }
+            ]
+        },
+        {
+            "id": "capture",
+            "text": "Center Mars in the eyepiece, fine‑tune the focus, and take a series of photos. Keep cables clear to avoid tripping in the dark.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "f439b57a-9df3-4bd9-9b6e-042476ceecf5", "count": 1 },
+                        { "id": "a96ce9ed-b9e0-44e5-bd9f-c068643e6749", "count": 1 }
+                    ],
+                    "text": "Mars photo secured."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great shot! Share the image with the crew and note the date for future comparisons.",
+            "options": [{ "type": "finish", "text": "Can't wait to process it." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["astronomy/meteor-shower"],
+    "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
+}


### PR DESCRIPTION
## Summary
- add astronomy/mars-opposition quest using telescope and camera
- update new quests listing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `npm run new-quests:update`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abaafea75c832fa3cde020d7cd27f0