### PR TITLE
Re-enable run-test-groups coverage

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -129,6 +129,7 @@ When creating new test files:
 
     - Place `.spec.ts` files in the `frontend/e2e/` directory
     - Add them to a test group in `frontend/scripts/run-test-groups.mjs`
+    - Update the Vitest coverage in `tests/run-test-groups.test.ts` when changing how groups execute
 
 2. For Jest tests:
     - Place `.test.js` files in the `frontend/__tests__/` directory

--- a/tests/run-test-groups.test.ts
+++ b/tests/run-test-groups.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { execSync } from 'child_process';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 let runTestGroup: any;
 let TEST_GROUPS: any;
 
 import path from 'path';
 import { pathToFileURL } from 'url';
+
+const execSyncMock = vi.fn();
+const frontendRoot = path.resolve(__dirname, '../frontend');
+
+vi.mock('child_process', () => ({
+  execSync: execSyncMock,
+  default: { execSync: execSyncMock },
+}));
 
 beforeAll(async () => {
   const fileUrl = pathToFileURL(path.resolve(__dirname, '../frontend/scripts/run-test-groups.mjs'));
@@ -13,32 +20,51 @@ beforeAll(async () => {
   TEST_GROUPS = mod.TEST_GROUPS;
 });
 
-vi.mock('child_process', () => ({ execSync: vi.fn() }));
+afterEach(() => {
+  execSyncMock.mockReset();
+});
 
 // Basic sanity check that TEST_GROUPS is populated
-describe.skip('run-test-groups', () => {
+describe('run-test-groups', () => {
   it('exposes test groups', () => {
     expect(Array.isArray(TEST_GROUPS)).toBe(true);
     expect(TEST_GROUPS.length).toBeGreaterThan(0);
   });
 
   it('returns true when exec succeeds', () => {
-    const spy = vi.mocked(execSync);
-    spy.mockImplementation(() => ({} as any));
+    execSyncMock.mockImplementation(() => ({} as any));
     const result = runTestGroup({ name: 'Demo', files: ['demo.spec.ts'], parallel: false });
-    expect(spy).toHaveBeenCalled();
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('demo.spec.ts --workers=1 --reporter=dot'),
+      expect.objectContaining({ cwd: frontendRoot })
+    );
     expect(result).toBe(true);
-    spy.mockRestore();
   });
 
   it('returns false when exec fails', () => {
-    const spy = vi.mocked(execSync);
-    spy.mockImplementation(() => {
+    execSyncMock.mockImplementation(() => {
       throw new Error('fail');
     });
     const result = runTestGroup({ name: 'Fail', files: ['fail.spec.ts'], parallel: true, workers: 2 });
-    expect(spy).toHaveBeenCalled();
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('fail.spec.ts --workers=2 --reporter=dot'),
+      expect.objectContaining({ cwd: frontendRoot })
+    );
     expect(result).toBe(false);
-    spy.mockRestore();
+  });
+
+  it('applies grep patterns when provided', () => {
+    execSyncMock.mockImplementation(() => ({} as any));
+    runTestGroup({
+      name: 'Grep',
+      files: ['alpha.spec.ts'],
+      parallel: true,
+      workers: 3,
+      grep: 'foo|bar',
+    });
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('alpha.spec.ts -g "foo|bar" --workers=3 --reporter=dot'),
+      expect.objectContaining({ cwd: frontendRoot })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Candidate scan surfaced backlog items in frontend/e2e/backlog/*.spec.ts, frontend/src/components/{svelte/Menu.svelte,Card.astro}, frontend/src/pages/docs/index.astro, and tests/run-test-groups.test.ts; after filtering out multi-feature UI TODOs, the remaining eligible tasks were randomly sampled and picked re-enabling tests/run-test-groups.test.ts because it ships previously skipped coverage without cross-team dependencies.
- Re-enabled the run-test-groups suite with stronger assertions around generated Playwright commands and mocks that exercise success, failure, and grep handling paths.
- Documented in frontend/TESTING.md that changes to the grouping script should be mirrored in the Vitest coverage.

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- npx vitest run tests/run-test-groups.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8f2c420b8832f856981d9798c9405