### PR TITLE
docs: refresh Codex prompt docs

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -31,8 +31,9 @@ the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
+> 4. Link new prompt guides from this page and `frontend/src/pages/docs/index.astro`.
+> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 6. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
 >    commit with an emoji prefix.
 
 ---

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -11,7 +11,8 @@ ready-made PR — but only if given a clear, file-scoped prompt. Use this guide 
 current and consistent. To keep these templates evolving, see the
 [Codex meta prompt](prompts-codex-meta.md). If they drift, refresh them with the
 [Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md). When branches diverge, resolve conflicts with the
+[Codex merge conflict prompt](prompts-codex-merge-conflicts.md).
 
 > **TL;DR**
 >


### PR DESCRIPTION
## Summary
- cross-link merge conflict prompt in docs guidance
- remind contributors to update docs index when adding prompt guides

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci` *(fails: hangs during Playwright install; unit tests passed)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b004ad6bf8832f988c37dd28175f8a