### PR TITLE
docs: document monitoring alerts and dashboard access

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -9,15 +9,28 @@ locally to collect and visualize metrics without sending data to third parties.
 docker-compose up
 ```
 
+Once the containers start:
+
+- Prometheus is available at [http://localhost:9090](http://localhost:9090).
+- Grafana runs at [http://localhost:3000](http://localhost:3000) with a preloaded
+  **DSpace Overview** dashboard.
+
 ## Features
 
 - Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
 - Grafana provisions a Prometheus data source and a sample dashboard.
 - The dashboard shows service availability and HTTP 5xx error rate over time.
+- Metrics follow standard Prometheus naming such as `up` and `http_requests_total`.
 
 ## Alerts
 
 ### DspaceDown
+
+Alert expression:
+
+```promql
+up{job="dspace"} == 0
+```
 
 Fires when the `dspace` job stops reporting `up` for one minute.
 
@@ -28,8 +41,14 @@ Fires when the `dspace` job stops reporting `up` for one minute.
 
 ### DspaceHighErrorRate
 
-Triggers when more than 5% of HTTP requests return 5xx status codes for five
-minutes.
+Alert expression:
+
+```promql
+rate(http_requests_total{job="dspace",status=~"5.."}[5m]) /
+rate(http_requests_total{job="dspace"}[5m]) > 0.05
+```
+
+Triggers when more than 5% of HTTP requests return 5xx status codes for five minutes.
 
 **Runbook**
 


### PR DESCRIPTION
## Summary
- clarify local Prometheus/Grafana URLs in monitoring README
- document alert expressions for DspaceDown and DspaceHighErrorRate

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004cd97e0832fb7aefbbd6685b920