### PR TITLE
🧩 : add clogged nozzle and blob-of-death quests

### DIFF
--- a/docs/new-quests.md
+++ b/docs/new-quests.md
@@ -11,16 +11,18 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 242
-New quests in this release: 220
+Current quest count: 244
+New quests in this release: 222
 
 ### 3dprinting
 
 -   3dprinting/bed-leveling
+-   3dprinting/blob-of-death
 -   3dprinting/cable-clip
 -   3dprinting/calibration-cube
 -   3dprinting/filament-change
 -   3dprinting/nozzle-cleaning
+-   3dprinting/nozzle-clog
 -   3dprinting/phone-stand
 -   3dprinting/retraction-test
 -   3dprinting/spool-holder

--- a/frontend/src/generated/processes.json
+++ b/frontend/src/generated/processes.json
@@ -228,6 +228,28 @@
         }
     },
     {
+        "id": "3dprint-nozzle-clog",
+        "title": "Start a print without checking the first layer that clogs the nozzle",
+        "requireItems": [
+            {
+                "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "d3590107-25ff-4de5-af3a-46e2497bfc52",
+                "count": 5
+            },
+            {
+                "id": "061fd221-404a-4bd1-9432-3e25b0f17a2c",
+                "count": 50
+            }
+        ],
+        "createItems": [],
+        "duration": "30m"
+    },
+    {
         "id": "level-3d-printer-bed",
         "title": "Use a sheet of printer paper to level an entry-level FDM 3D printer bed",
         "image": "/assets/3dprinter.jpg",

--- a/frontend/src/pages/docs/md/new-quests.md
+++ b/frontend/src/pages/docs/md/new-quests.md
@@ -11,16 +11,18 @@ These quests exist in the `v3` branch but are not present on `main` yet.
 Use this list when upgrading quests or proposing follow-up content.
 
 Prev quest count: 22
-Current quest count: 242
-New quests in this release: 220
+Current quest count: 244
+New quests in this release: 222
 
 ### 3dprinting
 
 -   3dprinting/bed-leveling
+-   3dprinting/blob-of-death
 -   3dprinting/cable-clip
 -   3dprinting/calibration-cube
 -   3dprinting/filament-change
 -   3dprinting/nozzle-cleaning
+-   3dprinting/nozzle-clog
 -   3dprinting/phone-stand
 -   3dprinting/retraction-test
 -   3dprinting/spool-holder

--- a/frontend/src/pages/inventory/json/items/tools.json
+++ b/frontend/src/pages/inventory/json/items/tools.json
@@ -25,6 +25,20 @@
         }
     },
     {
+        "id": "fbecc523-fb93-4d00-be08-2ed9f53f158c",
+        "name": "0.4 mm brass nozzle",
+        "description": "Replacement 0.4 mm brass nozzle compatible with entry-level FDM printers.",
+        "image": "/assets/3dprinter.jpg",
+        "price": "2 dUSD",
+        "type": "tool",
+        "hardening": {
+            "passes": 0,
+            "score": 0,
+            "emoji": "🛠️",
+            "history": []
+        }
+    },
+    {
         "id": "7892ffc6-c651-445f-946b-7edc998cf389",
         "name": "Benchy",
         "description": "60 mm long calibration tugboat 3D printed in PLA; weighs about 15 g and uses about 5 m of filament.",

--- a/frontend/src/pages/processes/base.json
+++ b/frontend/src/pages/processes/base.json
@@ -163,6 +163,28 @@
         "duration": "1h 30m"
     },
     {
+        "id": "3dprint-nozzle-clog",
+        "title": "Start a print without checking the first layer that clogs the nozzle",
+        "requireItems": [
+            {
+                "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f",
+                "count": 1
+            }
+        ],
+        "consumeItems": [
+            {
+                "id": "d3590107-25ff-4de5-af3a-46e2497bfc52",
+                "count": 5
+            },
+            {
+                "id": "061fd221-404a-4bd1-9432-3e25b0f17a2c",
+                "count": 50
+            }
+        ],
+        "createItems": [],
+        "duration": "30m"
+    },
+    {
         "id": "level-3d-printer-bed",
         "title": "Use a sheet of printer paper to level an entry-level FDM 3D printer bed",
         "image": "/assets/3dprinter.jpg",

--- a/frontend/src/pages/quests/json/3dprinting/blob-of-death.json
+++ b/frontend/src/pages/quests/json/3dprinting/blob-of-death.json
@@ -1,0 +1,33 @@
+{
+    "id": "3dprinting/blob-of-death",
+    "title": "Witness a Blob of Death",
+    "description": "Skipping a first-layer check lets a failed Z homing extrude in mid-air, engulfing the nozzle in molten plastic.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "You start a print and walk away. Without verifying the first layer, the Z axis mis-homes and the printer extrudes in mid-air.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "3dprint-nozzle-clog",
+                    "text": "Watch the blob grow."
+                },
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Kill power and note the damage."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "A molten glob encases the nozzle. Next time, watch the first layer to catch issues early.",
+            "options": [{ "type": "finish", "text": "Ugh." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinter/start"]
+}

--- a/frontend/src/pages/quests/json/3dprinting/nozzle-clog.json
+++ b/frontend/src/pages/quests/json/3dprinting/nozzle-clog.json
@@ -1,0 +1,82 @@
+{
+    "id": "3dprinting/nozzle-clog",
+    "title": "Fix a Clogged Nozzle",
+    "description": "Disassemble your printer after a blob of death from skipping the first layer to unclog or replace the nozzle.",
+    "image": "/assets/quests/benchy_25.jpg",
+    "npc": "/assets/npc/sydney.jpg",
+    "start": "start",
+    "dialogue": [
+        {
+            "id": "start",
+            "text": "Because the first layer wasn't checked, the Z axis mis-homes and filament piles around the hotend, clogging the nozzle.",
+            "options": [
+                {
+                    "type": "process",
+                    "process": "3dprint-nozzle-clog",
+                    "text": "Review the failed print."
+                },
+                {
+                    "type": "goto",
+                    "goto": "repair",
+                    "text": "Power down and prepare to fix it."
+                }
+            ]
+        },
+        {
+            "id": "repair",
+            "text": "Let the hotend cool, remove the plastic blob, then loosen the nozzle.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "clean",
+                    "text": "Unclog and reinstall the nozzle.",
+                    "requiresItems": [
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 },
+                        { "id": "5029f7cb-3359-4153-b7ca-4b53988ac086", "count": 1 }
+                    ]
+                },
+                {
+                    "type": "goto",
+                    "goto": "replace",
+                    "text": "Swap in a new nozzle.",
+                    "requiresItems": [
+                        { "id": "8aa6dc27-dc42-4622-ac88-cbd57f48625f", "count": 1 },
+                        { "id": "5a80f925-ec0a-4b08-b0e1-3b6b41ccace4", "count": 1 },
+                        { "id": "5029f7cb-3359-4153-b7ca-4b53988ac086", "count": 1 },
+                        { "id": "fbecc523-fb93-4d00-be08-2ed9f53f158c", "count": 1 }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "clean",
+            "text": "Heat the nozzle and push a cleaning needle through until clear, then tighten it while hot.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "Extrusion restored."
+                }
+            ]
+        },
+        {
+            "id": "replace",
+            "text": "Thread in the replacement nozzle, snug it down while hot, and reassemble the printer.",
+            "options": [
+                {
+                    "type": "goto",
+                    "goto": "finish",
+                    "text": "New nozzle installed."
+                }
+            ]
+        },
+        {
+            "id": "finish",
+            "text": "The printer is ready again. Watch the first layer on future prints to avoid blobs of death.",
+            "options": [{ "type": "finish", "text": "Back to printing." }]
+        }
+    ],
+    "rewards": [],
+    "requiresQuests": ["3dprinter/start", "3dprinting/blob-of-death"]
+}


### PR DESCRIPTION
what: replace blob-of-death outage with quest and link nozzle repair; stress checking first layer to avoid blobs
why: track z-axis mis-homing failure as playable quest and teach first-layer inspection
how to test:
- npm run lint
- npm run type-check
- npm run build
- SKIP_E2E=1 npm test

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b67992dfb0832fbf3739ba919a0c68