### PR TITLE
🧪 Add quest title uniqueness edge case tests

### DIFF
--- a/tests/quest-title-unique.test.ts
+++ b/tests/quest-title-unique.test.ts
@@ -11,4 +11,16 @@ describe('isQuestTitleUnique', () => {
     expect(isQuestTitleUnique('New Quest', quests)).toBe(true);
     expect(isQuestTitleUnique('Existing Quest', quests, 'q1')).toBe(true);
   });
+
+  it('matches titles case-insensitively', () => {
+    const quests = [{ id: 'q1', title: 'Existing Quest' }];
+    expect(isQuestTitleUnique('existing quest', quests)).toBe(false);
+    expect(isQuestTitleUnique('EXISTING QUEST', quests)).toBe(false);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    const quests = [{ id: 'q1', title: '  Existing Quest  ' }];
+    expect(isQuestTitleUnique('Existing Quest', quests)).toBe(false);
+    expect(isQuestTitleUnique('  Existing Quest  ', quests)).toBe(false);
+  });
 });


### PR DESCRIPTION
## What
- cover case-insensitive and whitespace edge cases in isQuestTitleUnique

## Why
- ensure quest title validation handles varied input

## How to test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8d7007e4832fa2532dc6eb8afccd