### PR TITLE
test: cover glossary doc and refine Playwright prompt

### DIFF
--- a/frontend/e2e/glossary-doc.spec.ts
+++ b/frontend/e2e/glossary-doc.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Glossary doc', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('glossary page loads', async ({ page }) => {
+        await page.goto('/docs/glossary');
+        await page.waitForLoadState('networkidle');
+        await expect(page.getByRole('heading', { name: /Glossary/i })).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -28,8 +28,8 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 >    once real coverage lands.
 > 4. If a placeholder exists, move it to `frontend/e2e` with `git mv` and
 >    implement the Playwright test; otherwise add a new test file.
-> 5. Write assertions against visible page content to ensure the UI renders as
->    expected.
+> 5. Write assertions against visible page content (use `getByRole` for headings
+>    when possible) to ensure the UI renders as expected.
 > 6. For authentication flows, confirm tokens persist in `localStorage` and can
 >    be cleared without network access.
 > 7. Update `user-journeys.md` with coverage status, test file path, and any

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -3,7 +3,7 @@ title: 'User Journeys and Test Coverage'
 slug: 'user-journeys'
 ---
 
-# User journeys
+# User Journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
 Tests under `frontend/e2e/backlog` are placeholders for journeys without automation; move them to
@@ -23,6 +23,7 @@ Tests under `frontend/e2e/backlog` are placeholders for journeys without automat
 | Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
 | Failover status page       | Yes                 | `frontend/e2e/failover-status.spec.ts`            |
+| Glossary page loads        | Yes                 | `frontend/e2e/glossary-doc.spec.ts`               |
 | Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
 | Item/process preview       | No                  | --                                                |
 | Legacy data import         | No                  | --                                                |


### PR DESCRIPTION
## Summary
- add E2E test ensuring the glossary docs page renders
- document coverage in user-journeys table
- clarify prompt to prefer `getByRole` when asserting headings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx playwright test glossary-doc.spec.ts` *(fails: localStorage is not defined)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d6bd7f4832fa1eab5640668b71c