### PR TITLE
Align carbon tax penalty with documented rate

### DIFF
--- a/frontend/__tests__/gameState/inventory.test.js
+++ b/frontend/__tests__/gameState/inventory.test.js
@@ -300,23 +300,23 @@ describe('gameState - inventory', () => {
         expect(getSalesTaxPercentage()).toBe(0);
     });
 
-    test('getSalesTaxPercentage should return 10% for 1000 dCarbon', () => {
+    test('getSalesTaxPercentage should return 1% for 1000 dCarbon', () => {
         mockGameState.inventory[dCarbonId] = 1000;
-        expect(getSalesTaxPercentage()).toBe(10);
+        expect(getSalesTaxPercentage()).toBe(1);
     });
 
-    test('getSalesTaxPercentage should return 20% for 2000 dCarbon', () => {
+    test('getSalesTaxPercentage should return 2% for 2000 dCarbon', () => {
         mockGameState.inventory[dCarbonId] = 2000;
-        expect(getSalesTaxPercentage()).toBe(20);
+        expect(getSalesTaxPercentage()).toBe(2);
     });
 
-    test('getSalesTaxPercentage should return 90% for 9000 dCarbon', () => {
+    test('getSalesTaxPercentage should return 9% for 9000 dCarbon', () => {
         mockGameState.inventory[dCarbonId] = 9000;
-        expect(getSalesTaxPercentage()).toBe(90);
+        expect(getSalesTaxPercentage()).toBe(9);
     });
 
-    test('getSalesTaxPercentage should cap at 90% for values greater than 9000 dCarbon', () => {
-        mockGameState.inventory[dCarbonId] = 9500;
+    test('getSalesTaxPercentage should cap at 90% for values greater than 90000 dCarbon', () => {
+        mockGameState.inventory[dCarbonId] = 95000;
         expect(getSalesTaxPercentage()).toBe(90);
     });
 });

--- a/frontend/src/pages/docs/md/electricity.md
+++ b/frontend/src/pages/docs/md/electricity.md
@@ -5,7 +5,7 @@ slug: 'electricity'
 
 ## Non-renewable energy
 
-If you plug a machine in the wall (on Earth, at least), chances are you're still using fossil fuels, either from coal or natural gas. In DSPACE, there is a built-in carbon tax that is applied to all electricity usage based on fossil fuels. For every 1000 [dCarbon](/docs/dCarbon) produced within the game, your sell prices in the shop will be reduced by 1%. This provides a monetary incentive to continue to adopt renewable energy production.
+If you plug a machine in the wall (on Earth, at least), chances are you're still using fossil fuels, either from coal or natural gas. In DSPACE, there is a built-in carbon tax that is applied to all electricity usage based on fossil fuels. For every 1000 [dCarbon](/docs/dCarbon) produced within the game, your sell prices in the shop will be reduced by 1%, up to a maximum reduction of 90%. This provides a monetary incentive to continue to adopt renewable energy production.
 
 ## Renewable energy
 

--- a/frontend/src/utils/gameState/inventory.js
+++ b/frontend/src/utils/gameState/inventory.js
@@ -47,7 +47,7 @@ export const getSalesTaxPercentage = () => {
 
     if (dCarbonId && getItemCount(dCarbonId) > 0) {
         const dCarbonCount = gameState.inventory[dCarbonId] || 0;
-        return Math.min(Math.floor(dCarbonCount / 1000) * 10, 90);
+        return Math.min(Math.floor(dCarbonCount / 1000), 90);
     }
     return 0; // No tax for other items
 };


### PR DESCRIPTION
## Summary
- Picked the roadmap promise in `frontend/src/pages/docs/md/electricity.md` stating that every 1,000 dCarbon should apply a 1% sales penalty—previously the engine charged 10%, so the doc promise wasn’t actually true yet.
- Adjusted the `getSalesTaxPercentage` helper to charge 1% per 1,000 dCarbon (capped at 90%) and updated the unit tests to lock in the new breakpoints.
- Clarified the electricity guide to mention the 90% ceiling so the documentation matches the live mechanic.

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `CI=1 npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68debff00bf8832fbede3425f8db7625