### PR TITLE
♿ Improve link and image accessibility

### DIFF
--- a/frontend/src/components/CompactCard.astro
+++ b/frontend/src/components/CompactCard.astro
@@ -8,7 +8,7 @@ const { title, text, href, image } = Astro.props;
     <div class="item">
         <h3>{title}</h3>
         <div class="section horizontal">
-            <img src={image} />
+            <img src={image} alt={title} />
             <div class="section vertical">
                 <p class="nobackground">{text}</p>
                 <div class="section horizontal">
@@ -24,6 +24,11 @@ const { title, text, href, image } = Astro.props;
     a {
         text-decoration: none;
         color: white;
+    }
+
+    a:focus-visible {
+        outline: 2px solid #ffffff;
+        outline-offset: 2px;
     }
 
     .section {

--- a/frontend/src/components/GrowableImage.astro
+++ b/frontend/src/components/GrowableImage.astro
@@ -1,8 +1,10 @@
 ---
-const { imageSrc, href } = Astro.props;
+const { imageSrc, href, altText = '', ariaLabel } = Astro.props;
 ---
 
-<a href={href}><img class="icon" src={imageSrc} /></a>
+<a href={href} aria-label={ariaLabel}>
+    <img class="icon" src={imageSrc} alt={altText} />
+</a>
 
 <style>
     .icon {
@@ -10,6 +12,11 @@ const { imageSrc, href } = Astro.props;
         border-radius: 10px;
         width: 30px;
         transition: 0.2s;
+    }
+
+    a:focus-visible .icon {
+        outline: 2px solid #ffffff;
+        outline-offset: 2px;
     }
 
     .icon:hover {


### PR DESCRIPTION
## Summary
- add alt and aria labels to GrowableImage component
- ensure CompactCard links and icons expose alt text
- add visible focus outlines for keyboard navigation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d87e89c832fa2792d659023a3d0