### PR TITLE
📝 : – document audit step in prompt guides

### DIFF
--- a/docs/prompts-outages.md
+++ b/docs/prompts-outages.md
@@ -19,7 +19,7 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 >    matching [`outages/schema.json`][outage-schema].
 > 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
-> 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+> 4. Scan staged changes for secrets with `git diff --cached | ripsecrets`.
 > 5. Use an emoji-prefixed commit message.
 
 ```text
@@ -40,7 +40,7 @@ REQUEST:
 2. Commit the outage entry and related docs.
 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+4. Run `git diff --cached | ripsecrets` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -19,7 +19,7 @@ HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
 > 2. Follow WCAG 2.1 AA: provide focus states, semantic elements, and ARIA labels.
 > 3. Validate with tooling like `npm run lint` and screen‑reader checks when possible.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets`.
 > 6. Commit with an emoji prefix.
 
 ```text
@@ -32,7 +32,7 @@ USER:
 1. Update files that affect user accessibility.
 2. Follow WCAG 2.1 AA with semantic HTML, visible focus states, and ARIA labels.
 3. Validate with linting and, when possible, screen-reader or keyboard checks.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-audit.md
+++ b/frontend/src/pages/docs/md/prompts-audit.md
@@ -17,7 +17,7 @@ refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
 > 2. Prefer minimal, well-maintained packages.
 > 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.
-> 4. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 4. Scan staged changes with `git diff --cached | ripsecrets`.
 > 5. Commit with an emoji prefix.
 
 ```text
@@ -30,7 +30,7 @@ USER:
 1. Resolve dependency vulnerabilities or update packages.
 2. Confirm no high-severity issues remain with `npm run audit:ci`.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Scan for secrets with `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -23,7 +23,7 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 >    obtain explicit user consent before storing or transmitting information.
 > 3. Add or update tests in `backend/__tests__` when behavior changes.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets`.
 > 6. Commit with an emoji prefix.
 
 ```text
@@ -37,7 +37,7 @@ USER:
 2. Prefer small, self-hosted services compatible with the Sugarkube cluster.
 3. Preserve end-user privacy and agency; avoid logging or transmitting personal data.
 4. Keep code idiomatic and covered by tests.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Run `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-backups.md
+++ b/frontend/src/pages/docs/md/prompts-backups.md
@@ -18,7 +18,7 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Preserve existing backup formats and import/export paths.
 > 3. Update tests when behavior changes.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets`.
 > 6. Commit with an emoji prefix.
 
 ```text
@@ -31,7 +31,7 @@ USER:
 1. Modify backup-related code or docs (`frontend/src/pages/docs/md/backups.md` or backup modules).
 2. Keep game save and custom content export formats stable.
 3. Add or update tests covering backup flows.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -55,7 +55,7 @@ CONTEXT:
 REQUEST:
 1. Explain in the pull-request body why the failure occurred (or would occur).
 2. Commit the minimal changes needed to fix it. Before committing, run
-   `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets. Use an
+   `git diff --cached | ripsecrets` and ensure no secrets. Use an
    emoji-prefixed commit message.
 3. Create `outages/YYYY-MM-DD-<slug>.json` describing the incident.
 4. Push to a branch named `codex/ci-fix/<short-description>`.

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -22,7 +22,7 @@ USER:
 2. Refine wording, fix links, or add new prompts when gaps appear.
 3. If you introduce a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Run `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -22,7 +22,7 @@ USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
 2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
 3. Link new prompt files from `prompts-codex.md` and the docs index.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `git diff --cached | ripsecrets` before committing.
 5. Run the checks above.
 6. Use an emoji-prefixed commit message.
 

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -29,8 +29,9 @@ the [Codex meta prompt](prompts-codex-meta.md), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets` and
 >    commit with an emoji prefix.
 
 For failing GitHub Actions runs, use the dedicated
@@ -105,7 +106,7 @@ REQUIREMENTS
 2. …
 3. …
 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Scan staged changes for secrets with `git diff --cached | ripsecrets`.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT
@@ -141,7 +142,7 @@ missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci
 
 USER:
 1. Follow the steps above.
-2. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+2. Run `git diff --cached | ripsecrets` before committing.
 3. After verifying the implementation, mark the corresponding changelog line
    with `💯`, replacing any `✅` or other emoji.
 4. Replace any remaining `✅` entries in the changelog with `💯` once they meet
@@ -172,7 +173,7 @@ USER:
 2. Fix outdated instructions, links or formatting.
 3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
 4. Run the checks above.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Run `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -197,7 +198,7 @@ USER:
 2. Update prompt templates, including this file, to reflect current practices.
 3. Link new prompt files from `prompts-codex.md` and the docs index.
 4. Propagate related changes across docs.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Run `git diff --cached | ripsecrets` before committing.
 6. Run the checks above.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -19,24 +19,25 @@ current and consistent. To keep these templates evolving, see the
 > 2. Fix outdated wording, links, or formatting.
 > 3. Link new prompt docs from [`prompts-codex.md`](/docs/prompts-codex) and
 >    `frontend/src/pages/docs/index.astro`.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+>    `npm run build`, and `npm run test:ci`.
