### PR TITLE
🧪 add quest schema validation test

### DIFF
--- a/frontend/__tests__/validateQuestSchema.test.js
+++ b/frontend/__tests__/validateQuestSchema.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import validateQuestSchema from '../src/utils/validateQuestSchema.js';
+
+describe('validateQuestSchema', () => {
+    const baseQuest = {
+        id: 'quest1',
+        title: 'Sample Quest',
+        description: 'A simple quest for testing',
+        image: 'quest.png',
+        npc: 'tester',
+        start: 'start',
+        dialogue: [
+            {
+                id: 'start',
+                text: 'begin',
+                options: [{ type: 'finish', text: 'done' }],
+            },
+        ],
+    };
+
+    it('accepts a valid quest object', () => {
+        const { valid, errors } = validateQuestSchema(baseQuest);
+        expect(valid).toBe(true);
+        expect(errors).toBeNull();
+    });
+
+    it('rejects an invalid quest object', () => {
+        const invalidQuest = { ...baseQuest };
+        delete invalidQuest.title;
+        const { valid, errors } = validateQuestSchema(invalidQuest);
+        expect(valid).toBe(false);
+        expect(Array.isArray(errors)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- add coverage for validateQuestSchema utility

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run coverage`
- `node scripts/checkPatchCoverage.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d7007e4832fa2532dc6eb8afccd