### PR TITLE
docs: refine Codex Prompt Upgrader instructions

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -5,8 +5,9 @@ slug: 'prompts-codex-upgrader'
 
 # Codex Prompt Upgrader
 
-Use this meta prompt when the Codex templates themselves need refreshing. It keeps our
-instructions current—the machine that builds the machine. See
+Use this meta prompt whenever the Codex templates need refreshing. It tracks new prompt
+types and required checks so the machine that builds the machine stays current. Keep
+each change scoped and easy to revert. See
 [Codex Prompts](/docs/prompts-codex) for the baseline templates, the
 [Codex Meta Prompt](/docs/prompts-codex-meta) for routine maintenance, and the
 [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix) for troubleshooting failing
@@ -34,7 +35,10 @@ A pull request refreshing the Codex prompt docs with passing checks.
 
 Type: evergreen
 
-Use this prompt to keep prompt-upgrader instructions current.
+Use this prompt to keep upgrader instructions current with all prompt types and checks.
+It summarizes the standard checks (`npm run lint`, `npm run type-check`,
+`npm run build`, `npm run test:ci`, and secret scanning) so upgrades always include
+them.
 
 ```text
 SYSTEM:


### PR DESCRIPTION
## Summary
- clarify that the Codex Prompt Upgrader tracks new prompt types and checks
- note the standard checks so upgrades stay scoped and reversible

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004b26c04832fa7f8163ac19efc0b