### PR TITLE
docs: tailor upgrader prompts per prompt doc

### DIFF
--- a/docs/prompts-outages.md
+++ b/docs/prompts-outages.md
@@ -49,3 +49,26 @@ A pull request referencing the new outage record and passing checks.
 
 [outage-dir]: https://github.com/democratizedspace/dspace/tree/main/outages
 [outage-schema]: https://github.com/democratizedspace/dspace/blob/main/outages/schema.json
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep outage-handling guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Confirm outage schema links and filename patterns are still correct.
+2. Add guidance for new outage categories or follow-up steps.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the outage prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -38,3 +38,26 @@ USER:
 OUTPUT:
 A pull request improving accessibility with passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep accessibility guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Confirm WCAG references and accessibility tooling are up to date.
+2. Link to new patterns or components that influence accessibility.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the accessibility prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-audit.md
+++ b/frontend/src/pages/docs/md/prompts-audit.md
@@ -37,3 +37,26 @@ USER:
 OUTPUT:
 A pull request that upgrades dependencies with passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep dependency audit instructions current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Ensure audit commands and vulnerability policies match current tooling.
+2. Note recent high-risk packages or lockfile locations if paths changed.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the dependency audit prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -43,3 +43,26 @@ USER:
 OUTPUT:
 A pull request with the backend change and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep backend guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify backend module paths and API references reflect the latest code.
+2. Refresh self-hosting and privacy notes with new links or commands.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the backend prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-backups.md
+++ b/frontend/src/pages/docs/md/prompts-backups.md
@@ -37,3 +37,26 @@ USER:
 OUTPUT:
 A pull request with the backup improvement and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep backup instructions current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Confirm backup formats, paths, and retention notes match current practice.
+2. Update links or scripts when backup tooling changes.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the backup prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -129,3 +129,26 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.
 -   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
     `fetch-depth: 0` so scripts can compare against the default branch.
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep CI troubleshooting steps current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Sync instructions with current GitHub Actions job names and failure patterns.
+2. Clarify log retrieval or rerun steps for new CI features.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the CI-failure fix prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
+++ b/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
@@ -47,3 +47,26 @@ USER:
 OUTPUT:
 A pull request improving the merge conflict prompt doc with passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep merge-conflict resolution tips current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify steps match current GitHub merge UI and git CLI behavior.
+2. Add guidance for large files or binary conflicts when relevant.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the merge-conflict prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -28,3 +28,26 @@ USER:
 OUTPUT:
 A pull request with upgraded prompt docs and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep meta-prompt guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Cross-link new prompt docs and prune obsolete ones.
