### PR TITLE
Add Playwright coverage for process previews

### DIFF
--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -119,6 +119,10 @@ We have automated checks to ensure no test files are orphaned from the test work
 
 This test runs as part of the `npm test` (alias `test:pr`) and `test:e2e:groups` commands.
 
+The `process-preview.spec.ts` Playwright test exercises the Manage Processes preview
+toggle to confirm process details render and only a single preview remains open. It
+guards against regressions that previously slipped through manual QA.
+
 ## Writing New Tests
 
 ### Adding New Test Files

--- a/frontend/e2e/backlog/process-preview.spec.ts
+++ b/frontend/e2e/backlog/process-preview.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: Implement process preview test
-
-test('process preview placeholder', async ({ page }) => {
-    await page.goto('/processes');
-});

--- a/frontend/e2e/process-preview.spec.ts
+++ b/frontend/e2e/process-preview.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+test.describe('Process preview', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('reveals and hides process details from the manage view', async ({ page }) => {
+        await page.goto('/processes/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const firstRow = page.locator('.process-row').first();
+        await expect(firstRow).toBeVisible();
+
+        const previewButton = firstRow.locator('.preview-button');
+        const rowTitle = await firstRow.locator('h3').first().textContent();
+
+        await previewButton.click();
+
+        const preview = firstRow.locator('.process-preview');
+        await expect(preview).toBeVisible();
+        if (rowTitle) {
+            await expect(preview.locator('h3')).toHaveText(rowTitle.trim());
+        }
+        await expect(preview).toContainText('Duration:');
+        await expect(preview.locator('li')).not.toHaveCount(0);
+
+        await previewButton.click();
+        await expect(preview).toBeHidden();
+    });
+
+    test('opening another preview closes the previous one', async ({ page }) => {
+        await page.goto('/processes/manage');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const rows = page.locator('.process-row');
+        await expect(rows.first()).toBeVisible();
+        await expect(rows.nth(1)).toBeVisible();
+
+        const firstPreviewButton = rows.nth(0).locator('.preview-button');
+        const secondPreviewButton = rows.nth(1).locator('.preview-button');
+
+        await firstPreviewButton.click();
+        const firstPreview = rows.nth(0).locator('.process-preview');
+        await expect(firstPreview).toBeVisible();
+
+        await secondPreviewButton.click();
+        const secondPreview = rows.nth(1).locator('.process-preview');
+        await expect(secondPreview).toBeVisible();
+        await expect(firstPreview).toBeHidden();
+    });
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -60,6 +60,12 @@ const TEST_GROUPS = [
         workers: 2,
     },
     {
+        name: 'Process Preview',
+        files: ['process-preview.spec.ts'],
+        parallel: true,
+        workers: 1,
+    },
+    {
         name: 'Quest Tests',
         files: [
             'test-quest-chat.spec.ts',


### PR DESCRIPTION
## Summary
- randomly selected backlog/process-preview TODO to ship the promised E2E check
- add process-preview.spec.ts to exercise Manage Processes preview toggles
- document the coverage and add the new spec to the Playwright groupings

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8f2c420b8832f856981d9798c9405