### PR TITLE
Add quest PR validation coverage

### DIFF
--- a/frontend/e2e/quest-pr-validation.spec.ts
+++ b/frontend/e2e/quest-pr-validation.spec.ts
@@ -14,6 +14,7 @@ test('invalid token shows validation message', async ({ page }) => {
 
     await page.click('button:has-text("Create Pull Request")');
 
-    const error = page.locator('.error-message');
-    await expect(error).toBeVisible();
+    const tokenError = page.locator('.error-message', { hasText: 'GitHub token looks invalid' });
+    await expect(tokenError).toBeVisible();
+    await expect(page.getByTestId('submit-error')).toHaveText('Please fix the errors above');
 });

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -82,6 +82,11 @@ const TEST_GROUPS = [
         workers: 2,
     },
     {
+        name: 'Quest PR Validation',
+        files: ['quest-pr-validation.spec.ts'],
+        parallel: false,
+    },
+    {
         name: 'Integration Tests',
         files: ['custom-content.spec.ts'],
         grep: 'integrate custom items, processes, and quests',

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -49,7 +49,7 @@ spec in `frontend/e2e/backlog` until coverage exists.
 | Quest form validation      | Yes                 | `frontend/e2e/quest-form-validation.spec.ts`      |
 | Quest list navigation      | Yes                 | `frontend/e2e/quests.spec.ts`                     |
 | Quest PR form              | No                  | --                                                |
-| Quest PR validation        | No                  | --                                                |
+| Quest PR validation        | Yes                 | `frontend/e2e/quest-pr-validation.spec.ts`        |
 | Quest success message      | Yes                 | `frontend/e2e/quest-success-message.spec.ts`      |
 | Settings page loads        | Yes                 | `frontend/e2e/settings-page.spec.ts`              |
 | Shop workflow              | Yes                 | `frontend/e2e/shop-functionality.spec.ts`         |


### PR DESCRIPTION
## Summary
- selected "Quest PR validation coverage" at random from the user journeys table because it still reported "No" coverage despite an existing backlog spec
- moved the quest PR validation Playwright test into the main suite, tightened its assertions, and registered it with the grouped runner
- marked the journey as covered so the documentation no longer advertises an unshipped test

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci *(fails: missing historical commit d956e807d49114da2d0ff28aacef91341813bf82 to evaluate quest diffs)*

------
https://chatgpt.com/codex/tasks/task_e_68debff00bf8832fbede3425f8db7625