### PR TITLE
fix: treat infinite durations as complete

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -107,6 +107,9 @@ frontend/
 > Utility note: `src/utils/strings.js` now clamps duration values to the 0-100% range
 > to avoid negative or overflowing percentages in the UI.
 
+> Utility note: `src/utils/strings.js` now treats infinite durations as `100%`
+> to prevent unexpected `0%` output.
+
 ## Getting Started
 
 ### Prerequisites

--- a/frontend/__tests__/strings.test.js
+++ b/frontend/__tests__/strings.test.js
@@ -13,6 +13,11 @@ describe('getDurationString', () => {
         expect(getDurationString(-10, '3s')).toBe('0.00% - 3s');
         expect(getDurationString(150, '3s')).toBe('100.00%');
     });
+
+    test('handles infinite durations', () => {
+        expect(getDurationString(Infinity, '3s')).toBe('100.00%');
+        expect(getDurationString(-Infinity, '3s')).toBe('0.00% - 3s');
+    });
 });
 
 describe('getDuration', () => {
@@ -23,5 +28,10 @@ describe('getDuration', () => {
     test('clamps values to 0-100%', () => {
         expect(getDuration(-5)).toBe('0.00%');
         expect(getDuration(150)).toBe('100.00%');
+    });
+
+    test('handles infinite durations', () => {
+        expect(getDuration(Infinity)).toBe('100.00%');
+        expect(getDuration(-Infinity)).toBe('0.00%');
     });
 });

--- a/frontend/src/utils/strings.js
+++ b/frontend/src/utils/strings.js
@@ -10,8 +10,11 @@
  */
 const sanitizeDuration = (duration) => {
     const num = Number(duration);
-    if (!Number.isFinite(num)) {
+    if (Number.isNaN(num)) {
         return 0;
+    }
+    if (!Number.isFinite(num)) {
+        return num > 0 ? 100 : 0;
     }
     return Math.min(Math.max(num, 0), 100);
 };

--- a/outages/2025-08-28-duration-infinity.json
+++ b/outages/2025-08-28-duration-infinity.json
@@ -1,0 +1,13 @@
+{
+  "id": "duration-infinity",
+  "date": "2025-08-28",
+  "component": "frontend",
+  "rootCause": "sanitizeDuration returned 0 for Infinity causing progress to show 0%",
+  "resolution": "treat infinite durations as 100% in sanitizeDuration",
+  "references": [
+    "frontend/src/utils/strings.js",
+    "tests/strings.test.ts",
+    "frontend/__tests__/strings.test.js",
+    "frontend/README.md"
+  ]
+}

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -21,6 +21,11 @@ describe('getDurationString', () => {
     expect(getDurationString(-10, '3s')).toBe('0.00% - 3s');
     expect(getDurationString(150, '3s')).toBe('100.00%');
   });
+
+  test('handles infinite durations', () => {
+    expect(getDurationString(Infinity, '3s')).toBe('100.00%');
+    expect(getDurationString(-Infinity, '3s')).toBe('0.00% - 3s');
+  });
 });
 
 describe('getDuration', () => {
@@ -37,5 +42,10 @@ describe('getDuration', () => {
   test('clamps values to 0-100%', () => {
     expect(getDuration(-5)).toBe('0.00%');
     expect(getDuration(150)).toBe('100.00%');
+  });
+
+  test('handles infinite durations', () => {
+    expect(getDuration(Infinity)).toBe('100.00%');
+    expect(getDuration(-Infinity)).toBe('0.00%');
   });
 });


### PR DESCRIPTION
## Summary
- clamp Infinity to 100% in sanitizeDuration
- document and test infinity duration handling
- record outage for sanitizeDuration Infinity case

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `SKIP_E2E=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004d530c0832fafb7f4b78f67d22c