### PR TITLE
Add FAQ guidance for custom quest submissions

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -12,6 +12,8 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   The main menu now highlights "More" links correctly even when the game runs from a subpath, so unpinned destinations stay active across deployments.
 -   Added a persistent dark mode toggle to the site header, letting players switch themes without losing their preference on reload.
 -   The Docs landing page now renders its sections from a JSON manifest and offers search with instant filtering, making navigation updates a single-data-source edit and ensuring a smoother docs navigation journey.
+-   The FAQ now covers custom quest submissions and links straight to the Quest Submission Guide,
+    replacing the "more content soon" placeholder with actionable steps.
 
 ## Development Checklist (Pre-Launch)
 

--- a/frontend/src/pages/docs/md/faq.md
+++ b/frontend/src/pages/docs/md/faq.md
@@ -6,7 +6,15 @@ slug: 'faq'
 ## What can I do?
 
 There are a variety of quests to complete. Quests are the primary way to learn about the lore and
-mechanics of the game. If you're all caught up, hang tight -- more content is coming soon!
+mechanics of the game. If you're all caught up, try building your own adventure with the
+[custom quest system](/docs/custom-quest-system) or replay story arcs to see the alternate
+outcomes hidden behind optional objectives.
+
+## How do I submit custom quests?
+
+Use the [Quest Submission Guide](/docs/quest-submission) to package your quest, process, or item
+so it can be reviewed for inclusion in the canon game. The guide walks through exporting your
+content, generating screenshots, and opening a pull request directly from the in-game tools.
 
 ## How do I make progress?
 

--- a/tests/docsFAQ.test.ts
+++ b/tests/docsFAQ.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('docs FAQ content', () => {
+  const faqPath = join(
+    process.cwd(),
+    'frontend',
+    'src',
+    'pages',
+    'docs',
+    'md',
+    'faq.md'
+  );
+
+  it('explains how to submit custom quests', () => {
+    const content = readFileSync(faqPath, 'utf8');
+    expect(content).toMatch(/## How do I submit custom quests\?/);
+    expect(content).toMatch(/\[Quest Submission Guide\]\(\/docs\/quest-submission\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- scanned for lingering TODO/FIXME/roadmap promises and randomly picked the FAQ "more content is coming soon" placeholder as the only eligible small item
- replaced the placeholder with actionable guidance that links to the custom quest system and Quest Submission Guide, and documented the change in the 2025-11-01 changelog
- added a vitest assertion that the FAQ now mentions the Quest Submission Guide so regressions are caught

## Testing
- `npm run audit:ci` *(fails: frontend audit reports dompurify, form-data, nanoid, postcss, and @babel/runtime vulnerabilities)*
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`
- `npx vitest run tests/docsFAQ.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68da30601544832f98829be1a3deca67