### PR TITLE
docs: use relative links in monitoring and backend prompts

### DIFF
--- a/frontend/src/pages/docs/md/prompts-backend.md
+++ b/frontend/src/pages/docs/md/prompts-backend.md
@@ -6,14 +6,17 @@ slug: 'prompts-backend'
 # Backend prompts for the _dspace_ repo
 
 DSPACE is mostly frontend code, but a few backend pieces support self-hosting via
-[Sugarkube's Raspberry Pi cluster](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md).
-Use this guide alongside [Codex Prompts](/docs/prompts-codex) when editing
+[Sugarkube's Raspberry Pi cluster][sugarkube].
+
+[sugarkube]: https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md
+
+Use this guide alongside [Codex Prompts](prompts-codex.md) when editing
 `backend/` modules. Contributions must deliver clear user value and honor
 end-user privacy, dignity, and agency as outlined in
 [Gabriel](https://github.com/futuroptimist/gabriel). To keep the prompt docs
-evolving, see the [Codex meta prompt](/docs/prompts-codex-meta). If these
-templates drift, refresh them with the [Codex Prompt Upgrader](/docs/prompts-codex-upgrader).
-For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+evolving, see the [Codex meta prompt](prompts-codex-meta.md). If these
+templates drift, refresh them with the [Codex Prompt Upgrader](prompts-codex-upgrader.md).
+For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -6,14 +6,14 @@ slug: 'prompts-monitoring'
 # Monitoring prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
-ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex)
-when editing files under [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
+ready-made pull requests. Use this guide alongside [Codex Prompts](prompts-codex.md)
+when editing files under [`monitoring/`](../../../../monitoring)
 to keep metrics, dashboards, and alerts consistent. For configuration details, see
-[`monitoring/README.md`](https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md).
-To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
+[`monitoring/README.md`](../../../../monitoring/README.md).
+To keep the prompt docs evolving, see the [Codex meta prompt](prompts-codex-meta.md); if
 these templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+[Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- use relative Codex links in backend prompts
- point monitoring guide at repo paths instead of GitHub URLs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b0049d8d2c832f9537b2d942acb7aa