### PR TITLE
docs: refresh accessibility prompt guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-accessibility.md
+++ b/frontend/src/pages/docs/md/prompts-accessibility.md
@@ -11,13 +11,17 @@ consistent. To keep the prompt docs evolving, see the
 [Codex meta prompt](/docs/prompts-codex-meta). If templates drift, refresh them with the
 [Codex Prompt Upgrader](/docs/prompts-codex-upgrader). For failing GitHub Actions runs, use
 the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix). The focus here is on semantic
-HTML, ARIA attributes, keyboard navigation, and sufficient color contrast.
+HTML, ARIA attributes, keyboard navigation, and sufficient color contrast. Recent components like
+[Button.astro](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/components/Button.astro)
+and [Menu.svelte](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/components/svelte/Menu.svelte)
+demonstrate built-in labels and keyboard support you can reuse. ESLint's accessibility rules
+(`npm run lint`) and tests with `@testing-library/svelte` help keep these patterns in check.
 
 > **TL;DR**
 >
 > 1. Limit changes to files that impact user accessibility.
-> 2. Follow WCAG 2.1 AA: provide focus states, semantic elements, and ARIA labels.
-> 3. Validate with tooling like `npm run lint` and screen‑reader checks when possible.
+> 2. Follow WCAG 2.2 AA: provide focus states, semantic elements, and ARIA labels.
+> 3. Validate with ESLint's a11y rules (`npm run lint`) and screen‑reader checks when possible.
 > 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
 > 6. Commit with an emoji prefix.
@@ -30,7 +34,7 @@ and `npm run test:ci` pass before committing.
 
 USER:
 1. Update files that affect user accessibility.
-2. Follow WCAG 2.1 AA with semantic HTML, visible focus states, and ARIA labels.
+2. Follow WCAG 2.2 AA with semantic HTML, visible focus states, and ARIA labels.
 3. Validate with linting and, when possible, screen-reader or keyboard checks.
 4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
 5. Use an emoji-prefixed commit message.


### PR DESCRIPTION
## Summary
- doc: update accessibility prompt for WCAG 2.2 and tooling
- doc: link to Button and Menu patterns

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68b00449ebd4832fb24aecdc9f83dffb