### PR TITLE
Align user journeys doc with changelog coverage spec

### DIFF
--- a/frontend/src/pages/docs/md/user-journeys.md
+++ b/frontend/src/pages/docs/md/user-journeys.md
@@ -16,7 +16,7 @@ spec in `frontend/e2e/backlog` until coverage exists.
 | About page loads           | Yes                 | `frontend/e2e/docs-navigation.spec.ts`            |
 | Authentication flow        | Yes                 | `frontend/e2e/authentication-flow.spec.ts`        |
 | Built-in quest details     | Yes                 | `frontend/e2e/builtin-quests.spec.ts`             |
-| Changelog page loads       | No                  | --                                                |
+| Changelog page loads       | Yes                 | `frontend/e2e/docs-changelog.spec.ts`             |
 | Cloud sync                 | Yes                 | `frontend/e2e/cloud-sync.spec.ts`                 |
 | Constellations quest       | Yes                 | `frontend/e2e/constellations-quest.spec.ts`       |
 | Cookie consent flow        | Yes                 | `frontend/e2e/cookie-consent.spec.ts`             |

--- a/tests/userJourneysCoverage.test.ts
+++ b/tests/userJourneysCoverage.test.ts
@@ -13,11 +13,10 @@ const docPath = path.join(
 );
 
 describe('User journeys documentation', () => {
-  it('marks the quest PR form journey as covered by an e2e spec', () => {
-    const markdown = readFileSync(docPath, 'utf8');
+  const getRowCells = (markdown: string, label: string) => {
     const row = markdown
       .split('\n')
-      .find((line) => line.trim().startsWith('| Quest PR form'));
+      .find((line) => line.trim().startsWith(`| ${label}`));
 
     expect(row).toBeDefined();
 
@@ -29,14 +28,38 @@ describe('User journeys documentation', () => {
     expect(cells).toBeDefined();
     expect(cells?.length).toBeGreaterThanOrEqual(3);
 
-    const coverageCell = cells?.[1] ?? '';
+    return cells as string[];
+  };
+
+  it('marks the quest PR form journey as covered by an e2e spec', () => {
+    const markdown = readFileSync(docPath, 'utf8');
+    const cells = getRowCells(markdown, 'Quest PR form');
+
+    const coverageCell = cells[1] ?? '';
     expect(coverageCell).toBe('Yes');
 
-    const testFileCell = cells?.[2] ?? '';
+    const testFileCell = cells[2] ?? '';
     expect(testFileCell).not.toBe('--');
 
     const referencedPath = testFileCell.replace(/`/g, '').trim();
     expect(referencedPath).toBe('frontend/e2e/quest-pr-form.spec.ts');
+
+    const absolutePath = path.join(repoRoot, referencedPath);
+    expect(existsSync(absolutePath)).toBe(true);
+  });
+
+  it('marks the changelog journey as covered once the docs changelog spec exists', () => {
+    const markdown = readFileSync(docPath, 'utf8');
+    const cells = getRowCells(markdown, 'Changelog page loads');
+
+    const coverageCell = cells[1] ?? '';
+    expect(coverageCell).toBe('Yes');
+
+    const testFileCell = cells[2] ?? '';
+    expect(testFileCell).not.toBe('--');
+
+    const referencedPath = testFileCell.replace(/`/g, '').trim();
+    expect(referencedPath).toBe('frontend/e2e/docs-changelog.spec.ts');
 
     const absolutePath = path.join(repoRoot, referencedPath);
     expect(existsSync(absolutePath)).toBe(true);


### PR DESCRIPTION
## Summary
- Built a candidate list of promised updates (checked docs for unchecked journeys) and randomly selected the outdated "Changelog page loads" entry because its Playwright spec already ships.
- Updated the user journeys documentation to mark the changelog path as covered and link to the existing docs-changelog test.
- Extended the userJourneysCoverage test to assert the changelog row references the docs-changelog Playwright spec so regressions fail fast.

## Testing
- npm run audit:ci (fails: upstream high/critical advisories in dompurify/form-data)
- npm run lint
- npm run type-check
- npm run build
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68e55c962f78832faba155620406b611