### PR TITLE
🗄️ : migrate game state to IndexedDB

### DIFF
--- a/frontend/__tests__/cloudSync.test.js
+++ b/frontend/__tests__/cloudSync.test.js
@@ -8,12 +8,12 @@ import {
     loadCloudGistId,
     clearCloudGistId,
 } from '../src/utils/cloudSync.js';
-import { saveGameState, loadGameState } from '../src/utils/gameState/common.js';
+import { saveGameState, loadGameState, resetGameState } from '../src/utils/gameState/common.js';
 import { saveGitHubToken } from '../src/utils/githubToken.js';
 
 describe('cloudSync', () => {
     beforeEach(() => {
-        localStorage.clear();
+        resetGameState();
         global.fetch = jest.fn();
     });
 
@@ -33,7 +33,9 @@ describe('cloudSync', () => {
     });
 
     test('uploadGameStateToGist patches existing gist', async () => {
-        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: 'a' } }));
+        const state = loadGameState();
+        state.cloudSync = { gistId: 'a' };
+        saveGameState(state);
         saveGitHubToken('ghp_x');
         global.fetch.mockResolvedValueOnce({
             ok: true,
@@ -59,10 +61,11 @@ describe('cloudSync', () => {
     });
 
     test('clearCloudGistId resets stored id', () => {
-        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: '42' } }));
+        const state = loadGameState();
+        state.cloudSync = { gistId: '42' };
+        saveGameState(state);
         clearCloudGistId();
         expect(loadCloudGistId()).toBe('');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.cloudSync.gistId).toBe('');
