### PR TITLE
Add cover compost bucket quest

### DIFF
--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -3955,6 +3955,24 @@
         }
     },
     {
+        "id": "cover-compost-bucket",
+        "title": "Cover a 5 gallon compost bucket with a snap-on lid",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            {
+                "id": "0564d441-7367-412e-b709-dad770814a39",
+                "count": 1
+            },
+            {
+                "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097",
+                "count": 1
+            }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s"
+    },
+    {
         "id": "measure-arduino-5v",
         "title": "Measure the 5 V pin on an Arduino Uno using a digital multimeter",
         "image": "/assets/launch_controller.jpg",

--- a/frontend/src/pages/inventory/json/items/misc.json
+++ b/frontend/src/pages/inventory/json/items/misc.json
@@ -249,6 +249,14 @@
         }
     },
     {
+        "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097",
+        "name": "5 gallon bucket lid",
+        "description": "Snap-on polyethylene lid for a standard 19 L (5 gal) bucket; keeps odors and pests in check.",
+        "image": "/assets/bucket.jpg",
+        "price": "2 dUSD",
+        "hardening": { "passes": 0, "score": 0, "emoji": "🛠️", "history": [] }
+    },
+    {
         "id": "d88ef09c-9191-4c18-8628-a888bb9f926d",
         "name": "dCarbon",
         "description": "A token that is generated for every 1 kg of carbon dioxide generated in-game.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -3109,6 +3109,18 @@
         "duration": "5m"
     },
     {
+        "id": "cover-compost-bucket",
+        "title": "Cover a 5 gallon compost bucket with a snap-on lid",
+        "image": "/assets/bucket.jpg",
+        "requireItems": [
+            { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
+            { "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097", "count": 1 }
+        ],
+        "consumeItems": [],
+        "createItems": [],
+        "duration": "30s"
+    },
+    {
         "id": "measure-arduino-5v",
         "title": "Measure the 5 V pin on an Arduino Uno using a digital multimeter",
         "image": "/assets/launch_controller.jpg",

--- a/frontend/src/pages/quests/json/composting/check-temperature.json
+++ b/frontend/src/pages/quests/json/composting/check-temperature.json
@@ -36,5 +36,5 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["composting/start"]
+    "requiresQuests": ["composting/cover-bucket"]
 }

--- a/frontend/src/pages/quests/json/composting/cover-bucket.json
+++ b/frontend/src/pages/quests/json/composting/cover-bucket.json
@@ -1,0 +1,58 @@
+{
+    "id": "composting/cover-bucket",
+    "title": "Cover Your Compost Bucket",
+    "description": "Snap on a lid to lock in moisture and keep pests away.",
+    "image": "/assets/bucket.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Flies love open compost. Let's seal the bucket.",
+            "options": [
+                {
+                    "type": "grantsItems",
+                    "grantsItems": [{ "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097", "count": 1 }],
+                    "text": "Hand me a lid."
+                },
+                {
+                    "type": "goto",
+                    "goto": "seal",
+                    "requiresItems": [{ "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097", "count": 1 }],
+                    "text": "Lid ready."
+                }
+            ]
+        },
+        {
+            "id": "seal",
+            "text": "Press the lid down until it snaps in place.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "cover-compost-bucket",
+                    "requiresItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
+                        { "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097", "count": 1 }
+                    ],
+                    "text": "Snap it on."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "requiresItems": [
+                        { "id": "0564d441-7367-412e-b709-dad770814a39", "count": 1 },
+                        { "id": "dbacd41f-f080-45fd-afdd-234fb6e7d097", "count": 1 }
+                    ],
+                    "text": "All sealed."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Your bucket is secure; check it every few days.",
+            "options": [{ "type": "finish", "text": "Done." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["composting/start"]
+}

--- a/frontend/src/pages/quests/json/composting/turn-pile.json
+++ b/frontend/src/pages/quests/json/composting/turn-pile.json
@@ -119,5 +119,5 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["composting/start"]
+    "requiresQuests": ["composting/cover-bucket"]
 }


### PR DESCRIPTION
## Summary
- add 5 gallon bucket lid item and cover-compost-bucket process
- introduce cover compost bucket quest and update compost chain

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `npm run new-quests:update`
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68abaafea75c832fa3cde020d7cd27f0