### PR TITLE
📝 docs: harden v3.0.1 /quests TTI launch gate comparison protocol

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -86,40 +86,105 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-### 3.1 `/quests` TTI performance launch gate (required for this optimization)
+### 3.1 `/quests` TTI performance launch gate (required)
 
-Primary validation stack for this feature (required):
+This gate compares exactly two immutable staging candidates on `staging.democratized.space`:
 
-1. Chrome DevTools Performance trace review
-2. `/quests` User Timing marks/measures
-3. Playwright measurement harness
+1. Optimized candidate from current `HEAD` (contains optimization logic + instrumentation)
+2. Instrumented baseline candidate branched from commit `3ec45a5517a35c96767f6b946c01104e6ec88f93`
 
-Lighthouse is supplementary only and cannot replace the three checks above.
+Baseline branch policy (mandatory):
 
-- [ ] Run `/quests` Playwright performance harness on staging/RC environment
+- Baseline candidate is **measurement-only instrumentation**.
+- Baseline candidate must **not** include the optimization logic itself.
+- Baseline instrumentation must emit comparable timing marks/measures without changing behavior beyond
+  what is necessary to measure timing.
+
+Required marks (exact names):
+
+- `quests:list-hydration-start`
+- `quests:list-visible`
+- `quests:snapshot-classification-ready`
+- `quests:full-state-reconciliation-complete`
+- `quests:custom-quests-merge-complete` (optional)
+
+Required measures (exact names):
+
+- `quests:time-to-list-visible`
+- `quests:time-to-snapshot-classification`
+- `quests:time-to-full-reconciliation`
+- `quests:time-to-custom-merge` (optional)
+
+Comparability note:
+
+- Baseline internal phases may differ from optimized implementation internals.
+- Preserve exact timing names above for comparability.
+- Keep baseline instrumentation honest; do not backfill with optimization logic.
+- If an optional phase is not meaningfully separable on baseline, omit it or clearly document the
+  approximation in recorded results.
+
+Primary evidence stack (all required):
+
+1. Raw Playwright harness output per candidate
+2. `/quests` User Timing marks/measures per candidate
+3. At least one Chrome DevTools Performance trace per candidate
+
+Lighthouse is supplementary only and cannot replace required evidence.
+
+Sequential procedure (must follow in order):
+
+1. Deploy baseline as an immutable staging candidate/tag (do not mutate artifacts in place).
+2. Validate staging health endpoints after deploy: `/config.json`, `/healthz`, `/livez`.
+3. Reset client/browser state before measurement (clear service worker + cache storage if used,
+   IndexedDB, localStorage, sessionStorage, and persisted quest state).
+4. Run `/quests` Playwright harness for cold-run baseline using fixed browser/device profile and
+   fixed CPU slowdown.
+5. Capture at least one Chrome DevTools Performance trace for baseline under the same conditions.
+6. Record baseline metadata and results.
+7. Deploy optimized `HEAD` as a separate immutable staging candidate/tag (same environment).
+8. Repeat steps 2-6 with identical seeded save/account state, route (`/quests`), browser profile,
+   CPU slowdown, and run mode.
+9. Compare results and decide go/no-go using comparable cold-run data first.
+
+Required run metadata to record for each candidate:
+
+- Immutable candidate tag
+- Commit SHA
+- Date/time (UTC)
+- Browser + device profile
+- CPU slowdown factor
+- Seeded save/test account state identifier
+- Route under test (`/quests`)
+- Run type (`cold` or `warm`)
+
+Acceptance rule:
+
+- Cold-run comparison is mandatory for launch decisions.
+- Warm-run data may be captured separately but must not replace cold-run comparison.
+
+Suggested harness commands (example):
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-- [ ] Optional low-end simulation run captured (`QUESTS_TTI_CPU_SLOWDOWN=4`)
-
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-- [ ] Record measured timings in release notes/QA notes:
-    - [ ] `quests:time-to-list-visible`
-    - [ ] `quests:time-to-snapshot-classification`
-    - [ ] `quests:time-to-full-reconciliation`
-    - [ ] `quests:time-to-custom-merge` (if custom quests present)
-- [ ] Confirm required User Timing marks exist and are sensible in trace/log output:
-    - [ ] `quests:list-hydration-start`
-    - [ ] `quests:list-visible`
-    - [ ] `quests:snapshot-classification-ready`
-    - [ ] `quests:full-state-reconciliation-complete`
-    - [ ] `quests:custom-quests-merge-complete` (optional if no custom quests)
-- [ ] Review at least one Chrome DevTools Performance trace for `/quests` and confirm improved critical path
+Release-decision evidence checklist:
+
+- [ ] Rollback path is confirmed before swapping staging candidates
+- [ ] Baseline and optimized candidates are distinct immutable tags/builds
+- [ ] Health endpoints validated after each candidate deploy (`/config.json`, `/healthz`, `/livez`)
+- [ ] Client/browser state reset between candidate runs (including service worker/cache where applicable)
+- [ ] Same seeded data/account state, route, browser/device profile, and CPU slowdown used for both
+- [ ] Raw Playwright outputs preserved
+- [ ] DevTools traces preserved (>=1 per candidate)
+- [ ] Candidate tag/SHA/timestamp/profile/slowdown/cold-warm metadata recorded for each run
+- [ ] Cross-device or cross-condition runs are labeled as separate experiments (not used for primary compare)
+- [ ] Logs/traces attached to release notes or PR discussion (or archived as release artifacts)
+
 - [ ] (Optional supporting audit) Run Lighthouse locally and attach summary, but do not use as sole gate
 
 ```bash


### PR DESCRIPTION
### Motivation
- Make the `/quests` Time-To-Interactive (TTI) QA gate in `docs/qa/v3.0.1.md` semver-correct and operationally robust so optimized `HEAD` can be compared apples-to-apples against an instrumentation-only baseline branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`.
- Prevent measurement drift by requiring immutable candidates, sequential same-environment testing, and explicit state-reset/metadata capture so launch decisions are based on comparable cold-run data.

### Description
- Rewrote the `/quests` TTI section in `docs/qa/v3.0.1.md` to require exactly two immutable staging candidates: optimized `HEAD` and an instrumentation-only baseline from commit `3ec45a5517a35c96767f6b946c01104e6ec88f93` and explicitly state the baseline must not contain the optimization logic. 
- Codified exact required User Timing marks and measures (exact spellings): marks `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`, optional `quests:custom-quests-merge-complete`; measures `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`, optional `quests:time-to-custom-merge`.
- Added a sequential 9-step procedure for immutable deploy → health validation → client/browser state reset → Playwright cold-run → DevTools trace capture → metadata recording → repeat for optimized candidate and a cold-first acceptance rule. 
- Added a release-decision evidence checklist and rollout hygiene (rollback confirmation, verify `/config.json`, `/healthz`, `/livez` after each deploy, clear service worker/cache/IndexedDB/localStorage/sessionStorage, preserve raw Playwright output and DevTools traces, and label cross-condition runs as separate experiments). 

### Testing
- Verified the timing names were added to the QA doc with `rg` against `docs/qa/v3.0.1.md` and confirmed matches for all required/optional marks and measures. 
- Ran the markdown link checker with `node scripts/link-check.mjs` which returned "All local markdown links resolved." 
- Ran the secrets scan on the staged diff via `./scripts/scan-secrets.py` which produced no findings. 
- No code changes were made; only the QA markdown was edited and committed (`📝 docs: harden v3.0.1 quests TTI gate`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74004fddc832f8f1c5bcecb5e38a8)