### PR TITLE
docs: refresh Codex prompt audit guidance

### DIFF
--- a/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
+++ b/frontend/src/pages/docs/md/prompts-codex-ci-fix.md
@@ -37,7 +37,8 @@ CONTEXT:
   error.
 - If no URL is given, inspect the codebase to reproduce the failure:
   * Examine `.github/workflows/` to learn which checks run in CI.
-    * Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` locally.
+    * Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+      `npm run test:ci` locally.
   * Study project docs to understand how to run the test suite and emulate the
     GitHub Actions environment.
 - Consult existing outage entries in `/outages` for similar symptoms.
@@ -139,7 +140,7 @@ Use this prompt to keep CI troubleshooting steps current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
+++ b/frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md
@@ -17,7 +17,8 @@ extra formatting.
 > 1. Copy the conflict block from the GitHub merge UI.
 > 2. Paste it into a ChatGPT message.
 > 3. The agent replies with the same text but conflicts resolved—ready to paste back.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and commit
 >    with an emoji prefix.
 
@@ -33,8 +34,8 @@ follow the same approach for each.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Refine `frontend/src/pages/docs/md/prompts-codex-merge-conflicts.md` for
@@ -57,7 +58,7 @@ Use this prompt to keep merge-conflict resolution tips current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-codex-meta.md
+++ b/frontend/src/pages/docs/md/prompts-codex-meta.md
@@ -14,7 +14,7 @@ see the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:
@@ -38,7 +38,7 @@ Use this prompt to keep meta-prompt guidance current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -31,7 +31,8 @@ the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
 > 2. Say **exactly** what output you expect (tests, docs, etc.).
 > 3. Stop talking when the spec is complete. Codex treats _all_ remaining text as
 >    mandatory instructions.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` and
 >    commit with an emoji prefix.
 
@@ -78,12 +79,12 @@ See the [OpenAI CLI repository][openai-cli] for more flags.
 
 ## 2. Prompt ingredients
 
-| Ingredient           | Why it matters                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                    |
-| **Files to touch**   | Limits search space → faster & cheaper.                                             |
-| **Constraints**      | Coding style, a11y, perf, etc.                                                      |
-| **Acceptance check** | e.g. `npm run lint`, `npm run type-check`, `npm run build`, `npm run test:ci` pass. |
+| Ingredient           | Why it matters                                                                                            |
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Goal sentence**    | Gives the agent a north star (“Add sort dropdown to Item page”).                                          |
+| **Files to touch**   | Limits search space → faster & cheaper.                                                                   |
+| **Constraints**      | Coding style, a11y, perf, etc.                                                                            |
+| **Acceptance check** | `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,<br>`npm run test:ci` all pass. |
 
 Codex merges those instructions with any `AGENTS.md` files it finds, so keep
 prompt‑level rules short and concrete.
@@ -105,7 +106,8 @@ REQUIREMENTS
 1. …
 2. …
 3. …
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 6. Use an emoji-prefixed commit message.
 
@@ -136,8 +138,9 @@ You are an automated contributor for the DSPACE repository. Choose one item
 from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
 `[x]` without 💯 (including those marked with ✅). Implement it fully, completing
 any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` all pass before committing. If Playwright browsers are
+`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:ci`
+all pass before committing. If Playwright browsers are
 missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
 
 USER:
@@ -164,8 +167,9 @@ dedicated to evolving the prompt guides themselves, see the
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:ci`
+pass before committing.
 
 USER:
 1. Pick one or more prompt docs under `frontend/src/pages/docs/md/` (for example,
@@ -189,8 +193,9 @@ guidance current—the machine that builds the machine. See the standalone
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md`
-and `README.md`. Ensure `npm run lint`, `npm run type-check`,
-`npm run build`, and `npm run test:ci` pass before committing.
+and `README.md`. Ensure `npm run audit:ci`, `npm run lint`,
+`npm run type-check`, `npm run build`, and `npm run test:ci`
+pass before committing.
 
 USER:
 1. Audit `frontend/src/pages/docs/md/prompts-*` for stale guidance or missing
@@ -216,8 +221,8 @@ Use this prompt to keep baseline Codex prompt guidance current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`,
-and `npm run test:ci` pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`,
+`npm run build`, and `npm run test:ci` pass before committing.
 
 USER:
 1. Update references to new or renamed prompt docs.

--- a/frontend/src/pages/docs/md/prompts-docs.md
+++ b/frontend/src/pages/docs/md/prompts-docs.md
@@ -19,14 +19,15 @@ current and consistent. To keep these templates evolving, see the
 > 2. Fix outdated wording, links, or formatting.
 > 3. Link new prompt docs from [`prompts-codex.md`](prompts-codex.md) and
 >    `frontend/src/pages/docs/index.astro`.
-> 4. Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`.
+> 4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+>    `npm run test:ci`.
 > 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`
 >    and use an emoji-prefixed commit message.
 
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
 `npm run test:ci` pass before committing.
 
 USER:
@@ -34,7 +35,7 @@ USER:
 2. Correct stale guidance, links, or formatting.
 3. If adding a new prompt doc, link it from `prompts-codex.md`
    and the docs index (`frontend/src/pages/docs/index.astro`).
-4. Run `npm run lint`, `npm run type-check`, `npm run build`, and
+4. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`.
 5. Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 6. Use an emoji-prefixed commit message.
@@ -50,8 +51,8 @@ Use this to polish grammar and style without changing technical meaning.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci` pass before
-committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
 
 USER:
 1. Proofread the selected docs for typos, grammar, and clarity.
@@ -70,8 +71,8 @@ Use this when adding or renaming docs to keep internal links current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`, and `npm run test:ci`
-pass before committing.
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+`npm run test:ci` pass before committing.
 
 USER:
 1. Audit the documentation for missing or broken cross-links.
@@ -92,7 +93,7 @@ Use this prompt to keep documentation-writing guidance current.
 ```text
 SYSTEM:
 You are an automated contributor for the DSPACE repository. Follow `AGENTS.md` and `README.md`.
-Ensure `npm run lint`, `npm run type-check`, `npm run build`,
+Ensure `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`,
 and `npm run test:ci` pass before committing.
 
 USER:


### PR DESCRIPTION
## Summary
- require `npm run audit:ci` in Codex baseline and meta prompts
- document audit step for docs and CI-fix workflows

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b004ad6bf8832f988c37dd28175f8a