### PR TITLE
✨ Add evergreen implement prompt doc

### DIFF
--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,0 +1,107 @@
+# Codex implement prompt for the _dspace_ repo
+
+Use this guide when you want Codex to turn a promised but unshipped improvement into reality.
+It produces a one-click, evergreen prompt that scopes the work, enforces our repo guardrails,
+and nudges the agent to pick a random qualifying task each run so the backlog keeps moving.
+
+## When to use it
+- There is an explicit commitment in the repo (TODO/FIXME, unchecked checklist item, pending
+  changelog entry, failing snapshot, skipped test, roadmap bullet, etc.) that describes
+  behaviour we still owe.
+- The promise can be fulfilled in a single pull request without blocking migrations or
+  multi-week efforts.
+- You can prove the behavior with automated tests (Vitest, Playwright, API tests, or a focused
+  script) and update any related docs or inline notes.
+
+## How Codex should pick a task
+1. Inventory candidates by searching for TODO, FIXME, `@todo`, `skip(`, `it.skip`, "future
+   work", unchecked checkboxes, or roadmap bullets. Use `rg` across the repo instead of `ls -R`
+   or `grep -R`.
+2. Filter out items that cannot ship in one PR or lack enough context to implement safely.
+3. Select one of the remaining items at random. Record the selection criteria in the PR body so
+   reviewers can follow along.
+4. If no viable candidates remain, exit early and leave a note in the PR summary.
+
+## Prompt block
+```prompt
+SYSTEM:
+You are an automated contributor for the democratizedspace/dspace repository.
+
+PURPOSE:
+Deliver one promised or implied improvement that already exists in the codebase or docs but has
+not shipped yet. Keep the change small, safe, and fully tested.
+
+USAGE NOTES:
+- Prompt name: `prompt-implement`.
+- Use this prompt when clearing DSPACE TODOs, backlog bullets, unchecked checklists, or other
+  explicit promises.
+- Each run must choose a random eligible task so the backlog drains evenly over time.
+
+CONTEXT:
+- Follow [README.md](../../README.md), [CONTRIBUTING.md](../../CONTRIBUTING.md), and the
+  root [AGENTS.md](../../AGENTS.md) for semantics.
+- Review [.github/workflows/](../../.github/workflows/) before coding so local checks mirror CI.
+- Reference [`llms.txt`](../../llms.txt),
+  [`docs/prompt-docs-summary.md`](../../docs/prompt-docs-summary.md),
+  and neighboring source files to understand feature intent before changing behavior.
+- Tests live under [`tests/`](../../tests/) and `frontend/__tests__/`; UI coverage uses
+  Vitest and Playwright. Match existing patterns when adding new assertions.
+- Install dependencies with `npm ci` (or `pnpm install`) before running repo scripts.
+- Move fast but keep trunk green: ship small, composable changes that pass CI on the first push.
+
+REQUEST:
+1. Build a candidate list of promised-but-unshipped work (TODO/FIXME, unchecked checklists,
+   skipped tests, roadmap bullets, etc.) using `rg`. Exclude items that need multi-step
+   migrations or cross-team approvals.
+2. Choose one remaining candidate at random and state the choice (and why it qualifies) in the
+   PR summary.
+3. Add or update automated tests so the expectation fails first, then implement the minimal code
+   to make them pass. Extend coverage for edge cases when feasible.
+4. Update or remove the original promise (TODO comment, checklist entry, doc note) so the repo no
+   longer advertises incomplete work.
+5. Refresh related documentation or changelog entries to reflect the shipped behavior.
+6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
+   `npm run test:ci`. Install Playwright browsers with
+   `npx playwright install chromium` if needed, or set `SKIP_E2E=1` only when browsers are
+   unavailable.
+7. Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py` before committing.
+8. Commit with an emoji-prefixed message and summarize the implemented promise plus test results
+   in the PR body.
+
+OUTPUT:
+A pull request implementing the randomly selected promise, with updated docs, green checks, and
+notes describing the selection process and test outcomes.
+```
+
+## Upgrade instructions
+```upgrade
+SYSTEM:
+You are an automated contributor for the democratizedspace/dspace repository.
+
+PURPOSE:
+Keep `docs/prompts/codex/implement.md` accurate, actionable, and aligned with the
+[prompt-docs summary](../../docs/prompt-docs-summary.md).
+
+USAGE NOTES:
+- Use this block when refining or expanding the DSPACE implement prompt.
+- Ensure cross-references to other prompt docs and indexes stay in sync.
+
+CONTEXT:
+- Follow [README.md](../../README.md), [CONTRIBUTING.md](../../CONTRIBUTING.md), and the root
+  [AGENTS.md](../../AGENTS.md) for instruction semantics.
+- Review [.github/workflows/](../../.github/workflows/) to anticipate CI checks.
+- Run the command suite from the main prompt (`npm run audit:ci`, `npm run lint`,
+  `npm run type-check`, `npm run build`, `npm run test:ci`) plus the secret scan
+  `git diff --cached | ./scripts/scan-secrets.py`.
+- Confirm new guidance matches the latest patterns in `docs/prompt-docs-summary.md` and related
+  prompt docs.
+
+REQUEST:
+1. Update this file so the implement prompt stays evergreen and mirrors current repo workflows.
+2. Verify all referenced files exist and links resolve.
+3. Document notable changes in the PR body and ensure the commands above pass.
+
+OUTPUT:
+A pull request updating `docs/prompts/codex/implement.md` with refreshed guidance and passing
+checks.
+```

--- a/docs/prompts/codex/prompts-codex.md
+++ b/docs/prompts/codex/prompts-codex.md
@@ -13,7 +13,8 @@ For task-specific templates see [Quest prompts](prompts-quests.md),
 [Docs prompts](prompts-docs.md),
 [Playwright test prompts](prompts-playwright-tests.md),
 [Vitest test prompts](prompts-vitest.md), [Frontend prompts](prompts-frontend.md), [Chat UI prompts](prompts-chat-ui.md),
-[Backend prompts](prompts-backend.md), [Refactor prompts](prompts-refactors.md), and
+[Backend prompts](prompts-backend.md), [Refactor prompts](prompts-refactors.md),
+[Implementation prompt](implement.md), and
 [Accessibility prompts](prompts-accessibility.md).
 For specialized workflows use the [Codex CI-failure fix prompt](prompts-codex-ci-fix.md),
 the [Codex merge conflict prompt](prompts-codex-merge-conflicts.md), the
@@ -57,6 +58,7 @@ When adding a new prompt doc, link it here and in
 - [Playwright Test Prompts](prompts-playwright-tests.md)
 - [Vitest Test Prompts](prompts-vitest.md)
 - [Refactor Prompts](prompts-refactors.md)
+- [Implementation Prompt](implement.md)
 - [Codex CI-Failure Fix Prompt](prompts-codex-ci-fix.md)
 - [Codex Merge Conflict Prompt](prompts-codex-merge-conflicts.md)
 - [Codex Meta Prompt](prompts-codex-meta.md)
@@ -114,49 +116,12 @@ OUTPUT
 A pull request with the required changes and tests.
 ```
 
