### PR TITLE
♿️ Add skip link for accessible navigation

### DIFF
--- a/frontend/__tests__/Header.test.js
+++ b/frontend/__tests__/Header.test.js
@@ -17,4 +17,9 @@ describe('Header.astro', () => {
         const content = fs.readFileSync(headerFile, 'utf8');
         expect(content).toMatch(/max-width: 100%;/);
     });
+
+    it('provides a skip link for accessibility', () => {
+        const content = fs.readFileSync(headerFile, 'utf8');
+        expect(content).toMatch(/<a href="#main" class="skip-link">Skip to main content<\/a>/);
+    });
 });

--- a/frontend/__tests__/Page.test.js
+++ b/frontend/__tests__/Page.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const pageFile = path.join(__dirname, '../src/components/Page.astro');
+
+describe('Page.astro', () => {
+    it('exposes main landmark for skip navigation', () => {
+        const content = fs.readFileSync(pageFile, 'utf8');
+        expect(content).toMatch(/<main id="main">/);
+    });
+});

--- a/frontend/src/components/Header.astro
+++ b/frontend/src/components/Header.astro
@@ -10,6 +10,8 @@ export interface Props {
 }
 ---
 
+<a href="#main" class="skip-link">Skip to main content</a>
+
 <a href="/" aria-label="Go to homepage">
     <div class="vertical">
         <Logo />
@@ -97,5 +99,19 @@ export interface Props {
         font-size: 0.8em;
         color: #00ff22;
         margin-top: 0px;
+    }
+
+    .skip-link {
+        position: absolute;
+        top: -40px;
+        left: 0;
+        background: #000;
+        color: #fff;
+        padding: 0.5rem 1rem;
+        z-index: 1000;
+    }
+
+    .skip-link:focus {
+        top: 0;
     }
 </style>

--- a/frontend/src/components/Page.astro
+++ b/frontend/src/components/Page.astro
@@ -16,7 +16,7 @@ const pathname = Astro.url.pathname;
 ---
 
 <Layout title="DSPACE">
-	<main>
+        <main id="main">
 		<div>
 			<Header title="" body="" href="" />
 


### PR DESCRIPTION
## Summary
- add visually hidden skip link to header for keyboard users
- expose `main` landmark for skip navigation and test coverage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004b7e888832f8912ddfc8f978762