### PR TITLE
Highlight unpinned menu routes under subpaths

### DIFF
--- a/frontend/__tests__/Menu.test.js
+++ b/frontend/__tests__/Menu.test.js
@@ -33,4 +33,12 @@ describe('Menu accessibility', () => {
         const homeLink = getByRole('link', { name: 'Home' });
         expect(homeLink).toHaveAttribute('aria-current', 'page');
     });
+
+    it('marks active unpinned link when its route is visited', () => {
+        const { getByRole } = render(Menu, { pathname: '/app/gamesaves' });
+        const gamesavesLink = getByRole('link', { name: 'Import/export gamesaves' });
+
+        expect(gamesavesLink).toHaveClass('active');
+        expect(gamesavesLink).toHaveAttribute('aria-current', 'page');
+    });
 });

--- a/frontend/src/components/svelte/Menu.svelte
+++ b/frontend/src/components/svelte/Menu.svelte
@@ -2,6 +2,7 @@
     import menu from '../../config/menu.json';
     import { getItemCount } from '../../utils/gameState/inventory.js';
     import { onMount } from 'svelte';
+    import { isMenuItemActive } from './menuActive.js';
 
     export let pathname;
 
@@ -17,14 +18,7 @@
         button.innerText = showUnpinned ? LABEL_FEWER : LABEL_MORE;
     };
 
-    const isActive = (item) => {
-        if (item.href === '/') {
-            return pathname === '/';
-        }
-
-        // TODO: support unpinned menu items
-        return pathname.startsWith(item.href);
-    };
+    const isActive = (item) => isMenuItemActive(pathname, item);
 
     const showMenuItem = (currentItem) => {
         if (currentItem && currentItem.hideIfOwned) {

--- a/frontend/src/components/svelte/menuActive.js
+++ b/frontend/src/components/svelte/menuActive.js
@@ -1,0 +1,69 @@
+const normalizePathname = (value) => {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    const [path] = value.split('?');
+    if (!path) {
+        return '';
+    }
+
+    if (path.length > 1 && path.endsWith('/')) {
+        return path.slice(0, -1);
+    }
+
+    return path;
+};
+
+const normalizeHref = (href) => {
+    if (typeof href !== 'string') {
+        return '';
+    }
+
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+        try {
+            return normalizePathname(new URL(href).pathname);
+        } catch {
+            return '';
+        }
+    }
+
+    return normalizePathname(href);
+};
+
+const matchesTarget = (current, target) => {
+    if (current === target) {
+        return true;
+    }
+
+    if (current.startsWith(`${target}/`)) {
+        return true;
+    }
+
+    if (current.endsWith(target)) {
+        return true;
+    }
+
+    return current.includes(`${target}/`);
+};
+
+export const isMenuItemActive = (pathname, item) => {
+    const target = normalizeHref(item?.href);
+    const current = normalizePathname(
+        typeof pathname === 'string'
+            ? pathname
+            : typeof window !== 'undefined'
+            ? window.location.pathname
+            : ''
+    );
+
+    if (!target || !current) {
+        return false;
+    }
+
+    if (target === '/') {
+        return current === '/';
+    }
+
+    return matchesTarget(current, target);
+};

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -7,6 +7,10 @@ It's been a while! Time for a DSPACE update! v3 is here.
 
 What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm glad you're here. DSPACE is a space exploration game that I've been working on for a while now. It's still in its early stages, but I'm excited to share it with you. You can learn more about the game on the [About](/docs/about) page.
 
+## Navigation
+
+-   The main menu now highlights "More" links correctly even when the game runs from a subpath, so unpinned destinations stay active across deployments.
+
 ## Development Checklist (Pre-Launch)
 
 -   [x] Custom Quest System 💯

--- a/tests/menu-active.test.ts
+++ b/tests/menu-active.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import menu from '../frontend/src/config/menu.json';
+import { isMenuItemActive } from '../frontend/src/components/svelte/menuActive.js';
+
+describe('Menu active state for unpinned links', () => {
+    it('marks unpinned routes active even when served from a subpath', () => {
+        const gamesaves = menu.find((item) => item.href === '/gamesaves');
+
+        expect(isMenuItemActive('/app/gamesaves', gamesaves)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- randomly selected the Menu.svelte TODO about supporting unpinned items and replaced the in-component matcher with a shared `isMenuItemActive` helper that understands subpath deployments
- expanded test coverage with a Vitest unit that exercises the helper and a jsdom menu test that ensures the "Import/export gamesaves" link still activates under `/app/...`
- documented the navigation fix in the November 2025 changelog entry so the promise no longer appears in backlog notes

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68d9a9f2c5e8832fa908b57fb91a823c