-## Implementation Prompt
+## Implementation prompt
 
-Use this template when you want Codex to automatically clear items from the
-[September&nbsp;1,&nbsp;2025 changelog](changelog/20250901.md). Tasks are
-tracked with Markdown checkboxes and an emoji status:
-
-- `- [ ]` – work not started
-- `- [x]` or `- [x] <emoji>` – implemented but not fully vetted
-- `- [x] ✅` – implemented before robustness checks; replace with `💯` once verified
-- `- [x] 💯` – thoroughly tested and reviewed
-
-Codex should pick a single entry that is either unchecked or checked without a
-💯 (for example, entries marked with ✅) and implement it completely. After all
-tests pass, update that row so the line ends with `💯`. When possible, also
-promote any previously completed rows lacking the 💯 emoji by swapping `✅` for
-`💯`.
-
-```text
-SYSTEM:
-You are an automated contributor for the DSPACE repository. Choose one item
-from `frontend/src/pages/docs/md/changelog/20250901.md` that is either `[ ]` or
-`[x]` without 💯 (including those marked with ✅). Implement it fully, completing
-any sub-tasks. Provide all code, tests and documentation required. Follow
-`AGENTS.md` and ensure `npm run audit:ci`, `npm run lint`,
-`npm run type-check`, `npm run build`, and `npm run test:ci`
-all pass before committing. If Playwright browsers are
-missing run `npx playwright install chromium` or use `SKIP_E2E=1 npm run test:ci`.
-
-USER:
-1. Follow the steps above.
-2. Use `rg` for file searches; avoid `ls -R` or `grep -R`.
-3. Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
-4. After verifying the implementation, mark the corresponding changelog line
-   with `💯`, replacing any `✅` or other emoji.
-5. Replace any remaining `✅` entries in the changelog with `💯` once they meet
-   the robustness standard.
-6. Use an emoji-prefixed commit message.
-7. Document new functionality as needed.
-
-OUTPUT:
-A pull request implementing the chosen item with all tests green. Summarize the
-completed task and test results in the PR body.
-```
+Looking for an evergreen way to ship promised functionality? Use the dedicated
+[implement prompt guide](implement.md). It instructs Codex to gather eligible
+TODOs, unchecked checklists, and other promises, pick one at random, and ship it
+with full test coverage and documentation updates.
 
 ## Upgrade Prompt
 

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -2,6 +2,9 @@
 import Page from '../../components/Page.astro';
 
 // TODO: create page dynamically with JSON
