### PR TITLE
📝 Clarify documentation prompt guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -6,22 +6,21 @@ slug: 'prompts-docs'
 # Documentation prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit a
-ready-made PR — but only if given a clear, file-scoped prompt. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when updating Markdown or JSDoc so instructions stay
-current and consistent. To keep these templates evolving, see the
-[Codex meta prompt](/docs/prompts-codex-meta). If they drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+ready-made PR—but only with a clear, file-scoped prompt. Use this guide alongside the
+[Codex prompts overview](/docs/prompts-codex) to keep Markdown and JSDoc instructions current.
+Keep templates evolving with the [Codex meta prompt](/docs/prompts-codex-meta), and refresh them
+using the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs,
+use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 
 > **TL;DR**
 >
-> 1. Limit changes to the relevant docs.
+> 1. Limit changes to the relevant docs under `frontend/src/pages/docs/md`.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Link new prompt docs from [`prompts-codex.md`](/docs/prompts-codex) and
->    `frontend/src/pages/docs/index.astro`.
+> 3. Link new prompt docs from [`prompts-codex.md`](/docs/prompts-codex) and the docs index
+>    (`frontend/src/pages/docs/index.astro`).
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
->    and use an emoji-prefixed commit message.
+> 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+> 6. Commit with an emoji prefix.
 
 ```text
 SYSTEM:


### PR DESCRIPTION
## Summary
- clarify wording in prompts-docs and separate secret-scan step

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ababc27ba0832fb1c3c471fb48db5e