### PR TITLE
📚 add user journeys doc test

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover

--- a/frontend/e2e/user-journeys-doc.spec.ts
+++ b/frontend/e2e/user-journeys-doc.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('User journeys documentation', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('shows coverage table', async ({ page }) => {
+        await page.goto('/docs/user-journeys');
+        await page.waitForLoadState('networkidle');
+
+        await expect(
+            page.getByRole('heading', { name: 'User journeys', exact: true })
+        ).toBeVisible();
+        const table = page.locator('table');
+        await expect(table).toBeVisible();
+        await expect(table).toContainText('Journey');
+    });
+});

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -9,8 +9,9 @@ Use this template to add end-to-end coverage for journeys listed in
 [User journeys](/docs/user-journeys) using
 [Playwright](https://playwright.dev/). While working, review the existing
 journeys for inaccuracies or gaps/misunderstandings and expand the list as new
-features land. Treat this prompt as living documentation—periodically refine it
-using other `prompts-*.md` files for inspiration. Use this guide alongside
+features land. Tests should assert visible UI content to verify that pages render
+correctly. Treat this prompt as living documentation—periodically refine it using
+other `prompts-*.md` files for inspiration. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
 [Codex meta prompt](/docs/prompts-codex-meta); if templates drift, refresh them
 with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub
@@ -27,16 +28,18 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 >    once real coverage lands.
 > 4. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
 >    implement the Playwright test; otherwise add a new test file.
-> 5. For authentication flows, confirm tokens persist in `localStorage` and can
+> 5. Write assertions against visible page content to ensure the UI renders as
+>    expected.
+> 6. For authentication flows, confirm tokens persist in `localStorage` and can
 >    be cleared without network access.
-> 6. Update `user-journeys.md` with coverage status, test file path, and any
+> 7. Update `user-journeys.md` with coverage status, test file path, and any
 >    fixes, keeping the table alphabetized. Verify apparent 404s aren't missing
 >    routes; if a page should exist, add a stub instead of asserting a 404.
-> 7. Run `npx playwright install chromium` if browsers are missing.
-> 8. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 8. Run `npx playwright install chromium` if browsers are missing.
+> 9. Run `npm run lint`, `npm run type-check`, `npm run build`, and
 >    `npm run test:ci`.
-> 9. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
->    and commit with an emoji.
+> 10. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+>     and commit with an emoji.
 
 ```text
 SYSTEM:

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -6,8 +6,8 @@ slug: 'user-journeys'
 # User journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
-Tests under `frontend/e2e/backlog` are placeholders for journeys without automation. Entries are
-sorted alphabetically by journey name.
+Tests under `frontend/e2e/backlog` are placeholders for journeys without automation; move them to
+`frontend/e2e` once coverage lands. Entries are sorted alphabetically by journey name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
@@ -50,3 +50,4 @@ sorted alphabetically by journey name.
 | Touch menu navigation      | No                  | --                                                |
 | Tutorial quest run         | Yes                 | `frontend/e2e/tutorial-quest.spec.ts`             |
 | UI responsiveness          | No                  | --                                                |
+| User journeys doc loads    | Yes                 | `frontend/e2e/user-journeys-doc.spec.ts`          |


### PR DESCRIPTION
## Summary
- document how to move backlog tests to coverage table
- clarify Playwright prompt to assert visible content
- cover user-journeys docs with a Playwright test
- sync new quests list docs with latest counts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx playwright test e2e/user-journeys-doc.spec.ts`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abac934938832f800db41a0458db6e