### PR TITLE
♿️ Improve process toast accessibility

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -63,7 +63,7 @@
         </button>
     {/if}
     {#if toastVisible}
-        <div class="toast">{toastMessage}</div>
+        <div class="toast" role="status" aria-live="polite">{toastMessage}</div>
     {/if}
 </div>
 
@@ -76,6 +76,10 @@
         padding: 8px 16px;
         margin-top: 10px;
         cursor: pointer;
+    }
+    .primary:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: 2px;
     }
     .primary[disabled] {
         opacity: 0.6;


### PR DESCRIPTION
## What
- announce process toasts to screen readers
- add keyboard-visible focus outline to buy button

## Why
- meet WCAG 2.1 AA for live regions and focus styles

## How to Test
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d87e89c832fa2792d659023a3d0