### PR TITLE
Add Playwright coverage for docs changelog placeholder

### DIFF
--- a/frontend/e2e/backlog/changelog-doc.spec.ts
+++ b/frontend/e2e/backlog/changelog-doc.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: Implement changelog doc page test
-
-test('changelog doc loads placeholder', async ({ page }) => {
-    await page.goto('/docs/changelog');
-});

--- a/frontend/e2e/changelog-doc.spec.ts
+++ b/frontend/e2e/changelog-doc.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Changelog doc placeholder', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('shows missing doc guidance', async ({ page }) => {
+        await page.goto('/docs/changelog');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.getByRole('heading', { name: /Doc not found/i })).toBeVisible();
+        await expect(
+            page.getByText(
+                'Should something exist here? Add a file on Github and submit a pull request.',
+                { exact: false }
+            )
+        ).toBeVisible();
+
+        await expect(
+            page.locator(
+                'a[href="https://github.com/democratizedspace/dspace/new/main/frontend/pages/settings/json"]'
+            )
+        ).toBeVisible();
+    });
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -35,6 +35,7 @@ const TEST_GROUPS = [
             'authentication-flow.spec.ts',
             'cloud-sync.spec.ts',
             'cookie-consent.spec.ts',
+            'changelog-doc.spec.ts',
             'docs-navigation.spec.ts',
             'failover-status.spec.ts',
             'home-page-basic.spec.ts',

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -16,7 +16,7 @@ spec in `frontend/e2e/backlog` until coverage exists.
 | About page loads           | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Authentication flow        | Yes                 | `frontend/e2e/authentication-flow.spec.ts`        |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
-| Changelog page loads       | No                  | --                                                |
+| Changelog page loads       | Yes                 | `frontend/e2e/changelog-doc.spec.ts`              |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
 | Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
 | Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |


### PR DESCRIPTION
## Summary
- inventoried TODOs/backlog placeholders and randomly selected the changelog doc journey promise to ship
- add a Playwright test that verifies /docs/changelog shows its missing-doc guidance and move it into the main suite
- reference the test in run-test-groups and mark the user journeys doc entry as covered

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68d9a9f2c5e8832fa908b57fb91a823c