### PR TITLE
Mark roadmap custom quests as shipped

### DIFF
--- a/frontend/src/pages/docs/md/roadmap.md
+++ b/frontend/src/pages/docs/md/roadmap.md
@@ -25,7 +25,7 @@ This is just a tentative roadmap showing what I'm hoping to work on next. Things
 
 ## August 2023
 
--   [ ] custom quests
+-   [x] [custom quests](/docs/custom-quest-system)
 
 ## July 2023
 

--- a/tests/roadmapCustomQuests.test.ts
+++ b/tests/roadmapCustomQuests.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('roadmap custom quests entry', () => {
+  const roadmapPath = join(
+    process.cwd(),
+    'frontend',
+    'src',
+    'pages',
+    'docs',
+    'md',
+    'roadmap.md'
+  );
+
+  it('reflects that the custom quest system has shipped', () => {
+    const content = readFileSync(roadmapPath, 'utf8');
+
+    expect(content).not.toMatch(/-\s+\[ \]\s+\[?custom quests/i);
+    expect(content).toContain('-   [x] [custom quests](/docs/custom-quest-system)');
+  });
+});


### PR DESCRIPTION
## Summary
- Randomly selected the roadmap promise for "custom quests" via `shuf`, since the in-game system already ships, and turned it green
- Added a regression test that fails if the roadmap ever reverts custom quests to an unchecked state
- Linked the roadmap entry to the custom quest system docs so the shipped feature is easy to find

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- CI=1 npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68de03d4f0d4832f9322a93b37296fc7