### PR TITLE
✨ add dChat knowledge context from game data

### DIFF
--- a/frontend/__tests__/dchatKnowledge.test.js
+++ b/frontend/__tests__/dchatKnowledge.test.js
@@ -18,4 +18,9 @@ describe('buildDchatKnowledge', () => {
         expect(knowledge).toContain('Quests:');
         expect(knowledge).toContain('Processes:');
     });
+
+    test('includes essential tutorial quests', () => {
+        const knowledge = buildDchatKnowledge({});
+        expect(knowledge).toContain('How to do quests');
+    });
 });

--- a/frontend/__tests__/dchatKnowledge.test.js
+++ b/frontend/__tests__/dchatKnowledge.test.js
@@ -1,0 +1,21 @@
+const { buildDchatKnowledge } = require('../src/utils/dchatKnowledge.js');
+
+describe('buildDchatKnowledge', () => {
+    test('includes inventory when available', () => {
+        const gameState = {
+            inventory: {
+                '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 3,
+            },
+        };
+
+        const knowledge = buildDchatKnowledge(gameState);
+        expect(knowledge).toContain('Inventory highlights');
+        expect(knowledge).toContain('white PLA filament');
+    });
+
+    test('includes quests and processes summary', () => {
+        const knowledge = buildDchatKnowledge({});
+        expect(knowledge).toContain('Quests:');
+        expect(knowledge).toContain('Processes:');
+    });
+});

--- a/frontend/__tests__/openAI.test.js
+++ b/frontend/__tests__/openAI.test.js
@@ -26,22 +26,34 @@ describe('GPT35Turbo', () => {
         createChatCompletionMock.mockClear();
     });
 