+> 5. Scan for secrets with `git diff --cached | ripsecrets`
 >    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
-`npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
-   `npm run test:ci`.
-5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
+5. Scan for secrets with `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -50,14 +51,16 @@ Use this to polish grammar and style without changing technical meaning.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Proofread the selected docs for typos, grammar, and clarity.
 2. Preserve the original intent and technical accuracy.
-3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-4. Use an emoji-prefixed commit message.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
+4. Run `git diff --cached | ripsecrets` before committing.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with polished documentation and passing checks.
@@ -70,14 +73,16 @@ Use this when adding or renaming docs to keep internal links current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Audit the documentation for missing or broken cross-links.
 2. Update `frontend/src/pages/docs/index.astro` and related guides to reference the new pages.
-3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-4. Use an emoji-prefixed commit message.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+   `npm run build`, and `npm run test:ci`.
+4. Run `git diff --cached | ripsecrets` before committing.
+5. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with updated links and passing checks.

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -20,7 +20,7 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Keep components accessible, responsive, and idiomatic.
 > 3. Update or add tests in `frontend/__tests__` when behavior changes.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets`.
 > 6. Commit with an emoji prefix.
 
 ```text
@@ -33,7 +33,7 @@ USER:
 1. Update UI code under `frontend/`.
 2. Maintain accessibility and responsive design.
 3. Add or adjust tests in `frontend/__tests__` when needed.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -23,7 +23,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`,
 >    `npm run itemValidation`, `npm run test:ci`, and
 >    `npm run test:ci -- itemQuality`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`;
+> 5. Scan staged changes with `git diff --cached | ripsecrets`;
 >    commit with an emoji prefix.
 
 ---