+const implementPromptUrl =
+    'https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/' +
+    'implement.md';
 ---
 
 <Page title="Docs">
@@ -76,6 +79,9 @@ import Page from '../../components/Page.astro';
 
             <!-- Prompt library -->
             <a href="/docs/prompts-codex">Codex prompt library</a>
+            <a href={implementPromptUrl}>
+                Implement prompt guide
+            </a>
         </nav>
     </span>
 </Page>

--- a/frontend/src/pages/docs/md/prompts-codex.md
+++ b/frontend/src/pages/docs/md/prompts-codex.md
@@ -20,7 +20,7 @@ canonical Markdown files and keep them in sync.
 -   **Core workflow:** [Codex prompt playbook][codex-playbook]
 -   **Repository maintenance:** [Codex meta prompt][meta]
 -   **Prompt upgrader:** [Codex prompt upgrader][upgrader]
--   **Implementation prompt:** [Ship a changelog item][implementation]
+-   **Implementation prompt:** [Ship a promised feature][implementation]
 -   **Upgrade prompt:** [Repository sweep][upgrade]
 -   **CI failures:** [Codex CI-failure fix][ci-fix]
 -   **Merge conflicts:** [Codex merge conflict prompt][merge]
@@ -75,5 +75,5 @@ Have ideas for improving the prompts? Open a pull request that updates the Markd
 [items]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/prompts-items.md
 [quests]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/prompts-quests.md
 [npcs]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/prompts-npcs.md
-[implementation]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/prompts-codex.md#implementation-prompt
+[implementation]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/implement.md
 [upgrade]: https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/prompts-codex.md#upgrade-prompt


### PR DESCRIPTION
## What
- add docs/prompts/codex/implement.md with random-task guidance
- link the new prompt from prompts indexes

## Why
- provide a reusable implement prompt that matches backlog reality

## How to test
- docs-only change (no tests run)


------
https://chatgpt.com/codex/tasks/task_e_68d8ed8dd8e0832fb7c477ef582287e4