### PR TITLE
🚀 : – add rocket body tube masking quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -251,6 +251,7 @@ New quests in this release: 218
 ### rocketry
 
 -   rocketry/fuel-mixture
+-   rocketry/mask-rocket-body-tube
 -   rocketry/night-launch
 -   rocketry/preflight-check
 -   rocketry/recovery-run

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -251,6 +251,7 @@ New quests in this release: 218
 ### rocketry
 
 -   rocketry/fuel-mixture
+-   rocketry/mask-rocket-body-tube
 -   rocketry/night-launch
 -   rocketry/preflight-check
 -   rocketry/recovery-run

--- a/frontend/src/pages/quests/json/rocketry/mask-rocket-body-tube.json
+++ b/frontend/src/pages/quests/json/rocketry/mask-rocket-body-tube.json
@@ -1,0 +1,41 @@
+{
+    "id": "rocketry/mask-rocket-body-tube",
+    "title": "Mask Rocket Body Tube",
+    "description": "Apply masking tape to protect areas of the rocket body before painting.",
+    "image": "/assets/3dprinted_rocket_body_tube.jpg",
+    "npc": "/assets/npc/nova.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "The body tube is ready for paint, but first we need to mask off the sections you want to keep clean.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "mask",
+                    "text": "Grab the masking tape."
+                }
+            ]
+        },
+        {
+            "id": "mask",
+            "text": "Wrap tape around fins and other areas to shield them from overspray.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "process": "mask-rocket-body-tube",
+                    "requiresItems": [{ "id": "13aaff4f-e4ba-4e4a-b21b-5852b118a0ed", "count": 1 }],
+                    "text": "All surfaces covered."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice work. The rocket is masked and ready for a crisp coat of paint.",
+            "options": [{ "type": "finish", "text": "Ready to paint." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["rocketry/recovery-run"]
+}

--- a/frontend/src/pages/quests/json/rocketry/night-launch.json
+++ b/frontend/src/pages/quests/json/rocketry/night-launch.json
@@ -89,5 +89,5 @@
             "count": 1
         }
     ],
-    "requiresQuests": ["rocketry/recovery-run"]
+    "requiresQuests": ["rocketry/mask-rocket-body-tube"]
 }


### PR DESCRIPTION
## Summary
- add masking quest for rocket body tube
- require masking step before night launch
- regenerate new-quests docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci -- questCanonical questQuality`
- `npm run new-quests:update`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abaafea75c832fa3cde020d7cd27f0