+2. Clarify cadence and scope for routine prompt maintenance.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the Codex meta prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -29,3 +29,26 @@ USER:
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep prompt-upgrader instructions current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Ensure it covers newly added prompt types and required checks.
+2. Tighten language so upgrades stay precise and reversible.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the Codex Prompt Upgrader doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -207,3 +207,26 @@ A pull request refreshing the Codex prompt docs with passing checks.
 ```
 
 [openai-cli]: https://github.com/openai/openai-cli
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep baseline Codex prompt guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Update references to new or renamed prompt docs.
+2. Confirm default template reflects current lint, test, and commit standards.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the baseline Codex prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -82,3 +82,26 @@ USER:
 OUTPUT:
 A pull request with updated links and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep documentation-writing guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify links to style guides and prompt docs remain valid.
+2. Capture new Markdown or JSDoc conventions.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the documentation prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -39,3 +39,26 @@ USER:
 OUTPUT:
 A pull request with the frontend change and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep frontend development guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Check component paths, build tooling, and hydration notes against current setup.
+2. Highlight new patterns for accessibility or performance tuning.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the frontend prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-items.md
+++ b/frontend/src/pages/docs/md/prompts-items.md
@@ -180,3 +180,26 @@ Modern assistants can be powerful collaborators. Keep in mind:
     but incorrect details.
 
 [openai-cli]: https://platform.openai.com/docs/guides/openai-cli/
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep item-writing rules current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Ensure item schema references and inventory paths are up to date.
+2. Fold in any new content guidelines from the item guide.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the item prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -44,3 +44,26 @@ USER:
 OUTPUT:
 A pull request with improved monitoring docs or configs and passing checks.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep monitoring instructions current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify Grafana/Prometheus configs and dashboard links are current.
+2. Note new alerts or metric conventions described in `monitoring/README.md`.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the monitoring prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-npcs.md
+++ b/frontend/src/pages/docs/md/prompts-npcs.md
@@ -136,3 +136,26 @@ Modern assistants can be powerful collaborators. Keep in mind:
 -   **Fact-check technical information**; AI systems can generate plausible but incorrect details.
 
 [openai-cli]: https://github.com/openai/openai-cli
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep NPC-writing guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Confirm voice and lore notes match the latest NPC guide.
+2. Update instructions for adding IDs or linking items and processes.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the NPC prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-outages.md
+++ b/frontend/src/pages/docs/md/prompts-outages.md
@@ -49,3 +49,26 @@ A pull request referencing the new outage record and passing checks.
 
 [outage-dir]: https://github.com/democratizedspace/dspace/tree/main/outages
 [outage-schema]: https://github.com/democratizedspace/dspace/blob/main/outages/schema.json
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep outage-handling guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Confirm outage schema links and filename patterns are still correct.
+2. Add guidance for new outage categories or follow-up steps.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the outage prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -63,3 +63,26 @@ OUTPUT:
 A pull request adding the test, doc updates, and any prompt refinements with all
 checks green.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep Playwright test guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Ensure user-journey links and Playwright version notes are current.
+2. Document new flags or helpers for running tests headlessly in CI.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the Playwright test prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-processes.md
+++ b/frontend/src/pages/docs/md/prompts-processes.md
@@ -167,3 +167,26 @@ Modern assistants can be powerful collaborators. Keep in mind:
     but incorrect details.
 
 [openai-cli]: https://github.com/openai/openai-cli
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep process-writing guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify process schema and `generated/processes.json` references remain accurate.
+2. Incorporate new process development guidelines or registry paths.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the process prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-quests.md
+++ b/frontend/src/pages/docs/md/prompts-quests.md
@@ -56,7 +56,7 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 | **Goal sentence**    | Gives the agent a north star (“Add safety step to `energy/solar`”). |
 | **Files to touch**   | Limits search space → faster & cheaper.                             |
 | **Constraints**      | Coding style, a11y, quest schema rules.                             |
-| **Acceptance check** | e.g. “`npm run test:ci -- questCanonical questQuality` passes”. |
+| **Acceptance check** | e.g. “`npm run test:ci -- questCanonical questQuality` passes”.     |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -200,3 +200,26 @@ Modern assistants can be powerful collaborators. Keep in mind:
     but incorrect details.
 
 [openai-cli]: https://github.com/openai/openai-cli
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep quest-writing guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Ensure quest schema links, hardening steps, and submission docs are current.
+2. Update examples when item or process registries change.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the quest prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-refactors.md
+++ b/frontend/src/pages/docs/md/prompts-refactors.md
@@ -37,3 +37,26 @@ USER:
 OUTPUT:
 A pull request with the refactor and all checks passing.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep refactor guidelines current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Reaffirm code style rules and commit granularity tips.
+2. Mention when to include benchmarks for performance-sensitive changes.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the refactor prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-secrets.md
+++ b/frontend/src/pages/docs/md/prompts-secrets.md
@@ -29,3 +29,26 @@ USER:
 OUTPUT:
 A pull request with no exposed secrets and all checks passing.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep secret-scanning guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Keep scanner command examples current and mention alternative tools if adopted.
+2. Clarify handling of false positives or credential rotation.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the secret scanning prompt doc with passing checks.
+```

--- a/frontend/src/pages/docs/md/prompts-vitest.md
+++ b/frontend/src/pages/docs/md/prompts-vitest.md
@@ -35,3 +35,26 @@ USER:
 OUTPUT:
 A pull request adding the tests with all checks green.
 ```
+
+## Upgrader Prompt
+
+Type: evergreen
+
+Use this prompt to keep unit test guidance current.
+
+```text
+SYSTEM:
+You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
+
+USER:
+1. Verify test file locations and naming conventions match current structure.
+2. Note new Vitest flags or coverage requirements.
+3. Run the checks above.
+4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+5. Commit with an emoji-prefixed message.
+
+OUTPUT:
+A pull request refining the Vitest prompt doc with passing checks.
+```


### PR DESCRIPTION
## Summary
- craft bespoke upgrader prompts for each prompt doc
- guide future updates with topic-specific checks and links

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci` *(hangs after root unit tests)*


------
https://chatgpt.com/codex/tasks/task_e_68ae8db59fc8832f860a5e93aa6a26b1