### PR TITLE
docs: clarify monitoring dashboard and alerts

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -11,11 +11,18 @@ docker-compose up
 
 ## Features
 
-- Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
-- Grafana provisions a Prometheus data source and a sample dashboard.
-- The dashboard shows service availability and HTTP 5xx error rate over time.
+- Prometheus scrapes the DSpace metrics endpoint as configured in
+  [`prometheus/prometheus.yml`](prometheus/prometheus.yml) and evaluates alert rules from
+  [`prometheus/alerts.yml`](prometheus/alerts.yml).
+- Grafana provisions a Prometheus data source and the
+  [DSpace Overview dashboard](http://localhost:3000/d/dspace-overview/dspace-overview).
+- The dashboard shows service availability (`up`) and HTTP 5xx error rate derived from
+  `http_requests_total` metrics.
 
 ## Alerts
+
+Alert rules live in [`prometheus/alerts.yml`](prometheus/alerts.yml) and use the `Dspace*`
+naming convention.
 
 ### DspaceDown
 

--- a/monitoring/grafana/dashboards/dspace-overview.json
+++ b/monitoring/grafana/dashboards/dspace-overview.json
@@ -1,5 +1,6 @@
 {
   "id": null,
+  "uid": "dspace-overview",
   "title": "DSpace Overview",
   "timezone": "browser",
   "panels": [


### PR DESCRIPTION
## Summary
- document Prometheus and Grafana config locations
- link to DSpace Overview dashboard and note metrics/alert naming convention

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: script required `./scripts/scan-secrets.py` missing? wait this is wrong; should note secret scan maybe? but make_pr body only for tests. but commit process? yes we summarizing tests.*


------
https://chatgpt.com/codex/tasks/task_e_68b004cd97e0832fb7aefbbd6685b920