### PR TITLE
Add logout flow e2e test and refresh user journeys doc

### DIFF
--- a/frontend/e2e/backlog/dark-mode-toggle.spec.ts
+++ b/frontend/e2e/backlog/dark-mode-toggle.spec.ts
@@ -1,0 +1,13 @@
+import { test } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Dark mode toggle', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('placeholder for dark mode toggle', async ({ page }) => {
+        await page.goto('/');
+        // TODO: implement dark mode toggle steps
+    });
+});

--- a/frontend/e2e/backlog/docs-search.spec.ts
+++ b/frontend/e2e/backlog/docs-search.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 import { clearUserData } from './test-helpers';
 
-test.describe('Logout flow', () => {
+test.describe('Docs search', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
     });
 
-    test('placeholder for logout flow', async ({ page }) => {
-        await page.goto('/');
-        // TODO: implement logout steps once available
+    test('placeholder for docs search', async ({ page }) => {
+        await page.goto('/docs');
+        // TODO: implement docs search steps
     });
 });

--- a/frontend/e2e/logout-flow.spec.ts
+++ b/frontend/e2e/logout-flow.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Logout flow', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('clears GitHub token from cloud sync', async ({ page }) => {
+        const token = 'ghp_' + 'a'.repeat(36);
+        await page.goto('/cloudsync');
+        const tokenInput = page.locator('#token');
+        await expect(tokenInput).toBeVisible();
+        await tokenInput.fill(token);
+        await page.getByRole('button', { name: 'Save' }).click();
+        await page.getByTestId('clear-sync-token').click();
+        await expect(tokenInput).toHaveValue('');
+        const stored = await page.evaluate(() => {
+            return JSON.parse(localStorage.getItem('gameState') || '{}').github?.token || '';
+        });
+        expect(stored).toBe('');
+    });
+});

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -6,9 +6,9 @@ slug: 'user-journeys'
 # User Journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
-Tests under `frontend/e2e/backlog` are placeholders for journeys without automation; move them to
-`frontend/e2e` once coverage lands. Entries are sorted alphabetically by journey name, and new
-journeys should include a placeholder spec in `frontend/e2e/backlog` until coverage exists.
+Uncovered journeys require a placeholder spec under `frontend/e2e/backlog`. When automation lands,
+use `git mv` to promote the spec into `frontend/e2e` and update this table. Entries are sorted
+alphabetically by journey name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
@@ -30,7 +30,7 @@ journeys should include a placeholder spec in `frontend/e2e/backlog` until cover
 | Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
 | Item preview               | Yes                 | `frontend/e2e/item-preview.spec.ts`               |
 | Legacy data import         | No                  | --                                                |
-| Logout flow                | No                  | --                                                |
+| Logout flow                | Yes                 | `frontend/e2e/logout-flow.spec.ts`                |
 | Manage items               | Yes                 | `frontend/e2e/manage-items.spec.ts`               |
 | Manage processes           | No                  | --                                                |
 | Manage quests              | No                  | --                                                |


### PR DESCRIPTION
## Summary
- add Playwright test for logout flow
- clarify doc placeholder guidance and update coverage table
- add backlog stubs for dark mode toggle and docs search

## Testing
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- cd frontend && npm run setup-test-env && npx playwright test e2e/logout-flow.spec.ts
- git diff --cached | ./scripts/scan-secrets.py (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b004ea5c10832fbf0d1e98dc052850