### PR TITLE
♿️: Improve copy button accessibility

### DIFF
--- a/frontend/src/pages/chat/svelte/Message.svelte
+++ b/frontend/src/pages/chat/svelte/Message.svelte
@@ -31,9 +31,12 @@
         const code = token.content.trim();
         const languageLabel = language ? `<span class="language-label">${language}</span>` : '';
 
-        return `<div>${languageLabel}<pre title="${language}"><code class="hljs ${language}">${
-            hljs.highlightAuto(code).value
-        }</code><button class="copy-button">Copy</button></pre></div>`;
+        return (
+            `<div>${languageLabel}<pre title="${language}"><code class="hljs ${language}">` +
+            `${hljs.highlightAuto(code).value}</code>` +
+            `<button class="copy-button" type="button" aria-label="Copy code to clipboard">Copy</button>` +
+            `</pre></div>`
+        );
     };
 
     $: {
@@ -148,6 +151,14 @@
         background-color: #68d46d;
         color: black;
         cursor: pointer;
+    }
+
+    .copy-button:focus-visible {
+        opacity: 1;
+        background-color: #68d46d;
+        color: black;
+        outline: 2px solid black;
+        outline-offset: 2px;
     }
 
     .toast {

--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -21,6 +21,7 @@ HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
+> 7. Provide `aria-label` and `:focus-visible` styles for icon-only controls like copy buttons.
 
 ```text
 SYSTEM:


### PR DESCRIPTION
## Summary
- add descriptive aria-label for code copy button
- highlight keyboard focus with :focus-visible styling
- document aria-label and focus guidance for icon-only controls

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(failed: script continued pre-PR checks? but tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68abab524878832f98f8f4481b646d82