-    test('uses opening message when no messages provided', async () => {
+    test('uses opening message and knowledge when no messages provided', async () => {
         await GPT35Turbo([]);
         expect(createChatCompletionMock).toHaveBeenCalledTimes(1);
         const call = createChatCompletionMock.mock.calls[0][0];
         expect(call.model).toBe('gpt-3.5-turbo');
         expect(call.messages[0].role).toBe('system');
-        expect(call.messages[1].role).toBe('assistant');
+        expect(call.messages[1]).toEqual(
+            expect.objectContaining({
+                role: 'system',
+                content: expect.stringContaining('DSPACE knowledge base:'),
+            })
+        );
+        expect(call.messages[1].content).toContain('white PLA filament');
+        expect(call.messages[1].content).toContain('How to do quests');
+        expect(call.messages[2].role).toBe('assistant');
     });
 
     test('prepends system message when messages supplied', async () => {
         await GPT35Turbo([{ role: 'user', content: 'hello' }]);
         const call = createChatCompletionMock.mock.calls[0][0];
-        expect(call.messages).toEqual([
-            expect.objectContaining({ role: 'system' }),
-            { role: 'user', content: 'hello' },
-        ]);
+        expect(call.messages[0]).toEqual(expect.objectContaining({ role: 'system' }));
+        expect(call.messages[1]).toEqual(
+            expect.objectContaining({
+                role: 'system',
+                content: expect.stringContaining('DSPACE knowledge base:'),
+            })
+        );
+        expect(call.messages[2]).toEqual({ role: 'user', content: 'hello' });
     });
 
     test('returns response content', async () => {

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -11,8 +11,8 @@
     let showSpinner = false;
     let welcomeMessage =
         "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any " +
-        "other topic. I may accidentally generate incorrect information, so please double-check anything I say. " +
-        "I just received new knowledge about quests, items, and processes—ask away!";
+        'other topic. I may accidentally generate incorrect information, so please double-check anything I say. ' +
+        'I just received new knowledge about quests, items, and processes—ask away!';
 
     function addMessage(msg) {
         messageHistory.update((history) => [...history, msg]);

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -10,7 +10,9 @@
     const messageHistory = writable([]);
     let showSpinner = false;
     let welcomeMessage =
-        "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any other topic. I may accidentally generate incorrect information, so please double-check anything I say. I'm still learning! I should have some shiny new upgrades soon!";
+        "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any " +
+        "other topic. I may accidentally generate incorrect information, so please double-check anything I say. " +
+        "I just received new knowledge about quests, items, and processes—ask away!";
 
     function addMessage(msg) {
         messageHistory.update((history) => [...history, msg]);

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -224,6 +224,10 @@ We've removed all blockchain integration plans from DSPACE. While Web3 features 
 
 Instead of relying on commercial LLM providers like OpenAI, DSPACE now uses our own distributed computing project [token.place](https://token.place). This allows us to use idle resources at home (and other people's homes, eventually) to fulfill the LLM needs of non‑business‑critical applications such as DSPACE. Both DSPACE and token.place are intended to be fully runnable on cheap home hardware, and are therefore both fully open source and permissively licensed.
 
+### dChat knowledge upgrade
+
+dChat now ships with an in-game knowledge base that summarizes canonical quests, items, processes, and the player's local inventory snapshot. This gives the assistant immediate context to answer gameplay questions without waiting for future updates or external documentation lookups.
+
 ## Community Features
 
 **Coming in future updates:** Enhanced social features focused on direct collaboration between players. You'll be able to share your achievements, help others with their space missions, and contribute to collective goals – all without any intermediary systems. This will create a more immediate and meaningful connection between players working toward common space exploration objectives.

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -7,7 +7,11 @@ slug: 'npcs'
 
 <img src="/assets/npc/dChat.jpg" />
 
-dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning and information retrieval capabilities, it can answer questions and engage in conversation effortlessly. dChat is provided free of charge to all metaguild members, and it's fully open source and self-hosted.
+dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning
+and information retrieval capabilities, it can answer questions and engage in conversation effortlessly.
+dChat now has a curated knowledge base covering the game's quests, items, processes, and the player's
+current inventory snapshot. dChat is provided free of charge to all metaguild members, and it's fully open
+source and self-hosted.
 
 ### Sample Dialogue
 

--- a/frontend/src/pages/docs/md/roadmap.md
+++ b/frontend/src/pages/docs/md/roadmap.md
@@ -21,7 +21,7 @@ This is just a tentative roadmap showing what I'm hoping to work on next. Things
 
 ## September 2023
 
--   [ ] smarter dChat (knowledge of the game, the items, your inventory, etc.)
+-   [x] smarter dChat (knowledge of the game, the items, your inventory, etc.)
 
 ## August 2023
 

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -1,0 +1,130 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+
+const MAX_ITEMS = 25;
+const MAX_PROCESSES = 20;
+const MAX_QUESTS = 25;
+const MAX_DESCRIPTION_LENGTH = 180;
+
+function truncate(text, maxLength = MAX_DESCRIPTION_LENGTH) {
+    if (typeof text !== 'string') {
+        return '';
+    }
+    if (text.length <= maxLength) {
+        return text;
+    }
+    return `${text.slice(0, maxLength - 1).trim()}…`;
+}
+
+function getQuestData() {
+    if (typeof import.meta === 'undefined' || typeof import.meta.glob !== 'function') {
+        return [];
+    }
+
+    const modules = import.meta.glob('../pages/quests/json/**/*.json', { eager: true });
+
+    return Object.values(modules)
+        .map((mod) => (mod?.default ? mod.default : mod))
+        .filter((quest) => quest && typeof quest.id === 'string')
+        .map((quest) => ({
+            id: quest.id,
+            title: quest.title || quest.id,
+            description: truncate(quest.description || ''),
+            requiresQuests: Array.isArray(quest.requiresQuests) ? quest.requiresQuests : [],
+            rewards:
+                Array.isArray(quest.rewards) && quest.rewards.length > 0
+                    ? quest.rewards
+                    : Array.isArray(quest.rewardItems)
+                    ? quest.rewardItems.map((item) => item.id)
+                    : [],
+        }))
+        .sort((a, b) => a.title.localeCompare(b.title));
+}
+
+const quests = getQuestData();
+
+function formatInventory(inventory = {}) {
+    if (!inventory || typeof inventory !== 'object') {
+        return [];
+    }
+
+    return Object.entries(inventory)
+        .filter(([, count]) => typeof count === 'number' && count > 0)
+        .map(([id, count]) => {
+            const item = items.find((entry) => entry.id === id);
+            const name = item ? item.name : id;
+            return `${name} (x${Number.isInteger(count) ? count : count.toFixed(2)})`;
+        })
+        .sort();
+}
+
+function summarizeItems() {
+    return items
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .slice(0, MAX_ITEMS)
+        .map((item) => `${item.name}: ${truncate(item.description || '')}`);
+}
+
+function summarizeProcesses() {
+    return processes
+        .slice()
+        .sort((a, b) => a.title.localeCompare(b.title))
+        .slice(0, MAX_PROCESSES)
+        .map((process) => {
+            const duration = process.duration ? ` (duration ${process.duration})` : '';
+            return `${process.title}${duration}`;
+        });
+}
+
+function summarizeQuests() {
+    return quests.slice(0, MAX_QUESTS).map((quest) => {
+        const parts = [`${quest.title} [${quest.id}]`];
+        if (quest.description) {
+            parts.push(quest.description);
+        }
+        if (quest.requiresQuests.length > 0) {
+            parts.push(`Prereqs: ${quest.requiresQuests.join(', ')}`);
+        }
+        if (quest.rewards.length > 0) {
+            parts.push(`Rewards: ${quest.rewards.join(', ')}`);
+        }
+        return parts.join(' — ');
+    });
+}
+
+export function buildDchatKnowledge(gameState = {}) {
+    const knowledgeSections = [];
+
+    const inventorySummary = formatInventory(gameState.inventory);
+    if (inventorySummary.length > 0) {
+        knowledgeSections.push(`Inventory highlights: ${inventorySummary.join('; ')}`);
+    }
+
+    const itemSummary = summarizeItems();
+    if (itemSummary.length > 0) {
+        knowledgeSections.push(`Items: ${itemSummary.join(' | ')}`);
+    }
+
+    const questSummary = summarizeQuests();
+    if (questSummary.length > 0) {
+        knowledgeSections.push(`Quests: ${questSummary.join(' || ')}`);
+    }
+
+    const processSummary = summarizeProcesses();
+    if (processSummary.length > 0) {
+        knowledgeSections.push(`Processes: ${processSummary.join(' | ')}`);
+    }
+
+    return knowledgeSections.join('\n\n');
+}
+
+export function __testables() {
+    return {
+        truncate,
+        formatInventory,
+        summarizeItems,
+        summarizeProcesses,
+        summarizeQuests,
+    };
+}

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -4,6 +4,13 @@ import processes from '../generated/processes.json' assert { type: 'json' };
 const MAX_ITEMS = 25;
 const MAX_PROCESSES = 20;
 const MAX_QUESTS = 25;
+const PRIORITY_QUEST_IDS = [
+    'welcome/howtodoquests',
+    'welcome/intro-inventory',
+    'welcome/run-tests',
+    'welcome/smart-plug-test',
+    'welcome/connect-github',
+];
 const MAX_DESCRIPTION_LENGTH = 180;
 
 function truncate(text, maxLength = MAX_DESCRIPTION_LENGTH) {
@@ -43,6 +50,27 @@ function getQuestData() {
 
 const quests = getQuestData();
 
+function prioritizeQuests(allQuests) {
+    if (!Array.isArray(allQuests) || allQuests.length === 0) {
+        return [];
+    }
+
+    const questMap = new Map(allQuests.map((quest) => [quest.id, quest]));
+    const prioritized = [];
+
+    for (const questId of PRIORITY_QUEST_IDS) {
+        if (!questMap.has(questId)) {
+            continue;
+        }
+        prioritized.push(questMap.get(questId));
+        questMap.delete(questId);
+    }
+
+    const remaining = Array.from(questMap.values()).sort((a, b) => a.title.localeCompare(b.title));
+
+    return prioritized.concat(remaining);
+}
+
 function formatInventory(inventory = {}) {
     if (!inventory || typeof inventory !== 'object') {
         return [];
@@ -78,7 +106,7 @@ function summarizeProcesses() {
 }
 
 function summarizeQuests() {
-    return quests.slice(0, MAX_QUESTS).map((quest) => {
+    return prioritizeQuests(quests).slice(0, MAX_QUESTS).map((quest) => {
         const parts = [`${quest.title} [${quest.id}]`];
         if (quest.description) {
             parts.push(quest.description);
@@ -126,5 +154,6 @@ export function __testables() {
         summarizeItems,
         summarizeProcesses,
         summarizeQuests,
+        prioritizeQuests,
     };
 }

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -106,19 +106,21 @@ function summarizeProcesses() {
 }
 
 function summarizeQuests() {
-    return prioritizeQuests(quests).slice(0, MAX_QUESTS).map((quest) => {
-        const parts = [`${quest.title} [${quest.id}]`];
-        if (quest.description) {
-            parts.push(quest.description);
-        }
-        if (quest.requiresQuests.length > 0) {
-            parts.push(`Prereqs: ${quest.requiresQuests.join(', ')}`);
-        }
-        if (quest.rewards.length > 0) {
-            parts.push(`Rewards: ${quest.rewards.join(', ')}`);
-        }
-        return parts.join(' — ');
-    });
+    return prioritizeQuests(quests)
+        .slice(0, MAX_QUESTS)
+        .map((quest) => {
+            const parts = [`${quest.title} [${quest.id}]`];
+            if (quest.description) {
+                parts.push(quest.description);
+            }
+            if (quest.requiresQuests.length > 0) {
+                parts.push(`Prereqs: ${quest.requiresQuests.join(', ')}`);
+            }
+            if (quest.rewards.length > 0) {
+                parts.push(`Rewards: ${quest.rewards.join(', ')}`);
+            }
+            return parts.join(' — ');
+        });
 }
 
 export function buildDchatKnowledge(gameState = {}) {

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -1,28 +1,47 @@
 import { loadGameState, ready } from './gameState/common.js';
+import { buildDchatKnowledge } from './dchatKnowledge.js';
 import OpenAI from 'openai';
 
 export const GPT35Turbo = async (messages) => {
     await ready;
-    const apiKey = loadGameState().openAI?.apiKey || '';
+    const gameState = loadGameState();
+    const apiKey = gameState.openAI?.apiKey || '';
     const openai = new OpenAI({ apiKey });
 
     const systemMessage = {
         role: 'system',
         content:
-            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-3.5, GPT-4, Stable Diffusion, and DALL-E 2. You will eventually be able to help users learn more about quests, items, and processes in the game, but this isn't implemented yet. There is a docs page in the game, but you don't have access yet. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!",
+            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-3.5, GPT-4, Stable Diffusion, and DALL-E 2. You have curated knowledge about quests, items, processes, and the player's inventory. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!",
     };
+
+    const knowledgeSummary = buildDchatKnowledge(gameState);
+    const knowledgeMessage = knowledgeSummary
+        ? {
+              role: 'system',
+              content: `DSPACE knowledge base:\n${knowledgeSummary}`,
+          }
+        : null;
 
     const openingMessage = {
         role: 'assistant',
         content: 'Welcome! How can I assist you today?',
     };
 
-    let combinedMessages = [...messages];
+    const userMessages = [...messages];
+    let combinedMessages = [...userMessages];
 
     if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage, openingMessage];
+        combinedMessages = [systemMessage];
+        if (knowledgeMessage) {
+            combinedMessages.push(knowledgeMessage);
+        }
+        combinedMessages.push(openingMessage);
     } else {
-        combinedMessages = [systemMessage, ...combinedMessages];
+        combinedMessages = [systemMessage];
+        if (knowledgeMessage) {
+            combinedMessages.push(knowledgeMessage);
+        }
+        combinedMessages = [...combinedMessages, ...userMessages];
     }
 
     const response = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary
- randomly selected the roadmap promise “smarter dChat (knowledge of the game, the items, your inventory, etc.)” as the only manageable item from the unchecked roadmap list
- add a curated in-game knowledge summary for dChat, surface it in the OpenAI prompt, and refresh the welcome copy
- document the upgrade, mark the roadmap item complete, and update NPC docs plus changelog

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68da30601544832f98829be1a3deca67