### PR TITLE
♿: improve focus visibility in selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Check out the [docs](https://democratized.space/docs)!
 
 The frontend aims to meet WCAG 2.1 AA. Navigation links include `aria-current`
 and visible focus indicators to support keyboard users.
+Interactive selectors expose `aria-selected` states and keyboard-focus outlines so
+screen readers and keyboard users can track selection.
 
 ## Table of Contents
 

--- a/frontend/__tests__/AvatarPicker.test.js
+++ b/frontend/__tests__/AvatarPicker.test.js
@@ -25,8 +25,18 @@ describe('AvatarPicker component', () => {
         const { getByRole, getAllByRole } = render(AvatarPicker, { defaultPFPs });
         const selectButton = getByRole('button', { name: 'Select' });
         expect(selectButton).toBeDisabled();
-        const options = getAllByRole('button', { name: /Select avatar/i });
+        const options = getAllByRole('option', { name: /Select avatar/i });
         await fireEvent.click(options[0]);
         expect(selectButton).not.toBeDisabled();
+    });
+
+    it('updates aria-selected when an avatar is chosen', async () => {
+        const defaultPFPs = ['a.png', 'b.png'];
+        const { getAllByRole } = render(AvatarPicker, { defaultPFPs });
+        const options = getAllByRole('option', { name: /Select avatar/i });
+        expect(options[0]).toHaveAttribute('aria-selected', 'false');
+        await fireEvent.click(options[0]);
+        expect(options[0]).toHaveAttribute('aria-selected', 'true');
+        expect(options[1]).toHaveAttribute('aria-selected', 'false');
     });
 });

--- a/frontend/__tests__/ItemSelector.test.js
+++ b/frontend/__tests__/ItemSelector.test.js
@@ -78,6 +78,22 @@ describe('ItemSelector Component', () => {
         expect(selectedId).toBe('item-1');
     });
 
+    test('should set aria-selected on items', () => {
+        const component = new ItemSelector({
+            target: container,
+            props: {
+                items: mockItems,
+                selectedItemId: '',
+                label: 'Select Item',
+            },
+        });
+
+        const firstItem = container.querySelector('.item-row');
+        expect(firstItem.getAttribute('aria-selected')).toBe('false');
+        firstItem.click();
+        expect(firstItem.getAttribute('aria-selected')).toBe('true');
+    });
+
     test('should emit select event on touch', () => {
         let selectedId = null;
         const component = new ItemSelector({

--- a/frontend/src/components/svelte/AvatarPicker.svelte
+++ b/frontend/src/components/svelte/AvatarPicker.svelte
@@ -34,7 +34,7 @@
         </button>
         Refresh the page to see more random avatars!
     </div>
-    <div class="horizontal">
+    <div class="horizontal" role="listbox">
         {#each defaultPFPs as pfp, i}
             <div
                 class="item-wrapper"
@@ -47,8 +47,9 @@
                     }
                 }}
                 tabindex="0"
-                role="button"
+                role="option"
                 aria-label={`Select avatar ${i + 1}`}
+                aria-selected={selectedIndex === i}
             >
                 <img class="item" src={pfp} alt={`Avatar option ${i + 1}`} />
             </div>
@@ -79,6 +80,11 @@
         opacity: 0.8;
         border: 2px solid transparent;
         cursor: pointer;
+    }
+
+    .item-wrapper:focus-visible {
+        border-color: #68d46d;
+        outline: none;
     }
 
     .item {

--- a/frontend/src/components/svelte/ItemSelector.svelte
+++ b/frontend/src/components/svelte/ItemSelector.svelte
@@ -45,7 +45,7 @@
         {#if isExpanded}
             <div class="selector-expanded" id="item-select-control">
                 <SearchBar data={items} on:search={handleSearch} />
-                <div class="items-list">
+                <div class="items-list" role="listbox">
                     {#each $filteredItems as item (item.id)}
                         <div
                             class="item-row"
@@ -58,7 +58,8 @@
                                 }
                             }}
                             tabindex="0"
-                            role="button"
+                            role="option"
+                            aria-selected={selectedItemId === item.id}
                         >
                             <div class="item-content">
                                 {#if item.image}
@@ -156,6 +157,11 @@
         margin-bottom: 4px;
         background: #2f5b2f;
         transition: all 0.2s ease;
+    }
+
+    .item-row:focus-visible {
+        outline: 2px solid #68d46d;
+        outline-offset: 2px;
     }
 
     .item-row:hover {


### PR DESCRIPTION
## Summary
- add aria-selected states and focus outlines to avatar and item selectors
- document focusable selectors in README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b0044827ac832fa9156613e65d21c8