### PR TITLE
📝 docs: harden /quests TTI launch gate for v3.0.1

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -88,7 +88,22 @@ curl -fsS https://staging.democratized.space/livez
 
 ### 3.1 `/quests` TTI performance launch gate (required for this optimization)
 
-Primary validation stack for this feature (required):
+This gate compares exactly two immutable staging candidates for `/quests` TTI, run sequentially under
+identical conditions:
+
+1. **Instrumented baseline candidate** (branch diverged from commit
+   `3ec45a5517a35c96767f6b946c01104e6ec88f93`)
+2. **Optimized HEAD candidate**
+
+Baseline vs optimized scope requirements:
+
+- The baseline candidate is **measurement-only instrumentation** and must not include optimization logic.
+- The optimized candidate contains the optimization implementation.
+- Preserve the exact timing names below for cross-candidate comparability.
+- Keep baseline instrumentation honest: if an optional phase is not meaningfully separable on baseline,
+  omit it or explicitly document any approximation in recorded results.
+
+Primary validation stack for this gate (all required):
 
 1. Chrome DevTools Performance trace review
 2. `/quests` User Timing marks/measures
@@ -96,31 +111,70 @@ Primary validation stack for this feature (required):
 
 Lighthouse is supplementary only and cannot replace the three checks above.
 
-- [ ] Run `/quests` Playwright performance harness on staging/RC environment
+#### Required timing signals (exact names)
+
+Required marks:
+
+- `quests:list-hydration-start`
+- `quests:list-visible`
+- `quests:snapshot-classification-ready`
+- `quests:full-state-reconciliation-complete`
+
+Optional mark:
+
+- `quests:custom-quests-merge-complete`
+
+Required measures:
+
+- `quests:time-to-list-visible`
+- `quests:time-to-snapshot-classification`
+- `quests:time-to-full-reconciliation`
+
+Optional measure:
+
+- `quests:time-to-custom-merge`
+
+#### Procedure (must run in order)
+
+1. Deploy the **instrumented baseline** as a distinct immutable build/tag to
+   `staging.democratized.space` (never mutate an already-deployed artifact in place).
+2. Validate staging health after deploy: `/config.json`, `/healthz`, and `/livez`.
+3. Confirm rollback path before continuing (known-good tag + command ready).
+4. Reset browser/app state before measurement: clear service worker and cache storage (if present),
+   IndexedDB, localStorage, sessionStorage, and any persisted quest state.
+5. Run the Playwright `/quests` TTI harness with the chosen browser/device profile and CPU slowdown.
+6. Capture and save raw harness output and at least one Chrome DevTools performance trace.
+7. Record result metadata: candidate tag, commit SHA, date/time, browser/device profile, CPU slowdown
+   factor, seeded save/test account state, route, and whether the run is cold or warm.
+8. Deploy the **optimized HEAD** candidate as a separate immutable tag and repeat steps 2-7 under the
+   same staging environment and identical test conditions.
+9. Compare candidates and decide go/no-go using comparable **cold-run** data first; warm-run data may be
+   recorded separately but must not replace the cold comparison.
+
+#### Evidence checklist (attach to release notes/PR discussion)
+
+- [ ] Baseline candidate tag/SHA and optimized candidate tag/SHA recorded
+- [ ] Both candidates deployed as distinct immutable artifacts on staging
+- [ ] Health endpoints verified after each deploy (`/config.json`, `/healthz`, `/livez`)
+- [ ] Browser/app state reset between candidate runs (including service worker/cache storage if applicable)
+- [ ] Same seeded save, same test account state, same route, same browser/device profile, and same CPU
+      slowdown used across compared runs
+- [ ] Raw Playwright harness output preserved for each candidate (release artifact or attached evidence)
+- [ ] At least one DevTools Performance trace preserved per candidate (release artifact or attached evidence)
+- [ ] Any comparisons using different device profiles, slowdown factors, or seeded data are labeled as
+      separate experiments and excluded from primary go/no-go comparison
+
+Harness commands:
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-- [ ] Optional low-end simulation run captured (`QUESTS_TTI_CPU_SLOWDOWN=4`)
-
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-- [ ] Record measured timings in release notes/QA notes:
-    - [ ] `quests:time-to-list-visible`
-    - [ ] `quests:time-to-snapshot-classification`
-    - [ ] `quests:time-to-full-reconciliation`
-    - [ ] `quests:time-to-custom-merge` (if custom quests present)
-- [ ] Confirm required User Timing marks exist and are sensible in trace/log output:
-    - [ ] `quests:list-hydration-start`
-    - [ ] `quests:list-visible`
-    - [ ] `quests:snapshot-classification-ready`
-    - [ ] `quests:full-state-reconciliation-complete`
-    - [ ] `quests:custom-quests-merge-complete` (optional if no custom quests)
-- [ ] Review at least one Chrome DevTools Performance trace for `/quests` and confirm improved critical path
-- [ ] (Optional supporting audit) Run Lighthouse locally and attach summary, but do not use as sole gate
+Optional supporting audit only:
 
 ```bash
 npx lighthouse http://localhost:3000/quests --preset=desktop --view


### PR DESCRIPTION
### Motivation
- Make the `/quests` TTI gate semver-correct and operationally robust so optimized `HEAD` can be compared apples-to-apples against an instrumented baseline. 
- Ensure the baseline is measurement-only (no optimization logic) and that comparisons use immutable staging artifacts and identical test conditions. 
- Reduce ambiguity in acceptance by prescribing exact timing names, reset/rollback hygiene, evidence capture, and cold-first decision rules.

### Description
- Edited `docs/qa/v3.0.1.md` to replace the original `/quests` TTI section with a focused gate that mandates comparing exactly two immutable staging candidates (instrumented baseline vs optimized HEAD) and explicitly requires the baseline to be instrumentation-only. 
- Added a canonical list of required and optional User Timing marks and measures using the exact names: required marks `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`, optional mark `quests:custom-quests-merge-complete`, required measures `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`, and optional measure `quests:time-to-custom-merge`. 
- Added a numbered procedure enforcing immutable per-candidate deploys to `staging.democratized.space`, post-deploy health checks (`/config.json`, `/healthz`, `/livez`), rollback confirmation, full browser/app state reset between runs (service worker/cache, IndexedDB, localStorage, sessionStorage, persisted quest state), running the Playwright TTI harness under the same seeded save/account/route/browser profile/CPU slowdown, capturing raw Playwright output and at least one Chrome DevTools trace per candidate, recording exact metadata, and running the optimized candidate only after baseline measurements. 
- Added an evidence checklist and harness command examples and clarified that cold-run data is the primary acceptance signal while warm-run data is secondary.

### Testing
- Verified no residual references to legacy patch naming with ripgrep: `rg -n "v3\.0\.0\.1|3\.0\.0\.1" docs` returned no matches. 
- Verified the required timing names are present in `docs/qa/v3.0.1.md` with ripgrep and the matches were found. 
- Ran `node scripts/link-check.mjs` and confirmed all local markdown links resolved successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74004fddc832f8f1c5bcecb5e38a8)