### PR TITLE
📝: clarify secret scanning prompt doc

### DIFF
--- a/frontend/src/pages/docs/md/prompts-secrets.md
+++ b/frontend/src/pages/docs/md/prompts-secrets.md
@@ -8,17 +8,28 @@ slug: 'prompts-secrets'
 Use this template to prevent leaking credentials or other sensitive data. Combine it with
 other prompt guides to keep the repository secure.
 
+The default scanner command is `git diff --cached | ./scripts/scan-secrets.py`. If the
+repo adopts tools such as `ripsecrets`, `detect-secrets`, or `git-secrets`, update the
+example accordingly so contributors run the current scanner.
+
 > **TL;DR**
 >
 > 1. Run `git diff --cached | ./scripts/scan-secrets.py` before every commit.
-> 2. Investigate any findings and remove credentials.
+> 2. Investigate any findings. Remove secrets and rotate credentials if exposed, or
+>    document false positives.
 > 3. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 4. Commit with an emoji prefix.
+
+### Handling findings
+
+-   False positives: add an allowlist entry or document the reasoning in the commit message.
+-   Real secrets: remove them from history and rotate the credential immediately.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before committing.
+Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `npm run test:ci` pass before committing.
 
 USER:
 1. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
## Summary
- note current scan script and mention other tools
- document handling of false positives and credential rotation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `detect-secrets scan`

------
https://chatgpt.com/codex/tasks/task_e_68b00534f194832f8f41cea929fd4015