### PR TITLE
♿️ Improve copy button accessibility

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   ENOENT errors related to missing Playwright artifact files
 -   Structured documentation for image validation requirements
 -   Improved test reliability with proper directory structure
+-   Copy code button now has visible focus and an ARIA label for screen readers
 
 ### Documentation
 

--- a/frontend/__tests__/Message.test.js
+++ b/frontend/__tests__/Message.test.js
@@ -17,4 +17,14 @@ describe('Message component', () => {
         expect(img).not.toHaveAttribute('onerror');
         expect(window).not.toHaveProperty('hacked');
     });
+
+    it('renders copy button with accessible label', () => {
+        const { container } = render(Message, {
+            messageMarkdown: '```js\nconsole.log("hi")\n```',
+            className: 'assistant',
+            timestamp: Date.now(),
+        });
+        const button = container.querySelector('.copy-button');
+        expect(button).toHaveAttribute('aria-label', 'Copy code to clipboard');
+    });
 });

--- a/frontend/src/pages/chat/svelte/Message.svelte
+++ b/frontend/src/pages/chat/svelte/Message.svelte
@@ -33,7 +33,7 @@
 
         return `<div>${languageLabel}<pre title="${language}"><code class="hljs ${language}">${
             hljs.highlightAuto(code).value
-        }</code><button class="copy-button">Copy</button></pre></div>`;
+        }</code><button class="copy-button" type="button" aria-label="Copy code to clipboard">Copy</button></pre></div>`;
     };
 
     $: {
@@ -148,6 +148,11 @@
         background-color: #68d46d;
         color: black;
         cursor: pointer;
+    }
+
+    .copy-button:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: 2px;
     }
 
     .toast {


### PR DESCRIPTION
## Summary
- add ARIA label and focus style to code block copy button
- test copy button accessibility and update changelog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68abab524878832f98f8f4481b646d82