### PR TITLE
fix: skip Playwright install when E2E tests disabled

### DIFF
--- a/frontend/scripts/prepare-pr.ps1
+++ b/frontend/scripts/prepare-pr.ps1
@@ -12,9 +12,11 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location -Path "$scriptDir\.."
 
 try {
-    # Ensure Playwright browsers are installed
-    Write-Host "Ensuring Playwright browsers are installed..."
-    npx playwright install --with-deps > $null 2>&1
+    # Ensure Playwright browsers are installed when running E2E tests
+    if (-not $env:SKIP_E2E) {
+        Write-Host "Ensuring Playwright browsers are installed..."
+        npx playwright install --with-deps > $null 2>&1
+    }
 
     # Step 1: Run linting and formatting
     Write-Host "Step 1/3: Checking code formatting and linting..."

--- a/frontend/scripts/prepare-pr.sh
+++ b/frontend/scripts/prepare-pr.sh
@@ -13,8 +13,10 @@ ORIGINAL_DIR=$(pwd)
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 cd "$SCRIPT_DIR/.." || exit 1
 
-# Ensure Playwright browsers are installed
-npx playwright install --with-deps >/dev/null 2>&1
+# Ensure Playwright browsers are installed when running E2E tests
+if [ -z "$SKIP_E2E" ]; then
+  npx playwright install --with-deps >/dev/null 2>&1
+fi
 
 # Step 1: Run linting and formatting
 echo "Step 1/3: Checking code formatting and linting..."

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -115,3 +115,5 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
     `playwright install --with-deps` runs before grouped tests.
 -   2025-08-14 – missing Jest `testMatch` in `frontend/package.json` let a coverage check fail; add a
     pattern so E2E tests detect all Jest files.
+-   2025-08-25 – `prepare-pr` always installed Playwright browsers even when `SKIP_E2E` was set,
+    hanging `npm run test:ci`; guard the install behind the variable so CI skips the download.

--- a/outages/2025-08-25-skip-playwright-install.json
+++ b/outages/2025-08-25-skip-playwright-install.json
@@ -1,0 +1,12 @@
+{
+  "id": "skip-playwright-install",
+  "date": "2025-08-25",
+  "component": "frontend/scripts/prepare-pr",
+  "rootCause": "prepare-pr scripts always installed Playwright browsers even when SKIP_E2E was set, causing npm run test:ci to hang in CI environments without browsers.",
+  "resolution": "Skip browser installation when SKIP_E2E is set.",
+  "references": [
+    "frontend/scripts/prepare-pr.sh",
+    "frontend/scripts/prepare-pr.ps1",
+    "scripts/tests/preparePrBrowserInstall.test.ts"
+  ]
+}

--- a/scripts/tests/preparePrBrowserInstall.test.ts
+++ b/scripts/tests/preparePrBrowserInstall.test.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'fs';
 import { expect, test } from 'vitest';
 
-test('prepare-pr scripts install Playwright browsers', () => {
+test('prepare-pr scripts install Playwright browsers only when E2E tests run', () => {
   const sh = readFileSync('frontend/scripts/prepare-pr.sh', 'utf8');
   const ps = readFileSync('frontend/scripts/prepare-pr.ps1', 'utf8');
-  expect(sh).toMatch(/playwright install --with-deps/);
-  expect(ps).toMatch(/playwright install --with-deps/);
+  expect(sh).toMatch(/if \[ -z "\$SKIP_E2E" \]; then\s+npx playwright install --with-deps/);
+  expect(ps).toMatch(/if \(-not \$env:SKIP_E2E\)/);
+  expect(ps).toMatch(/npx playwright install --with-deps/);
 });


### PR DESCRIPTION
## Summary
- skip Playwright browser install when `SKIP_E2E` is set
- test for conditional install
- document and log the incident

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: timeout installing or running tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ababa4c49c832f8d86e037bf5ae045