### PR TITLE
Update dChat API key settings copy to mention knowledge base

### DIFF
--- a/frontend/__tests__/OpenAIAPIKeySettings.test.js
+++ b/frontend/__tests__/OpenAIAPIKeySettings.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import OpenAIAPIKeySettings from '../src/pages/chat/svelte/OpenAIAPIKeySettings.svelte';
+
+vi.mock('../src/utils/gameState/common.js', () => ({
+    loadGameState: vi.fn(() => ({
+        openAI: { apiKey: '' },
+        inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 3 },
+    })),
+    saveGameState: vi.fn(),
+    ready: Promise.resolve(),
+}));
+
+describe('OpenAIAPIKeySettings', () => {
+    it('mentions the built-in knowledge base used for chat responses', async () => {
+        const { findByText } = render(OpenAIAPIKeySettings);
+        const info = await findByText((content) =>
+            content.includes(
+                'curated knowledge base covering quest lore, items, and highlights from your local inventory'
+            )
+        );
+        expect(info).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/chat/svelte/OpenAIAPIKeySettings.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIAPIKeySettings.svelte
@@ -75,8 +75,9 @@
         </div>
 
         <p>
-            Currently, the game doesn't know anything about the lore, the items in the game, or your
-            inventory. This will be introduced in a future version, as an opt-in feature.
+            When you connect your API key, dChat includes a curated knowledge base covering quest
+            lore, items, and highlights from your local inventory so it can answer gameplay
+            questions right away.
         </p>
     </div>
 {/if}

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -10,8 +10,9 @@ slug: 'npcs'
 dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning
 and information retrieval capabilities, it can answer questions and engage in conversation effortlessly.
 dChat now has a curated knowledge base covering the game's quests, items, processes, and the player's
-current inventory snapshot. dChat is provided free of charge to all metaguild members, and it's fully open
-source and self-hosted.
+current inventory snapshot. Connect your OpenAI API key in the chat settings and dChat will
+automatically include this context when answering questions. dChat is provided free of charge to all
+metaguild members, and it's fully open source and self-hosted.
 
 ### Sample Dialogue
 


### PR DESCRIPTION
## Summary
- Randomly picked the outdated promise in `OpenAIAPIKeySettings.svelte`, which still said the dChat knowledge base was coming later.
- Added a regression test that fails unless the settings panel copy mentions the curated knowledge base available during chat.
- Updated the chat settings copy and NPC docs so both describe the shipped knowledge base integration accurately.

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68dcd653cf2c832fa13b78529ad17632