### PR TITLE
✨ Sync frontend package metadata with root manifest

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -138,6 +138,10 @@ cd frontend
 npm install
 ```
 
+> ℹ️ The frontend's `postinstall` hook runs `npm run sync`, which copies the
+> root package name, version, description, and license into
+> `frontend/package.json` so both manifests stay aligned.
+
 3. Start the development server:
 
 ```bash

--- a/frontend/scripts/sync-package.js
+++ b/frontend/scripts/sync-package.js
@@ -1,3 +1,59 @@
-// Simple script to sync package.json files
-// This is a placeholder that just logs success
-console.log('Package sync complete.');
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_METADATA_KEYS = Object.freeze(['name', 'version', 'description', 'license']);
+
+const formatJson = (data) => `${JSON.stringify(data, null, 4)}\n`;
+
+const readJson = (filePath) => JSON.parse(readFileSync(filePath, 'utf8'));
+
+const isEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+export function syncPackageMetadata({
+    rootPackagePath = path.resolve(process.cwd(), '..', 'package.json'),
+    targetPackagePath = path.resolve(process.cwd(), 'package.json'),
+    metadataKeys = DEFAULT_METADATA_KEYS,
+    logger = console,
+} = {}) {
+    const rootPackage = readJson(rootPackagePath);
+    const targetPackage = readJson(targetPackagePath);
+    const updatedPackage = { ...targetPackage };
+
+    const changedKeys = metadataKeys.reduce((acc, key) => {
+        if (!(key in rootPackage)) {
+            return acc;
+        }
+
+        if (!isEqual(rootPackage[key], targetPackage[key])) {
+            updatedPackage[key] = rootPackage[key];
+            acc.push(key);
+        }
+
+        return acc;
+    }, []);
+
+    if (changedKeys.length > 0) {
+        writeFileSync(targetPackagePath, formatJson(updatedPackage));
+        logger.log(`Synced package metadata fields: ${changedKeys.join(', ')}`);
+    } else {
+        logger.log('Package metadata already synchronized.');
+    }
+
+    return changedKeys;
+}
+
+const isExecutedDirectly = (() => {
+    if (!process.argv[1]) {
+        return false;
+    }
+
+    const invokedPath = path.resolve(process.argv[1]);
+    const modulePath = fileURLToPath(import.meta.url);
+
+    return invokedPath === modulePath;
+})();
+
+if (isExecutedDirectly) {
+    syncPackageMetadata();
+}

--- a/tests/packageMetadataSync.test.ts
+++ b/tests/packageMetadataSync.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { syncPackageMetadata } from '../frontend/scripts/sync-package.js';
+
+describe('sync-package metadata script', () => {
+  const writeJson = (filePath: string, data: Record<string, unknown>) => {
+    writeFileSync(filePath, `${JSON.stringify(data, null, 4)}\n`, 'utf8');
+  };
+
+  const setupWorkspace = (
+    rootData: Record<string, unknown>,
+    frontendData: Record<string, unknown>
+  ) => {
+    const workspace = mkdtempSync(path.join(os.tmpdir(), 'pkg-sync-'));
+    const rootPackagePath = path.join(workspace, 'package.json');
+    const frontendDir = path.join(workspace, 'frontend');
+    mkdirSync(frontendDir);
+    const targetPackagePath = path.join(frontendDir, 'package.json');
+
+    writeJson(rootPackagePath, rootData);
+    writeJson(targetPackagePath, frontendData);
+
+    const cleanup = () => rmSync(workspace, { recursive: true, force: true });
+
+    return { workspace, rootPackagePath, targetPackagePath, cleanup };
+  };
+
+  it('syncs basic package metadata fields from the root manifest', () => {
+    const { rootPackagePath, targetPackagePath, cleanup } = setupWorkspace(
+      {
+        name: 'dspace',
+        version: '3.1.0',
+        description: 'Root description',
+        license: 'Apache-2.0',
+      },
+      {
+        name: 'dspace-frontend',
+        version: '3.0.0',
+        description: 'Out-of-date description',
+        license: 'MIT',
+      }
+    );
+
+    try {
+      const updates = syncPackageMetadata({
+        rootPackagePath,
+        targetPackagePath,
+        logger: { log: () => {} },
+      });
+
+      const updated = JSON.parse(
+        readFileSync(targetPackagePath, 'utf8')
+      ) as Record<string, string>;
+
+      expect(updates).toEqual(['name', 'version', 'description', 'license']);
+      expect(updated).toMatchObject({
+        name: 'dspace',
+        version: '3.1.0',
+        description: 'Root description',
+        license: 'Apache-2.0',
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not rewrite the frontend manifest when metadata already matches', () => {
+    const manifest = {
+      name: 'dspace',
+      version: '3.1.0',
+      description: 'Root description',
+      license: 'Apache-2.0',
+    };
+
+    const { rootPackagePath, targetPackagePath, cleanup } = setupWorkspace(
+      manifest,
+      manifest
+    );
+
+    try {
+      const updates = syncPackageMetadata({
+        rootPackagePath,
+        targetPackagePath,
+        logger: { log: () => {} },
+      });
+
+      expect(updates).toEqual([]);
+      const finalContents = readFileSync(targetPackagePath, 'utf8');
+      expect(finalContents).toBe(`${JSON.stringify(manifest, null, 4)}\n`);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Randomly selected the placeholder `frontend/scripts/sync-package.js` backlog item (advertised as a future metadata sync) and implemented the actual copy logic so it no longer logs a stub message.
- Added unit coverage for syncing and no-op scenarios plus README guidance so the repo stops promising unfinished behavior.

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e4c22c3270832fa1b65208b4190447