### PR TITLE
fix: parse spaceless duration strings

### DIFF
--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -41,7 +41,7 @@ These are the items produced by the process, which are added to your inventory u
 
 <img src="/assets/docs/process_duration.jpg">
 
-Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency. Units are case-insensitive, so `1H 30M` works as well.
+Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency. Units are case-insensitive, so `1H 30M` works as well. Spaces between units are optional—`1h30m` is treated the same as `1h 30m`.
 
 #### Duration Examples
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -120,15 +120,14 @@ export const datetimeAfterDuration = (durationSeconds) => {
 
 export const durationInSeconds = (durationString) => {
     try {
-        const durationComponents = durationString.split(' ').filter(Boolean);
+        const durationComponents = durationString.match(/(\d+(?:\.\d+)?[dhms])/gi) ?? [];
 
-        // for each item in durationComponents, get the number and the unit
-        // then convert the number to seconds
         let durationSeconds = 0;
         for (const component of durationComponents) {
-            const number = parseFloat(component);
-            if (isNaN(number)) continue;
-            const unit = component.replace(String(number), '').toLowerCase();
+            const match = component.match(/(\d+(?:\.\d+)?)([dhms])/i);
+            if (!match) continue;
+            const number = parseFloat(match[1]);
+            const unit = match[2].toLowerCase();
             let seconds = 0;
             switch (unit) {
                 case 'd':

--- a/frontend/tests/duration.test.ts
+++ b/frontend/tests/duration.test.ts
@@ -6,4 +6,9 @@ describe('durationInSeconds', () => {
         expect(durationInSeconds('1H 30M')).toBe(5400);
         expect(durationInSeconds('45S')).toBe(45);
     });
+
+    it('parses concatenated units without spaces', () => {
+        expect(durationInSeconds('1h30m')).toBe(5400);
+        expect(durationInSeconds('2m10s')).toBe(130);
+    });
 });

--- a/outages/2025-08-28-duration-no-space.json
+++ b/outages/2025-08-28-duration-no-space.json
@@ -1,0 +1,12 @@
+{
+  "id": "duration-no-space",
+  "date": "2025-08-28",
+  "component": "frontend",
+  "rootCause": "durationInSeconds split on spaces, failing to parse durations like '1h30m'",
+  "resolution": "match number+unit groups with regex to support concatenated durations and added tests and docs",
+  "references": [
+    "frontend/src/utils.js",
+    "frontend/tests/duration.test.ts",
+    "frontend/src/pages/docs/md/processes.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- support duration strings without spaces (e.g. `1h30m`)
- document optional spacing in process durations
- record outage: duration-no-space (2025-08-28)

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004d530c0832fafb7f4b78f67d22c