### PR TITLE
fix: ignore backup directories in noConflictMarkers test

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – temporary backup tarballs were deleted after globbing, so
+    noConflictMarkers crashed; exclude backup dirs.

--- a/outages/2025-08-25-no-conflict-markers-temp-backups.json
+++ b/outages/2025-08-25-no-conflict-markers-temp-backups.json
@@ -1,0 +1,11 @@
+{
+  "id": "no-conflict-markers-temp-backups",
+  "date": "2025-08-25",
+  "component": "tests/noConflictMarkers",
+  "rootCause": "noConflictMarkers test scanned temporary backup tarballs removed during test run, producing ENOENT",
+  "resolution": "Exclude backup directories from the conflict marker scan",
+  "references": [
+    "tests/noConflictMarkers.test.ts",
+    "tests/backupScript.test.ts"
+  ]
+}

--- a/tests/noConflictMarkers.test.ts
+++ b/tests/noConflictMarkers.test.ts
@@ -18,6 +18,8 @@ describe('repository sanity ‑ no merge-conflict markers', () => {
     '**/coverage/**',
     '**/dist/**',
     '**/.turbo/**',
+    '**/backups/**',
+    '**/tmp-backups/**',
   ];
 
   const patterns = ['**/*'];


### PR DESCRIPTION
## Summary
- skip temporary backup dirs in noConflictMarkers test
- document and log the outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ababa4c49c832f8d86e037bf5ae045