+        expect(loadGameState().cloudSync.gistId).toBe('');
     });
 });

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 const {
     loadGameState,
     saveGameState,
@@ -10,7 +11,6 @@ const {
 
 describe('gameState - common utilities', () => {
     beforeEach(() => {
-        localStorage.clear();
         resetGameState();
     });
 
@@ -60,7 +60,7 @@ describe('gameState - common utilities', () => {
         expect(validated).toEqual({ quests: {}, inventory: {}, processes: {} });
     });
 
-    test('rollbackGameState should restore previous state', () => {
+    test('rollbackGameState should restore previous state', async () => {
         const state = loadGameState();
         state.inventory['1'] = 1;
         saveGameState(state);
@@ -69,12 +69,12 @@ describe('gameState - common utilities', () => {
         updated.inventory['1'] = 2;
         saveGameState(updated);
 
-        rollbackGameState();
+        await rollbackGameState();
         const rolled = loadGameState();
         expect(rolled.inventory['1']).toBe(1);
     });
 
-    test('rollbackGameState does nothing when no backup exists', () => {
+    test('rollbackGameState does nothing when no backup exists', async () => {
         const state = loadGameState();
         state.inventory['1'] = 3;
         saveGameState(state);
@@ -82,9 +82,20 @@ describe('gameState - common utilities', () => {
         const updated = loadGameState();
         updated.inventory['1'] = 4;
         saveGameState(updated);
-        localStorage.removeItem('gameStateBackup');
 
-        rollbackGameState();
+        await new Promise((resolve, reject) => {
+            const req = indexedDB.open('dspaceGameState', 1);
+            req.onsuccess = (e) => {
+                const db = e.target.result;
+                const tx = db.transaction('backup', 'readwrite');
+                tx.objectStore('backup').clear();
+                tx.oncomplete = resolve;
+                tx.onerror = (ev) => reject(ev.target.error);
+            };
+            req.onerror = (e) => reject(e.target.error);
+        });
+
+        await rollbackGameState();
         const rolled = loadGameState();
         expect(rolled.inventory['1']).toBe(4);
     });

--- a/frontend/__tests__/gameState/gameState.test.js
+++ b/frontend/__tests__/gameState/gameState.test.js
@@ -120,9 +120,10 @@ describe('gameState top-level helpers', () => {
         expect(mockGameState.versionNumberString).toBe(VERSIONS.V2);
     });
 
-    test('importV2V3 updates version to V3', () => {
+    test('importV2V3 adds processes and updates version to V3', () => {
         mockGameState.versionNumberString = VERSIONS.V2;
         importV2V3();
         expect(mockGameState.versionNumberString).toBe(VERSIONS.V3);
+        expect(mockGameState.processes).toEqual({});
     });
 });

--- a/frontend/__tests__/gameState/migration.test.js
+++ b/frontend/__tests__/gameState/migration.test.js
@@ -1,0 +1,43 @@
+const { jest } = require('@jest/globals');
+require('fake-indexeddb/auto');
+
+describe('game state localStorage migration', () => {
+    beforeEach(async () => {
+        localStorage.clear();
+        await new Promise((resolve) => {
+            const req = indexedDB.deleteDatabase('dspaceGameState');
+            req.onsuccess = () => resolve();
+            req.onerror = () => resolve();
+        });
+        jest.resetModules();
+    });
+
+    test('migrates v2 data to IndexedDB and upgrades version', async () => {
+        const legacyState = { quests: {}, inventory: { 1: 1 }, versionNumberString: '2' };
+        const legacyBackup = { quests: {}, inventory: { 1: 0 }, processes: {} };
+        localStorage.setItem('gameState', JSON.stringify(legacyState));
+        localStorage.setItem('gameStateBackup', JSON.stringify(legacyBackup));
+        const mod = require('../../src/utils/gameState/common.js');
+        await mod.ready;
+        const loaded = mod.loadGameState();
+        expect(loaded.versionNumberString).toBe('3');
+        expect(loaded.inventory['1']).toBe(1);
+        expect(localStorage.getItem('gameState')).toBeNull();
+        expect(localStorage.getItem('gameStateBackup')).toBeNull();
+        const backup = await new Promise((resolve, reject) => {
+            const req = indexedDB.open('dspaceGameState', 1);
+            req.onsuccess = () => {
+                const db = req.result;
+                const tx = db.transaction('backup', 'readonly');
+                const getReq = tx.objectStore('backup').get('root');
+                getReq.onsuccess = () => {
+                    resolve(getReq.result);
+                    db.close();
+                };
+                getReq.onerror = (e) => reject(e.target.error);
+            };
+            req.onerror = (e) => reject(e.target.error);
+        });
+        expect(backup.inventory['1']).toBe(0);
+    });
+});

--- a/frontend/__tests__/githubToken.test.js
+++ b/frontend/__tests__/githubToken.test.js
@@ -1,31 +1,31 @@
 /**
  * @jest-environment jsdom
  */
+import 'fake-indexeddb/auto';
 import {
     loadGitHubToken,
     saveGitHubToken,
     clearGitHubToken,
     isValidGitHubToken,
 } from '../src/utils/githubToken.js';
+import { loadGameState, resetGameState } from '../src/utils/gameState/common.js';
 
 describe('githubToken utils', () => {
     beforeEach(() => {
-        localStorage.clear();
+        resetGameState();
     });
 
     test('saves and loads token', () => {
         saveGitHubToken('abc');
         expect(loadGitHubToken()).toBe('abc');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.github.token).toBe('abc');
+        expect(loadGameState().github.token).toBe('abc');
     });
 
     test('clears token', () => {
         saveGitHubToken('xyz');
         clearGitHubToken();
         expect(loadGitHubToken()).toBe('');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.github.token).toBe('');
+        expect(loadGameState().github.token).toBe('');
     });
 
     test('validates tokens correctly', () => {

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -186,7 +186,8 @@ We've rebuilt DSPACE's architecture to be truly local‑first. Your progress, ac
 
 A few technical details that might interest you:
 
--   Your v2 progress will automatically migrate to v3
+-   Your v2 progress stored in localStorage automatically migrates to the new
+    IndexedDB save format
 -   All custom content includes rollback functionality (in case something goes wrong)
 
 The new **Cloud Sync** feature lets you back up your progress across devices using a private

--- a/frontend/src/pages/docs/md/rollback.md
+++ b/frontend/src/pages/docs/md/rollback.md
@@ -5,14 +5,14 @@ slug: 'rollback'
 
 # Game State Rollback
 
-DSPACE keeps a backup of the previous game state before every save. If a change corrupts your data,
-you can revert to the last snapshot using `rollbackGameState()`.
+DSPACE keeps a backup of the previous game state in IndexedDB before every save. If a change corrupts
+your data, you can revert to the last snapshot using `rollbackGameState()`.
 
 ```ts
 import { rollbackGameState } from '../utils/gameState/common.js';
 
-rollbackGameState();
+await rollbackGameState();
 ```
 
-The helper restores the most recently saved snapshot from `localStorage`. If no backup exists,
-the call has no effect.
+The helper restores the most recently saved snapshot from IndexedDB. If no backup exists, the call has
+no effect.

--- a/frontend/src/utils/cloudSync.js
+++ b/frontend/src/utils/cloudSync.js
@@ -1,30 +1,29 @@
-import { exportGameStateString, importGameStateString } from './gameState/common.js';
+import {
+    exportGameStateString,
+    importGameStateString,
+    loadGameState,
+    saveGameState,
+} from './gameState/common.js';
 import { loadGitHubToken } from './githubToken.js';
 
-const storageKey = 'gameState';
-
 function loadCloudGistId() {
-    try {
-        const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
-        return state.cloudSync?.gistId || '';
-    } catch {
-        return '';
-    }
+    const state = loadGameState();
+    return state.cloudSync?.gistId || '';
 }
 
 function saveCloudGistId(id) {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    const state = loadGameState();
     state.cloudSync = state.cloudSync || {};
     state.cloudSync.gistId = id;
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    saveGameState(state);
 }
 
 function clearCloudGistId() {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    const state = loadGameState();
     if (state.cloudSync) {
         state.cloudSync.gistId = '';
     }
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    saveGameState(state);
 }
 
 async function uploadGameStateToGist(token) {

--- a/frontend/src/utils/gameState.js
+++ b/frontend/src/utils/gameState.js
@@ -131,7 +131,6 @@ export const importV2V3 = () => {
     if (!gameState.processes) {
         gameState.processes = {};
     }
-
-    setVersionNumber(VERSIONS.V3);
+    gameState.versionNumberString = VERSIONS.V3;
     saveGameState(gameState);
 };

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -1,21 +1,79 @@
 import { writable } from 'svelte/store';
 
-const gameStateKey = 'gameState';
-const gameStateBackupKey = 'gameStateBackup';
+const DB_NAME = 'dspaceGameState';
+const DB_VERSION = 1;
+const STATE_STORE = 'state';
+const BACKUP_STORE = 'backup';
+const ROOT_KEY = 'root';
+const LOCAL_STATE_KEY = 'gameState';
+const LOCAL_BACKUP_KEY = 'gameStateBackup';
+const V2 = '2';
+const V3 = '3';
 
-const initializeGameState = () => {
-    return {
-        quests: {},
-        inventory: {},
-        processes: {},
-    };
-};
+let dbPromise;
+
+function openDB() {
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                if (!db.objectStoreNames.contains(STATE_STORE)) {
+                    db.createObjectStore(STATE_STORE);
+                }
+                if (!db.objectStoreNames.contains(BACKUP_STORE)) {
+                    db.createObjectStore(BACKUP_STORE);
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+    return dbPromise;
+}
+
+function read(store) {
+    return openDB().then(
+        (db) =>
+            new Promise((resolve, reject) => {
+                const tx = db.transaction(store, 'readonly');
+                const req = tx.objectStore(store).get(ROOT_KEY);
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = (e) => reject(e.target.error);
+            })
+    );
+}
+
+function write(store, value) {
+    return openDB().then(
+        (db) =>
+            new Promise((resolve, reject) => {
+                const tx = db.transaction(store, 'readwrite');
+                tx.objectStore(store).put(value, ROOT_KEY);
+                tx.oncomplete = () => resolve();
+                tx.onerror = (e) => reject(e.target.error);
+            })
+    );
+}
+
+function clearStore(store) {
+    return openDB().then(
+        (db) =>
+            new Promise((resolve, reject) => {
+                const tx = db.transaction(store, 'readwrite');
+                tx.objectStore(store).clear();
+                tx.oncomplete = () => resolve();
+                tx.onerror = (e) => reject(e.target.error);
+            })
+    );
+}
+
+const initializeGameState = () => ({ quests: {}, inventory: {}, processes: {} });
 
 export const validateGameState = (state) => {
     if (!state || typeof state !== 'object') {
         return initializeGameState();
     }
-
     if (typeof state.quests !== 'object' || state.quests === null) {
         state.quests = {};
     }
@@ -25,59 +83,76 @@ export const validateGameState = (state) => {
     if (typeof state.processes !== 'object' || state.processes === null) {
         state.processes = {};
     }
-
     return state;
 };
 
-export const loadGameState = () => {
-    const storedGameState = localStorage.getItem(gameStateKey);
-    if (storedGameState) {
-        return validateGameState(JSON.parse(storedGameState));
-    }
-    return initializeGameState();
-};
-
-export const saveGameState = (newState) => {
-    localStorage.setItem(gameStateBackupKey, JSON.stringify(gameState));
-    gameState = validateGameState(newState);
-    localStorage.setItem(gameStateKey, JSON.stringify(gameState));
-    state.set(gameState); // Update the state store directly
-};
-
-let gameState = loadGameState();
-
-// Create the state store and set the initial value
+let gameState = initializeGameState();
 export const state = writable(gameState);
 
-/**
- * Export the game state as a Base64-encoded JSON string.
- * The schema {quests, inventory, processes} is public and must remain stable.
- */
-export const exportGameStateString = () => {
-    return btoa(JSON.stringify(gameState));
+export const ready = (async () => {
+    try {
+        let stored = await read(STATE_STORE);
+        if (!stored) {
+            try {
+                const legacy = localStorage.getItem(LOCAL_STATE_KEY);
+                if (legacy) {
+                    stored = JSON.parse(legacy);
+                    const backup = localStorage.getItem(LOCAL_BACKUP_KEY);
+                    if (backup) {
+                        await write(BACKUP_STORE, JSON.parse(backup));
+                        localStorage.removeItem(LOCAL_BACKUP_KEY);
+                    }
+                    localStorage.removeItem(LOCAL_STATE_KEY);
+                }
+            } catch (e) {
+                console.error('Error migrating game state from localStorage:', e);
+            }
+        }
+        if (stored) {
+            gameState = validateGameState(stored);
+            if (gameState.versionNumberString === V2) {
+                gameState.processes = gameState.processes || {};
+                gameState.versionNumberString = V3;
+            }
+            state.set(gameState);
+            await write(STATE_STORE, gameState);
+        }
+    } catch (err) {
+        console.error('Error loading game state from IndexedDB:', err);
+    }
+})();
+
+export const loadGameState = () => gameState;
+
+export const saveGameState = (newState) => {
+    write(BACKUP_STORE, gameState).catch(() => undefined);
+    gameState = validateGameState(newState);
+    state.set(gameState);
+    write(STATE_STORE, gameState).catch(() => undefined);
 };
 
+export const exportGameStateString = () => btoa(JSON.stringify(gameState));
+
 export const importGameStateString = (gameStateString) => {
-    // Decode from Base64 and parse the JSON string
-    const importedGameState = JSON.parse(atob(gameStateString));
-
-    // Overwrite the game state with the imported game state
-    gameState = importedGameState;
-
-    // Save the updated game state to local storage and update the state store
-    saveGameState(gameState);
+    const imported = JSON.parse(atob(gameStateString));
+    saveGameState(imported);
 };
 
 export const resetGameState = () => {
-    const freshState = initializeGameState();
-    saveGameState(freshState);
+    gameState = initializeGameState();
+    state.set(gameState);
+    write(STATE_STORE, gameState).catch(() => undefined);
+    clearStore(BACKUP_STORE).catch(() => undefined);
 };
 
-export const rollbackGameState = () => {
-    const backup = localStorage.getItem(gameStateBackupKey);
-    if (!backup) return;
-    const previous = validateGameState(JSON.parse(backup));
-    gameState = previous;
-    localStorage.setItem(gameStateKey, JSON.stringify(gameState));
-    state.set(gameState);
+export const rollbackGameState = async () => {
+    try {
+        const backup = await read(BACKUP_STORE);
+        if (!backup) return;
+        gameState = validateGameState(backup);
+        state.set(gameState);
+        await write(STATE_STORE, gameState);
+    } catch (err) {
+        console.error('Error rolling back game state:', err);
+    }
 };

--- a/frontend/src/utils/githubToken.js
+++ b/frontend/src/utils/githubToken.js
@@ -5,28 +5,24 @@ export function isValidGitHubToken(token) {
     return patterns.some((p) => p.test(trimmed));
 }
 
-const storageKey = 'gameState';
+import { loadGameState, saveGameState } from './gameState/common.js';
 
 export function loadGitHubToken() {
-    try {
-        const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
-        return state.github?.token || '';
-    } catch {
-        return '';
-    }
+    const state = loadGameState();
+    return state.github?.token || '';
 }
 
 export function saveGitHubToken(token) {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    const state = loadGameState();
     state.github = state.github || {};
     state.github.token = token;
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    saveGameState(state);
 }
 
 export function clearGitHubToken() {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    const state = loadGameState();
     if (state.github) {
         state.github.token = '';
     }
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    saveGameState(state);
 }


### PR DESCRIPTION
## Summary
- switch quest/inventory/process state persistence from localStorage to IndexedDB
- update cloud sync and GitHub token helpers to read/write game state via IndexedDB
- document that rollback now restores from IndexedDB
- add v2→v3 migration to move legacy localStorage saves into IndexedDB

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bd10713318832fa37710c43bcc9114