### PR TITLE
Draft: docs: refine Vitest prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-vitest.md
+++ b/frontend/src/pages/docs/md/prompts-vitest.md
@@ -21,6 +21,13 @@ use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit with an emoji prefix.
 
+Root Vitest specs live in `tests/**/*.test.ts`, `scripts/tests/**/*.test.ts`, and
+`backend/**/*.test.ts`. Frontend component tests sit in `frontend/__tests__` and usually
+end with `.test.js`. Align any new test files with these locations and naming conventions.
+
+For coverage, run `npm run coverage`. This invokes `vitest run --coverage` using the V8
+provider and writes reports to `frontend/coverage`.
+
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
@@ -49,8 +56,10 @@ Ensure `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:
-1. Verify test file locations and naming conventions match current structure.
-2. Note new Vitest flags or coverage requirements.
+1. Confirm root specs stay in `tests/**/*.test.ts`, `scripts/tests/**/*.test.ts`, and
+   `backend/**/*.test.ts`, while frontend specs use `frontend/__tests__/*.test.js`.
+2. Note any new Vitest flags (e.g. `--testTimeout 20000`) or coverage expectations
+   (`npm run coverage` writes reports to `frontend/coverage`).
 3. Run the checks above.
 4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 5. Commit with an emoji-prefixed message.


### PR DESCRIPTION
## Summary
- document test file locations and naming
- note `npm run coverage` and test timeout flag for Vitest

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: ERR_IPC_CHANNEL_CLOSED)*

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68b0054929c8832fb2855de029bedf10