### PR TITLE
📝 : – clarify changelog guidance in implement prompt

### DIFF
--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -59,7 +59,11 @@ REQUEST:
    to make them pass. Extend coverage for edge cases when feasible.
 4. Update or remove the original promise (TODO comment, checklist entry, doc note) so the repo no
    longer advertises incomplete work.
-5. Refresh related documentation or changelog entries to reflect the shipped behavior.
+5. Refresh related documentation or changelog entries to reflect the shipped behavior. When
+   touching the changelog, do **not** create a new dated file—append your notes to the most
+   recent future-dated entry instead (for example,
+   [`frontend/src/pages/docs/md/changelog/20251101.md`](../../frontend/src/pages/docs/md/changelog/20251101.md)
+   on the `v3` branch).
 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`. Install Playwright browsers with
    `npx playwright install chromium` if needed, or set `SKIP_E2E=1` only when browsers are


### PR DESCRIPTION
what: remind implement prompt to update the existing future changelog entry instead of making a new file.
why: release managers still curate changelog files manually, so agents must append to the pending entry.
how to test: not run (docs-only change).

------
https://chatgpt.com/codex/tasks/task_e_68d9a83a9860832f899b6b310e230601