### PR TITLE
Activate stats menu with aggregated overview

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Improved image reference tests with size and dimension validation
 -   Auto-creation of placeholder artifacts in Playwright trace directories
 -   Better .gitignore handling for test artifacts
+-   Live `/stats` page highlighting quest, inventory, and process totals
 
 ### Fixed
 

--- a/frontend/e2e/stats-page.spec.ts
+++ b/frontend/e2e/stats-page.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Stats page', () => {
+    test('surfaces quest and inventory counts', async ({ page }) => {
+        await page.goto('/stats');
+
+        await expect(page.getByRole('heading', { name: 'Game Stats' })).toBeVisible();
+        await expect(page.getByTestId('stats-total-quests')).toHaveText(/\d+/);
+        await expect(page.getByTestId('stats-total-items')).toHaveText(/\d+/);
+        await expect(page.getByRole('row', { name: /Energy/i })).toContainText('Energy');
+    });
+});

--- a/frontend/src/config/menu.json
+++ b/frontend/src/config/menu.json
@@ -63,8 +63,7 @@
     },
     {
         "name": "Stats",
-        "href": "/stats",
-        "comingSoon": true
+        "href": "/stats"
     },
     {
         "name": "Achievements",

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -24,6 +24,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   Inventory management now ships with category filter chips so you can narrow results to tools,
     awards, or hydroponics gear in a single click instead of paging through every item you own.
 -   The Settings menu entry now appears alongside other destinations instead of posing as a coming soon teaser.
+-   The Stats destination now opens a live breakdown of quests, inventory, and processes instead of a disabled placeholder link.
 
 ## Content updates
 

--- a/frontend/src/pages/stats.astro
+++ b/frontend/src/pages/stats.astro
@@ -1,0 +1,332 @@
+---
+import Page from '../components/Page.astro';
+import inventoryItems from './inventory/json/items';
+import processes from '../generated/processes.json';
+
+const questModules = await Astro.glob('./quests/json/*/*.json');
+const quests = questModules.map((module) =>
+    Object.prototype.hasOwnProperty.call(module, 'default') ? module.default : module
+);
+
+const formatQuestCategoryLabel = (value) => {
+    if (value === '3dprinting') {
+        return '3D Printing';
+    }
+
+    return value
+        .replace(/[-_]/g, ' ')
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+const questCategoryStats = new Map();
+let totalDialogueNodes = 0;
+let totalDialogueOptions = 0;
+const rewardedItemIds = new Set();
+const questsRequiringProcesses = new Set();
+
+for (const quest of quests) {
+    const nodes = Array.isArray(quest.dialogue) ? quest.dialogue.length : 0;
+    const optionCount = Array.isArray(quest.dialogue)
+        ? quest.dialogue.reduce(
+              (sum, node) => sum + (Array.isArray(node.options) ? node.options.length : 0),
+              0
+          )
+        : 0;
+
+    totalDialogueNodes += nodes;
+    totalDialogueOptions += optionCount;
+
+    const [categoryKey] = (quest.id || '').split('/');
+    const category = categoryKey || 'uncategorized';
+
+    if (!questCategoryStats.has(category)) {
+        questCategoryStats.set(category, {
+            quests: 0,
+            dialogueNodes: 0,
+            dialogueOptions: 0,
+        });
+    }
+
+    const stats = questCategoryStats.get(category);
+    stats.quests += 1;
+    stats.dialogueNodes += nodes;
+    stats.dialogueOptions += optionCount;
+
+    if (Array.isArray(quest.dialogue)) {
+        for (const node of quest.dialogue) {
+            if (!Array.isArray(node.options)) continue;
+            for (const option of node.options) {
+                if (option?.type === 'grantsItems' && Array.isArray(option.grantsItems)) {
+                    option.grantsItems.forEach((item) => {
+                        if (item?.id) {
+                            rewardedItemIds.add(item.id);
+                        }
+                    });
+                }
+                if (option?.type === 'process' && option.process) {
+                    questsRequiringProcesses.add(quest.id);
+                }
+            }
+        }
+    }
+}
+
+const questCategories = Array.from(questCategoryStats.entries())
+    .map(([key, stats]) => ({
+        key,
+        label: formatQuestCategoryLabel(key),
+        ...stats,
+    }))
+    .sort((a, b) => b.quests - a.quests);
+
+const uniqueNpcCount = new Set(quests.map((quest) => quest.npc).filter(Boolean)).size;
+const totalQuests = quests.length;
+
+const inventoryCategoryStats = inventoryItems.reduce((acc, item) => {
+    const category = item.category ?? 'Misc';
+    acc.set(category, (acc.get(category) ?? 0) + 1);
+    return acc;
+}, new Map());
+
+const inventoryCategories = Array.from(inventoryCategoryStats.entries())
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count);
+
+const totalItems = inventoryItems.length;
+
+const totalProcesses = processes.length;
+const processesWithHardening = processes.filter((process) => process.hardening).length;
+const totalHardeningPasses = processes.reduce(
+    (sum, process) => sum + (process.hardening?.passes ?? 0),
+    0
+);
+const processesWithDuration = processes.filter((process) => Boolean(process.duration)).length;
+---
+
+<Page title="Game Stats">
+    <section class="intro">
+        <p>
+            DSPACE keeps growing. Here’s a snapshot of the quests, inventory, and processes that power
+            your exploration.
+        </p>
+    </section>
+
+    <section aria-labelledby="quest-overview">
+        <h3 id="quest-overview">Quest overview</h3>
+        <dl class="stat-grid">
+            <div>
+                <dt>Total quests</dt>
+                <dd data-testid="stats-total-quests">{totalQuests}</dd>
+            </div>
+            <div>
+                <dt>Quest categories</dt>
+                <dd>{questCategories.length}</dd>
+            </div>
+            <div>
+                <dt>Dialogue nodes</dt>
+                <dd>{totalDialogueNodes}</dd>
+            </div>
+            <div>
+                <dt>Dialogue options</dt>
+                <dd>{totalDialogueOptions}</dd>
+            </div>
+            <div>
+                <dt>NPC guides</dt>
+                <dd>{uniqueNpcCount}</dd>
+            </div>
+            <div>
+                <dt>Quests rewarding items</dt>
+                <dd>{rewardedItemIds.size}</dd>
+            </div>
+            <div>
+                <dt>Quests that launch processes</dt>
+                <dd>{questsRequiringProcesses.size}</dd>
+            </div>
+        </dl>
+
+        <table>
+            <caption>Quest catalog by category</caption>
+            <thead>
+                <tr>
+                    <th scope="col">Category</th>
+                    <th scope="col">Quests</th>
+                    <th scope="col">Dialogue nodes</th>
+                    <th scope="col">Dialogue options</th>
+                </tr>
+            </thead>
+            <tbody>
+                {questCategories.map((category) => (
+                    <tr>
+                        <th scope="row">{category.label}</th>
+                        <td>{category.quests}</td>
+                        <td>{category.dialogueNodes}</td>
+                        <td>{category.dialogueOptions}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    </section>
+
+    <section aria-labelledby="inventory-overview">
+        <h3 id="inventory-overview">Inventory overview</h3>
+        <dl class="stat-grid">
+            <div>
+                <dt>Inventory items</dt>
+                <dd data-testid="stats-total-items">{totalItems}</dd>
+            </div>
+            <div>
+                <dt>Categories</dt>
+                <dd>{inventoryCategories.length}</dd>
+            </div>
+        </dl>
+
+        <table>
+            <caption>Inventory by category</caption>
+            <thead>
+                <tr>
+                    <th scope="col">Category</th>
+                    <th scope="col">Items</th>
+                </tr>
+            </thead>
+            <tbody>
+                {inventoryCategories.map((category) => (
+                    <tr>
+                        <th scope="row">{category.label}</th>
+                        <td>{category.count}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    </section>
+
+    <section aria-labelledby="process-overview">
+        <h3 id="process-overview">Process overview</h3>
+        <dl class="stat-grid">
+            <div>
+                <dt>Total processes</dt>
+                <dd data-testid="stats-total-processes">{totalProcesses}</dd>
+            </div>
+            <div>
+                <dt>With hardening history</dt>
+                <dd>{processesWithHardening}</dd>
+            </div>
+            <div>
+                <dt>Recorded hardening passes</dt>
+                <dd>{totalHardeningPasses}</dd>
+            </div>
+            <div>
+                <dt>Processes with durations</dt>
+                <dd>{processesWithDuration}</dd>
+            </div>
+        </dl>
+    </section>
+</Page>
+
+<style>
+    section {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 16px;
+        padding: 1.5rem;
+        margin-bottom: 2rem;
+        border: 1px solid var(--color-border);
+    }
+
+    .intro p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.5;
+    }
+
+    h3 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        font-size: 1.4rem;
+    }
+
+    .stat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+        margin: 0 0 1.5rem;
+    }
+
+    .stat-grid div {
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 12px;
+        padding: 1rem;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    dt {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.5rem;
+        color: var(--color-muted-text, #cde6d2);
+    }
+
+    dd {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 600;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 12px;
+        overflow: hidden;
+    }
+
+    caption {
+        text-align: left;
+        font-weight: 600;
+        padding: 1rem;
+        background: rgba(0, 0, 0, 0.25);
+    }
+
+    th,
+    td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        text-align: left;
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    @media (max-width: 600px) {
+        section {
+            padding: 1rem;
+        }
+
+        table,
+        tbody,
+        tr,
+        th,
+        td {
+            display: block;
+        }
+
+        th,
+        td {
+            padding: 0.5rem 0;
+            border: none;
+        }
+
+        th[scope='row'] {
+            font-size: 1.1rem;
+        }
+
+        td {
+            color: var(--color-muted-text, #cde6d2);
+        }
+
+        caption {
+            padding: 0.75rem 0;
+        }
+    }
+</style>

--- a/tests/menu-stats.test.ts
+++ b/tests/menu-stats.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import menu from '../frontend/src/config/menu.json';
+
+describe('Menu stats entry', () => {
+    it('exposes Stats as an available destination', () => {
+        const stats = menu.find((item) => item.name === 'Stats');
+
+        expect(stats).toBeDefined();
+        expect(stats?.comingSoon).not.toBe(true);
+        expect(stats?.href).toBe('/stats');
+    });
+});


### PR DESCRIPTION
## Summary
- Randomly selected the `Stats` navigation entry from the remaining coming-soon menu items and shipped its live dashboard.
- Added a `/stats` Astro page that aggregates quest, inventory, and process totals with responsive tables and data-test hooks.
- Enabled the Stats menu link, updated docs/changelog, and added vitest + Playwright coverage for the new experience.

## Testing
- npm run audit:ci *(fails: upstream dompurify/form-data advisories)*
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci
- npx playwright test stats-page.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68e55c962f78832faba155620406b611