### PR TITLE
🗄️ : migrate game state to IndexedDB

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, jest, test } from 'vitest';
-import Quests from '../src/pages/quests/svelte/Quests.svelte';
 import * as gameState from '../src/utils/gameState.js';
 
 // Mock the gameState module
@@ -113,10 +112,14 @@ global.indexedDB = {
     },
 };
 
+let Quests;
+
 describe('Quests Component', () => {
     let quests;
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        Quests = (await import('../src/pages/quests/svelte/Quests.svelte')).default;
+
         // Set up test data
         quests = [
             {

--- a/frontend/__tests__/cloudSync.test.js
+++ b/frontend/__tests__/cloudSync.test.js
@@ -8,24 +8,24 @@ import {
     loadCloudGistId,
     clearCloudGistId,
 } from '../src/utils/cloudSync.js';
-import { saveGameState, loadGameState } from '../src/utils/gameState/common.js';
+import { saveGameState, loadGameState, resetGameState } from '../src/utils/gameState/common.js';
 import { saveGitHubToken } from '../src/utils/githubToken.js';
 
 describe('cloudSync', () => {
-    beforeEach(() => {
-        localStorage.clear();
+    beforeEach(async () => {
+        await resetGameState();
         global.fetch = jest.fn();
     });
 
     test('uploadGameStateToGist creates gist when none exists', async () => {
-        saveGitHubToken('ghp_x');
+        await saveGitHubToken('ghp_x');
         global.fetch.mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve({ id: '1' }),
         });
         const id = await uploadGameStateToGist();
         expect(id).toBe('1');
-        expect(loadCloudGistId()).toBe('1');
+        expect(await loadCloudGistId()).toBe('1');
         expect(global.fetch).toHaveBeenCalledWith(
             'https://api.github.com/gists',
             expect.any(Object)
@@ -33,8 +33,10 @@ describe('cloudSync', () => {
     });
 
     test('uploadGameStateToGist patches existing gist', async () => {
-        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: 'a' } }));
-        saveGitHubToken('ghp_x');
+        const state = loadGameState();
+        state.cloudSync = { gistId: 'a' };
+        await saveGameState(state);
+        await saveGitHubToken('ghp_x');
         global.fetch.mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve({ id: 'a' }),
@@ -47,7 +49,7 @@ describe('cloudSync', () => {
     });
 
     test('downloadGameStateFromGist updates state', async () => {
-        saveGitHubToken('ghp_x');
+        await saveGitHubToken('ghp_x');
         const encoded = btoa(JSON.stringify({ quests: { q: true }, inventory: {}, processes: {} }));
         global.fetch.mockResolvedValueOnce({
             ok: true,
@@ -55,14 +57,15 @@ describe('cloudSync', () => {
         });
         await downloadGameStateFromGist('ghp_x', '1');
         expect(loadGameState().quests.q).toBe(true);
-        expect(loadCloudGistId()).toBe('1');
+        expect(await loadCloudGistId()).toBe('1');
     });
 
-    test('clearCloudGistId resets stored id', () => {
-        localStorage.setItem('gameState', JSON.stringify({ cloudSync: { gistId: '42' } }));
-        clearCloudGistId();
-        expect(loadCloudGistId()).toBe('');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.cloudSync.gistId).toBe('');
+    test('clearCloudGistId resets stored id', async () => {
+        const state = loadGameState();
+        state.cloudSync = { gistId: '42' };
+        await saveGameState(state);
+        await clearCloudGistId();
+        expect(await loadCloudGistId()).toBe('');
+        expect(loadGameState().cloudSync.gistId).toBe('');
     });
 });

--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 const {
     loadGameState,
     saveGameState,
@@ -9,25 +10,24 @@ const {
 } = require('../../src/utils/gameState/common.js');
 
 describe('gameState - common utilities', () => {
-    beforeEach(() => {
-        localStorage.clear();
-        resetGameState();
+    beforeEach(async () => {
+        await resetGameState();
     });
 
-    test('resetGameState should initialize empty state', () => {
+    test('resetGameState should initialize empty state', async () => {
         const state = loadGameState();
         state.inventory['1'] = 5;
-        saveGameState(state);
+        await saveGameState(state);
 
-        resetGameState();
+        await resetGameState();
         const fresh = loadGameState();
         expect(fresh).toEqual({ quests: {}, inventory: {}, processes: {} });
     });
 
-    test('exportGameStateString should reflect latest saved state', () => {
+    test('exportGameStateString should reflect latest saved state', async () => {
         const state = loadGameState();
         state.inventory['1'] = 5;
-        saveGameState(state);
+        await saveGameState(state);
 
         const exported = exportGameStateString();
         const decoded = JSON.parse(Buffer.from(exported, 'base64').toString('utf8'));
@@ -46,10 +46,10 @@ describe('gameState - common utilities', () => {
         expect(Object.keys(decoded).sort()).toEqual(['inventory', 'processes', 'quests']);
     });
 
-    test('importGameStateString should replace current state', () => {
+    test('importGameStateString should replace current state', async () => {
         const newState = { quests: { foo: true }, inventory: { 2: 3 }, processes: {} };
         const encoded = Buffer.from(JSON.stringify(newState)).toString('base64');
-        importGameStateString(encoded);
+        await importGameStateString(encoded);
         const loaded = loadGameState();
         expect(loaded).toEqual(newState);
     });
@@ -60,31 +60,42 @@ describe('gameState - common utilities', () => {
         expect(validated).toEqual({ quests: {}, inventory: {}, processes: {} });
     });
 
-    test('rollbackGameState should restore previous state', () => {
+    test('rollbackGameState should restore previous state', async () => {
         const state = loadGameState();
         state.inventory['1'] = 1;
-        saveGameState(state);
+        await saveGameState(state);
 
         const updated = loadGameState();
         updated.inventory['1'] = 2;
-        saveGameState(updated);
+        await saveGameState(updated);
 
-        rollbackGameState();
+        await rollbackGameState();
         const rolled = loadGameState();
         expect(rolled.inventory['1']).toBe(1);
     });
 
-    test('rollbackGameState does nothing when no backup exists', () => {
+    test('rollbackGameState does nothing when no backup exists', async () => {
         const state = loadGameState();
         state.inventory['1'] = 3;
-        saveGameState(state);
+        await saveGameState(state);
 
         const updated = loadGameState();
         updated.inventory['1'] = 4;
-        saveGameState(updated);
-        localStorage.removeItem('gameStateBackup');
+        await saveGameState(updated);
 
-        rollbackGameState();
+        await new Promise((resolve, reject) => {
+            const req = indexedDB.open('dspaceGameState', 1);
+            req.onsuccess = (e) => {
+                const db = e.target.result;
+                const tx = db.transaction('backup', 'readwrite');
+                tx.objectStore('backup').clear();
+                tx.oncomplete = resolve;
+                tx.onerror = (ev) => reject(ev.target.error);
+            };
+            req.onerror = (e) => reject(e.target.error);
+        });
+
+        await rollbackGameState();
         const rolled = loadGameState();
         expect(rolled.inventory['1']).toBe(4);
     });

--- a/frontend/__tests__/gameState/fallback.test.js
+++ b/frontend/__tests__/gameState/fallback.test.js
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { vi } from 'vitest';
+
+describe('game state storage fallback', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        localStorage.clear();
+    });
+
+    test('falls back to localStorage when IndexedDB is unavailable', async () => {
+        const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+        // @ts-expect-error - simulate missing IndexedDB
+        delete global.indexedDB;
+        const module = await import('../../src/utils/gameState/common.js');
+        const state = module.loadGameState();
+        state.inventory.item = 1;
+        const ok = await module.saveGameState(state);
+        expect(ok).toBe(true);
+        const stored = JSON.parse(localStorage.getItem('gameState'));
+        expect(stored.inventory.item).toBe(1);
+        expect(alertSpy).toHaveBeenCalled();
+        alertSpy.mockRestore();
+    });
+});

--- a/frontend/__tests__/gameState/gameState.test.js
+++ b/frontend/__tests__/gameState/gameState.test.js
@@ -1,11 +1,10 @@
 import { vi } from 'vitest';
 
-vi.mock('../../src/utils/gameState/common.js', () => {
-    return {
-        loadGameState: vi.fn(),
-        saveGameState: vi.fn(),
-    };
-});
+vi.mock('../../src/utils/gameState/common.js', () => ({
+    loadGameState: vi.fn(),
+    saveGameState: vi.fn().mockResolvedValue(undefined),
+    validateGameState: (s) => s,
+}));
 
 vi.mock('../../src/utils/gameState/inventory.js', () => {
     return {
@@ -47,6 +46,7 @@ describe('gameState top-level helpers', () => {
         loadGameState.mockImplementation(() => mockGameState);
         saveGameState.mockImplementation((state) => {
             mockGameState = state;
+            return true;
         });
         addItems.mockClear();
         loadGameState.mockClear();
@@ -120,9 +120,48 @@ describe('gameState top-level helpers', () => {
         expect(mockGameState.versionNumberString).toBe(VERSIONS.V2);
     });
 
-    test('importV2V3 updates version to V3', () => {
+    test('importV2V3 migrates localStorage data and clears legacy keys', async () => {
         mockGameState.versionNumberString = VERSIONS.V2;
-        importV2V3();
-        expect(mockGameState.versionNumberString).toBe(VERSIONS.V3);
+        const legacy = { quests: { q: { finished: true } }, inventory: { a: 1 } };
+        const removeItem = vi.fn();
+        global.localStorage = {
+            getItem: vi.fn((k) => (k === 'gameState' ? JSON.stringify(legacy) : null)),
+            removeItem,
+        };
+
+        await importV2V3();
+
+        expect(saveGameState).toHaveBeenCalledWith(
+            expect.objectContaining({
+                quests: legacy.quests,
+                inventory: legacy.inventory,
+                processes: {},
+                versionNumberString: VERSIONS.V3,
+            })
+        );
+        expect(removeItem).toHaveBeenCalledWith('gameState');
+        expect(removeItem).toHaveBeenCalledWith('gameStateBackup');
+        // cleanup
+        // @ts-expect-error - cleanup stub
+        delete global.localStorage;
+    });
+
+    test('importV2V3 preserves legacy keys when save fails', async () => {
+        mockGameState.versionNumberString = VERSIONS.V2;
+        const legacy = { quests: { q: { finished: true } }, inventory: { a: 1 } };
+        const removeItem = vi.fn();
+        global.localStorage = {
+            getItem: vi.fn((k) => (k === 'gameState' ? JSON.stringify(legacy) : null)),
+            removeItem,
+        };
+
+        saveGameState.mockResolvedValueOnce(false);
+
+        await importV2V3();
+
+        expect(removeItem).not.toHaveBeenCalled();
+        // cleanup
+        // @ts-expect-error - cleanup stub
+        delete global.localStorage;
     });
 });

--- a/frontend/__tests__/gameState/inventory.test.js
+++ b/frontend/__tests__/gameState/inventory.test.js
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 vi.mock('../../src/utils/gameState/common.js', () => {
     return {
         loadGameState: vi.fn(),
-        saveGameState: vi.fn(),
+        saveGameState: vi.fn().mockResolvedValue(true),
     };
 });
 
@@ -42,6 +42,7 @@ describe('gameState - inventory', () => {
         loadGameState.mockImplementation(() => mockGameState);
         saveGameState.mockImplementation((newState) => {
             mockGameState = newState;
+            return true;
         });
 
         loadGameState.mockClear();

--- a/frontend/__tests__/gameState/processes.test.js
+++ b/frontend/__tests__/gameState/processes.test.js
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 vi.mock('../../src/utils/gameState/common.js', () => {
     return {
         loadGameState: vi.fn(),
-        saveGameState: vi.fn(),
+        saveGameState: vi.fn().mockResolvedValue(true),
     };
 });
 
@@ -56,6 +56,7 @@ describe('gameState - processes', () => {
 
         saveGameState.mockImplementation((newState) => {
             mockGameState = newState;
+            return true;
         });
 
         loadGameState.mockClear();

--- a/frontend/__tests__/githubToken.test.js
+++ b/frontend/__tests__/githubToken.test.js
@@ -1,31 +1,64 @@
 /**
  * @jest-environment jsdom
  */
+import 'fake-indexeddb/auto';
 import {
     loadGitHubToken,
     saveGitHubToken,
     clearGitHubToken,
     isValidGitHubToken,
 } from '../src/utils/githubToken.js';
+import { loadGameState, resetGameState } from '../src/utils/gameState/common.js';
 
 describe('githubToken utils', () => {
-    beforeEach(() => {
-        localStorage.clear();
+    beforeEach(async () => {
+        await resetGameState();
     });
 
-    test('saves and loads token', () => {
-        saveGitHubToken('abc');
-        expect(loadGitHubToken()).toBe('abc');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.github.token).toBe('abc');
+    test('saves and loads token', async () => {
+        await saveGitHubToken('abc');
+        expect(await loadGitHubToken()).toBe('abc');
+        expect(loadGameState().github.token).toBe('abc');
     });
 
-    test('clears token', () => {
-        saveGitHubToken('xyz');
-        clearGitHubToken();
-        expect(loadGitHubToken()).toBe('');
-        const state = JSON.parse(localStorage.getItem('gameState'));
-        expect(state.github.token).toBe('');
+    test('clears token', async () => {
+        await saveGitHubToken('xyz');
+        await clearGitHubToken();
+        expect(await loadGitHubToken()).toBe('');
+        expect(loadGameState().github.token).toBe('');
+    });
+
+    test('save before init preserves existing state', async () => {
+        await new Promise((resolve, reject) => {
+            const req = indexedDB.open('dspaceGameState', 1);
+            req.onupgradeneeded = () => {
+                const db = req.result;
+                if (!db.objectStoreNames.contains('state')) db.createObjectStore('state');
+                if (!db.objectStoreNames.contains('backup')) db.createObjectStore('backup');
+            };
+            req.onsuccess = () => {
+                const db = req.result;
+                const tx = db.transaction('state', 'readwrite');
+                tx.objectStore('state').put(
+                    { quests: {}, inventory: { a: 1 }, processes: {} },
+                    'root'
+                );
+                tx.oncomplete = resolve;
+                tx.onerror = (e) => reject(e.target.error);
+            };
+            req.onerror = (e) => reject(e.target.error);
+        });
+
+        jest.resetModules();
+        const {
+            saveGitHubToken: saveToken,
+            loadGitHubToken: loadToken,
+        } = require('../src/utils/githubToken.js');
+        const { loadGameState: loadState } = require('../src/utils/gameState/common.js');
+
+        await saveToken('abc');
+        expect(loadState().inventory.a).toBe(1);
+        expect(await loadToken()).toBe('abc');
     });
 
     test('validates tokens correctly', () => {

--- a/frontend/__tests__/openAI.test.js
+++ b/frontend/__tests__/openAI.test.js
@@ -16,6 +16,7 @@ jest.mock('openai', () => {
 
 jest.mock('../src/utils/gameState/common.js', () => ({
     loadGameState: jest.fn(() => ({ openAI: { apiKey: 'test-key' } })),
+    ready: Promise.resolve(),
 }));
 
 const { GPT35Turbo } = require('../src/utils/openAI.js');

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -3,6 +3,7 @@ const jest = vi;
 
 jest.mock('../src/utils/gameState/common.js', () => ({
     loadGameState: jest.fn(),
+    ready: Promise.resolve(),
 }));
 
 const { tokenPlaceChat } = require('../src/utils/tokenPlace.js');

--- a/frontend/src/components/svelte/QuestPRForm.svelte
+++ b/frontend/src/components/svelte/QuestPRForm.svelte
@@ -15,8 +15,8 @@
     } from '../../utils/githubToken.js';
     import { submitQuestPR } from '../../utils/submitQuestPR.js';
 
-    onMount(() => {
-        token = loadGitHubToken();
+    onMount(async () => {
+        token = await loadGitHubToken();
     });
 
     function validateForm() {
@@ -43,7 +43,7 @@
             prUrl = await submitQuestPR(token, branch, questJson);
             submitError = '';
             dispatch('success', { message: 'Pull request created', url: prUrl });
-            saveGitHubToken(token);
+            await saveGitHubToken(token);
         } catch (err) {
             console.error(err);
             submitError = 'Failed to submit quest';
@@ -51,9 +51,9 @@
         }
     }
 
-    function clearToken() {
+    async function clearToken() {
         token = '';
-        clearGitHubToken();
+        await clearGitHubToken();
     }
 
     export { handleSubmit, clearToken };

--- a/frontend/src/pages/chat/svelte/Integrations.svelte
+++ b/frontend/src/pages/chat/svelte/Integrations.svelte
@@ -1,11 +1,16 @@
 <script>
     import OpenAIAPIKeySettings from './OpenAIAPIKeySettings.svelte';
+    import { onMount } from 'svelte';
     import { writable } from 'svelte/store';
-    import { loadGameState } from '../../../utils/gameState/common.js';
+    import { loadGameState, ready } from '../../../utils/gameState/common.js';
     import OpenAIChat from './OpenAIChat.svelte';
     import TokenPlaceChat from './TokenPlaceChat.svelte';
 
-    const apiKey = writable(loadGameState().openAI?.apiKey || '');
+    const apiKey = writable('');
+    onMount(async () => {
+        await ready;
+        apiKey.set(loadGameState().openAI?.apiKey || '');
+    });
 </script>
 
 <div class="container">

--- a/frontend/src/pages/chat/svelte/OpenAIAPIKeySettings.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIAPIKeySettings.svelte
@@ -1,36 +1,43 @@
 <script>
     import { onMount } from 'svelte';
     import { writable } from 'svelte/store';
-    import { loadGameState, saveGameState } from '../../../utils/gameState/common.js';
+    import { loadGameState, saveGameState, ready } from '../../../utils/gameState/common.js';
 
-    export let apiKey = writable(loadGameState().openAI?.apiKey || '');
+    export let apiKey = writable('');
 
     const isMounted = writable(false);
-    let isEditing = writable(!$apiKey);
+    const isEditing = writable(true);
 
-    onMount(() => {
+    onMount(async () => {
+        await ready;
+        const state = loadGameState();
+        const current = state.openAI?.apiKey || '';
+        apiKey.set(current);
+        isEditing.set(!current);
         isMounted.set(true);
     });
 
-    function saveAPIKey() {
+    async function saveAPIKey() {
+        await ready;
         let gameState = loadGameState();
         gameState.openAI = gameState.openAI || {};
         gameState.openAI.apiKey = $apiKey;
-        saveGameState(gameState);
+        await saveGameState(gameState);
         isEditing.set(false);
     }
 
-    function deleteAPIKey() {
+    async function deleteAPIKey() {
+        await ready;
         let gameState = loadGameState();
         gameState.openAI = gameState.openAI || {};
         gameState.openAI.apiKey = '';
-        saveGameState(gameState);
+        await saveGameState(gameState);
         apiKey.set('');
         isEditing.set(true);
     }
 
-    function handleSubmit() {
-        saveAPIKey();
+    async function handleSubmit() {
+        await saveAPIKey();
         // reload the page
         window.location.reload();
     }

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -6,6 +6,7 @@
         downloadGameStateFromGist,
         clearCloudGistId,
     } from '../../../utils/cloudSync.js';
+    import { onMount } from 'svelte';
     import {
         isValidGitHubToken,
         loadGitHubToken,
@@ -17,16 +18,18 @@
     let gistId = '';
     let message = '';
 
-    token = loadGitHubToken();
-    gistId = loadCloudGistId();
+    onMount(async () => {
+        token = await loadGitHubToken();
+        gistId = await loadCloudGistId();
+    });
 
-    const saveToken = () => {
-        saveGitHubToken(token);
+    const saveToken = async () => {
+        await saveGitHubToken(token);
     };
 
-    const clearTokenLocal = () => {
+    const clearTokenLocal = async () => {
         token = '';
-        clearGitHubToken();
+        await clearGitHubToken();
     };
 
     const handleUpload = async () => {
@@ -44,9 +47,9 @@
         }
     };
 
-    const clearGistId = () => {
+    const clearGistId = async () => {
         gistId = '';
-        clearCloudGistId();
+        await clearCloudGistId();
     };
 
     const handleDownload = async () => {

--- a/frontend/src/pages/docs/md/authentication.md
+++ b/frontend/src/pages/docs/md/authentication.md
@@ -13,9 +13,11 @@ To authenticate, generate a GitHub personal access token with the `repo` and `gi
 2. Create a token granting **repo** and **gist** permissions.
 3. Paste the token into the relevant form in DSPACE and click **Save**.
 
-## Local Storage
+## Token Storage
 
-Your token is stored in `localStorage` under `gameState.github.token` so you don't need to re-enter it each time you open the game. You can clear the saved token using the **Clear** button next to the input field.
+Your token is stored in IndexedDB under `gameState.github.token` so you don't
+need to re-enter it each time you open the game. You can clear the saved token
+using the **Clear** button next to the input field.
 
 ## Security Considerations
 

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -137,7 +137,10 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
     -   [x] **Node version standardization** 💯
         -   [x] Add `.nvmrc` and document Node.js 20 LTS requirement 💯
 
-Authentication for the quest submission form was audited. Tokens are now saved in `localStorage` so you don't need to re‑enter them, and you can clear them at any time. See the updated [Authentication Flow](/docs/authentication) documentation for details.
+Authentication for the quest submission form was audited. Tokens are now saved
+in IndexedDB so you don't need to re‑enter them, and you can clear them at any
+time. See the updated [Authentication Flow](/docs/authentication) documentation
+for details.
 
 _Note: This checklist will be removed before the final release._
 
@@ -186,7 +189,9 @@ We've rebuilt DSPACE's architecture to be truly local‑first. Your progress, ac
 
 A few technical details that might interest you:
 
--   Your v2 progress will automatically migrate to v3
+-   Your v2 progress will automatically migrate to v3. On first launch, v3 checks for the legacy
+    `gameState` key in `localStorage`. If found, it copies the data into IndexedDB and removes the
+    old keys.
 -   All custom content includes rollback functionality (in case something goes wrong)
 
 The new **Cloud Sync** feature lets you back up your progress across devices using a private

--- a/frontend/src/pages/docs/md/cloud-sync.md
+++ b/frontend/src/pages/docs/md/cloud-sync.md
@@ -20,7 +20,8 @@ DSPACE can back up your progress to a private GitHub gist.
 
 ### Token storage
 
-The token and gist ID are stored in `localStorage`. Remove them at any time from the Settings page.
+The token and gist ID are stored in IndexedDB and load after the game initialises.
+Remove them at any time from the Settings page.
 
 ## What gets synced?
 

--- a/frontend/src/pages/docs/md/prompts-playwright-tests.md
+++ b/frontend/src/pages/docs/md/prompts-playwright-tests.md
@@ -37,7 +37,7 @@ Actions runs, use the [Codex CI-failure fix prompt](/docs/prompts-codex-ci-fix).
 >    fully loaded before assertions.
 > 8. For dynamic metrics (e.g., UI responsiveness), assert text patterns rather
 >    than hard-coded values.
-> 9. For authentication flows, confirm tokens persist in `localStorage` and can
+> 9. For authentication flows, confirm tokens persist in IndexedDB and can
 >    be cleared without network access.
 > 10. Update `user-journeys.md` with coverage status, test file path, and any
 >     fixes, keeping the table alphabetized. Mark new journeys with `No` coverage

--- a/frontend/src/pages/docs/md/quest-submission.md
+++ b/frontend/src/pages/docs/md/quest-submission.md
@@ -54,4 +54,7 @@ For the full workflow, see the [Quest Contribution Guidelines](/docs/quest-contr
 1. Visit [github.com/settings/tokens](https://github.com/settings/tokens) and generate a new **classic** token with `repo` scope.
 2. Copy the token and keep it somewhere safe. You can revoke it at any time.
 3. When using the submission form, paste the token into the "GitHub Token" field. The token is used solely in your browser to create the pull request.
-4. The token is saved to your browser's `localStorage` under `gameState.github.token` for convenience. Use the **Clear Token** button when you're finished or revoke it on GitHub. See the [Authentication Flow](/docs/authentication) for more details.
+4. The token is saved in IndexedDB under `gameState.github.token` for
+   convenience. Use the **Clear Token** button when you're finished or revoke it
+   on GitHub. See the [Authentication Flow](/docs/authentication) for more
+   details.

--- a/frontend/src/pages/docs/md/rollback.md
+++ b/frontend/src/pages/docs/md/rollback.md
@@ -5,14 +5,14 @@ slug: 'rollback'
 
 # Game State Rollback
 
-DSPACE keeps a backup of the previous game state before every save. If a change corrupts your data,
-you can revert to the last snapshot using `rollbackGameState()`.
+DSPACE keeps a backup of the previous game state in IndexedDB before every save. If a change corrupts
+your data, you can revert to the last snapshot using `rollbackGameState()`.
 
 ```ts
 import { rollbackGameState } from '../utils/gameState/common.js';
 
-rollbackGameState();
+await rollbackGameState();
 ```
 
-The helper restores the most recently saved snapshot from `localStorage`. If no backup exists,
-the call has no effect.
+The helper restores the most recently saved snapshot from IndexedDB. If no backup exists, the call has
+no effect.

--- a/frontend/src/pages/docs/md/state-migration.md
+++ b/frontend/src/pages/docs/md/state-migration.md
@@ -1,0 +1,34 @@
+---
+title: 'Game State Migration'
+slug: 'state-migration'
+---
+
+# Game State Migration
+
+DSPACE v3 stores quests, inventory and processes in IndexedDB instead of `localStorage`.
+On first launch, the app checks for the legacy `gameState` key in `localStorage`. If it
+exists and no IndexedDB data has been saved yet, the `importV2V3` helper copies the old
+state into IndexedDB and clears the legacy keys. The migration runs automatically and
+needs no manual action.
+
+If IndexedDB is unavailable (for example in Safari private mode), the game falls back to
+`localStorage` and displays a warning. Progress will still save, but space is limited and
+may not support all features.
+
+```ts
+import { importV2V3 } from '../utils/gameState.js';
+
+importV2V3();
+```
+
+## Async game state
+
+Because IndexedDB calls are asynchronous, wait for the shared `ready` promise before
+reading or writing game data. Components that compute quest availability or export saves
+should only run after this promise resolves.
+
+```ts
+import { ready } from '../utils/gameState/common.js';
+
+await ready; // game state is now loaded
+```

--- a/frontend/src/pages/gamesaves/svelte/Exporter.svelte
+++ b/frontend/src/pages/gamesaves/svelte/Exporter.svelte
@@ -1,25 +1,39 @@
 <script>
     import Chip from '../../../components/svelte/Chip.svelte';
-    import { exportGameStateString } from '../../../utils/gameState/common.js';
+    import { exportGameStateString, state, ready } from '../../../utils/gameState/common.js';
     import { copyToClipboard } from '../../../utils/copyToClipboard.js';
+    import { onMount } from 'svelte';
 
-    const gameStateString = exportGameStateString();
+    let gameStateString = '';
+    let loaded = false;
+
+    onMount(async () => {
+        await ready;
+        loaded = true;
+    });
+
+    $: if (loaded) {
+        const _gs = $state; // refresh when game state changes
+        gameStateString = exportGameStateString();
+    }
 </script>
 
-<Chip text="">
-    <div class="vertical">
-        <p>Here is a string representation of your game state:</p>
+{#if loaded}
+    <Chip text="">
+        <div class="vertical">
+            <p>Here is a string representation of your game state:</p>
 
-        <!-- code block -->
-        <div class="code-block">
-            <code>
-                {gameStateString}
-            </code>
+            <!-- code block -->
+            <div class="code-block">
+                <code>
+                    {gameStateString}
+                </code>
+            </div>
+
+            <Chip text="Copy" onClick={() => copyToClipboard(gameStateString)} inverted={true} />
         </div>
-
-        <Chip text="Copy" onClick={() => copyToClipboard(gameStateString)} inverted={true} />
-    </div>
-</Chip>
+    </Chip>
+{/if}
 
 <style>
     p {

--- a/frontend/src/pages/quests/svelte/ManageQuests.svelte
+++ b/frontend/src/pages/quests/svelte/ManageQuests.svelte
@@ -3,28 +3,33 @@
     import Quest from './Quest.svelte';
     import { questFinished } from '../../../utils/gameState.js';
     import { db } from '../../../utils/customcontent.js';
+    import { state, ready } from '../../../utils/gameState/common.js';
 
     export let quests = [];
     let mounted = false;
     let searchTerm = '';
     let selectedStatus = 'all';
+    let filteredQuests = [];
 
-    // Reactive filtered quests
-    $: filteredQuests = quests.filter((quest) => {
-        const matchesSearch =
-            quest.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            quest.description.toLowerCase().includes(searchTerm.toLowerCase());
+    $: if (mounted) {
+        const _gs = $state; // recompute when game state changes
+        filteredQuests = quests.filter((quest) => {
+            const matchesSearch =
+                quest.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                quest.description.toLowerCase().includes(searchTerm.toLowerCase());
 
-        const isFinished = questFinished(quest.id);
+            const isFinished = questFinished(quest.id);
 
-        if (selectedStatus === 'all') return matchesSearch;
-        if (selectedStatus === 'active') return matchesSearch && !isFinished;
-        if (selectedStatus === 'completed') return matchesSearch && isFinished;
+            if (selectedStatus === 'all') return matchesSearch;
+            if (selectedStatus === 'active') return matchesSearch && !isFinished;
+            if (selectedStatus === 'completed') return matchesSearch && isFinished;
 
-        return false;
-    });
+            return false;
+        });
+    }
 
-    onMount(() => {
+    onMount(async () => {
+        await ready;
         mounted = true;
     });
 

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -3,26 +3,31 @@
     import Chip from '../../../components/svelte/Chip.svelte';
     import { onMount } from 'svelte';
     import { questFinished, canStartQuest } from '../../../utils/gameState.js';
+    import { state, ready } from '../../../utils/gameState/common.js';
 
     export let quests = [];
-    let filteredQuests = [],
-        finishedQuests = [];
+    let filteredQuests = [];
+    let finishedQuests = [];
     let mounted = false;
 
     onMount(async () => {
+        await ready;
         mounted = true;
     });
 
-    quests.forEach((quest) => {
-        const finished = questFinished(quest.id);
-        if (finished) {
-            finishedQuests.push(quest);
-        } else {
-            if (canStartQuest(quest)) {
+    $: if (mounted) {
+        const _gs = $state; // rerun when game state updates
+        filteredQuests = [];
+        finishedQuests = [];
+        quests.forEach((quest) => {
+            const finished = questFinished(quest.id);
+            if (finished) {
+                finishedQuests.push(quest);
+            } else if (canStartQuest(quest)) {
                 filteredQuests.push(quest);
             }
-        }
-    });
+        });
+    }
 
     // Define buttons for easy expansion
     const actionButtons = [

--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -8,9 +8,10 @@
     export let quest, option;
     let githubConnected = false;
 
-    const checkConnection = () => {
-        githubConnected = isValidGitHubToken(loadGitHubToken());
-    };
+    async function checkConnection() {
+        const token = await loadGitHubToken();
+        githubConnected = isValidGitHubToken(token);
+    }
 
     onMount(checkConnection);
 

--- a/frontend/src/utils/cloudSync.js
+++ b/frontend/src/utils/cloudSync.js
@@ -1,37 +1,40 @@
-import { exportGameStateString, importGameStateString } from './gameState/common.js';
+import {
+    exportGameStateString,
+    importGameStateString,
+    loadGameState,
+    saveGameState,
+    ready,
+} from './gameState/common.js';
 import { loadGitHubToken } from './githubToken.js';
 
-const storageKey = 'gameState';
-
-function loadCloudGistId() {
-    try {
-        const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
-        return state.cloudSync?.gistId || '';
-    } catch {
-        return '';
-    }
+async function loadCloudGistId() {
+    await ready;
+    const state = loadGameState();
+    return state.cloudSync?.gistId || '';
 }
 
-function saveCloudGistId(id) {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+async function saveCloudGistId(id) {
+    await ready;
+    const state = loadGameState();
     state.cloudSync = state.cloudSync || {};
     state.cloudSync.gistId = id;
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    await saveGameState(state);
 }
 
-function clearCloudGistId() {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+async function clearCloudGistId() {
+    await ready;
+    const state = loadGameState();
     if (state.cloudSync) {
         state.cloudSync.gistId = '';
     }
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    await saveGameState(state);
 }
 
 async function uploadGameStateToGist(token) {
     if (!token) {
-        token = loadGitHubToken();
+        token = await loadGitHubToken();
     }
-    const gistId = loadCloudGistId();
+    const gistId = await loadCloudGistId();
     const headers = {
         Authorization: `token ${token}`,
         'Content-Type': 'application/json',
@@ -57,14 +60,17 @@ async function uploadGameStateToGist(token) {
     }
     if (!res.ok) throw new Error('Failed to upload game state');
     const data = await res.json();
-    saveCloudGistId(data.id);
+    await saveCloudGistId(data.id);
     return data.id;
 }
 
-async function downloadGameStateFromGist(token, gistId = loadCloudGistId()) {
+async function downloadGameStateFromGist(token, gistId) {
+    if (!gistId) {
+        gistId = await loadCloudGistId();
+    }
     if (!gistId) throw new Error('No gist id specified');
     if (!token) {
-        token = loadGitHubToken();
+        token = await loadGitHubToken();
     }
     const headers = token ? { Authorization: `token ${token}` } : {};
     const res = await fetch(`https://api.github.com/gists/${gistId}`, { headers });
@@ -72,8 +78,8 @@ async function downloadGameStateFromGist(token, gistId = loadCloudGistId()) {
     const data = await res.json();
     const content = data.files['dspace-save.json']?.content;
     if (!content) throw new Error('Invalid gist content');
-    importGameStateString(content);
-    saveCloudGistId(gistId);
+    await importGameStateString(content);
+    await saveCloudGistId(gistId);
 }
 
 export { loadCloudGistId, uploadGameStateToGist, downloadGameStateFromGist, clearCloudGistId };

--- a/frontend/src/utils/gameState.js
+++ b/frontend/src/utils/gameState.js
@@ -1,4 +1,9 @@
-import { loadGameState, saveGameState } from './gameState/common.js';
+import {
+    loadGameState,
+    saveGameState,
+    validateGameState,
+    usingLocalStorageFallback,
+} from './gameState/common.js';
 import { addItems } from './gameState/inventory.js';
 import items from '../pages/inventory/json/items';
 
@@ -124,14 +129,37 @@ export const importV1V2 = (itemList) => {
 };
 
 // v2 -> v3
-export const importV2V3 = () => {
-    const gameState = loadGameState();
-
-    // Ensure new properties exist for v3
-    if (!gameState.processes) {
-        gameState.processes = {};
+export const importV2V3 = async () => {
+    let migrated;
+    try {
+        const legacy = localStorage.getItem('gameState');
+        if (legacy) {
+            migrated = validateGameState(JSON.parse(legacy));
+        }
+    } catch (err) {
+        console.error('Error reading legacy v2 state:', err);
     }
-
-    setVersionNumber(VERSIONS.V3);
-    saveGameState(gameState);
+    if (!migrated) return;
+    if (!migrated.processes) {
+        migrated.processes = {};
+    }
+    migrated.versionNumberString = VERSIONS.V3;
+    const ok = await saveGameState(migrated);
+    if (ok && !usingLocalStorageFallback()) {
+        try {
+            localStorage.removeItem('gameState');
+            localStorage.removeItem('gameStateBackup');
+        } catch {
+            /* ignore */
+        }
+    }
 };
+
+// Auto-migrate legacy v2 state on first v3 load when localStorage data is present.
+try {
+    if (typeof window !== 'undefined' && window.localStorage?.getItem('gameState')) {
+        importV2V3();
+    }
+} catch {
+    /* ignore */
+}

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -1,21 +1,147 @@
 import { writable } from 'svelte/store';
 
+const DB_NAME = 'dspaceGameState';
+const DB_VERSION = 1;
+const STATE_STORE = 'state';
+const BACKUP_STORE = 'backup';
+const ROOT_KEY = 'root';
+
 const gameStateKey = 'gameState';
 const gameStateBackupKey = 'gameStateBackup';
 
-const initializeGameState = () => {
-    return {
-        quests: {},
-        inventory: {},
-        processes: {},
-    };
-};
+let dbPromise;
+let useLocalStorage = false;
+let warned = false;
+
+function alertFallback(err) {
+    if (useLocalStorage) return;
+    useLocalStorage = true;
+    console.warn('IndexedDB unavailable, falling back to localStorage:', err);
+    if (typeof window !== 'undefined' && typeof window.alert === 'function' && !warned) {
+        window.alert(
+            'IndexedDB is unavailable. Progress is stored in localStorage and may be lost.'
+        );
+        warned = true;
+    }
+}
+
+function openDB() {
+    if (useLocalStorage) return Promise.reject(new Error('IndexedDB disabled'));
+    if (!('indexedDB' in globalThis)) {
+        return Promise.reject(new Error('IndexedDB is not supported'));
+    }
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                if (!db.objectStoreNames.contains(STATE_STORE)) {
+                    db.createObjectStore(STATE_STORE);
+                }
+                if (!db.objectStoreNames.contains(BACKUP_STORE)) {
+                    db.createObjectStore(BACKUP_STORE);
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+    return dbPromise;
+}
+
+async function read(store) {
+    const key = store === STATE_STORE ? gameStateKey : gameStateBackupKey;
+    if (useLocalStorage) {
+        try {
+            return JSON.parse(localStorage.getItem(key));
+        } catch {
+            return null;
+        }
+    }
+    try {
+        const db = await openDB();
+        return await new Promise((resolve, reject) => {
+            const tx = db.transaction(store, 'readonly');
+            const req = tx.objectStore(store).get(ROOT_KEY);
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = (e) => reject(e.target.error);
+        });
+    } catch (err) {
+        alertFallback(err);
+        try {
+            return JSON.parse(localStorage.getItem(key));
+        } catch {
+            return null;
+        }
+    }
+}
+
+async function write(store, value) {
+    const key = store === STATE_STORE ? gameStateKey : gameStateBackupKey;
+    if (useLocalStorage) {
+        try {
+            localStorage.setItem(key, JSON.stringify(value));
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    try {
+        const db = await openDB();
+        await new Promise((resolve, reject) => {
+            const tx = db.transaction(store, 'readwrite');
+            tx.objectStore(store).put(value, ROOT_KEY);
+            tx.oncomplete = resolve;
+            tx.onerror = (e) => reject(e.target.error);
+        });
+        return true;
+    } catch (err) {
+        alertFallback(err);
+        try {
+            localStorage.setItem(key, JSON.stringify(value));
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+async function clearStore(store) {
+    const key = store === STATE_STORE ? gameStateKey : gameStateBackupKey;
+    if (useLocalStorage) {
+        try {
+            localStorage.removeItem(key);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    try {
+        const db = await openDB();
+        await new Promise((resolve, reject) => {
+            const tx = db.transaction(store, 'readwrite');
+            tx.objectStore(store).clear();
+            tx.oncomplete = resolve;
+            tx.onerror = (e) => reject(e.target.error);
+        });
+        return true;
+    } catch (err) {
+        alertFallback(err);
+        try {
+            localStorage.removeItem(key);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+const initializeGameState = () => ({ quests: {}, inventory: {}, processes: {} });
 
 export const validateGameState = (state) => {
     if (!state || typeof state !== 'object') {
         return initializeGameState();
     }
-
     if (typeof state.quests !== 'object' || state.quests === null) {
         state.quests = {};
     }
@@ -25,59 +151,60 @@ export const validateGameState = (state) => {
     if (typeof state.processes !== 'object' || state.processes === null) {
         state.processes = {};
     }
-
     return state;
 };
 
-export const loadGameState = () => {
-    const storedGameState = localStorage.getItem(gameStateKey);
-    if (storedGameState) {
-        return validateGameState(JSON.parse(storedGameState));
-    }
-    return initializeGameState();
-};
-
-export const saveGameState = (newState) => {
-    localStorage.setItem(gameStateBackupKey, JSON.stringify(gameState));
-    gameState = validateGameState(newState);
-    localStorage.setItem(gameStateKey, JSON.stringify(gameState));
-    state.set(gameState); // Update the state store directly
-};
-
-let gameState = loadGameState();
-
-// Create the state store and set the initial value
+let gameState = initializeGameState();
 export const state = writable(gameState);
 
-/**
- * Export the game state as a Base64-encoded JSON string.
- * The schema {quests, inventory, processes} is public and must remain stable.
- */
-export const exportGameStateString = () => {
-    return btoa(JSON.stringify(gameState));
-};
+export const ready = (async () => {
+    try {
+        const stored = await read(STATE_STORE);
+        if (stored) {
+            gameState = validateGameState(stored);
+            state.set(gameState);
+        }
+    } catch (err) {
+        console.error('Error loading game state from IndexedDB:', err);
+    }
+})();
 
-export const importGameStateString = (gameStateString) => {
-    // Decode from Base64 and parse the JSON string
-    const importedGameState = JSON.parse(atob(gameStateString));
+export const loadGameState = () => structuredClone(gameState);
 
-    // Overwrite the game state with the imported game state
-    gameState = importedGameState;
-
-    // Save the updated game state to local storage and update the state store
-    saveGameState(gameState);
-};
-
-export const resetGameState = () => {
-    const freshState = initializeGameState();
-    saveGameState(freshState);
-};
-
-export const rollbackGameState = () => {
-    const backup = localStorage.getItem(gameStateBackupKey);
-    if (!backup) return;
-    const previous = validateGameState(JSON.parse(backup));
-    gameState = previous;
-    localStorage.setItem(gameStateKey, JSON.stringify(gameState));
+export const saveGameState = async (newState) => {
+    await ready;
+    const snapshot = structuredClone(gameState);
+    const backupOk = await write(BACKUP_STORE, snapshot);
+    gameState = validateGameState(newState);
     state.set(gameState);
+    const stateOk = await write(STATE_STORE, gameState);
+    return backupOk && stateOk;
 };
+
+export const exportGameStateString = () => btoa(JSON.stringify(gameState));
+
+export const importGameStateString = async (gameStateString) => {
+    const imported = JSON.parse(atob(gameStateString));
+    await saveGameState(imported);
+};
+
+export const resetGameState = async () => {
+    gameState = initializeGameState();
+    state.set(gameState);
+    await write(STATE_STORE, gameState);
+    await clearStore(BACKUP_STORE);
+};
+
+export const rollbackGameState = async () => {
+    try {
+        const backup = await read(BACKUP_STORE);
+        if (!backup) return;
+        gameState = validateGameState(backup);
+        state.set(gameState);
+        await write(STATE_STORE, gameState);
+    } catch (err) {
+        console.error('Error rolling back game state:', err);
+    }
+};
+
+export const usingLocalStorageFallback = () => useLocalStorage;

--- a/frontend/src/utils/githubToken.js
+++ b/frontend/src/utils/githubToken.js
@@ -5,28 +5,27 @@ export function isValidGitHubToken(token) {
     return patterns.some((p) => p.test(trimmed));
 }
 
-const storageKey = 'gameState';
+import { loadGameState, saveGameState, ready } from './gameState/common.js';
 
-export function loadGitHubToken() {
-    try {
-        const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
-        return state.github?.token || '';
-    } catch {
-        return '';
-    }
+export async function loadGitHubToken() {
+    await ready;
+    const state = loadGameState();
+    return state.github?.token || '';
 }
 
-export function saveGitHubToken(token) {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+export async function saveGitHubToken(token) {
+    await ready;
+    const state = loadGameState();
     state.github = state.github || {};
     state.github.token = token;
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    await saveGameState(state);
 }
 
-export function clearGitHubToken() {
-    const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+export async function clearGitHubToken() {
+    await ready;
+    const state = loadGameState();
     if (state.github) {
         state.github.token = '';
     }
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    await saveGameState(state);
 }

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -1,9 +1,9 @@
-import { loadGameState } from './gameState/common.js';
+import { loadGameState, ready } from './gameState/common.js';
 import OpenAI from 'openai';
 
-const apiKey = (loadGameState().openAI && loadGameState().openAI.apiKey) || '';
-
 export const GPT35Turbo = async (messages) => {
+    await ready;
+    const apiKey = loadGameState().openAI?.apiKey || '';
     const openai = new OpenAI({ apiKey });
 
     const systemMessage = {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,4 +1,4 @@
-import { loadGameState } from './gameState/common.js';
+import { loadGameState, ready } from './gameState/common.js';
 
 const DEFAULT_URL = 'https://token.place/api';
 
@@ -15,6 +15,7 @@ const getEnvUrl = () => {
 
 export const tokenPlaceChat = async (messages, { signal } = {}) => {
     const envUrl = getEnvUrl();
+    await ready;
     const baseUrl = loadGameState().tokenPlace?.url || envUrl || DEFAULT_URL;
 
     const systemMessage = {


### PR DESCRIPTION
## Summary
- recompute quest lists only after IndexedDB-backed state loads
- wait for async game state before filtering quests in management view
- delay game state export until initialization and document async loading
- fall back to localStorage when IndexedDB is unavailable and warn the user
- avoid clearing legacy saves until IndexedDB migration succeeds

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bd10713318832fa37710c43bcc9114