### PR TITLE
📝: add Codex merge conflict prompt

### DIFF
--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -118,6 +118,7 @@ import Page from '../../components/Page.astro';
             <a href="/docs/prompts-codex-meta">Codex meta prompt</a>
             <a href="/docs/prompts-codex-upgrader">Codex Prompt Upgrader</a>
             <a href="/docs/prompts-codex-ci-fix">Codex CI-failure fix prompt</a>
+            <a href="/docs/prompts-codex-merge-conflicts">Codex merge conflict prompt</a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
+++ b/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
@@ -1,0 +1,49 @@
+---
+title: 'Codex Merge Conflict Prompt'
+slug: 'prompts-codex-merge-conflicts'
+---
+
+# Codex merge conflict prompt
+
+Use this template when a pull request has merge conflicts and you want Codex to
+resolve them. The snippet is designed for 2-click use: copy the conflict block
+from GitHub, paste it into ChatGPT, and then paste the returned, conflict-free
+block back into the UI. For large files GitHub may show only a subset of lines;
+always return exactly what you received with the conflicts resolved and no
+extra formatting.
+
+> **TL;DR**
+>
+> 1. Copy the conflict block from the GitHub merge UI.
+> 2. Paste it into a ChatGPT message.
+> 3. The agent replies with the same text but conflicts resolved—ready to paste back.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit
+>    with an emoji prefix.
+
+```text
+Please resolve the merge conflicts in the code block below by returning a code
+block with the exact same content (no formatting or lint fixes) but with the
+conflicts resolved. In future messages, I'll provide additional conflict blocks;
+follow the same approach for each.
+```
+
+## Upgrade Prompt
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
+and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Refine `frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md` for
+   clarity and 2-click accuracy.
+2. Update related docs and links if needed.
+3. Run the checks above.
+4. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Use an emoji-prefixed commit message.
+
+OUTPUT:
+A pull request improving the merge conflict prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -61,6 +61,7 @@ For failing GitHub Actions runs, use the dedicated
 -   [Vitest Test Prompts](prompts-vitest.md)
 -   [Refactor Prompts](prompts-refactors.md)
 -   [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md)
+-   [Codex Merge Conflict Prompt](prompts-codex-merge-conflicts.md)
 -   [Codex Meta Prompt](prompts-codex-meta.md)
 -   [Codex Prompt Upgrader](prompts-codex-upgrader.md)
 

--- a/tests/noConflictMarkers.test.ts
+++ b/tests/noConflictMarkers.test.ts
@@ -21,20 +21,29 @@ describe('repository sanity ‑ no merge-conflict markers', () => {
   ];
 
   const patterns = ['**/*'];
-  const files = patterns.flatMap((pattern) =>
-    globSync(pattern, {
-      cwd: REPO_ROOT,
-      nodir: true,
-      ignore,
-    }),
-  );
 
   it('contains no <<<<<<< or >>>>>>> markers', () => {
+    const files = patterns.flatMap((pattern) =>
+      globSync(pattern, {
+        cwd: REPO_ROOT,
+        nodir: true,
+        ignore,
+      }),
+    );
+
     const offenders: string[] = [];
 
     files.forEach((relativePath) => {
       const fullPath = join(REPO_ROOT, relativePath);
-      const content = readFileSync(fullPath, 'utf8');
+      let content: string;
+      try {
+        content = readFileSync(fullPath, 'utf8');
+      } catch (err: any) {
+        if (err.code === 'ENOENT') {
+          return; // Skip files removed during the test run
+        }
+        throw err;
+      }
       if (/^<<<<<<< |^>>>>>>> |^======= $/m.test(content)) {
         offenders.push(relativePath);
       }


### PR DESCRIPTION
## Summary
- document 2-click Codex merge conflict prompt
- link doc from Codex prompts and docs index
- guard noConflictMarkers test against temporary files removed by other suites

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `npx ripsecrets` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abea826458832f8431de9c023990d2