### PR TITLE
feat: add HTTP PUT programming quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -219,6 +219,7 @@ New quests in this release: 218
 -   programming/graph-temp-data
 -   programming/hello-sensor
 -   programming/http-post
+-   programming/http-put
 -   programming/json-api
 -   programming/json-endpoint
 -   programming/median-temp

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 240
-New quests in this release: 218
+Current quest count: 241
+New quests in this release: 219
 
 ### 3dprinting
 
@@ -219,6 +219,7 @@ New quests in this release: 218
 -   programming/graph-temp-data
 -   programming/hello-sensor
 -   programming/http-post
+-   programming/http-put
 -   programming/json-api
 -   programming/json-endpoint
 -   programming/median-temp

--- a/frontend/src/pages/quests/json/programming/http-put.json
+++ b/frontend/src/pages/quests/json/programming/http-put.json
@@ -1,0 +1,34 @@
+{
+    "id": "programming/http-put",
+    "title": "Handle PUT Updates",
+    "description": "Extend your server so a PUT to /data replaces the stored JSON object.",
+    "image": "/assets/quests/basic_circuit.svg",
+    "npc": "/assets/npc/dChat.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Your API handles POST. Let's support PUT to update records.",
+            "options": [{ "type": "goto", "goto": "code", "text": "Let's do it." }]
+        },
+        {
+            "id": "code",
+            "text": "Accept a PUT to /data that overwrites the stored JSON object.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "PUT endpoint working!",
+                    "requiresItems": [{ "id": "ce140453-c7ef-42c9-b9f9-38acfb4219cf", "count": 1 }]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great! Clients can now replace data with PUT.",
+            "options": [{ "type": "finish", "text": "Server updated." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["programming/http-post"]
+}


### PR DESCRIPTION
## Summary
- add programming quest to handle PUT requests
- document quest in new-quests list

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npx vitest run tests/questSchemaValidation.test.ts scripts/tests/questQuality.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68abab182ff4832fbf9d714e1d877618