### PR TITLE
🌱: add EC meter calibration quest

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 241
-New quests in this release: 219
+Current quest count: 242
+New quests in this release: 220
 
 ### 3dprinting
 
@@ -193,6 +193,7 @@ New quests in this release: 219
 ### hydroponics
 
 -   hydroponics/air-stone-soak
+-   hydroponics/ec-calibrate
 -   hydroponics/ec-check
 -   hydroponics/filter-clean
 -   hydroponics/grow-light

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -2243,6 +2243,35 @@
         "duration": "1m"
     },
     {
+        "id": "calibrate-ec-meter",
+        "title": "Calibrate EC meter with 1000 ppm solution",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            {
+                "id": "71655665-4a59-41f4-9084-dad4d976df91",
+                "count": 1
+            },
+            {
+                "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40",
+                "count": 1
+            }
+        ],
+        "createItems": [],
+        "duration": "2m",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "adjust-ph",
         "title": "Adjust solution pH",
         "requireItems": [

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,8 +11,8 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 241
-New quests in this release: 219
+Current quest count: 242
+New quests in this release: 220
 
 ### 3dprinting
 
@@ -193,6 +193,7 @@ New quests in this release: 219
 ### hydroponics
 
 -   hydroponics/air-stone-soak
+-   hydroponics/ec-calibrate
 -   hydroponics/ec-check
 -   hydroponics/filter-clean
 -   hydroponics/grow-light

--- a/frontend/src/pages/inventory/json/items/hydroponics.json
+++ b/frontend/src/pages/inventory/json/items/hydroponics.json
@@ -347,6 +347,20 @@
         }
     },
     {
+        "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40",
+        "name": "EC calibration solution (1000 ppm)",
+        "description": "100 mL bottle of 1000 ppm standard for EC meter calibration.",
+        "image": "/assets/hydroponics_nutrients.jpg",
+        "price": "5 dUSD",
+        "unit": "100 mL bottle",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🌀",
+            "history": []
+        }
+    },
+    {
         "id": "6360b1e7-84d6-4256-b085-f36fc53ef299",
         "name": "digital pH meter",
         "description": "Pocket-sized meter measures pH 0–14 with ±0.1 accuracy; includes calibration solution.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -1936,6 +1936,18 @@
         "duration": "1m"
     },
     {
+        "id": "calibrate-ec-meter",
+        "title": "Calibrate EC meter with 1000 ppm solution",
+        "image": "/assets/aquarium_thermometer.jpg",
+        "requireItems": [
+            { "id": "71655665-4a59-41f4-9084-dad4d976df91", "count": 1 },
+            { "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40", "count": 1 }
+        ],
+        "consumeItems": [{ "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40", "count": 1 }],
+        "createItems": [],
+        "duration": "2m"
+    },
+    {
         "id": "adjust-ph",
         "title": "Adjust solution pH",
         "requireItems": [

--- a/frontend/src/pages/processes/hardening/calibrate-ec-meter.json
+++ b/frontend/src/pages/processes/hardening/calibrate-ec-meter.json
@@ -1,0 +1,6 @@
+{
+    "passes": 0,
+    "score": 0,
+    "emoji": "🛠️",
+    "history": []
+}

--- a/frontend/src/pages/quests/json/hydroponics/ec-calibrate.json
+++ b/frontend/src/pages/quests/json/hydroponics/ec-calibrate.json
@@ -1,0 +1,48 @@
+{
+    "id": "hydroponics/ec-calibrate",
+    "title": "Calibrate EC Meter",
+    "description": "Use calibration solution so readings stay accurate.",
+    "image": "/assets/aquarium_thermometer.jpg",
+    "npc": "/assets/npc/hydro.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "An accurate EC meter keeps nutrients on point. Let's calibrate it with solution.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "calibrate",
+                    "text": "Ready to calibrate"
+                }
+            ]
+        },
+        {
+            "id": "calibrate",
+            "text": "Rinse the probe, dip in 1000 ppm solution, and adjust until the meter matches.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "calibrate-ec-meter",
+                    "text": "Meter aligned"
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Calibration complete",
+                    "requiresItems": [
+                        { "id": "71655665-4a59-41f4-9084-dad4d976df91", "count": 1 },
+                        { "id": "d3d8bb59-8364-46b2-ad42-c5f56cc72b40", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "Nice. A calibrated meter keeps your plants fed properly.",
+            "options": [{ "type": "finish", "text": "Back to the grow." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["hydroponics/ph-check"]
+}

--- a/frontend/src/pages/quests/json/hydroponics/ec-check.json
+++ b/frontend/src/pages/quests/json/hydroponics/ec-check.json
@@ -49,5 +49,5 @@
         }
     ],
     "rewards": [],
-    "requiresQuests": ["hydroponics/ph-check"]
+    "requiresQuests": ["hydroponics/ec-calibrate"]
 }


### PR DESCRIPTION
what: add EC meter calibration quest, item, and process
why: guide users to keep EC readings accurate
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci -- questCanonical questQuality
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_68ae8d7b55b0832f931964554f7b2212