### PR TITLE
docs: refine frontend prompt guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-frontend.md
+++ b/frontend/src/pages/docs/md/prompts-frontend.md
@@ -7,21 +7,31 @@ slug: 'prompts-frontend'
 
 DSPACE's UI is built with Svelte and Astro. Codex can open this repository and run its own
 tests. Use this guide alongside [Codex Prompts](prompts-codex.md) when working on files inside
-`frontend/`, including Svelte components, pages, and styles. Changes should improve clarity,
-accessibility, or performance while keeping tests green. For deeper accessibility guidance, see
+`frontend/`, including Svelte components, pages, and styles. Place UI pieces in
+`frontend/src/components` and shared utilities in `frontend/src/lib`. Astro pages live in
+`frontend/src/pages`. Hydrate Svelte components with Astro `client:` directives and run
+interactive code in `onMount`; when hydration completes, set `data-hydrated="true"` on the
+component root to avoid double rendering. Changes should improve clarity, accessibility, or
+performance while keeping tests green. For deeper accessibility guidance, see
 [Accessibility prompts](prompts-accessibility.md). To keep the prompt docs evolving, see the
 [Codex meta prompt](prompts-codex-meta.md). If templates drift, refresh them with the
 [Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
 [Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
 
+Favor semantic HTML, visible focus states, and `prefers-reduced-motion` media queries for
+accessibility. For performance, defer heavy components with `client:idle` or `client:visible`
+and lazily load images using `loading="lazy"` or Astro's `<Image>` component.
+
 > **TL;DR**
 >
 > 1. Touch only the necessary files under `frontend/`.
 > 2. Keep components accessible, responsive, and idiomatic.
-> 3. Update or add tests in `frontend/__tests__` when behavior changes.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
-> 6. Commit with an emoji prefix.
+> 3. Use `frontend/src/components` (`src/lib` for shared) and hydrate with `client:` directives,
+>    setting `data-hydrated="true"` in `onMount`.
+> 4. Update or add tests in `frontend/__tests__` when behavior changes.
+> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 6. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+> 7. Commit with an emoji prefix.
 
 ```text
 SYSTEM:


### PR DESCRIPTION
## Summary
- clarify component locations and hydration workflow in frontend prompt
- note accessibility and performance patterns like deferred hydration and lazy images

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(tests passed; script required manual exit afterwards)*
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b004bbe89c832fa38a1ccb9ecc59d8