### PR TITLE
Drive docs index from JSON configuration

### DIFF
--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -4,11 +4,41 @@ import path from 'path';
 import { describe, it, expect } from 'vitest';
 
 const docsIndexFile = path.join(__dirname, '../src/pages/docs/index.astro');
+const docsIndexData = path.join(__dirname, '../src/pages/docs/json/index.json');
 
 describe('docs index.astro', () => {
-    it('links to Codex prompt docs', () => {
+    it('renders navigation from JSON data', () => {
         const content = fs.readFileSync(docsIndexFile, 'utf8');
-        expect(content).toMatch(/<a href="\/docs\/prompts-codex">Codex prompts<\/a>/);
-        expect(content).toMatch(/<a href="\/docs\/prompts-codex-meta">Codex meta prompt<\/a>/);
+        expect(content).toContain("import sections from './json/index.json'");
+        expect(content).toMatch(/sections\.(map|forEach|reduce)/);
+
+        expect(fs.existsSync(docsIndexData)).toBe(true);
+        const sections = JSON.parse(fs.readFileSync(docsIndexData, 'utf8'));
+        expect(Array.isArray(sections)).toBe(true);
+        expect(sections.length).toBeGreaterThan(0);
+
+        const seenHrefs = new Set();
+        sections.forEach((section) => {
+            expect(typeof section.title).toBe('string');
+            expect(section.title.length).toBeGreaterThan(0);
+            expect(Array.isArray(section.links)).toBe(true);
+            expect(section.links.length).toBeGreaterThan(0);
+
+            section.links.forEach((link) => {
+                expect(typeof link.href).toBe('string');
+                expect(link.href.length).toBeGreaterThan(0);
+                expect(typeof link.label).toBe('string');
+                expect(link.label.length).toBeGreaterThan(0);
+                expect(seenHrefs.has(link.href)).toBe(false);
+                seenHrefs.add(link.href);
+
+                if (!link.external) {
+                    expect(link.href.startsWith('/docs/')).toBe(true);
+                    const slug = link.href.replace(/^\/docs\//, '');
+                    const markdownPath = path.join(__dirname, '../src/pages/docs/md', `${slug}.md`);
+                    expect(fs.existsSync(markdownPath)).toBe(true);
+                }
+            });
+        });
     });
 });

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -1,89 +1,19 @@
 ---
 import Page from '../../components/Page.astro';
-
-// TODO: create page dynamically with JSON
-const implementPromptUrl =
-    'https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/' +
-    'implement.md';
+import sections from './json/index.json';
 ---
 
 <Page title="Docs">
-    <span>
-        <h2>The basics</h2>
-        <nav>
-            <a href="/docs/about">About</a>
-            <a href="/docs/mission">Mission</a>
-            <a href="/docs/roadmap">Roadmap</a>
-            <a href="/docs/faq">FAQ</a>
-            <a href="/docs/glossary">Glossary</a>
-            <a href="/docs/contribute">Contribute</a>
-            <a href="/docs/team">Meet the team</a>
-        </nav>
-    </span>
-
-    <span>
-        <h2>Skills</h2>
-        <nav>
-            <a href="/docs/3dprinting">3D printing</a>
-            <a href="/docs/solar">Solar power</a>
-            <a href="/docs/electricity">Electricity</a>
-            <a href="/docs/hydroponics">Hydroponics</a>
-            <a href="/docs/chemistry-lab">Chemistry Lab Basics</a>
-            <a href="/docs/rockets">Rockets</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Game systems</h2>
-        <nav>
-            <a href="/docs/npcs">NPCs</a>
-            <a href="/docs/realtime">Everything is real-time</a>
-            <a href="/docs/inventory">Inventory</a>
-            <a href="/docs/cloud-sync">Cloud Sync</a>
-            <a href="/docs/backups">Backups</a>
-            <a href="/docs/rollback">Game state rollback</a>
-            <a href="/docs/authentication">Authentication</a>
-            <a href="/docs/achievements">Achievements</a>
-            <a href="/docs/titles">Titles</a>
-            <a href="/docs/processes">Processes</a>
-            <a href="/docs/guilds">Guilds</a>
-            <a href="/docs/amazing">Amazing</a>
-            <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dCarbon">dCarbon</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Quests</h2>
-        <nav>
-            <a href="/docs/quest-guidelines">Quest Development Guidelines</a>
-            <a href="/docs/quest-template">Quest Template Example</a>
-            <a href="/docs/quest-schema">Quest Schema Requirements</a>
-            <a href="/docs/quest-contribution">Quest Contribution Guidelines</a>
-            <a href="/docs/quest-submission">Quest Submission Guide</a>
-            <a href="/docs/custom-quest-system">Custom Quest System</a>
-            <a href="/docs/quest-trees">Quest trees</a>
-            <a href="/docs/new-quests">New quests list</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Dev</h2>
-        <nav>
-            <a href="/docs/prs">Pull Requests</a>
-            <a href="/docs/bounties">Bounties</a>
-            <a href="/docs/user-journeys">User journeys</a>
-            <a href="/docs/self-hosting">Self-hosting</a>
-            <a href="/docs/outages">Outages</a>
-            <a href="/docs/db-benchmark">Database benchmark</a>
-            <a href="/docs/token-place">token.place API</a>
-            <a href="/docs/schema-versioning">Schema versioning</a>
-            <a href="/docs/ui-lifecycle">UI lifecycle</a>
-
-            <!-- Prompt library -->
-            <a href="/docs/prompts-codex">Codex prompt library</a>
-            <a href={implementPromptUrl}>
-                Implement prompt guide
-            </a>
-        </nav>
-    </span>
+    {sections.map((section) => (
+        <span>
+            <h2>{section.title}</h2>
+            <nav>
+                {section.links.map((link) => (
+                    <a href={link.href}>{link.label}</a>
+                ))}
+            </nav>
+        </span>
+    ))}
 </Page>
 
 <style>

--- a/frontend/src/pages/docs/json/index.json
+++ b/frontend/src/pages/docs/json/index.json
@@ -1,0 +1,77 @@
+[
+    {
+        "title": "The basics",
+        "links": [
+            { "href": "/docs/about", "label": "About" },
+            { "href": "/docs/mission", "label": "Mission" },
+            { "href": "/docs/roadmap", "label": "Roadmap" },
+            { "href": "/docs/faq", "label": "FAQ" },
+            { "href": "/docs/glossary", "label": "Glossary" },
+            { "href": "/docs/contribute", "label": "Contribute" },
+            { "href": "/docs/team", "label": "Meet the team" }
+        ]
+    },
+    {
+        "title": "Skills",
+        "links": [
+            { "href": "/docs/3dprinting", "label": "3D printing" },
+            { "href": "/docs/solar", "label": "Solar power" },
+            { "href": "/docs/electricity", "label": "Electricity" },
+            { "href": "/docs/hydroponics", "label": "Hydroponics" },
+            { "href": "/docs/chemistry-lab", "label": "Chemistry Lab Basics" },
+            { "href": "/docs/rockets", "label": "Rockets" }
+        ]
+    },
+    {
+        "title": "Game systems",
+        "links": [
+            { "href": "/docs/npcs", "label": "NPCs" },
+            { "href": "/docs/realtime", "label": "Everything is real-time" },
+            { "href": "/docs/inventory", "label": "Inventory" },
+            { "href": "/docs/cloud-sync", "label": "Cloud Sync" },
+            { "href": "/docs/backups", "label": "Backups" },
+            { "href": "/docs/rollback", "label": "Game state rollback" },
+            { "href": "/docs/authentication", "label": "Authentication" },
+            { "href": "/docs/achievements", "label": "Achievements" },
+            { "href": "/docs/titles", "label": "Titles" },
+            { "href": "/docs/processes", "label": "Processes" },
+            { "href": "/docs/guilds", "label": "Guilds" },
+            { "href": "/docs/amazing", "label": "Amazing" },
+            { "href": "/docs/dwatt", "label": "dWatt" },
+            { "href": "/docs/dCarbon", "label": "dCarbon" }
+        ]
+    },
+    {
+        "title": "Quests",
+        "links": [
+            { "href": "/docs/quest-guidelines", "label": "Quest Development Guidelines" },
+            { "href": "/docs/quest-template", "label": "Quest Template Example" },
+            { "href": "/docs/quest-schema", "label": "Quest Schema Requirements" },
+            { "href": "/docs/quest-contribution", "label": "Quest Contribution Guidelines" },
+            { "href": "/docs/quest-submission", "label": "Quest Submission Guide" },
+            { "href": "/docs/custom-quest-system", "label": "Custom Quest System" },
+            { "href": "/docs/quest-trees", "label": "Quest trees" },
+            { "href": "/docs/new-quests", "label": "New quests list" }
+        ]
+    },
+    {
+        "title": "Dev",
+        "links": [
+            { "href": "/docs/prs", "label": "Pull Requests" },
+            { "href": "/docs/bounties", "label": "Bounties" },
+            { "href": "/docs/user-journeys", "label": "User journeys" },
+            { "href": "/docs/self-hosting", "label": "Self-hosting" },
+            { "href": "/docs/outages", "label": "Outages" },
+            { "href": "/docs/db-benchmark", "label": "Database benchmark" },
+            { "href": "/docs/token-place", "label": "token.place API" },
+            { "href": "/docs/schema-versioning", "label": "Schema versioning" },
+            { "href": "/docs/ui-lifecycle", "label": "UI lifecycle" },
+            { "href": "/docs/prompts-codex", "label": "Codex prompt library" },
+            {
+                "href": "https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/implement.md",
+                "label": "Implement prompt guide",
+                "external": true
+            }
+        ]
+    }
+]

--- a/frontend/src/pages/docs/md/changelog/20250901.md
+++ b/frontend/src/pages/docs/md/changelog/20250901.md
@@ -130,6 +130,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Rename orphan `/docs/new-quests-v3` folder to match actual path 💯
         -   [x] Add Prism plaintext mapping to silence “language text” warnings 💯
         -   [x] Remove hardcoded numeric item ID from shop index 💯
+        -   [x] Drive `/docs` index navigation from JSON data 💯
     -   [x] **CI speed & log cleanliness** 💯
         -   [x] Silence non‑critical build messages 💯
         -   [x] Consolidate install logs for readability 💯


### PR DESCRIPTION
## Summary
- Randomly selected the TODO in `frontend/src/pages/docs/index.astro` to "create page dynamically with JSON" and replaced the hardcoded navigation with data from `json/index.json`
- Added `docsIndexPage` vitest coverage that ensures the Astro page consumes the JSON config and that each internal link resolves to a markdown doc
- Logged the completed work in the September 1, 2025 changelog entry

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8f2c420b8832f856981d9798c9405