### PR TITLE
📝 : – clarify CI job names and log retrieval

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -34,10 +34,15 @@ Diagnose a failed CI run and make it pass.
 
 CONTEXT:
 - If a failed job URL is provided, fetch the logs and identify the first real
-  error.
+  error. Use GitHub's UI or `gh run view --log <run-id>` to inspect steps and
+  `gh run rerun <run-id>` to retry.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-    * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` locally.
+  * The main job names are `tests` and `CI`; focus on failing steps such as
+    `Run test suite`, `Check patch coverage`, or `Upload coverage to Codecov`.
+    The `tests` job prints `/tmp/preview.log` when the preview server fails.
+  * Run `npm run lint`, `npm run type-check`, `npm run build`, and
+    `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.
@@ -129,6 +134,8 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.
 -   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
     `fetch-depth: 0` so scripts can compare against the default branch.
+-   2025-08-28 – Documented `tests` and `CI` job names and added guidance on viewing
+    or rerunning logs with `gh run`.
 
 ## Upgrader Prompt
 


### PR DESCRIPTION
## Summary
- document current `tests` and `CI` job names
- note how to view or rerun logs with `gh run`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(hangs after tests; Playwright install)


------
https://chatgpt.com/codex/tasks/task_e_68b0045d3258832f9d751ab617cb2fbc