### PR TITLE
docs: clarify monitoring/outage prompts and sync quest list

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -53,6 +53,7 @@ New quests in this release: 218
 -   astronomy/andromeda
 -   astronomy/aurora-watch
 -   astronomy/basic-telescope
+-   astronomy/binary-star
 -   astronomy/comet-tracking
 -   astronomy/constellations
 -   astronomy/iss-flyover

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -7,9 +7,9 @@ slug: 'prompts-monitoring'
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
 ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex)
-when editing files in the
-[`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
-stack so metrics, dashboards, and alerts stay consistent.
+when editing files under [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
+to keep metrics, dashboards, and alerts consistent. For configuration details, see
+[`monitoring/README.md`](https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md).
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
 these templates drift, refresh them with the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
@@ -18,7 +18,8 @@ these templates drift, refresh them with the
 > **TL;DR**
 >
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
-> 2. Prefer lightweight, self-hosted tools; avoid collecting personal data.
+> 2. Prefer open-source tools on self-managed infrastructure (e.g., Prometheus, Grafana) and
+>    avoid sending personal data to third-party services.
 > 3. Add sample dashboards or alert rules when relevant.
 > 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -6,7 +6,7 @@ slug: 'prompts-outages'
 # Outage prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository and run its own tests.
-Use this guide alongside [Codex Prompts](/docs/prompts-codex) so every fix ships with a matching
+Use this guide alongside [Codex Prompts](/docs/prompts-codex) to ensure every fix ships with a matching
 record in the outage catalog. For an overview of the catalog itself, see
 [Outages](/docs/outages).
 To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta);
@@ -15,10 +15,11 @@ For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/pro
 
 > **TL;DR**
 >
-> 1. Investigate the failure and implement a fix.
+> 1. Investigate the failure, identify the root cause, document it in the outage entry, and
+>    implement a fix.
 > 2. Add [`outages/YYYY-MM-DD-<slug>.json`][outage-dir]
 >    matching [`outages/schema.json`][outage-schema].
-> 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Use an emoji-prefixed commit message.
 
@@ -37,8 +38,8 @@ CONTEXT:
 
 REQUEST:
 1. Apply the fix with appropriate tests.
-2. Commit the outage entry and related docs.
-3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+2. Commit the outage entry noting the root cause and related docs.
+3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` and ensure no secrets.
 5. Use an emoji-prefixed commit message.
 


### PR DESCRIPTION
## Summary
- link monitoring prompt to repo's monitoring README and stress self-hosted tools
- ask outage prompts to document root cause
- sync new-quests doc with latest quests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ababc27ba0832fb1c3c471fb48db5e