### PR TITLE
docs: refine Playwright test prompt

### DIFF
--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -6,10 +6,11 @@ slug: 'prompts-playwright-tests'
 # Playwright test prompts for the _dspace_ repo
 
 Use this template to add end-to-end coverage for journeys listed in
-[User journeys](/docs/user-journeys) using
-[Playwright](https://playwright.dev/). While working, review the existing
-journeys for inaccuracies or gaps/misunderstandings and expand the list as new
-features land. Tests should assert visible UI content to verify that pages render
+[User journeys](user-journeys.md) using
+[Playwright](https://playwright.dev/) (currently v1.51.0). While working, review
+the existing journeys for inaccuracies or gaps/misunderstandings and expand the
+list as new features land. Tests should assert visible UI content to verify that
+pages render
 correctly. Treat this prompt as living documentation—periodically refine it using
 other `prompts-*.md` files for inspiration. Use this guide alongside
 [Codex Prompts](/docs/prompts-codex). To keep the prompt docs evolving, see the
@@ -40,10 +41,13 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 >    fixes, keeping the table alphabetized. Mark new journeys with `No` coverage
 >    until a test lands, and verify apparent 404s aren't missing routes; if a
 >    page should exist, add a stub instead of asserting a 404.
-> 10. Run `npx playwright install chromium` if browsers are missing.
-> 11. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+> 10. CI runs headlessly; the config sets `use.headless=true` and adds
+>     Chromium's `--headless=new` flag. Override worker count with
+>     `PW_WORKERS` as needed.
+> 11. Run `npx playwright install chromium` if browsers are missing.
+> 12. Run `npm run lint`, `npm run type-check`, `npm run build`, and
 >     `npm run test:ci`.
-> 12. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
+> 13. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`
 >     and commit with an emoji.
 
 ```text


### PR DESCRIPTION
## Summary
- note Playwright v1.51.0 and switch user-journey link to relative path
- document headless CI flags and PW_WORKERS helper

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b004eee0e8832fbd1a84a405ff9f29