### PR TITLE
Add regression for changelog contributor guide link

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20230630.md
+++ b/frontend/src/pages/docs/md/changelog/20230630.md
@@ -101,7 +101,9 @@ If you're wondering how you can help, here are some ways:
 
 -   Join the conversation about the game on the [Discord server](https://discord.gg/A3UAfYvnxM).
 -   Report bugs or suggest features on [Github](https://github.com/democratizedspace/dspace/issues) or in the Discord's #bugs and #feedback channels.
--   If you're a developer hoping to contribute, stay tuned! I'll be releasing a contributors guide soon.
+-   If you're a developer hoping to contribute, read the
+    [Contribute guide](/docs/contribute) and review the
+    [CONTRIBUTING.md](https://github.com/democratizedspace/dspace/blob/main/CONTRIBUTING.md) handbook.
 -   Upvote Github [issues](https://github.com/democratizedspace/dspace/issues) to help prioritize tasks.
 -   Spread the word among your space enthusiast friends!
 

--- a/tests/changelogContributorsGuide.test.ts
+++ b/tests/changelogContributorsGuide.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('changelog 20230630 contributors guidance', () => {
+  const changelogPath = join(
+    process.cwd(),
+    'frontend',
+    'src',
+    'pages',
+    'docs',
+    'md',
+    'changelog',
+    '20230630.md'
+  );
+
+  it('links to the shipped contributors guide instead of promising it later', () => {
+    const content = readFileSync(changelogPath, 'utf8');
+    expect(content).not.toMatch(/I'\ll be releasing a contributors guide soon\./i);
+    expect(content).toMatch(/\[Contribute guide\]\(\/docs\/contribute\)/i);
+  });
+});


### PR DESCRIPTION
## Summary
- scanned for stale "stay tuned" promises with `rg -i "stay tuned"` and randomly picked the 20230630 changelog line promising a future contributors guide, since the guide already ships
- added a vitest to fail if the changelog regresses back to promising the guide instead of linking to it
- updated the changelog to point to /docs/contribute and CONTRIBUTING.md so the promise is retired

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68e4098b34ac832fb1c7f6d334e8b592