### PR TITLE
docs: refine dependency audit prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-audit.md
+++ b/frontend/src/pages/docs/md/prompts-audit.md
@@ -14,12 +14,17 @@ Actions runs, use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >
-> 1. Address high or critical vulnerabilities in `package.json` or `pnpm-lock.yaml`.
+> 1. Address high or critical vulnerabilities in `package.json`, `pnpm-lock.yaml`, or the temporary `frontend/package-lock.json`.
 > 2. Prefer minimal, well-maintained packages.
 > 3. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.
 > 4. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 5. Commit with an emoji prefix.
+
+`npm run audit:ci` executes `npm audit --omit=dev --audit-level=high` in the repo root and the
+`frontend` workspace. The script generates `frontend/package-lock.json` for the audit and removes
+it afterward—don't commit this file. The most recent high-risk package was the OpenAI SDK, fixed in
+August 2025; current audits report no high-severity vulnerabilities.
 
 ```text
 SYSTEM:
@@ -51,8 +56,10 @@ Ensure `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:
-1. Ensure audit commands and vulnerability policies match current tooling.
-2. Note recent high-risk packages or lockfile locations if paths changed.
+1. Ensure audit commands and vulnerability policies match current tooling (`npm run audit:ci` runs
+   `npm audit --omit=dev --audit-level=high` for both root and `frontend`).
+2. Note recent high-risk packages or lockfile locations if paths changed (root `pnpm-lock.yaml`,
+   temporary `frontend/package-lock.json`).
 3. Run the checks above.
 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 5. Commit with an emoji-prefixed message.


### PR DESCRIPTION
## Summary
- document npm audit workflow and temporary frontend lockfile
- note resolved OpenAI SDK vulnerability and absence of high-risk packages

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b004443e44832fa61d9191af10136a