### PR TITLE
📝 docs: refine monitoring and accessibility prompts

### DIFF
--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -5,13 +5,7 @@ slug: 'prompts-accessibility'
 
 # Accessibility prompts for the _dspace_ repo
 
-Codex can open this repository and run its own tests. Use this guide alongside
-[Codex Prompts](/docs/prompts-codex) when improving accessibility so instructions stay
-consistent. To keep the prompt docs evolving, see the
-[Codex meta prompt](/docs/prompts-codex-meta). If templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use
-the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix). The focus here is on semantic
-HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
+Codex is a sandboxed engineering agent that can open this repository, run tests, and submit ready-made pull requests. Use this guide alongside [Codex Prompts](prompts-codex.md) when improving accessibility so instructions remain consistent. To keep the prompt docs evolving, see the [Codex meta prompt](prompts-codex-meta.md). If templates drift, refresh them with the [Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md). This doc focuses on semantic HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
 
 > **TL;DR**
 >

--- a/frontend/src/pages/docs/md/prompts-monitoring.md
+++ b/frontend/src/pages/docs/md/prompts-monitoring.md
@@ -6,19 +6,19 @@ slug: 'prompts-monitoring'
 # Monitoring prompts for the _dspace_ repo
 
 Codex is a sandboxed engineering agent that can open this repository, run tests, and submit
-ready-made pull requests. Use this guide alongside [Codex Prompts](/docs/prompts-codex)
+ready-made pull requests. Use this guide alongside [Codex Prompts](prompts-codex.md)
 when editing files under [`monitoring/`](https://github.com/democratizedspace/dspace/tree/main/monitoring)
 to keep metrics, dashboards, and alerts consistent. For configuration details, see
 [`monitoring/README.md`](https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md).
-To keep the prompt docs evolving, see the [Codex meta prompt](/docs/prompts-codex-meta); if
+To keep the prompt docs evolving, see the [Codex meta prompt](prompts-codex-meta.md); if
 these templates drift, refresh them with the
-[Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
+[Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
 > **TL;DR**
 >
 > 1. Scope changes to `monitoring/` configs or supporting scripts.
-> 2. Prefer open-source tools on self-managed infrastructure (e.g., Prometheus, Grafana) and
+> 2. Prefer open-source, self-hosted tools (e.g., Prometheus, Grafana);
 >    avoid sending personal data to third-party services.
 > 3. Add sample dashboards or alert rules when relevant.
 > 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`,


### PR DESCRIPTION
## Summary
- switch /docs/ links to relative ones in accessibility and monitoring prompts
- clarify monitoring bullet about self-hosted tools

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b0049d8d2c832f9537b2d942acb7aa