### PR TITLE
docs: refresh CI-failure fix prompt with current jobs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -33,13 +33,17 @@ PURPOSE:
 Diagnose a failed CI run and make it pass.
 
 CONTEXT:
-- If a failed job URL is provided, fetch the logs and identify the first real
-  error.
-- If no URL is given, inspect the codebase to reproduce the failure:
-  * Examine `.github/workflows/` to learn which checks run in CI.
-    * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` locally.
-  * Study project docs to understand how to run the test suite and emulate the
-    GitHub Actions environment.
+ - If a failed job URL is provided, fetch the logs and identify the first real
+   error. Download the full log or run `gh run view <run-id> --log`, then rerun
+   fixes with **Re-run failed jobs** or `gh run rerun --failed`.
+ - If no URL is given, inspect the codebase to reproduce the failure:
+   * Examine `.github/workflows/` to learn which checks run in CI.
+     * Jobs include `build` in `ci.yml` (runs coverage) and `test` in `tests.yml`
+       (runs unit, E2E, and patch coverage). Common failures include missing
+       Playwright browsers, patch coverage gaps, or dev server timeouts.
+     * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` locally.
+   * Study project docs to understand how to run the test suite and emulate the
+     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.
 - Constraints:
   * Keep existing behaviour intact.
@@ -129,6 +133,9 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.
 -   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
     `fetch-depth: 0` so scripts can compare against the default branch.
+
+-   2025-08-28 – Document lists current `build` and `test` jobs and shows how to
+    download logs or rerun failed GitHub Actions jobs with `gh run`.
 
 ## Upgrader Prompt
 


### PR DESCRIPTION
## Summary
- document current `build` and `test` jobs in the CI failure prompt
- note `gh run` commands for log downloads and reruns
- record the update in Lessons learned

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b00496e848832fa8e3f928465281af