### PR TITLE
🧵 : add filament diameter quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 241
-New quests in this release: 219
+Current quest count: 242
+New quests in this release: 220
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 219
 -   3dprinting/cable-clip
 -   3dprinting/calibration-cube
 -   3dprinting/filament-change
+-   3dprinting/filament-diameter
 -   3dprinting/nozzle-cleaning
 -   3dprinting/phone-stand
 -   3dprinting/retraction-test

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 241
-New quests in this release: 219
+Current quest count: 242
+New quests in this release: 220
 
 ### 3dprinting
 
@@ -20,6 +20,7 @@ New quests in this release: 219
 -   3dprinting/cable-clip
 -   3dprinting/calibration-cube
 -   3dprinting/filament-change
+-   3dprinting/filament-diameter
 -   3dprinting/nozzle-cleaning
 -   3dprinting/phone-stand
 -   3dprinting/retraction-test

--- a/frontend/src/pages/quests/json/3dprinting/calibration-cube.json
+++ b/frontend/src/pages/quests/json/3dprinting/calibration-cube.json
@@ -68,7 +68,7 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["3dprinter/start"],
+    "requiresQuests": ["3dprinting/filament-diameter"],
     "hardening": {
         "passes": 3,
         "score": 82,

--- a/frontend/src/pages/quests/json/3dprinting/filament-diameter.json
+++ b/frontend/src/pages/quests/json/3dprinting/filament-diameter.json
@@ -1,0 +1,48 @@
+{
+    "id": "3dprinting/filament-diameter",
+    "title": "Measure Filament Diameter",
+    "description": "Check your PLA with calipers so the slicer knows the real width before printing.",
+    "image": "/assets/pla_white.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "As an engineer I always check filament first; accurate diameter keeps builds reliable.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "measure",
+                    "text": "Show me how to check it"
+                }
+            ]
+        },
+        {
+            "id": "measure",
+            "text": "Use digital calipers to sample 1.75 mm PLA at three points and average the numbers for consistent builds.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "measure-filament-diameter",
+                    "text": "Give me step-by-step"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Average noted.",
+                    "requiresItems": [
+                        { "id": "e37c86b0-caaf-485d-b5c1-c15f7029973c", "count": 1 },
+                        { "id": "58580f6f-f3be-4be0-80b9-f6f8bf0b05a6", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Great work! With the diameter logged your printer can build parts with better precision.",
+            "options": [{ "type": "finish", "text": "Ready for calibration" }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinting/filament-change"]
+}


### PR DESCRIPTION
what: add 3dprinting quest for measuring filament and link to calibration cube
why: improves calibration flow with explicit measurement step
how to test:
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci -- questCanonical questQuality

------
https://chatgpt.com/codex/tasks/task_e_68ae8d7b55b0832f931964554f7b2212