### PR TITLE
Add min price lookup for IRL item prices

### DIFF
--- a/backend/approximateIrlPrice.bench.ts
+++ b/backend/approximateIrlPrice.bench.ts
@@ -2,6 +2,7 @@ import { bench, describe } from 'vitest';
 import {
   approximateIrlPrice,
   approximateIrlTotalPrice,
+  approximateIrlMinPrice,
 } from './approximateIrlPrice';
 
 describe('approximateIrlPrice benchmark', () => {
@@ -15,5 +16,9 @@ describe('approximateIrlPrice benchmark', () => {
 
   bench('total price for cart', () => {
     approximateIrlTotalPrice(['3d_printer', 'arduino_nano']);
+  });
+
+  bench('min price for cart', () => {
+    approximateIrlMinPrice(['3d_printer', 'arduino_nano']);
   });
 });

--- a/backend/approximateIrlPrice.test.ts
+++ b/backend/approximateIrlPrice.test.ts
@@ -3,6 +3,7 @@ import {
   approximateIrlPrice,
   approximateIrlTotalPrice,
   approximateIrlAveragePrice,
+  approximateIrlMinPrice,
   __resetPriceTableCacheForTests,
 } from './approximateIrlPrice';
 import { writeFileSync, mkdtempSync } from 'fs';
@@ -99,6 +100,26 @@ describe('approximateIrlPrice', () => {
     it('returns null for non-array input', () => {
       expect(approximateIrlAveragePrice(null as any)).toBeNull();
       expect(approximateIrlAveragePrice(undefined as any)).toBeNull();
+    });
+  });
+
+  describe('approximateIrlMinPrice', () => {
+    it('returns the lowest price among known items', () => {
+      expect(
+        approximateIrlMinPrice(['3d_printer', 'arduino_nano', 'resistor_220_ohm'])
+      ).toBe(0.02);
+    });
+
+    it('ignores unknown items and returns null when none are known', () => {
+      expect(
+        approximateIrlMinPrice(['nonexistent', 'arduino_nano'])
+      ).toBe(22);
+      expect(approximateIrlMinPrice(['foo'])).toBeNull();
+    });
+
+    it('returns null for non-array input', () => {
+      expect(approximateIrlMinPrice(null as any)).toBeNull();
+      expect(approximateIrlMinPrice(undefined as any)).toBeNull();
     });
   });
 });

--- a/backend/approximateIrlPrice.ts
+++ b/backend/approximateIrlPrice.ts
@@ -139,3 +139,21 @@ export function approximateIrlAveragePrice(
   });
   return found ? total / count : null;
 }
+
+/**
+ * Find the cheapest known item price from a list of identifiers.
+ *
+ * Unknown or non-string identifiers are ignored. Returns `null` when no known
+ * items are provided.
+ */
+export function approximateIrlMinPrice(
+  ids: Array<string | null | undefined> | null | undefined
+): number | null {
+  let min = Infinity;
+  const found = forEachKnownPrice(ids, (price) => {
+    if (price < min) {
+      min = price;
+    }
+  });
+  return found ? min : null;
+}

--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover


### PR DESCRIPTION
## What
- add `approximateIrlMinPrice` to backend price utilities
- cover new helper with tests and benchmarks
- sync new quests list with v3 branch

## Why
- enable determining cheapest item cost without external services
- ensure quest docs stay current and tests pass

## How to Test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68abab867f50832f987ae61497e3c2ca