### PR TITLE
♿ Add visible focus outlines to form fields

### DIFF
--- a/frontend/src/components/svelte/ItemForm.svelte
+++ b/frontend/src/components/svelte/ItemForm.svelte
@@ -203,7 +203,6 @@
         color: black;
         font-size: 16px;
         border: 2px solid #007006;
-        outline: none;
         transition: border-color 0.2s, box-shadow 0.2s;
     }
 
@@ -211,6 +210,8 @@
     textarea:focus {
         border-color: #0f0;
         box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
+        outline: 3px solid #0f0;
+        outline-offset: 2px;
     }
 
     textarea {

--- a/frontend/src/components/svelte/ProcessForm.svelte
+++ b/frontend/src/components/svelte/ProcessForm.svelte
@@ -352,7 +352,6 @@
         color: black;
         font-size: 16px;
         border: 2px solid #007006;
-        outline: none;
         transition: border-color 0.2s, box-shadow 0.2s;
     }
 
@@ -373,6 +372,8 @@
     input:focus {
         border-color: #0f0;
         box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
+        outline: 3px solid #0f0;
+        outline-offset: 2px;
     }
 
     .item-row {

--- a/frontend/src/components/svelte/QuestForm.svelte
+++ b/frontend/src/components/svelte/QuestForm.svelte
@@ -347,7 +347,6 @@
         color: black;
         font-size: 16px;
         border: 2px solid #007006;
-        outline: none;
         transition: border-color 0.2s, box-shadow 0.2s;
     }
 
@@ -359,7 +358,6 @@
         color: black;
         font-size: 16px;
         border: 2px solid #007006;
-        outline: none;
     }
 
     input.error,
@@ -379,6 +377,15 @@
     textarea:focus {
         border-color: #0f0;
         box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
+        outline: 3px solid #0f0;
+        outline-offset: 2px;
+    }
+
+    select:focus {
+        border-color: #0f0;
+        box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
+        outline: 3px solid #0f0;
+        outline-offset: 2px;
     }
 
     textarea {


### PR DESCRIPTION
## Summary
- add keyboard-visible outlines for inputs in ProcessForm, ItemForm, and QuestForm
- ensure form controls meet WCAG 2.1 AA focus requirements

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d87e89c832fa2792d659023a3d0