### PR TITLE
docs: refine monitoring and outage prompts

### DIFF
--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -7,9 +7,8 @@ slug: 'prompts-monitoring'
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
 ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex)
-when editing files in the
-[`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
-stack so metrics, dashboards, and alerts stay consistent.
+when editing files under [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
+to keep metrics, dashboards, and alerts consistent.
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
 these templates drift, refresh them with the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
@@ -18,7 +17,7 @@ these templates drift, refresh them with the
 > **TL;DR**
 >
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
-> 2. Prefer lightweight, self-hosted tools; avoid collecting personal data.
+> 2. Prefer lightweight, self-hosted tools and avoid collecting personal data.
 > 3. Add sample dashboards or alert rules when relevant.
 > 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -6,7 +6,7 @@ slug: 'prompts-outages'
 # Outage prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository and run its own tests.
-Use this guide alongside [Codex Prompts](/docs/prompts-codex) so every fix ships with a matching
+Use this guide alongside [Codex Prompts](/docs/prompts-codex) to ensure every fix ships with a matching
 record in the outage catalog. For an overview of the catalog itself, see
 [Outages](/docs/outages).
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta);
@@ -15,10 +15,10 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 
 > **TL;DR**
 >
-> 1. Investigate the failure and implement a fix.
+> 1. Investigate the failure, identify the root cause, and implement a fix.
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Use an emoji-prefixed commit message.
 
@@ -38,7 +38,7 @@ CONTEXT:
 REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- clarify monitoring prompt wording and privacy guidance
- require root cause and audit checks in outage prompt

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababc27ba0832fb1c3c471fb48db5e