### PR TITLE
fix duration parser for compact units

### DIFF
--- a/frontend/src/pages/docs/md/process-guidelines.md
+++ b/frontend/src/pages/docs/md/process-guidelines.md
@@ -24,7 +24,7 @@ DSPACE processes should:
 Every process requires the following properties:
 
 -   **title**: Clear, descriptive name for the process (required)
--   **duration**: Time required to complete the process in format `#h #m` (units are case-insensitive, required)
+-   **duration**: Time required to complete the process in format `#h #m` (space optional, e.g., `1h30m`; units are case-insensitive, required)
 -   **requireItems**: Items needed but not consumed (optional)
 -   **consumeItems**: Items removed from inventory when process starts (optional)
 -   **createItems**: Items added to inventory when process completes (optional)

--- a/frontend/src/pages/docs/md/processes.md
+++ b/frontend/src/pages/docs/md/processes.md
@@ -41,12 +41,12 @@ These are the items produced by the process, which are added to your inventory u
 
 <img src="/assets/docs/process_duration.jpg">
 
-Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency. Units are case-insensitive, so `1H 30M` works as well.
+Duration indicates the amount of time required for the process to complete. It's expressed in the form 1d 2h 3m 4s, meaning 1 day, 2 hours, 3 minutes, and 4 seconds. Process durations can range from mere seconds to several months or even years. The form normalizes input like `0.5h 30s` to `30m 30s` for consistency. Units are case-insensitive, so `1H 30M` works as well, and spaces between units are optional (e.g., `1h30m`).
 
 #### Duration Examples
 
 -   Quick processes: "2s", "30s", "1m"
--   Medium processes: "1h 30m", "2h 8m 11s"
+-   Medium processes: "1h30m", "1h 30m", "2h 8m 11s"
 -   Long processes: "12h 52m 51s", "48h", "7d", "28d"
 
 The system automatically converts these durations into milliseconds for precise timing.

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -120,34 +120,29 @@ export const datetimeAfterDuration = (durationSeconds) => {
 
 export const durationInSeconds = (durationString) => {
     try {
-        const durationComponents = durationString.split(' ').filter(Boolean);
-
-        // for each item in durationComponents, get the number and the unit
-        // then convert the number to seconds
+        const regex = /(\d*\.?\d+)([dhms])/gi;
         let durationSeconds = 0;
-        for (const component of durationComponents) {
-            const number = parseFloat(component);
-            if (isNaN(number)) continue;
-            const unit = component.replace(String(number), '').toLowerCase();
-            let seconds = 0;
+        let match;
+        while ((match = regex.exec(durationString)) !== null) {
+            const number = parseFloat(match[1]);
+            const unit = match[2].toLowerCase();
             switch (unit) {
                 case 'd':
-                    seconds = number * 86400;
+                    durationSeconds += number * 86400;
                     break;
                 case 'h':
-                    seconds = number * 3600;
+                    durationSeconds += number * 3600;
                     break;
                 case 'm':
-                    seconds = number * 60;
+                    durationSeconds += number * 60;
                     break;
                 case 's':
-                    seconds = number;
+                    durationSeconds += number;
                     break;
                 /* istanbul ignore next */
                 default:
                     break;
             }
-            durationSeconds += seconds;
         }
 
         return durationSeconds;

--- a/frontend/tests/duration.test.ts
+++ b/frontend/tests/duration.test.ts
@@ -6,4 +6,8 @@ describe('durationInSeconds', () => {
         expect(durationInSeconds('1H 30M')).toBe(5400);
         expect(durationInSeconds('45S')).toBe(45);
     });
+
+    it('parses compact duration without spaces', () => {
+        expect(durationInSeconds('1h30m')).toBe(5400);
+    });
 });

--- a/outages/2025-08-28-duration-compact-units.json
+++ b/outages/2025-08-28-duration-compact-units.json
@@ -1,0 +1,13 @@
+{
+  "id": "duration-compact-units",
+  "date": "2025-08-28",
+  "component": "frontend",
+  "rootCause": "duration parser ignored values when time units lacked spaces",
+  "resolution": "parse duration components with regex to allow compact strings",
+  "references": [
+    "frontend/src/utils.js",
+    "frontend/tests/duration.test.ts",
+    "frontend/src/pages/docs/md/processes.md",
+    "frontend/src/pages/docs/md/process-guidelines.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- handle compact duration strings like "1h30m"
- document optional spaces in process duration format
- record outage duration-compact-units

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b004d530c0832fafb7f4b78f67d22c