### PR TITLE
Implement docs search automation and coverage

### DIFF
--- a/frontend/e2e/backlog/docs-search.spec.ts
+++ b/frontend/e2e/backlog/docs-search.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '@playwright/test';
-
-// TODO: Implement docs search test
-
-test('docs search placeholder', async ({ page }) => {
-    await page.goto('/docs');
-});

--- a/frontend/e2e/docs-search.spec.ts
+++ b/frontend/e2e/docs-search.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Docs search', () => {
+    test('filters docs list by query and resets on clear', async ({ page }) => {
+        await page.goto('/docs');
+
+        const searchInput = page.getByRole('textbox', { name: /search docs/i });
+        await expect(searchInput).toBeVisible();
+
+        await searchInput.fill('quest');
+
+        await expect(
+            page.getByRole('link', { name: 'Quest Development Guidelines', exact: true })
+        ).toBeVisible();
+        await expect(
+            page.getByRole('link', { name: 'Quest Schema Requirements', exact: true })
+        ).toBeVisible();
+        await expect(page.getByRole('link', { name: 'About', exact: true })).toHaveCount(0);
+
+        await searchInput.fill('');
+        await expect(page.getByRole('link', { name: 'About', exact: true })).toBeVisible();
+    });
+});

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -1,0 +1,171 @@
+<script>
+    /**
+     * @typedef {Object} DocLink
+     * @property {string} title
+     * @property {string} href
+     * @property {string[]=} keywords
+     * @property {boolean=} external
+     */
+
+    /**
+     * @typedef {Object} DocsSection
+     * @property {string} title
+     * @property {DocLink[]} links
+     */
+
+    /** @type {DocsSection[]} */
+    export let sections = [];
+
+    let query = '';
+
+    const normalize = (value) => value.toLowerCase().trim();
+
+    const matchLink = (link, normalizedQuery) => {
+        if (!normalizedQuery) {
+            return true;
+        }
+
+        const searchableValues = [link.title, ...(link.keywords ?? [])].map(normalize);
+        const words = normalizedQuery.split(/\s+/).filter(Boolean);
+
+        return words.every((word) => searchableValues.some((value) => value.includes(word)));
+    };
+
+    $: normalizedQuery = normalize(query);
+    $: filteredSections = sections
+        .map((section) => ({
+            title: section.title,
+            links: section.links.filter((link) => matchLink(link, normalizedQuery)),
+        }))
+        .filter((section) => section.links.length > 0);
+
+    $: totalResults = filteredSections.reduce((count, section) => count + section.links.length, 0);
+</script>
+
+<div class="docs-index">
+    <label class="sr-only" for="docs-search-input">Search docs</label>
+    <input
+        id="docs-search-input"
+        type="search"
+        bind:value={query}
+        placeholder="Search docs"
+        aria-label="Search docs"
+    />
+
+    {#if normalizedQuery && totalResults === 0}
+        <p class="empty-state">No docs found for "{query}".</p>
+    {:else}
+        <div class="docs-grid" data-testid="docs-grid">
+            {#each normalizedQuery ? filteredSections : sections as section}
+                <section class="docs-section">
+                    <h2>{section.title}</h2>
+                    <nav aria-label={`Docs ${section.title}`}>
+                        {#each section.links as link}
+                            <a
+                                href={link.href}
+                                rel={link.external ? 'noopener noreferrer' : undefined}
+                                target={link.external ? '_blank' : undefined}
+                            >
+                                {link.title}
+                            </a>
+                        {/each}
+                    </nav>
+                </section>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .docs-index {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        align-items: center;
+        width: 100%;
+    }
+
+    input {
+        width: 100%;
+        max-width: 28rem;
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.1);
+        color: #ffffff;
+    }
+
+    input::placeholder {
+        color: rgba(255, 255, 255, 0.75);
+    }
+
+    .docs-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+        gap: 1.5rem;
+        width: 100%;
+    }
+
+    .docs-section {
+        background-color: #2f5b2f;
+        border-radius: 2rem;
+        padding: 1.25rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    h2 {
+        color: white;
+        margin: 0;
+    }
+
+    nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+
+    a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.625rem 1rem;
+        background-color: #84d484;
+        border-radius: 999px;
+        color: black;
+        text-decoration: none;
+        white-space: nowrap;
+        opacity: 0.85;
+        transition: opacity 0.2s ease-in-out;
+    }
+
+    a:hover,
+    a:focus {
+        opacity: 1;
+    }
+
+    .empty-state {
+        background-color: #2f5b2f;
+        border-radius: 2rem;
+        padding: 1.5rem;
+        color: white;
+        text-align: center;
+        width: 100%;
+        max-width: 32rem;
+    }
+
+    .sr-only {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        width: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        position: absolute;
+    }
+</style>

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -1,140 +1,23 @@
 ---
 import Page from '../../components/Page.astro';
+import DocsIndex from '../../components/svelte/DocsIndex.svelte';
+import sections from './json/sections.json' assert { type: 'json' };
 
-// TODO: create page dynamically with JSON
-const implementPromptUrl =
-    'https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/' +
-    'implement.md';
+type DocLink = {
+    title: string;
+    href: string;
+    keywords?: string[];
+    external?: boolean;
+};
+
+type DocsSection = {
+    title: string;
+    links: DocLink[];
+};
+
+const docsSections = sections as DocsSection[];
 ---
 
 <Page title="Docs">
-    <span>
-        <h2>The basics</h2>
-        <nav>
-            <a href="/docs/about">About</a>
-            <a href="/docs/mission">Mission</a>
-            <a href="/docs/roadmap">Roadmap</a>
-            <a href="/docs/faq">FAQ</a>
-            <a href="/docs/glossary">Glossary</a>
-            <a href="/docs/contribute">Contribute</a>
-            <a href="/docs/team">Meet the team</a>
-        </nav>
-    </span>
-
-    <span>
-        <h2>Skills</h2>
-        <nav>
-            <a href="/docs/3dprinting">3D printing</a>
-            <a href="/docs/solar">Solar power</a>
-            <a href="/docs/electricity">Electricity</a>
-            <a href="/docs/hydroponics">Hydroponics</a>
-            <a href="/docs/chemistry-lab">Chemistry Lab Basics</a>
-            <a href="/docs/rockets">Rockets</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Game systems</h2>
-        <nav>
-            <a href="/docs/npcs">NPCs</a>
-            <a href="/docs/realtime">Everything is real-time</a>
-            <a href="/docs/inventory">Inventory</a>
-            <a href="/docs/cloud-sync">Cloud Sync</a>
-            <a href="/docs/backups">Backups</a>
-            <a href="/docs/rollback">Game state rollback</a>
-            <a href="/docs/authentication">Authentication</a>
-            <a href="/docs/achievements">Achievements</a>
-            <a href="/docs/titles">Titles</a>
-            <a href="/docs/processes">Processes</a>
-            <a href="/docs/guilds">Guilds</a>
-            <a href="/docs/amazing">Amazing</a>
-            <a href="/docs/dwatt">dWatt</a>
-            <a href="/docs/dCarbon">dCarbon</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Quests</h2>
-        <nav>
-            <a href="/docs/quest-guidelines">Quest Development Guidelines</a>
-            <a href="/docs/quest-template">Quest Template Example</a>
-            <a href="/docs/quest-schema">Quest Schema Requirements</a>
-            <a href="/docs/quest-contribution">Quest Contribution Guidelines</a>
-            <a href="/docs/quest-submission">Quest Submission Guide</a>
-            <a href="/docs/custom-quest-system">Custom Quest System</a>
-            <a href="/docs/quest-trees">Quest trees</a>
-            <a href="/docs/new-quests">New quests list</a>
-        </nav>
-    </span>
-    <span>
-        <h2>Dev</h2>
-        <nav>
-            <a href="/docs/prs">Pull Requests</a>
-            <a href="/docs/bounties">Bounties</a>
-            <a href="/docs/user-journeys">User journeys</a>
-            <a href="/docs/self-hosting">Self-hosting</a>
-            <a href="/docs/outages">Outages</a>
-            <a href="/docs/db-benchmark">Database benchmark</a>
-            <a href="/docs/token-place">token.place API</a>
-            <a href="/docs/schema-versioning">Schema versioning</a>
-            <a href="/docs/ui-lifecycle">UI lifecycle</a>
-
-            <!-- Prompt library -->
-            <a href="/docs/prompts-codex">Codex prompt library</a>
-            <a href={implementPromptUrl}>
-                Implement prompt guide
-            </a>
-        </nav>
-    </span>
+    <DocsIndex sections={docsSections} client:load />
 </Page>
-
-<style>
-    h2 {
-        color: white;
-    }
-
-    a:hover {
-        opacity: 1;
-    }
-
-    span {
-        background-color: #2f5b2f;
-        border-radius: 2rem;
-        text-align: justify;
-        text-justify: inter-word;
-        text-align: center;
-        padding: 1rem;
-    }
-    /* Navbar */
-
-    nav {
-        text-align: center;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        padding: 0px;
-    }
-
-    nav a {
-        opacity: 0.8;
-        background-color: #84d484;
-        border-radius: 100px;
-        color: black;
-        text-decoration: none;
-        flex-direction: row;
-        padding-left: 5px;
-        padding-right: 5px;
-        text-align: center;
-        white-space: nowrap;
-        margin: 5px;
-        padding: 10px;
-    }
-
-    nav a:hover {
-        opacity: 1;
-    }
-
-    p {
-        background-color: #2f5b2f;
-        padding: 15px;
-        border-radius: 2rem;
-    }
-</style>

--- a/frontend/src/pages/docs/json/sections.json
+++ b/frontend/src/pages/docs/json/sections.json
@@ -1,0 +1,154 @@
+[
+    {
+        "title": "The basics",
+        "links": [
+            { "title": "About", "href": "/docs/about", "keywords": ["overview", "intro"] },
+            { "title": "Mission", "href": "/docs/mission", "keywords": ["vision", "values"] },
+            { "title": "Roadmap", "href": "/docs/roadmap", "keywords": ["plan", "future"] },
+            { "title": "FAQ", "href": "/docs/faq", "keywords": ["questions"] },
+            { "title": "Glossary", "href": "/docs/glossary", "keywords": ["definitions"] },
+            { "title": "Contribute", "href": "/docs/contribute", "keywords": ["get involved"] },
+            {
+                "title": "Meet the team",
+                "href": "/docs/team",
+                "keywords": ["people", "contributors"]
+            }
+        ]
+    },
+    {
+        "title": "Skills",
+        "links": [
+            { "title": "3D printing", "href": "/docs/3dprinting", "keywords": ["fabrication"] },
+            { "title": "Solar power", "href": "/docs/solar", "keywords": ["energy", "panels"] },
+            {
+                "title": "Electricity",
+                "href": "/docs/electricity",
+                "keywords": ["power", "generation"]
+            },
+            {
+                "title": "Hydroponics",
+                "href": "/docs/hydroponics",
+                "keywords": ["farming", "plants"]
+            },
+            {
+                "title": "Chemistry Lab Basics",
+                "href": "/docs/chemistry-lab",
+                "keywords": ["chemistry", "laboratory"]
+            },
+            { "title": "Rockets", "href": "/docs/rockets", "keywords": ["launch", "propulsion"] }
+        ]
+    },
+    {
+        "title": "Game systems",
+        "links": [
+            { "title": "NPCs", "href": "/docs/npcs", "keywords": ["characters"] },
+            {
+                "title": "Everything is real-time",
+                "href": "/docs/realtime",
+                "keywords": ["time", "simulation"]
+            },
+            { "title": "Inventory", "href": "/docs/inventory", "keywords": ["items", "storage"] },
+            { "title": "Cloud Sync", "href": "/docs/cloud-sync", "keywords": ["sync", "backup"] },
+            { "title": "Backups", "href": "/docs/backups", "keywords": ["saves", "safety"] },
+            { "title": "Game state rollback", "href": "/docs/rollback", "keywords": ["restore"] },
+            {
+                "title": "Authentication",
+                "href": "/docs/authentication",
+                "keywords": ["login", "security"]
+            },
+            {
+                "title": "Achievements",
+                "href": "/docs/achievements",
+                "keywords": ["milestones", "badges"]
+            },
+            { "title": "Titles", "href": "/docs/titles", "keywords": ["reputation"] },
+            {
+                "title": "Processes",
+                "href": "/docs/processes",
+                "keywords": ["automation", "crafting"]
+            },
+            { "title": "Guilds", "href": "/docs/guilds", "keywords": ["teams", "co-op"] },
+            { "title": "Amazing", "href": "/docs/amazing", "keywords": ["wonder", "delight"] },
+            { "title": "dWatt", "href": "/docs/dwatt", "keywords": ["energy", "token"] },
+            { "title": "dCarbon", "href": "/docs/dCarbon", "keywords": ["carbon", "token"] }
+        ]
+    },
+    {
+        "title": "Quests",
+        "links": [
+            {
+                "title": "Quest Development Guidelines",
+                "href": "/docs/quest-guidelines",
+                "keywords": ["quests", "design"]
+            },
+            {
+                "title": "Quest Template Example",
+                "href": "/docs/quest-template",
+                "keywords": ["template", "quests"]
+            },
+            {
+                "title": "Quest Schema Requirements",
+                "href": "/docs/quest-schema",
+                "keywords": ["schema", "quests"]
+            },
+            {
+                "title": "Quest Contribution Guidelines",
+                "href": "/docs/quest-contribution",
+                "keywords": ["quests", "contribute"]
+            },
+            {
+                "title": "Quest Submission Guide",
+                "href": "/docs/quest-submission",
+                "keywords": ["submit", "quests"]
+            },
+            {
+                "title": "Custom Quest System",
+                "href": "/docs/custom-quest-system",
+                "keywords": ["custom", "quests"]
+            },
+            {
+                "title": "Quest trees",
+                "href": "/docs/quest-trees",
+                "keywords": ["quests", "structure"]
+            },
+            {
+                "title": "New quests list",
+                "href": "/docs/new-quests",
+                "keywords": ["quests", "updates"]
+            }
+        ]
+    },
+    {
+        "title": "Dev",
+        "links": [
+            { "title": "Pull Requests", "href": "/docs/prs", "keywords": ["contribution"] },
+            { "title": "Bounties", "href": "/docs/bounties", "keywords": ["rewards"] },
+            { "title": "User journeys", "href": "/docs/user-journeys", "keywords": ["testing"] },
+            { "title": "Self-hosting", "href": "/docs/self-hosting", "keywords": ["setup"] },
+            { "title": "Outages", "href": "/docs/outages", "keywords": ["status"] },
+            {
+                "title": "Database benchmark",
+                "href": "/docs/db-benchmark",
+                "keywords": ["performance", "database"]
+            },
+            { "title": "token.place API", "href": "/docs/token-place", "keywords": ["api"] },
+            {
+                "title": "Schema versioning",
+                "href": "/docs/schema-versioning",
+                "keywords": ["migrations"]
+            },
+            { "title": "UI lifecycle", "href": "/docs/ui-lifecycle", "keywords": ["frontend"] },
+            {
+                "title": "Codex prompt library",
+                "href": "/docs/prompts-codex",
+                "keywords": ["prompts", "automation"]
+            },
+            {
+                "title": "Implement prompt guide",
+                "href": "https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/implement.md",
+                "keywords": ["prompts", "implementation"],
+                "external": true
+            }
+        ]
+    }
+]

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -10,6 +10,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 ## Navigation
 
 -   The main menu now highlights "More" links correctly even when the game runs from a subpath, so unpinned destinations stay active across deployments.
+-   The Docs landing page now offers search with instant filtering, backed by automated coverage for the docs navigation journey.
 
 ## Development Checklist (Pre-Launch)
 

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -25,7 +25,7 @@ spec in `frontend/e2e/backlog` until coverage exists.
 | Dark mode toggle           | No                  | --                                                |
 | Docs landing page loads    | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Docs navigation            | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
-| Docs search                | No                  | --                                                |
+| Docs search                | Yes                 | `frontend/e2e/docs-search.spec.ts`                |
 | Error pages                | Yes                 | `frontend/e2e/error-pages.spec.ts`                |
 | Failover status page       | Yes                 | `frontend/e2e/failover-status.spec.ts`            |
 | Glossary page loads        | Yes                 | `frontend/e2e/glossary-doc.spec.ts`               |


### PR DESCRIPTION
## Summary
- randomly picked frontend/e2e/backlog/docs-search.spec.ts from the
  backlog TODOs and implemented the promised docs search automation
- replace the static /docs landing page with a JSON-driven, searchable
  DocsIndex.svelte component
- document the shipped docs search journey in user-journeys and the
  changelog

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- (playwright) npm run test:e2e -- --project=chromium docs-search.spec.ts
  (fails: missing system deps)


------
https://chatgpt.com/codex/tasks/task_e_68d9b84fd174832f99e67d3d3996e1a0