### PR TITLE
⬆️ : update openai and move astro adapter to dev

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     },
     "devDependencies": {
         "@astrojs/svelte": "^2.1.0",
+        "@astrojs/node": "^5.1.1",
         "@babel/core": "^7.26.9",
         "@babel/eslint-parser": "^7.26.8",
         "@babel/plugin-syntax-import-assertions": "^7.26.0",
@@ -87,7 +88,6 @@
     },
     "dependencies": {
         "@algolia/client-search": "^4.13.1",
-        "@astrojs/node": "^5.1.1",
         "@types/node": "^18.0.0",
         "astro-seo": "^0.7.4",
         "autoprefixer": "^10.4.14",
@@ -100,7 +100,7 @@
         "markdown-it": "^13.0.1",
         "marked": "^4.3.0",
         "node-fetch": "^3.3.1",
-        "openai": "^5.12.2",
+        "openai": "^5.16.0",
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",
         "prom-client": "^15.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "openai": "^5.15.0"
+        "openai": "^5.16.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -6031,9 +6031,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.15.0.tgz",
-      "integrity": "sha512-kcUdws8K/A8m02I+IqFBwO51gS+87GP89yWEufGbzEi8anBz4FB/bti2QxaJdGwwY4mwJGzx85XO7TuL/Tpu1w==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.16.0.tgz",
+      "integrity": "sha512-hoEH8ZNvg1HXjU9mp88L/ZH8O082Z8r6FHCXGiWAzVRrEv443aI57qhch4snu07yQydj+AUAWLenAiBXhu89Tw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "wait-on": "^7.0.1"
   },
   "dependencies": {
-    "openai": "^5.15.0"
+    "openai": "^5.16.0"
   },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       openai:
-        specifier: ^5.15.0
-        version: 5.15.0(ws@8.18.3)(zod@3.25.76)
+        specifier: ^5.16.0
+        version: 5.16.0(ws@8.18.3)(zod@3.25.76)
     devDependencies:
       '@jest/globals':
         specifier: ^29.5.0
@@ -84,9 +84,6 @@ importers:
       '@algolia/client-search':
         specifier: ^4.13.1
         version: 4.25.2
-      '@astrojs/node':
-        specifier: ^5.1.1
-        version: 5.3.6(astro@2.10.15(@types/node@18.19.121))
       '@types/node':
         specifier: ^18.0.0
         version: 18.19.121
@@ -124,8 +121,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.2
       openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.3)(zod@3.25.76)
+        specifier: ^5.16.0
+        version: 5.16.0(ws@8.18.3)(zod@3.25.76)
       postcss:
         specifier: ^8.4.23
         version: 8.5.6
@@ -139,6 +136,9 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
     devDependencies:
+      '@astrojs/node':
+        specifier: ^5.1.1
+        version: 5.3.6(astro@2.10.15(@types/node@18.19.121))
       '@astrojs/svelte':
         specifier: ^2.1.0
         version: 2.2.0(astro@2.10.15(@types/node@18.19.121))(svelte@3.59.2)(typescript@5.1.6)(vite@4.5.14(@types/node@18.19.121))
@@ -4013,20 +4013,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@5.12.2:
-    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openai@5.15.0:
-    resolution: {integrity: sha512-kcUdws8K/A8m02I+IqFBwO51gS+87GP89yWEufGbzEi8anBz4FB/bti2QxaJdGwwY4mwJGzx85XO7TuL/Tpu1w==}
+  openai@5.16.0:
+    resolution: {integrity: sha512-hoEH8ZNvg1HXjU9mp88L/ZH8O082Z8r6FHCXGiWAzVRrEv443aI57qhch4snu07yQydj+AUAWLenAiBXhu89Tw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -10101,12 +10089,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@5.12.2(ws@8.18.3)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.18.3
-      zod: 3.25.76
-
-  openai@5.15.0(ws@8.18.3)(zod@3.25.76):
+  openai@5.16.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.3
       zod: 3.25.76


### PR DESCRIPTION
## Summary
- bump OpenAI client to 5.16.0
- move @astrojs/node to devDependencies to keep prod tree slim

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- ⚠️ `git diff --cached | ./scripts/scan-secrets.py` *(script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d8384ec832fb1b0d3c6c46de5f3