### PR TITLE
Ship achievements feature and docs

### DIFF
--- a/frontend/src/config/menu.json
+++ b/frontend/src/config/menu.json
@@ -68,8 +68,7 @@
     },
     {
         "name": "Achievements",
-        "href": "/achievements",
-        "comingSoon": true
+        "href": "/achievements"
     },
     {
         "name": "Leaderboard",

--- a/frontend/src/pages/achievements/Achievements.svelte
+++ b/frontend/src/pages/achievements/Achievements.svelte
@@ -8,18 +8,13 @@
     let hydrated = false;
     let summaries = [];
 
-    const recompute = () => {
-        summaries = evaluateAchievements($state);
-    };
-
     onMount(async () => {
         await ready;
         hydrated = true;
-        recompute();
     });
 
     $: if (hydrated) {
-        recompute();
+        summaries = evaluateAchievements($state);
     }
 
     const statusLabel = (summary) => (summary.unlocked ? 'Unlocked' : 'Locked');

--- a/frontend/src/pages/achievements/Achievements.svelte
+++ b/frontend/src/pages/achievements/Achievements.svelte
@@ -1,0 +1,185 @@
+<script>
+    import { onMount } from 'svelte';
+    import { ACHIEVEMENTS, evaluateAchievements } from '../../utils/achievements.js';
+    import { ready, state } from '../../utils/gameState/common.js';
+
+    const categories = [...new Set(ACHIEVEMENTS.map((achievement) => achievement.category))];
+
+    let hydrated = false;
+    let summaries = [];
+
+    const recompute = () => {
+        summaries = evaluateAchievements($state);
+    };
+
+    onMount(async () => {
+        await ready;
+        hydrated = true;
+        recompute();
+    });
+
+    $: if (hydrated) {
+        recompute();
+    }
+
+    const statusLabel = (summary) => (summary.unlocked ? 'Unlocked' : 'Locked');
+</script>
+
+<div class="achievements" data-hydrated={hydrated ? 'true' : 'false'}>
+    {#if hydrated}
+        {#each categories as category}
+            <section class="category">
+                <h2>{category}</h2>
+                <div class="cards">
+                    {#each summaries.filter((summary) => summary.category === category) as summary}
+                        <article class:unlocked={summary.unlocked}>
+                            <header>
+                                <h3>{summary.title}</h3>
+                                <span class="status" aria-live="polite">{statusLabel(summary)}</span
+                                >
+                            </header>
+                            <p class="description">{summary.description}</p>
+                            <div
+                                class="progress"
+                                role="group"
+                                aria-label={`Progress toward ${summary.title}`}
+                            >
+                                <div class="bar" aria-hidden="true">
+                                    <div
+                                        class="fill"
+                                        style={`width: ${summary.progress.percent}%`}
+                                    />
+                                </div>
+                                <span class="value">{summary.progress.displayValue}</span>
+                            </div>
+                        </article>
+                    {/each}
+                </div>
+            </section>
+        {/each}
+    {:else}
+        <p class="loading" role="status">Loading achievements…</p>
+    {/if}
+</div>
+
+<style>
+    .achievements {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        padding: 1rem 0;
+    }
+
+    .category {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .category h2 {
+        margin: 0;
+        font-size: 1.5rem;
+        color: #b8f7c0;
+    }
+
+    .cards {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    article {
+        background: rgba(32, 64, 32, 0.7);
+        border: 1px solid rgba(128, 192, 128, 0.4);
+        border-radius: 16px;
+        padding: 1rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transition: transform 150ms ease, border-color 150ms ease;
+    }
+
+    article.unlocked {
+        border-color: rgba(180, 255, 180, 0.8);
+        box-shadow: 0 0 20px rgba(120, 220, 120, 0.25);
+    }
+
+    article:hover {
+        transform: translateY(-4px);
+    }
+
+    header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    h3 {
+        margin: 0;
+        font-size: 1.1rem;
+    }
+
+    .status {
+        font-size: 0.85rem;
+        padding: 0.25rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(0, 0, 0, 0.35);
+        color: #f2fff3;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+
+    article.unlocked .status {
+        background: rgba(26, 115, 52, 0.85);
+        color: #e5ffe8;
+    }
+
+    .description {
+        margin: 0;
+        color: #d6f1da;
+        line-height: 1.4;
+    }
+
+    .progress {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .bar {
+        height: 10px;
+        border-radius: 999px;
+        background: rgba(0, 0, 0, 0.4);
+        overflow: hidden;
+    }
+
+    .fill {
+        height: 100%;
+        background: linear-gradient(90deg, #3bd26f, #67f7a2);
+        border-radius: inherit;
+        transition: width 150ms ease;
+    }
+
+    article.unlocked .fill {
+        background: linear-gradient(90deg, #a7ff83, #5de094);
+    }
+
+    .value {
+        font-size: 0.85rem;
+        color: #f1fff5;
+        font-family: 'Fira Code', monospace;
+    }
+
+    .loading {
+        text-align: center;
+        font-style: italic;
+        color: #cfead4;
+    }
+
+    @media (max-width: 640px) {
+        .cards {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>

--- a/frontend/src/pages/achievements/index.astro
+++ b/frontend/src/pages/achievements/index.astro
@@ -1,0 +1,14 @@
+---
+import Page from '../../components/Page.astro';
+import Achievements from './Achievements.svelte';
+---
+
+<Page title="Achievements" columns="1">
+    <Achievements client:load />
+</Page>
+
+<style>
+    :global(body) {
+        background: radial-gradient(circle at top, #1b2f1b, #101510 70%);
+    }
+</style>

--- a/frontend/src/pages/docs/md/achievements.md
+++ b/frontend/src/pages/docs/md/achievements.md
@@ -3,6 +3,18 @@ title: 'Achievements'
 slug: 'achievements'
 ---
 
-Achievements are granted when your account reaches certain milestones or completes certain objectives. They could be granted as a reward for completing a quest, or for performing a certain action a specific number of times.
+Achievements celebrate major milestones in your save file. They unlock the first time you meet the
+listed requirements and update automatically whenever your quest log or inventory changes. Each
+entry in the Achievements menu tracks progress toward its goal so you can see how close you are to
+the next badge.
 
-Achievements are not currently implemented, but will be in the future.
+## Current achievements
+
+-   **First Steps** – Complete your first quest.
+-   **Mission Specialist** – Finish ten quests across any quest line.
+-   **Energy Investor** – Store a combined total of 500 dWatt in your inventory.
+-   **Wind Pioneer** – Acquire at least one 500 W wind turbine.
+
+Visit [/achievements](/achievements) to view your progress. Cards update in real time as you finish
+quests, generate dWatt, or pick up new equipment. Progress is stored locally alongside your game
+state, so achievements persist between sessions without sending any data to a server.

--- a/frontend/src/utils/achievements.js
+++ b/frontend/src/utils/achievements.js
@@ -1,0 +1,98 @@
+import items from '../pages/inventory/json/items/index.js';
+
+const QUEST_CATEGORY = 'Quests';
+const ENERGY_CATEGORY = 'Energy';
+
+const findItemId = (itemName) => items.find((item) => item.name === itemName)?.id;
+
+const dWattId = findItemId('dWatt');
+const windTurbineId = findItemId('500 W wind turbine');
+
+const toSafeNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+const formatProgress = (current, target, unit) => {
+    if (!target || target <= 0) {
+        return unit ? `0 ${unit}` : '0';
+    }
+    const base = `${current} / ${target}`;
+    return unit ? `${base} ${unit}` : base;
+};
+
+const countFinishedQuests = (quests) =>
+    Object.values(quests || {}).reduce((total, quest) => (quest?.finished ? total + 1 : total), 0);
+
+const getInventoryCount = (inventory, itemId) => {
+    if (!itemId) return 0;
+    return toSafeNumber(inventory?.[itemId] ?? 0);
+};
+
+const definitions = [
+    {
+        id: 'quests:first',
+        title: 'First Steps',
+        description: 'Complete your first quest.',
+        category: QUEST_CATEGORY,
+        goal: 1,
+        unit: 'quests',
+        compute: (state) => countFinishedQuests(state.quests),
+    },
+    {
+        id: 'quests:ten',
+        title: 'Mission Specialist',
+        description: 'Finish 10 quests to prove your dedication.',
+        category: QUEST_CATEGORY,
+        goal: 10,
+        unit: 'quests',
+        compute: (state) => countFinishedQuests(state.quests),
+    },
+    {
+        id: 'energy:stored',
+        title: 'Energy Investor',
+        description: 'Store 500 dWatt across your inventory.',
+        category: ENERGY_CATEGORY,
+        goal: 500,
+        unit: 'dWatt',
+        requirement: { progressItemId: dWattId },
+        compute: (state) => getInventoryCount(state.inventory, dWattId),
+    },
+    {
+        id: 'equipment:wind-turbine',
+        title: 'Wind Pioneer',
+        description: 'Add a 500 W wind turbine to your base.',
+        category: ENERGY_CATEGORY,
+        goal: 1,
+        unit: 'turbines',
+        requirement: { itemId: windTurbineId, progressItemId: dWattId },
+        compute: (state) => getInventoryCount(state.inventory, windTurbineId),
+    },
+];
+
+export const ACHIEVEMENTS = definitions.map(({ compute, ...rest }) => Object.freeze({ ...rest }));
+
+export const evaluateAchievements = (rawState = {}) => {
+    const state = {
+        quests: rawState.quests ?? {},
+        inventory: rawState.inventory ?? {},
+        processes: rawState.processes ?? {},
+    };
+
+    return definitions.map(({ compute, goal, unit, ...rest }) => {
+        const current = toSafeNumber(compute(state));
+        const target = goal;
+        const clamped = target > 0 ? Math.min(current, target) : current;
+        const percent = target > 0 ? Math.min(100, Math.round((clamped / target) * 100)) : 100;
+
+        return {
+            ...rest,
+            goal,
+            unit,
+            progress: {
+                current,
+                target,
+                percent,
+                displayValue: formatProgress(current, target, unit),
+            },
+            unlocked: current >= target,
+        };
+    });
+};

--- a/tests/achievementsFeature.test.ts
+++ b/tests/achievementsFeature.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ACHIEVEMENTS, evaluateAchievements } from '../frontend/src/utils/achievements.js';
+
+describe('achievements feature', () => {
+  it('computes progress and unlocks based on game state', () => {
+    const windTurbine = ACHIEVEMENTS.find((achievement) => achievement.id === 'equipment:wind-turbine');
+    if (!windTurbine) {
+      throw new Error('Expected equipment:wind-turbine achievement to be defined');
+    }
+
+    const sampleState = {
+      quests: {
+        'welcome/howtodoquests': { finished: true },
+        'energy/solar': { finished: true }
+      },
+      inventory: {
+        [windTurbine.requirement?.itemId ?? '']: 1,
+        [windTurbine.requirement?.progressItemId ?? '']: 800
+      },
+      processes: {}
+    } satisfies Parameters<typeof evaluateAchievements>[0];
+
+    const results = evaluateAchievements(sampleState);
+
+    const firstQuest = results.find((result) => result.id === 'quests:first');
+    const questStreak = results.find((result) => result.id === 'quests:ten');
+    const energyStored = results.find((result) => result.id === 'energy:stored');
+    const ownsTurbine = results.find((result) => result.id === 'equipment:wind-turbine');
+
+    expect(firstQuest?.unlocked).toBe(true);
+    expect(firstQuest?.progress.current).toBe(2);
+    expect(firstQuest?.progress.target).toBe(1);
+    expect(firstQuest?.progress.percent).toBe(100);
+
+    expect(questStreak?.unlocked).toBe(false);
+    expect(questStreak?.progress.current).toBe(2);
+    expect(questStreak?.progress.target).toBeGreaterThan(2);
+    expect(questStreak?.progress.percent).toBeGreaterThan(0);
+
+    expect(energyStored?.unlocked).toBe(true);
+    expect(energyStored?.progress.current).toBeGreaterThanOrEqual(800);
+    expect(energyStored?.progress.target).toBeLessThanOrEqual(800);
+    expect(energyStored?.progress.percent).toBe(100);
+
+    expect(ownsTurbine?.unlocked).toBe(true);
+    expect(ownsTurbine?.progress.current).toBe(1);
+    expect(ownsTurbine?.progress.target).toBe(1);
+  });
+
+  it('docs describe the shipped achievements system', () => {
+    const docPath = join(
+      process.cwd(),
+      'frontend',
+      'src',
+      'pages',
+      'docs',
+      'md',
+      'achievements.md'
+    );
+
+    const content = readFileSync(docPath, 'utf8');
+
+    expect(content).not.toMatch(/not currently implemented/i);
+    expect(content).toMatch(/track/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Candidate selection: scanned `frontend/src/config/menu.json` for `comingSoon` promises and randomly picked the "Achievements" entry (was still flagged before this change), so I shipped it.
- Added shared achievement evaluation logic plus Vitest coverage to exercise unlock and progress calculations.
- Exposed the Achievements page in navigation, built the Svelte UI, and refreshed the docs to describe the shipped system.

## Testing
- `CI=1 npm run test:ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run audit:ci`


------
https://chatgpt.com/codex/tasks/task_e_68e55c962f78832faba155620406b611