### PR TITLE
📊 Add error rate alert and dashboard

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -13,6 +13,27 @@ docker-compose up
 
 - Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
 - Grafana provisions a Prometheus data source and a sample dashboard.
-- Alerts include `DspaceDown`, which fires when the `dspace` job stops reporting `up`.
+- The dashboard shows service availability and HTTP 5xx error rate over time.
+
+## Alerts
+
+### DspaceDown
+
+Fires when the `dspace` job stops reporting `up` for one minute.
+
+**Runbook**
+
+1. Check the application logs for crashes or outages.
+2. Restart the DSpace service if it is not running.
+
+### DspaceHighErrorRate
+
+Triggers when more than 5% of HTTP requests return 5xx status codes for five
+minutes.
+
+**Runbook**
+
+1. Inspect recent server logs for stack traces or failed requests.
+2. Investigate upstream dependencies that might be causing errors.
 
 All services are self-hosted to respect user privacy.

--- a/monitoring/grafana/dashboards/dspace-overview.json
+++ b/monitoring/grafana/dashboards/dspace-overview.json
@@ -12,6 +12,26 @@
           "legendFormat": "dspace"
         }
       ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total{job=\"dspace\",status=~\"5..\"}[5m])/rate(http_requests_total{job=\"dspace\"}[5m])",
+          "legendFormat": "5xx rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "yaxes": [
+        {"format": "percentunit", "min": 0, "max": 1},
+        {"format": "short"}
+      ]
     }
   ],
   "schemaVersion": 36,

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -8,3 +8,16 @@ groups:
           severity: critical
         annotations:
           summary: DSpace service is down
+          description: No metrics have been scraped from the dspace job for over a minute
+          runbook: https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md#dspacedown
+      - alert: DspaceHighErrorRate
+        expr: |
+          rate(http_requests_total{job="dspace",status=~"5.."}[5m]) /
+          rate(http_requests_total{job="dspace"}[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High error rate on DSpace
+          description: More than 5% of HTTP requests returned 5xx status codes
+          runbook: https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md#dspacehigherrorrate


### PR DESCRIPTION
## Summary
- document runbooks for DspaceDown and DspaceHighErrorRate alerts
- add runbook annotations in Prometheus rules and show error rate as percent in Grafana

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68abac778bdc832faa57081e0fbc4a17