### PR TITLE
💾 Document backup schema stability and add tests

### DIFF
--- a/frontend/__tests__/customBackup.test.js
+++ b/frontend/__tests__/customBackup.test.js
@@ -49,4 +49,10 @@ describe('custom content backup', () => {
         expect(typeof str).toBe('string');
         expect(() => atob(str)).not.toThrow();
     });
+
+    test('exportCustomContentString uses stable schema', async () => {
+        const encoded = await exportCustomContentString();
+        const decoded = JSON.parse(atob(encoded));
+        expect(Object.keys(decoded).sort()).toEqual(['items', 'processes', 'quests']);
+    });
 });

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -40,6 +40,12 @@ describe('gameState - common utilities', () => {
         expect(() => Buffer.from(exported, 'base64').toString('utf8')).not.toThrow();
     });
 
+    test('exportGameStateString uses stable schema', () => {
+        const exported = exportGameStateString();
+        const decoded = JSON.parse(Buffer.from(exported, 'base64').toString('utf8'));
+        expect(Object.keys(decoded).sort()).toEqual(['inventory', 'processes', 'quests']);
+    });
+
     test('importGameStateString should replace current state', () => {
         const newState = { quests: { foo: true }, inventory: { 2: 3 }, processes: {} };
         const encoded = Buffer.from(JSON.stringify(newState)).toString('base64');

--- a/frontend/src/pages/docs/md/backups.md
+++ b/frontend/src/pages/docs/md/backups.md
@@ -12,8 +12,9 @@ entire progress. Click **Copy** to place the backup string on your clipboard
 (works without the Clipboard API) or paste a previously saved string and click
 **Import** to restore it on another device.
 
-Game save exports are Base64‑encoded JSON. The format is stable across
-releases so older backups remain compatible.
+Game save exports are Base64‑encoded JSON containing `quests`, `inventory` and
+`processes` keys. The schema and key names are stable across releases so older
+backups remain compatible.
 
 ## Custom content
 
@@ -21,8 +22,8 @@ If you only need to back up user‑created items, quests or processes, open the
 [Custom Content Backup](/contentbackup) page. It provides the same copy and
 import controls but limited to custom creations.
 
-Custom content exports use the same Base64‑encoded JSON format and are likewise
-version‑stable.
+Custom content exports use the same Base64‑encoded JSON format with stable
+`items`, `processes` and `quests` keys, ensuring cross‑version compatibility.
 
 These backups are stored locally until you manually save them elsewhere. For
 automatic cloud backups see [Cloud Sync](/docs/cloud-sync).

--- a/frontend/src/utils/customcontent.js
+++ b/frontend/src/utils/customcontent.js
@@ -229,6 +229,10 @@ export function deleteProcess(id) {
     return db.processes.delete(id);
 }
 
+/**
+ * Export custom content as a Base64-encoded JSON string.
+ * The schema {items, processes, quests} is public and must remain stable.
+ */
 export async function exportCustomContentString() {
     const [items, processes, quests] = await Promise.all([getItems(), getProcesses(), getQuests()]);
     return btoa(

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -49,6 +49,10 @@ let gameState = loadGameState();
 // Create the state store and set the initial value
 export const state = writable(gameState);
 
+/**
+ * Export the game state as a Base64-encoded JSON string.
+ * The schema {quests, inventory, processes} is public and must remain stable.
+ */
 export const exportGameStateString = () => {
     return btoa(JSON.stringify(gameState));
 };


### PR DESCRIPTION
## Summary
- detail backup schema in docs
- assert stable game state and custom content backup formats
- note export functions' public schema

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababa424cc832fa93c8c734fbdf7a3