### PR TITLE
Add coverage for changelog doc placeholder CTA

### DIFF
--- a/frontend/e2e/backlog/changelog-doc.spec.ts
+++ b/frontend/e2e/backlog/changelog-doc.spec.ts
@@ -1,7 +1,28 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-// TODO: Implement changelog doc page test
+test.describe('docs changelog placeholder', () => {
+    test('encourages contributors to add the missing doc', async ({ page }) => {
+        await page.goto('/docs/changelog');
+        await page.waitForLoadState('domcontentloaded');
 
-test('changelog doc loads placeholder', async ({ page }) => {
-    await page.goto('/docs/changelog');
+        await expect(page.getByRole('heading', { name: 'Doc not found' })).toBeVisible();
+
+        const placeholderBody = page.getByText(
+            'Should something exist here? Add a file on Github and submit a pull request.',
+            { exact: true }
+        );
+        const placeholderCta = placeholderBody.locator('xpath=ancestor::a[1]');
+        await expect(placeholderCta).toBeVisible();
+        await expect(placeholderCta).toHaveAttribute(
+            'href',
+            'https://github.com/democratizedspace/dspace/new/main/frontend/src/pages/docs/md/changelog.md'
+        );
+
+        await expect(
+            page.getByText(
+                'Should something exist here? Add a file on Github and submit a pull request.',
+                { exact: true }
+            )
+        ).toBeVisible();
+    });
 });

--- a/frontend/src/pages/docs/[slug].astro
+++ b/frontend/src/pages/docs/[slug].astro
@@ -15,6 +15,19 @@ if (doc) {
     html = fixMarkdownText(doc.compiledContent());
     title = doc.frontmatter.title;
 }
+
+const slugString = typeof slug === 'string' ? slug : '';
+const prettyDocName = slugString
+    ? slugString
+          .split('-')
+          .filter(Boolean)
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join(' ')
+    : 'Doc';
+const docCtaTitle = `Write the ${prettyDocName} doc`;
+const newDocUrl = slugString
+    ? `https://github.com/democratizedspace/dspace/new/main/frontend/src/pages/docs/md/${slugString}.md`
+    : 'https://github.com/democratizedspace/dspace/new/main/frontend/src/pages/docs/md';
 ---
 
 {
@@ -35,8 +48,9 @@ if (doc) {
         <Page title="Doc not found" columns="1">
             <Chip text="Docs" href="/docs" />
             <Card
+                title={docCtaTitle}
                 body={`Should something exist here? Add a file on Github and submit a pull request.`}
-                href="https://github.com/democratizedspace/dspace/new/main/frontend/pages/settings/json"
+                href={newDocUrl}
                 image="/assets/quill.jpg"
                 imageAlt="Quill pen on paper"
             />

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -87,6 +87,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
         -   [x] Test IndexedDB in all major browsers 💯
         -   [x] Verify UI components across browsers 💯
         -   [x] Check offline functionality 💯
+    -   [x] Documentation coverage 💯
+        -   [x] Add /docs/changelog placeholder CTA Playwright test 💯
     -   [x] Mobile responsiveness 💯
         -   [x] Adapt quest creation UI for mobile 💯
         -   [x] Test touch interactions 💯


### PR DESCRIPTION
## Summary
- Randomly selected the backlog TODO in `frontend/e2e/backlog/changelog-doc.spec.ts` and implemented the promised changelog placeholder Playwright assertions.
- Update the docs slug fallback to surface a slug-aware "Write the … doc" CTA that links contributors directly to the correct GitHub new-file path.
- Record the new documentation coverage in the 20251101 changelog entry so the roadmap no longer lists the unshipped promise.

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d9a9f2c5e8832fa908b57fb91a823c