### PR TITLE
Add request latency alert and Grafana panel

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -13,7 +13,8 @@ docker-compose up
 
 - Prometheus scrapes the DSpace metrics endpoint and evaluates alert rules.
 - Grafana provisions a Prometheus data source and a sample dashboard.
-- The dashboard shows service availability and HTTP 5xx error rate over time.
+- The dashboard shows service availability, HTTP 5xx error rate, and 99th percentile request
+  latency.
 
 ## Alerts
 
@@ -35,5 +36,14 @@ minutes.
 
 1. Inspect recent server logs for stack traces or failed requests.
 2. Investigate upstream dependencies that might be causing errors.
+
+### DspaceHighLatency
+
+Triggers when the 99th percentile request latency exceeds 500ms for five minutes.
+
+**Runbook**
+
+1. Examine recent deployments or configuration changes.
+2. Check database and external service performance.
 
 All services are self-hosted to respect user privacy.

--- a/monitoring/grafana/dashboards/dspace-overview.json
+++ b/monitoring/grafana/dashboards/dspace-overview.json
@@ -29,8 +29,38 @@
         "overrides": []
       },
       "yaxes": [
-        {"format": "percentunit", "min": 0, "max": 1},
-        {"format": "short"}
+        {
+          "format": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        {
+          "format": "short"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "99th Percentile Latency",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99,sum(rate(http_request_duration_seconds_bucket{job=\"dspace\"}[5m]))by(le))",
+          "legendFormat": "p99 latency"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "yaxes": [
+        {
+          "format": "s"
+        },
+        {
+          "format": "short"
+        }
       ]
     }
   ],

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -21,3 +21,18 @@ groups:
           summary: High error rate on DSpace
           description: More than 5% of HTTP requests returned 5xx status codes
           runbook: https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md#dspacehigherrorrate
+      - alert: DspaceHighLatency
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum(
+              rate(http_request_duration_seconds_bucket{job="dspace"}[5m])
+            ) by (le)
+          ) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High request latency on DSpace
+          description: 99th percentile request latency above 500ms
+          runbook: https://github.com/democratizedspace/dspace/blob/main/monitoring/README.md#dspacehighlatency


### PR DESCRIPTION
## Summary
- track 99th percentile request latency in Prometheus alert rules
- surface request latency in Grafana sample dashboard
- document new latency alert and runbook in monitoring README

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b004c94404832f8e9527925d7e9347