### PR TITLE
docs: refresh Codex prompt guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-upgrader.md
+++ b/frontend/src/pages/docs/md/prompts-codex-upgrader.md
@@ -20,11 +20,12 @@ You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` a
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing cross-links.
-2. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
-3. Link new prompt files from `prompts-codex.md` and the docs index.
-4. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-5. Run the checks above.
-6. Use an emoji-prefixed commit message.
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Update prompt templates, including `prompts-codex.md`, to reflect current practices.
+4. Link new prompt files from `prompts-codex.md` and the docs index.
+5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+6. Run the checks above.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
@@ -44,10 +45,11 @@ and `npm run test:ci` pass before committing.
 
 USER:
 1. Ensure it covers newly added prompt types and required checks.
-2. Tighten language so upgrades stay precise and reversible.
-3. Run the checks above.
-4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-5. Commit with an emoji-prefixed message.
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Tighten language so upgrades stay precise and reversible.
+4. Run the checks above.
+5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+6. Commit with an emoji-prefixed message.
 
 OUTPUT:
 A pull request refining the Codex Prompt Upgrader doc with passing checks.

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -24,6 +24,8 @@ For specialized workflows use the [Codex CI-failure fix prompt](prompts-codex-ci
 the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
 [Codex meta prompt](prompts-codex-meta.md), and the
 [Codex Prompt Upgrader](prompts-codex-upgrader.md).
+When adding a new prompt doc, link it here and in
+[the docs index](../index.astro).
 
 > **TL;DR**
 >
@@ -31,8 +33,9 @@ the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
+> 4. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 6. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
 >    commit with an emoji prefix.
 
 ---
@@ -105,9 +108,10 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-6. Use an emoji-prefixed commit message.
+4. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+6. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT
 A pull request with the required changes and tests.
@@ -142,13 +146,14 @@ missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci
 
 USER:
 1. Follow the steps above.
-2. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-3. After verifying the implementation, mark the corresponding changelog line
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+4. After verifying the implementation, mark the corresponding changelog line
    with `💯`, replacing any `✅` or other emoji.
-4. Replace any remaining `✅` entries in the changelog with `💯` once they meet
+5. Replace any remaining `✅` entries in the changelog with `💯` once they meet
    the robustness standard.
-5. Use an emoji-prefixed commit message.
-6. Document new functionality as needed.
+6. Use an emoji-prefixed commit message.
+7. Document new functionality as needed.
 
 OUTPUT:
 A pull request implementing the chosen item with all tests green. Summarize the
@@ -170,11 +175,12 @@ and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
    `prompts-items.md`).
-2. Fix outdated instructions, links or formatting.
-3. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
-4. Run the checks above.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-6. Use an emoji-prefixed commit message.
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Fix outdated instructions, links or formatting.
+4. If you add a new prompt, link it from `prompts-codex.md` and the docs index.
+5. Run the checks above.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.
@@ -195,11 +201,12 @@ and `README.md`. Ensure `npm run lint`, `npm run type-check`,
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing
    cross-links.
-2. Update prompt templates, including this file, to reflect current practices.
-3. Link new prompt files from `prompts-codex.md` and the docs index.
-4. Propagate related changes across docs.
-5. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-6. Run the checks above.
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Update prompt templates, including this file, to reflect current practices.
+4. Link new prompt files from `prompts-codex.md` and the docs index.
+5. Propagate related changes across docs.
+6. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Run the checks above.
 
 OUTPUT:
 A pull request refreshing the Codex prompt docs with passing checks.
@@ -221,10 +228,11 @@ and `npm run test:ci` pass before committing.
 
 USER:
 1. Update references to new or renamed prompt docs.
-2. Confirm default template reflects current lint, test, and commit standards.
-3. Run the checks above.
-4. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-5. Commit with an emoji-prefixed message.
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Confirm default template reflects current lint, test, and commit standards.
+4. Run the checks above.
+5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+6. Commit with an emoji-prefixed message.
 
 OUTPUT:
 A pull request refining the baseline Codex prompt doc with passing checks.

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -11,16 +11,18 @@ ready-made PR — but only if given a clear, file-scoped prompt. Use this guide 
 current and consistent. To keep these templates evolving, see the
 [Codex meta prompt](prompts-codex-meta.md). If they drift, refresh them with the
 [Codex Prompt Upgrader](prompts-codex-upgrader.md). For failing GitHub Actions runs, use the
-[Codex CI-failure fix prompt](prompts-codex-ci-fix.md).
+[Codex CI-failure fix prompt](prompts-codex-ci-fix.md), and for merge conflicts see the
+[Codex merge conflict prompt](prompts-codex-merge-conflicts.md).
 
 > **TL;DR**
 >
 > 1. Limit changes to the relevant docs.
 > 2. Fix outdated wording, links, or formatting.
-> 3. Link new prompt docs from [`prompts-codex.md`](prompts-codex.md) and
+> 3. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+> 4. Link new prompt docs from [`prompts-codex.md`](prompts-codex.md) and
 >    `frontend/src/pages/docs/index.astro`.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
-> 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+> 5. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 6. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 
 ```text
@@ -31,13 +33,14 @@ Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
 
 USER:
 1. Edit or add docs under `frontend/src/pages/docs/md`.
-2. Correct stale guidance, links, or formatting.
-3. If adding a new prompt doc, link it from `prompts-codex.md`
+2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
+3. Correct stale guidance, links, or formatting.
+4. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+5. Run `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
-5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
-6. Use an emoji-prefixed commit message.
+6. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+7. Use an emoji-prefixed commit message.
 
 OUTPUT:
 A pull request with refreshed documentation and passing checks.


### PR DESCRIPTION
## Summary
- document ripgrep as the preferred search tool in Codex prompt templates
- cross-link merge conflict prompt from docs guide and note to link new prompt docs

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004ad6bf8832f988c37dd28175f8a