### PR TITLE
Add test for invalid percent-encoded paths in fs checks

### DIFF
--- a/tests/fsChecksInvalidEncoding.test.ts
+++ b/tests/fsChecksInvalidEncoding.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { listMissingImages } from '../scripts/utils/fs-checks';
+
+describe('listMissingImages', () => {
+  test('handles invalid percent-encoded paths safely', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'images-'));
+    try {
+      const images = ['bad%2Gname.png'];
+      const missing = listMissingImages(images, tmp);
+      expect(missing).toEqual(['bad%2Gname.png']);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- test listMissingImages with invalid percent-encoded path

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0053bb7c8832f889ad3314f59f732