### PR TITLE
Fix quest listing when origin ref missing

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – `listQuestFiles` logged Git errors when `origin/v3` was missing; suppress stderr and
+    fall back to `HEAD` so tests run cleanly.

--- a/outages/2025-08-25-listquestfiles-git-error.json
+++ b/outages/2025-08-25-listquestfiles-git-error.json
@@ -1,0 +1,10 @@
+{
+  "id": "listquestfiles-git-error",
+  "date": "2025-08-25",
+  "component": "scripts/update-new-quests",
+  "rootCause": "listQuestFiles invoked git on origin/v3 without verifying the branch existed, emitting fatal errors on clones without that remote.",
+  "resolution": "listQuestFiles now suppresses git stderr and falls back to HEAD when the ref is missing.",
+  "references": [
+    "frontend/src/pages/docs/md/prompts-codex-ci-fix.md"
+  ]
+}

--- a/scripts/update-new-quests.js
+++ b/scripts/update-new-quests.js
@@ -28,12 +28,21 @@ function listQuestFiles(ref) {
     'quests',
     'json'
   );
-  const output = execSync(
-    ref
-      ? `git ls-tree -r --name-only ${ref} ${questDir}`
-      : `git ls-tree -r --name-only HEAD ${questDir}`,
-    { encoding: 'utf8' }
-  );
+  const cmd = ref
+    ? `git ls-tree -r --name-only ${ref} ${questDir}`
+    : `git ls-tree -r --name-only HEAD ${questDir}`;
+  let output;
+  try {
+    output = execSync(cmd, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch {
+    output = execSync(`git ls-tree -r --name-only HEAD ${questDir}`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  }
   return output.trim().split(/\n/).filter(Boolean);
 }
 

--- a/tests/newQuestsList.test.ts
+++ b/tests/newQuestsList.test.ts
@@ -61,12 +61,7 @@ describe('new quests list', () => {
   });
 
   it('lists total quest count accurately', () => {
-    let quests: string[];
-    try {
-      quests = listQuestFiles('origin/v3');
-    } catch {
-      quests = listQuestFiles();
-    }
+    const quests = listQuestFiles('origin/v3');
     const doc = fs.readFileSync(listPath, 'utf8');
     const match = doc.match(/Current quest count: (\d+)/);
     expect(match).not.toBeNull();


### PR DESCRIPTION
## Summary
- suppress git errors when origin/v3 is absent
- keep new quests list test up to date
- document and record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ababa4c49c832f8d86e037bf5ae045