### PR TITLE
fix: avoid prepare-pr recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ If Playwright browsers aren't installed, you may skip E2E tests:
 SKIP_E2E=1 npm test
 ```
 
+The pre-PR script runs root unit tests via `npm run test:root`. If those have
+already been executed, set `SKIP_UNIT_TESTS=1` to skip them when invoking the
+script directly.
+
 GitHub Actions runs the E2E tests and fails pull requests when they do not pass.
 If you encounter an error like `browserType.launch: Executable doesn't exist`,
 download the browsers with:

--- a/frontend/scripts/prepare-pr.ps1
+++ b/frontend/scripts/prepare-pr.ps1
@@ -26,19 +26,23 @@ try {
     }
     Write-Host "✅ Code formatting and linting passed!" -ForegroundColor Green
 
-    # Step 2: Run unit tests
-    Write-Host "`nStep 2/3: Running unit tests..."
-    $testOutput = npm test 2>&1
-    Write-Host $testOutput
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Unit tests failed. Please fix them before submitting your PR." -ForegroundColor Red
-        Set-Location -Path $originalDir
-        exit 1
+    # Step 2: Run unit tests unless skipped
+    if (-not $env:SKIP_UNIT_TESTS) {
+        Write-Host "`nStep 2/3: Running unit tests..."
+        $testOutput = npm run test:root 2>&1
+        Write-Host $testOutput
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "❌ Unit tests failed. Please fix them before submitting your PR." -ForegroundColor Red
+            Set-Location -Path $originalDir
+            exit 1
+        }
+        if ($testOutput -match 'Test Files\s+0' -or $testOutput -match 'Tests\s+0' -or $testOutput -match 'No test files? found') {
+            Write-Warning "No unit tests were run."
+        }
+        Write-Host "✅ Unit tests passed!" -ForegroundColor Green
+    } else {
+        Write-Host "`nStep 2/3: Skipping unit tests..."
     }
-    if ($testOutput -match 'Test Files\s+0' -or $testOutput -match 'Tests\s+0' -or $testOutput -match 'No test files? found') {
-        Write-Warning "No unit tests were run."
-    }
-    Write-Host "✅ Unit tests passed!" -ForegroundColor Green
 
     # Step 3: Run grouped E2E tests
     Write-Host "`nStep 3/3: Running end-to-end tests (grouped)..."

--- a/frontend/scripts/prepare-pr.sh
+++ b/frontend/scripts/prepare-pr.sh
@@ -26,20 +26,24 @@ if [ $? -ne 0 ]; then
 fi
 echo "✅ Code formatting and linting passed!"
 
-# Step 2: Run unit tests
-echo -e "\nStep 2/3: Running unit tests..."
-TEST_OUTPUT=$(npm test 2>&1)
-TEST_EXIT=$?
-echo "$TEST_OUTPUT"
-if [ $TEST_EXIT -ne 0 ]; then
-  echo "❌ Unit tests failed. Please fix them before submitting your PR."
-  cd "$ORIGINAL_DIR" || exit 1
-  exit 1
+# Step 2: Run unit tests unless skipped
+if [ -z "$SKIP_UNIT_TESTS" ]; then
+  echo -e "\nStep 2/3: Running unit tests..."
+  TEST_OUTPUT=$(npm run test:root 2>&1)
+  TEST_EXIT=$?
+  echo "$TEST_OUTPUT"
+  if [ $TEST_EXIT -ne 0 ]; then
+    echo "❌ Unit tests failed. Please fix them before submitting your PR."
+    cd "$ORIGINAL_DIR" || exit 1
+    exit 1
+  fi
+  if echo "$TEST_OUTPUT" | grep -Eq "Test Files\\s+0|Tests\\s+0|No test files? found"; then
+    echo "⚠️  Warning: no unit tests were run."
+  fi
+  echo "✅ Unit tests passed!"
+else
+  echo -e "\nStep 2/3: Skipping unit tests..."
 fi
-if echo "$TEST_OUTPUT" | grep -Eq "Test Files\\s+0|Tests\\s+0|No test files? found"; then
-  echo "⚠️  Warning: no unit tests were run."
-fi
-echo "✅ Unit tests passed!"
 
 # Step 3: Run grouped E2E tests (unless disabled)
 if [ -z "$SKIP_E2E" ]; then

--- a/outages/2025-08-28-prepare-pr-recursion.json
+++ b/outages/2025-08-28-prepare-pr-recursion.json
@@ -1,0 +1,13 @@
+{
+  "id": "prepare-pr-recursion",
+  "date": "2025-08-28",
+  "component": "pre-PR script",
+  "rootCause": "prepare-pr scripts invoked \"npm test\", which called run-tests.js recursively and caused \"npm run test:ci\" to hang",
+  "resolution": "Run root tests directly with \"npm run test:root\" and allow skipping via SKIP_UNIT_TESTS to avoid recursion",
+  "references": [
+    "frontend/scripts/prepare-pr.sh",
+    "frontend/scripts/prepare-pr.ps1",
+    "run-tests.js",
+    "scripts/tests/preparePrScripts.test.ts"
+  ]
+}

--- a/run-tests.js
+++ b/run-tests.js
@@ -51,7 +51,10 @@ function runTests(exec = execSync, platform = os.platform()) {
         };
         const { message, command } = scripts[platform] || scripts.default;
         console.log(message);
-        exec(command, { stdio: 'inherit' });
+        exec(command, {
+            stdio: 'inherit',
+            env: { ...process.env, SKIP_UNIT_TESTS: '1' }
+        });
 
         console.log(
             `\n${colors.bright}${colors.green}All tests completed successfully!${colors.reset}`

--- a/scripts/tests/preparePrScripts.test.ts
+++ b/scripts/tests/preparePrScripts.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'fs';
 import { expect, test } from 'vitest';
 
-test('prepare-pr scripts install Playwright browsers', () => {
+test('prepare-pr scripts install Playwright browsers and run root tests', () => {
   const sh = readFileSync('frontend/scripts/prepare-pr.sh', 'utf8');
   const ps = readFileSync('frontend/scripts/prepare-pr.ps1', 'utf8');
   expect(sh).toMatch(/playwright install --with-deps/);
   expect(ps).toMatch(/playwright install --with-deps/);
+  expect(sh).toMatch(/npm run test:root/);
+  expect(ps).toMatch(/npm run test:root/);
 });

--- a/scripts/tests/run-tests.test.ts
+++ b/scripts/tests/run-tests.test.ts
@@ -20,6 +20,13 @@ describe('runTests', () => {
       .mockReturnValueOnce('');
     const code = runTests(exec, 'linux');
     expect(code).toBe(0);
-    expect(exec).toHaveBeenNthCalledWith(2, 'bash ./frontend/scripts/prepare-pr.sh', { stdio: 'inherit' });
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      'bash ./frontend/scripts/prepare-pr.sh',
+      expect.objectContaining({
+        stdio: 'inherit',
+        env: expect.objectContaining({ SKIP_UNIT_TESTS: '1' })
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- skip recursive `npm test` in pre-PR scripts and allow skipping unit tests
- propagate `SKIP_UNIT_TESTS` from run-tests.js
- document unit-test skipping and record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:ci` *(fails: stuck installing Playwright browsers)*


------
https://chatgpt.com/codex/tasks/task_e_68b004d530c0832fafb7f4b78f67d22c