@@ -47,7 +47,7 @@ For general content rules see the [Item Development Guidelines](/docs/item-guide
         npm run itemValidation && \
         npm run test:ci && \
         npm run test:ci -- itemQuality && \
-        git diff --cached | ./scripts/scan-secrets.py"
+        git diff --cached | ripsecrets"
         ```
 
 See the [OpenAI CLI docs][openai-cli] for more flags.
@@ -86,7 +86,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run itemValidation` and `npm run test:ci -- itemQuality`, fixing any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | ripsecrets` and ensure no secrets.
 8. Use an emoji-prefixed commit message like `📝 : – add price field`.
 9. Update docs or processes if needed.
 
@@ -106,7 +106,7 @@ appropriate category file. Ensure realistic details, required fields, and
 passing checks (`npm run lint`, `npm run type-check`,
 `npm run build`, `npm run test:ci`, `npm run itemValidation`, and
 `npm run test:ci -- itemQuality`). Verify the item appears in at least one quest or process,
-reuse existing image assets, and scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+reuse existing image assets, and scan for secrets with `git diff --cached | ripsecrets`
 before committing. If a quest's text changes, run `npm run test:ci -- questQuality` and update the quest's
 `hardening` block with a fresh evaluation score.
 
@@ -156,7 +156,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`,
    `npm run test:ci`, `npm run itemValidation`, and `npm run test:ci -- itemQuality`. Update docs if needed.
-6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run `git diff --cached | ripsecrets` before committing.
 7. Use an emoji-prefixed commit message like `📝 : – refine item details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -22,7 +22,7 @@ these templates drift, refresh them with the
 > 3. Add sample dashboards or alert rules when relevant.
 > 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 5. Scan staged changes with `git diff --cached | ripsecrets`.
 > 6. Commit with an emoji prefix.
 
 ```text
@@ -37,7 +37,7 @@ USER:
 3. Include or update sample dashboards and alerting rules when adding metrics.
 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
    `npm run build`, and `npm run test:ci`.
-5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Scan for secrets with `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -20,7 +20,7 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Specify the expected output (tests, docs).
 > 3. Stop when the spec is complete; remaining text becomes mandatory.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`;
->    scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`;
+>    scan staged changes with `git diff --cached | ripsecrets`;
 >    commit with an emoji prefix.
 
 ---
@@ -76,7 +76,7 @@ REQUIREMENTS
 1. Preserve established character voice and lore.
 2. Keep sample dialogue short and approachable.
    3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+4. Run `git diff --cached | ripsecrets` and ensure no secrets.
 5. Update related docs if needed.
 
 OUTPUT
@@ -93,7 +93,7 @@ SYSTEM:
   `frontend/src/pages/docs/md/npcs.md`, adding or refining NPC sections.
   Maintain each character’s voice, keep sample dialogue realistic, and ensure
   `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-  pass. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  pass. Scan for secrets with `git diff --cached | ripsecrets`
   before committing.
 
 USER:
@@ -119,7 +119,7 @@ USER:
 3. Reuse existing image assets; do not add new images.
 4. Cross-reference related quests or processes and update them if needed.
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+6. Scan staged changes for secrets with `git diff --cached | ripsecrets`.
 7. Use an emoji-prefixed commit message like `📝 : – refine NPC bio`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -19,7 +19,7 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+> 4. Scan staged changes for secrets with `git diff --cached | ripsecrets`.
 > 5. Use an emoji-prefixed commit message.
 
 ```text
@@ -39,7 +39,7 @@ REQUEST:
 1. Apply the fix with appropriate tests.
 2. Commit the outage entry and related docs.
 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+4. Run `git diff --cached | ripsecrets` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -35,7 +35,7 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 7. Run `npx playwright install chromium` if browsers are missing.
 > 8. Run `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
-> 9. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+> 9. Scan staged changes with `git diff --cached | ripsecrets`
 >    and commit with an emoji.
 
 ```text
@@ -53,7 +53,7 @@ USER:
 3. Update the coverage table in `frontend/src/pages/docs/md/user-journeys.md`
    with the new test path and any corrected steps, keeping it alphabetized.
 4. Improve this prompt if clearer guidance emerges.
-5. Run `git diff --cached | ./scripts/scan-secrets.py`.
+5. Run `git diff --cached | ripsecrets`.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -22,7 +22,7 @@ For fundamental design tips see the
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`;
->    scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`;
+>    scan staged changes with `git diff --cached | ripsecrets`;
 >    commit with an emoji prefix.
 
 ---
@@ -42,7 +42,7 @@ For fundamental design tips see the
         codex exec "npm run lint && npm run type-check && npm run build && \
         npm run test:ci && \
         npm run test:ci -- processQuality && \
-        git diff --cached | ./scripts/scan-secrets.py"
+        git diff --cached | ripsecrets"
         ```
 
 See the [OpenAI CLI repository][openai-cli] for more flags.
@@ -82,7 +82,7 @@ REQUIREMENTS
 4. Use only existing image assets; do not add new image files.
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality` and fix any failures.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+7. Run `git diff --cached | ripsecrets` and ensure no secrets.
 8. Update docs or items if needed.
 
 OUTPUT
@@ -103,7 +103,7 @@ steps, durations, item references, and passing checks (`npm run lint`,
 `npm run test:ci -- processQuality`).
 Verify the process links to existing quests or items, add missing registry
 entries if needed, reuse existing image assets, and scan for secrets with
-`git diff --cached | ./scripts/scan-secrets.py` before committing.
+`git diff --cached | ripsecrets` before committing.
 
 USER:
 1. Follow the steps above.
@@ -149,7 +149,7 @@ USER:
    }
 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 6. Run `npm run test:ci -- processQuality`. Update docs or items if needed.
-7. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Run `git diff --cached | ripsecrets` before committing.
 8. Use an emoji-prefixed commit message like `📝 : – refine process details`.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -24,7 +24,7 @@ which covers quests, items and processes in detail.
 > 3. Stop when the spec is complete. Codex treats all remaining text as
 >    mandatory instructions.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`;
->    scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`;
+>    scan staged changes with `git diff --cached | ripsecrets`;
 >    commit with an emoji prefix.
 
 ---
@@ -83,7 +83,7 @@ REQUIREMENTS
 5. Run `npm run lint`, `npm run type-check`, and `npm run build`.
 6. Run `npm run test:ci -- questCanonical questQuality` and fix any failures.
 7. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
-8. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+8. Run `git diff --cached | ripsecrets` and ensure no secrets.
 9. Update docs or dialogue as needed.
 
 OUTPUT
@@ -103,7 +103,7 @@ completion nodes, at least one item or process reference, and passing checks
 `npm run test:ci -- questCanonical questQuality`). Survey existing quests to
 pick a natural predecessor and update `requiresQuests` accordingly. Add missing
 items or processes to their registries, reuse existing image assets, and scan
-for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+for secrets with `git diff --cached | ripsecrets` before
 committing.
 
 USER:
@@ -134,7 +134,7 @@ USER:
    3. Run `npm run lint`, `npm run type-check`, `npm run build`, and
       `npm run test:ci -- questCanonical questQuality`. Fix any failures.
 4. Run `npm run new-quests:update` and commit `/docs/new-quests.md`.
-5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+5. Scan for secrets with `git diff --cached | ripsecrets` before committing.
 6. Use an emoji-prefixed commit message.
 
 OUTPUT:
@@ -182,7 +182,7 @@ USER:
    }
    6. Run `npm run lint`, `npm run type-check`, `npm run build`, and
       `npm run test:ci -- questCanonical questQuality`. Update docs if needed.
-   7. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
+   7. Run `git diff --cached | ripsecrets` and ensure no secrets.
    8. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -20,7 +20,7 @@ runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 3. Keep commits small and reversible.
 > 4. Include before-and-after benchmarks if performance could change.
 > 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 6. Run `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
+> 6. Run `git diff --cached | ripsecrets` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
@@ -31,7 +31,7 @@ USER:
 1. Refactor code in the specified files without changing behavior.
 2. Avoid mixing refactors with feature additions or bug fixes.
 3. Add benchmarks if performance could regress.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. Run `git diff --cached | ripsecrets` before committing.
 5. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prompts-vitest.md
+++ b/frontend/src/pages/docs/md/prompts-vitest.md
@@ -19,7 +19,7 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 2. Add or update a Vitest spec under `frontend/__tests__/` or `tests/`.
 > 3. Keep tests deterministic and focused on behavior.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
+> 5. Scan staged changes with `git diff --cached | ripsecrets` and commit with an emoji prefix.
 
 ```text
 SYSTEM:
@@ -29,7 +29,7 @@ Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:
 USER:
 1. Identify an untested or under-tested module.
 2. Write or refine a Vitest unit test in `frontend/__tests__/` or `tests/`.
-3. Run the commands above and `git diff --cached | ./scripts/scan-secrets.py` before committing.
+3. Run the commands above and `git diff --cached | ripsecrets` before committing.
 4. Use an emoji-prefixed commit message.
 
 OUTPUT:

--- a/frontend/src/pages/docs/md/prs.md
+++ b/frontend/src/pages/docs/md/prs.md
@@ -8,5 +8,5 @@ Pull requests are welcome! See our [Contribution Guide](/CONTRIBUTING.md) for de
 Before opening a pull request:
 
 -   run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
--   scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+-   scan staged changes with `git diff --cached | ripsecrets`
 -   use an emoji-prefixed commit message


### PR DESCRIPTION
## Summary
- document `npm run audit:ci` in Codex and docs prompt templates
- clarify doc prompts to run full checks and secret scan with `ripsecrets`

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`
- `git diff --cached | ripsecrets` *(flags GitHub token test string)*

------
https://chatgpt.com/codex/tasks/task_e_68abac66a770832fa745a084de4f9111