### PR TITLE
Improve keyboard focus for selectors

### DIFF
--- a/frontend/src/components/svelte/AvatarPicker.svelte
+++ b/frontend/src/components/svelte/AvatarPicker.svelte
@@ -36,22 +36,16 @@
     </div>
     <div class="horizontal">
         {#each defaultPFPs as pfp, i}
-            <div
+            <button
+                type="button"
                 class="item-wrapper"
                 class:highlighted={selectedIndex === i}
                 id={`img-${i}`}
                 on:click={() => setHighlighted(i)}
-                on:keydown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        setHighlighted(i);
-                    }
-                }}
-                tabindex="0"
-                role="button"
                 aria-label={`Select avatar ${i + 1}`}
             >
                 <img class="item" src={pfp} alt={`Avatar option ${i + 1}`} />
-            </div>
+            </button>
         {/each}
     </div>
 </div>
@@ -79,6 +73,14 @@
         opacity: 0.8;
         border: 2px solid transparent;
         cursor: pointer;
+        background: none;
+        padding: 0;
+        appearance: none;
+    }
+
+    .item-wrapper:focus-visible {
+        outline: 2px solid #68d46d;
+        outline-offset: 2px;
     }
 
     .item {
@@ -107,7 +109,7 @@
         border: 2px solid #68d46d;
     }
 
-    button {
+    .selectbutton {
         width: 40%;
         margin: 10px;
         border-radius: 20px;
@@ -118,12 +120,12 @@
         color: black;
     }
 
-    button:hover {
+    .selectbutton:hover {
         cursor: pointer;
         opacity: 1;
     }
 
-    button:disabled {
+    .selectbutton:disabled {
         cursor: not-allowed;
         opacity: 0.5;
     }

--- a/frontend/src/components/svelte/ItemSelector.svelte
+++ b/frontend/src/components/svelte/ItemSelector.svelte
@@ -47,18 +47,13 @@
                 <SearchBar data={items} on:search={handleSearch} />
                 <div class="items-list">
                     {#each $filteredItems as item (item.id)}
-                        <div
+                        <button
+                            type="button"
                             class="item-row"
                             class:selected={selectedItemId === item.id}
                             on:click={() => handleItemSelect(item.id)}
                             on:touchstart={() => handleItemSelect(item.id)}
-                            on:keydown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                    handleItemSelect(item.id);
-                                }
-                            }}
-                            tabindex="0"
-                            role="button"
+                            aria-label={`Select ${item.name}`}
                         >
                             <div class="item-content">
                                 {#if item.image}
@@ -73,7 +68,7 @@
                                     {/if}
                                 </div>
                             </div>
-                        </div>
+                        </button>
                     {/each}
                 </div>
             </div>
@@ -150,12 +145,21 @@
     }
 
     .item-row {
+        display: block;
+        width: 100%;
         padding: 8px;
         cursor: pointer;
         border-radius: 4px;
         margin-bottom: 4px;
         background: #2f5b2f;
         transition: all 0.2s ease;
+        border: none;
+        text-align: left;
+    }
+
+    .item-row:focus-visible {
+        outline: 2px solid #68d46d;
+        outline-offset: 2px;
     }
 
     .item-row:hover {


### PR DESCRIPTION
## Summary
- make avatar options real buttons with focus outlines
- convert item selector rows to buttons and add focus styles

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abab524878832f98f8f4481b646d82