### PR TITLE
📝 Refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-audit.md
+++ b/frontend/src/pages/docs/md/prompts-audit.md
@@ -6,10 +6,11 @@ slug: 'prompts-audit'
 # Dependency audit prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
-ready-made pull requests. Use this guide when updating dependencies or addressing
-security vulnerabilities. To keep the prompt docs evolving, see the
-[Codex meta prompt](/docs/prompts-codex-meta); if these templates drift,
-refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
+ready-made pull requests. Use this guide alongside [Codex Prompts](prompts-codex.md) when
+updating dependencies or addressing security vulnerabilities. To keep the prompt docs
+evolving, see the [Codex meta prompt](prompts-codex-meta.md); if these templates drift,
+refresh them with the [Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub
+Actions runs, use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -14,7 +14,7 @@ For task-specific templates see [Quest prompts](prompts-quests.md),
 [Item prompts](prompts-items.md), [Process prompts](prompts-processes.md),
 [NPC prompts](prompts-npcs.md), [Outage prompts](prompts-outages.md),
 [Backup prompts](prompts-backups.md), [Monitoring prompts](prompts-monitoring.md),
-[Audit prompts](prompts-audit.md), [Docs prompts](prompts-docs.md),
+[Dependency audit prompts](prompts-audit.md), [Docs prompts](prompts-docs.md),
 [Playwright test prompts](prompts-playwright-tests.md),
 [Vitest test prompts](prompts-vitest.md), [Frontend prompts](prompts-frontend.md),
 [Backend prompts](prompts-backend.md), [Refactor prompts](prompts-refactors.md), and
@@ -29,7 +29,8 @@ the [Codex meta prompt](prompts-codex-meta.md), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
 >    commit with an emoji prefix.
 
@@ -47,7 +48,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Outage Prompts](prompts-outages.md)
 -   [Backup Prompts](prompts-backups.md)
 -   [Monitoring Prompts](prompts-monitoring.md)
--   [Audit Prompts](prompts-audit.md)
+-   [Dependency Audit Prompts](prompts-audit.md)
 -   [Docs Prompts](prompts-docs.md)
 -   [Docs cross-link prompt](prompts-docs.md#cross-link-check-prompt)
 -   [Docs proofreading prompt](prompts-docs.md#proofreading-prompt)

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -6,13 +6,13 @@ slug: 'prompts-frontend'
 # Frontend prompts for the _dspace_ repo
 
 DSPACE's UI is built with Svelte and Astro. Codex can open this repository and run its own
-tests. Use this guide when working on files inside `frontend/`, including Svelte components,
-pages, and styles. Changes should improve clarity, accessibility, or performance while keeping
-tests green. For deeper accessibility guidance, see
-[Accessibility prompts](/docs/prompts-accessibility). To keep the prompt docs evolving,
-see the [Codex meta prompt](/docs/prompts-codex-meta). If templates drift, refresh them
-with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions
-runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+tests. Use this guide alongside [Codex Prompts](prompts-codex.md) when working on files inside
+`frontend/`, including Svelte components, pages, and styles. Changes should improve clarity,
+accessibility, or performance while keeping tests green. For deeper accessibility guidance, see
+[Accessibility prompts](prompts-accessibility.md). To keep the prompt docs evolving, see the
+[Codex meta prompt](prompts-codex-meta.md). If templates drift, refresh them with the
+[Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- add cross-links in dependency audit and frontend prompt docs
- include `npm run audit:ci` in Codex TL;DR and label dependency audit prompts

## Testing
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: file not found)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababc60a8c832fa1179f5faf7f22c3