### PR TITLE
✨ Activate the Settings menu link

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   Improved test reliability with proper directory structure
 -   Copy code button now has visible focus and an ARIA label for screen readers
 -   Manage quests page now lists and manages custom quests saved in IndexedDB
+-   Settings menu entry now appears as an active destination instead of a disabled placeholder
 
 ### Documentation
 

--- a/frontend/__tests__/Menu.test.js
+++ b/frontend/__tests__/Menu.test.js
@@ -41,4 +41,14 @@ describe('Menu accessibility', () => {
         expect(gamesavesLink).toHaveClass('active');
         expect(gamesavesLink).toHaveAttribute('aria-current', 'page');
     });
+
+    it('renders Settings as a navigable link instead of a disabled chip', async () => {
+        const { getByRole, queryByRole } = render(Menu, { pathname: '/' });
+
+        const toggle = getByRole('button', { name: /More/ });
+        await fireEvent.click(toggle);
+
+        expect(queryByRole('button', { name: 'Settings' })).toBeNull();
+        expect(getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings');
+    });
 });

--- a/frontend/src/config/menu.json
+++ b/frontend/src/config/menu.json
@@ -98,8 +98,7 @@
     },
     {
         "name": "Settings",
-        "href": "/settings",
-        "comingSoon": true
+        "href": "/settings"
     },
     {
         "name": "Discord",

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -23,6 +23,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   The quest creation form now keeps its controls full-width on small screens so mobile players can complete submissions without horizontal scrolling.
 -   Inventory management now ships with category filter chips so you can narrow results to tools,
     awards, or hydroponics gear in a single click instead of paging through every item you own.
+-   The Settings menu entry now appears alongside other destinations instead of posing as a coming soon teaser.
 
 ## Content updates
 

--- a/tests/menu-settings.test.ts
+++ b/tests/menu-settings.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import menu from '../frontend/src/config/menu.json';
+
+describe('Menu settings entry', () => {
+    it('treats Settings as an available destination', () => {
+        const settings = menu.find((item) => item.name === 'Settings');
+
+        expect(settings).toBeDefined();
+        expect(settings?.comingSoon).not.toBe(true);
+        expect(settings?.href).toBe('/settings');
+    });
+});


### PR DESCRIPTION
## Summary
- randomly selected the `Settings` menu entry from the menu.json coming-soon candidate list and removed its `comingSoon` flag now that the page ships
- added a vitest guard and a Menu component test to lock the Settings link in place
- documented the change in the unreleased changelog and the 20251101 release notes

## Testing
- `npm run audit:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68e4c22c3270832fa1b65208b4190447