### PR TITLE
Add legacy import test and document coverage

### DIFF
--- a/frontend/e2e/backlog/changelog-doc.spec.ts
+++ b/frontend/e2e/backlog/changelog-doc.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+
+// TODO: Implement changelog doc page test
+
+test('changelog doc loads placeholder', async ({ page }) => {
+    await page.goto('/docs/changelog');
+});

--- a/frontend/e2e/backlog/dark-mode-toggle.spec.ts
+++ b/frontend/e2e/backlog/dark-mode-toggle.spec.ts
@@ -1,0 +1,6 @@
+import { test } from '@playwright/test';
+
+// TODO: Implement dark mode toggle test
+test('dark mode toggle placeholder', async ({ page }) => {
+    await page.goto('/');
+});

--- a/frontend/e2e/backlog/docs-search.spec.ts
+++ b/frontend/e2e/backlog/docs-search.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+
+// TODO: Implement docs search test
+
+test('docs search placeholder', async ({ page }) => {
+    await page.goto('/docs');
+});

--- a/frontend/e2e/backlog/legacy-import.spec.ts
+++ b/frontend/e2e/backlog/legacy-import.spec.ts
@@ -1,6 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: Add full legacy data import flow.
-test('legacy data import flow placeholder', async () => {
-    // Placeholder test
-});

--- a/frontend/e2e/backlog/process-preview.spec.ts
+++ b/frontend/e2e/backlog/process-preview.spec.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+
+// TODO: Implement process preview test
+
+test('process preview placeholder', async ({ page }) => {
+    await page.goto('/processes');
+});

--- a/frontend/e2e/legacy-import.spec.ts
+++ b/frontend/e2e/legacy-import.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Legacy data import', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('shows upgrade path when no v1 cookies are present', async ({ page }) => {
+        await page.goto('/import/v2/v1');
+        await expect(page.getByRole('heading', { name: 'Upgrade from v1 to v2' })).toBeVisible();
+        await expect(page.getByText("didn't play v1")).toBeVisible();
+    });
+});

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -6,15 +6,16 @@ slug: 'user-journeys'
 # User Journeys
 
 This document tracks major journeys in DSPACE and whether a Playwright test covers each path.
-Tests under `frontend/e2e/backlog` are placeholders for journeys without automation; move them to
-`frontend/e2e` once coverage lands. Entries are sorted alphabetically by journey name, and new
-journeys should include a placeholder spec in `frontend/e2e/backlog` until coverage exists.
+Uncovered journeys must ship a placeholder spec in `frontend/e2e/backlog/` until automation exists;
+move that spec to `frontend/e2e/` once coverage lands. Entries are sorted alphabetically by journey
+name.
 
 | Journey                    | Playwright coverage | Test file                                         |
 | -------------------------- | ------------------- | ------------------------------------------------- |
 | About page loads           | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Authentication flow        | Yes                 | `frontend/e2e/authentication-flow.spec.ts`        |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
+| Changelog page loads       | No                  | --                                                |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
 | Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
 | Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |
@@ -29,7 +30,7 @@ journeys should include a placeholder spec in `frontend/e2e/backlog` until cover
 | Glossary page loads        | Yes                 | `frontend/e2e/glossary-doc.spec.ts`               |
 | Home page loads            | Yes                 | `frontend/e2e/home-page-basic.spec.ts`            |
 | Item preview               | Yes                 | `frontend/e2e/item-preview.spec.ts`               |
-| Legacy data import         | No                  | --                                                |
+| Legacy data import         | Yes                 | `frontend/e2e/legacy-import.spec.ts`              |
 | Logout flow                | No                  | --                                                |
 | Manage items               | Yes                 | `frontend/e2e/manage-items.spec.ts`               |
 | Manage processes           | No                  | --                                                |


### PR DESCRIPTION
## Summary
- test legacy import path showing upgrade hint
- document coverage and add backlog placeholders

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004ea5c10832fbf0d1e98dc052850