### PR TITLE
docs: refine monitoring prompt links

### DIFF
--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -3,7 +3,7 @@ title: 'Monitoring Prompts'
 slug: 'prompts-monitoring'
 ---
 
-# Monitoring prompts for the _dspace_ repo
+# Monitoring prompts for the DSPACE repository
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
 ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex)
@@ -18,8 +18,9 @@ these templates drift, refresh them with the
 > **TL;DR**
 >
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
-> 2. Prefer open-source tools on self-managed infrastructure (e.g., Prometheus, Grafana) and
->    avoid sending personal data to third-party services.
+> 2. Prefer open-source tools on self-managed infrastructure
+>    (e.g., [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/)) and avoid
+>    sending personal data to third-party services.
 > 3. Add sample dashboards or alert rules when relevant.
 > 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 >    `npm run build`, and `npm run test:ci`.
@@ -34,7 +35,8 @@ Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
 
 USER:
 1. Update monitoring configs or code under `monitoring/`.
-2. Use open-source, self-hosted tools (e.g., Prometheus, Grafana) that respect user privacy.
+2. Use open-source, self-hosted tools (e.g., [Prometheus](https://prometheus.io/),
+   [Grafana](https://grafana.com/)) that respect user privacy.
 3. Include or update sample dashboards and alerting rules when adding metrics.
 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,
    `npm run build`, and `npm run test:ci`.


### PR DESCRIPTION
## Summary
- add Prometheus and Grafana links to monitoring prompts
- clarify repository name in monitoring prompt guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npm run audit:ci`
- `git diff --cached | detect-secrets scan --string` *(fallback, `scripts/scan-secrets.py` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0049d8d2c832f9537b2d942acb7aa