### PR TITLE
Add tests for fix-markdown-image-paths script

### DIFF
--- a/scripts/fix-markdown-image-paths.js
+++ b/scripts/fix-markdown-image-paths.js
@@ -1,7 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
-const dir = path.join(__dirname, '..', 'frontend', 'src', 'pages', 'docs', 'md', 'changelog');
+const dir = path.join(
+  __dirname,
+  '..',
+  'frontend',
+  'src',
+  'pages',
+  'docs',
+  'md',
+  'changelog',
+);
 const changed = [];
 
 function walk(folder) {
@@ -31,10 +40,18 @@ function fixFile(file) {
   }
 }
 
-walk(dir);
-if (changed.length) {
-  console.log('Updated files:');
-  for (const f of changed) console.log(' - ' + f);
-} else {
-  console.log('No changes found.');
+function run(targetDir = dir) {
+  walk(targetDir);
+  if (changed.length) {
+    console.log('Updated files:');
+    for (const f of changed) console.log(' - ' + f);
+  } else {
+    console.log('No changes found.');
+  }
+}
+
+module.exports = { walk, fixFile, run };
+
+if (require.main === module) {
+  run();
 }

--- a/tests/fix-markdown-image-paths.test.ts
+++ b/tests/fix-markdown-image-paths.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fixFile } from '../scripts/fix-markdown-image-paths.js';
+
+describe('fix-markdown-image-paths', () => {
+  it('rewrites image paths and cleans markdown', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'md-'));
+    const file = path.join(tmpDir, 'doc.md');
+    const original = `---\ntitle: Test\n---\n![Alt](/assets/img.png)\nText\n【1†Image: sample.png】`;
+    fs.writeFileSync(file, original, 'utf8');
+
+    fixFile(file);
+
+    const result = fs.readFileSync(file, 'utf8');
+    expect(result).toContain('![Alt](../../../../../public/assets/img.png)');
+    expect(result).toContain('<!-- image removed: sample.png -->');
+    expect(result.startsWith('---\ntitle: Test\n---\n\n')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- export utilities from fix-markdown-image-paths script
- test image path rewrite and frontmatter cleanup

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b0053bb7c8832f889ad3314f59f732