### PR TITLE
📝: refine CI-failure fix prompt for current workflows

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -33,11 +33,17 @@ PURPOSE:
 Diagnose a failed CI run and make it pass.
 
 CONTEXT:
-- If a failed job URL is provided, fetch the logs and identify the first real
-  error.
+- If a failed job URL is provided, fetch logs with
+  `gh run view <run-id> --log` and identify the first real error. Rerun flaky
+  jobs with `gh run rerun <run-id>` or the "Re-run failed jobs" button.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-    * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` locally.
+    * Workflows include `CI` (job `build`), `tests` (job `test`), `link-check`
+      (job `lychee`), and `ci-sentinel` (job `ensure-tests-exist`).
+    * Common failures: lint or type errors, build breaks, test failures,
+      coverage regressions, link rot, or missing workflows.
+    * Run `npm run lint`, `npm run type-check`, `npm run build`, and
+      `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.
@@ -129,6 +135,8 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.
 -   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
     `fetch-depth: 0` so scripts can compare against the default branch.
+-   2025-08-28 – Documented current GitHub Actions job names and `gh run` commands for log
+    retrieval and reruns so the prompt stays aligned with CI tooling.
 
 ## Upgrader Prompt
 


### PR DESCRIPTION
what: sync CI-failure fix prompt with job names and gh log/rerun steps
why: keep troubleshooting prompt aligned with current workflows
how to test: npm run lint && npm run type-check && npm run build && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b00496e848832fa8e3f928465281af