### PR TITLE
🧪 test: cover scoreQuest heuristics

### DIFF
--- a/tests/scoreQuestOpenAI.test.ts
+++ b/tests/scoreQuestOpenAI.test.ts
@@ -28,4 +28,19 @@ describe('scoreQuest', () => {
       process.env.OPENAI_API_KEY = originalKey;
     }
   });
+
+  test('uses heuristic when API key is missing', async () => {
+    const originalKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    const { scoreQuest } = await import('../scripts/utils/llm.js');
+    const shortScore = await scoreQuest('short');
+    const longScore = await scoreQuest('x'.repeat(101));
+    expect(shortScore).toBe(0.5);
+    expect(longScore).toBe(0.8);
+    if (originalKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalKey;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for scoreQuest fallback heuristics without API key

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b0053bb7c8832f889ad3314f59f732