### PR TITLE
codex: refresh codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -21,7 +21,8 @@ For task-specific templates see [Quest prompts](prompts-quests.md),
 [Backend prompts](prompts-backend.md), [Refactor prompts](prompts-refactors.md), and
 [Accessibility prompts](prompts-accessibility.md).
 For specialized workflows use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md),
-the [Codex meta prompt](prompts-codex-meta.md), and the
+the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
+[Codex meta prompt](prompts-codex-meta.md), and the
 [Codex Prompt Upgrader](prompts-codex-upgrader.md).
 
 > **TL;DR**
@@ -30,8 +31,7 @@ the [Codex meta prompt](prompts-codex-meta.md), and the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
->    `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
 >    commit with an emoji prefix.
 
@@ -78,12 +78,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                        |
-| **Files to touch**   | Limits search space → faster & cheaper.                                                                 |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                                          |
-| **Acceptance check** | e.g. `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
+| **Files to touch**   | Limits search space → faster & cheaper.                                             |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
+| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -105,8 +105,7 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
-   `npm run build`, and `npm run test:ci`.
+4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -137,7 +136,7 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`AGENTS.md` and ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
@@ -165,7 +164,7 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
@@ -190,7 +189,7 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 `npm run build`, and `npm run test:ci` pass before committing.
 
 USER:


### PR DESCRIPTION
## Summary
- remove outdated `npm run audit:ci` references from Codex prompt templates
- cross-link Codex merge conflict prompt for specialized workflows

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d9a4a38832f926d5233bab8fbaa