### PR TITLE
Guard tutorial quest E2E interactions

### DIFF
--- a/frontend/e2e/tutorial-quest.spec.ts
+++ b/frontend/e2e/tutorial-quest.spec.ts
@@ -44,8 +44,8 @@ async function interactWithQuestTutorial(page: Page): Promise<void> {
         // Look for clickable elements and interact with them
         while (clickCount < maxClicks) {
             // Check for claim buttons that might appear
-            const claimButton = page.locator('text=Claim');
-            if ((await claimButton.count()) > 0) {
+            const claimButton = page.getByRole('button', { name: 'Claim', exact: true });
+            if ((await claimButton.count()) > 0 && (await claimButton.isEnabled())) {
                 console.log('Clicking claim button');
                 await claimButton.click();
                 await page.waitForTimeout(500);
@@ -57,8 +57,8 @@ async function interactWithQuestTutorial(page: Page): Promise<void> {
             }
 
             // Check for process options
-            const processButton = page.locator('text=Process');
-            if ((await processButton.count()) > 0) {
+            const processButton = page.getByRole('button', { name: 'Process', exact: true });
+            if ((await processButton.count()) > 0 && (await processButton.isEnabled())) {
                 console.log('Clicking process button');
                 await processButton.click();
                 await page.waitForTimeout(500);
@@ -80,11 +80,10 @@ async function interactWithQuestTutorial(page: Page): Promise<void> {
             }
 
             // Try to find clickable options - first try with 'a' elements
-            const options = optionsContainer.locator('a');
+            const options = optionsContainer.locator('a:enabled');
             const optionsCount = await options.count();
 
             if (optionsCount > 0) {
-                // Click the first option
                 console.log(`Clicking option ${clickCount + 1} of ${optionsCount} available`);
                 await options.first().click();
                 await page.waitForTimeout(500);

--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -129,6 +129,7 @@ Copy this file forward whenever CI fails so future fixes stay consistent.
 -   2025-08-25 – ESLint failed to load @typescript-eslint plugins when frontend dev dependencies were missing; install frontend packages before linting.
 -   2025-08-25 – shallow checkout hid `origin/v3`, making coverage tests fail; fetch with
     `fetch-depth: 0` so scripts can compare against the default branch.
+-   2025-08-28 – tutorial quest E2E test clicked disabled elements; ensure buttons and options are enabled before interacting.
 
 ## Upgrader Prompt
 

--- a/outages/2025-08-28-tutorial-quest-disabled-buttons.json
+++ b/outages/2025-08-28-tutorial-quest-disabled-buttons.json
@@ -1,0 +1,10 @@
+{
+  "id": "tutorial-quest-disabled-buttons",
+  "date": "2025-08-28",
+  "component": "e2e tests",
+  "rootCause": "tutorial quest spec attempted to click disabled buttons and links, timing out",
+  "resolution": "check button enablement and target :enabled links before clicking",
+  "references": [
+    "frontend/e2e/tutorial-quest.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- avoid clicking disabled buttons and links in the tutorial quest E2E spec
- document CI fix and record outage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx playwright test e2e/tutorial-quest.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b00455f198832f827cc65700eb33ff