### PR TITLE
Mark changelog docs journey covered with labeled list

### DIFF
--- a/frontend/e2e/docs-changelog.spec.ts
+++ b/frontend/e2e/docs-changelog.spec.ts
@@ -104,7 +104,7 @@ test.describe('docs changelog page', () => {
 
         await expect(page.getByRole('heading', { name: 'Changelog' })).toBeVisible();
 
-        const releasesList = page.getByRole('list', { name: 'Release entries' });
+        const releasesList = page.getByRole('list', { name: 'Latest releases' });
         await expect(releasesList).toBeVisible();
 
         if (latestChangelog) {

--- a/frontend/src/pages/docs/[slug].astro
+++ b/frontend/src/pages/docs/[slug].astro
@@ -38,7 +38,7 @@ const buildLatestChangelogHtml = (entries = []) => {
         ? `\n        <p>${escapeHtml(summaryText)}</p>`
         : '';
 
-    return `\n<ul aria-label="Release entries">\n    <li>\n        <a href="/changelog">${escapeHtml(latest.title)}${taglineSuffix}</a>${summaryHtml}\n    </li>\n</ul>`;
+    return `\n<ul aria-label="Latest releases">\n    <li>\n        <a href="/changelog">${escapeHtml(latest.title)}${taglineSuffix}</a>${summaryHtml}\n    </li>\n</ul>`;
 };
 
 const { slug } = Astro.params;

--- a/frontend/src/pages/docs/md/changelog/20251101.md
+++ b/frontend/src/pages/docs/md/changelog/20251101.md
@@ -20,6 +20,7 @@ What's DSPACE, you ask? You must be new around here, and if so, welcome! I'm gla
 -   The FAQ now covers custom quest submissions and links straight to the Quest Submission Guide,
     replacing the "more content soon" placeholder with actionable steps.
 -   `/docs/changelog` now ships with a proper landing page that spotlights the latest release notes instead of the GitHub placeholder card.
+-   `/docs/changelog` now labels its release list as “Latest releases,” giving screen readers a clearer summary of the newest notes.
 -   The quest creation form now keeps its controls full-width on small screens so mobile players can complete submissions without horizontal scrolling.
 -   Inventory management now ships with category filter chips so you can narrow results to tools,
     awards, or hydroponics gear in a single click instead of paging through every item you own.

--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -16,7 +16,7 @@ spec in `frontend/e2e/backlog` until coverage exists.
 | About page loads           | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Authentication flow        | Yes                 | `frontend/e2e/authentication-flow.spec.ts`        |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
-| Changelog page loads       | No                  | --                                                |
+| Changelog page loads       | Yes                 | `frontend/e2e/docs-changelog.spec.ts`             |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
 | Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
 | Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |


### PR DESCRIPTION
## Summary
- picked random backlog item: user-journeys "Changelog page loads" row marked No coverage and shipped it
- renamed the docs changelog Playwright assertion and markup so the release list exposes the "Latest releases" label for screen readers
- noted the accessibility tweak in the November 2025 changelog entry and flipped the journey table to Yes with the live spec path

## Testing
- npm run audit:ci
- npm run lint
- npm run type-check
- npm run build
- CI=1 npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68e55c962f78832faba155620406b611