### PR TITLE
📝 docs: harden v3.0.1 /quests TTI launch-gate for baseline vs optimized comparison

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -88,7 +88,16 @@ curl -fsS https://staging.democratized.space/livez
 
 ### 3.1 `/quests` TTI performance launch gate (required for this optimization)
 
-Primary validation stack for this feature (required):
+This launch gate compares exactly two immutable staging candidates:
+
+- **Instrumented baseline candidate**: branch from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
+  containing measurement-only instrumentation.
+- **Optimized `HEAD` candidate**: current optimization implementation.
+
+Baseline instrumentation must remain measurement-only and must **not** include optimization logic.
+Its purpose is only to emit comparable timing marks/measures.
+
+Primary validation stack for this feature (required for both candidates):
 
 1. Chrome DevTools Performance trace review
 2. `/quests` User Timing marks/measures
@@ -96,30 +105,97 @@ Primary validation stack for this feature (required):
 
 Lighthouse is supplementary only and cannot replace the three checks above.
 
-- [ ] Run `/quests` Playwright performance harness on staging/RC environment
+### 3.1.1 Required timing names (exact)
+
+Required marks:
+
+- `quests:list-hydration-start`
+- `quests:list-visible`
+- `quests:snapshot-classification-ready`
+- `quests:full-state-reconciliation-complete`
+
+Optional mark:
+
+- `quests:custom-quests-merge-complete`
+
+Required measures:
+
+- `quests:time-to-list-visible`
+- `quests:time-to-snapshot-classification`
+- `quests:time-to-full-reconciliation`
+
+Optional measure:
+
+- `quests:time-to-custom-merge`
+
+Baseline and optimized branches may not share identical internal phase structure. Preserve these exact
+timing names for comparability and keep baseline instrumentation honest. If an optional phase is not
+meaningfully separable on baseline, omit it or explicitly document the approximation in recorded
+results.
+
+### 3.1.2 Sequential apples-to-apples procedure (required)
+
+1. Deploy the **instrumented baseline immutable candidate** to `staging.democratized.space`
+   (do not mutate an existing artifact in place).
+2. Verify post-deploy health before testing:
+    - `https://staging.democratized.space/config.json`
+    - `https://staging.democratized.space/healthz`
+    - `https://staging.democratized.space/livez`
+3. Reset client state before measurement (clear IndexedDB, `localStorage`, `sessionStorage`,
+   service worker/cache storage, and any persisted quest/save data for the test account).
+4. Run the `/quests` Playwright harness using the fixed test conditions (same seeded save, same test
+   account state, same route, same browser/device profile, same CPU slowdown setting).
+5. Capture at least one Chrome DevTools Performance trace for baseline under the same conditions.
+6. Record baseline result metadata: candidate tag, commit SHA, date/time, browser/device profile,
+   CPU slowdown factor, and cold vs warm run.
+7. Confirm rollback path is ready, then deploy the **optimized `HEAD` immutable candidate** to
+   `staging.democratized.space` (again, no in-place mutation of prior artifact).
+8. Repeat steps 2-6 under identical conditions, including another explicit client-state reset before
+   running optimized measurements.
+9. Compare results and make go/no-go decision using **comparable cold-run data first**; warm-run data
+   may be recorded separately but must not replace the cold comparison.
+
+Run harness commands:
+
+- [ ] Baseline candidate run captured (raw output saved):
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-- [ ] Optional low-end simulation run captured (`QUESTS_TTI_CPU_SLOWDOWN=4`)
+- [ ] Optional low-end simulation run captured for the same candidate/conditions (`QUESTS_TTI_CPU_SLOWDOWN=4`):
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-- [ ] Record measured timings in release notes/QA notes:
+### 3.1.3 Evidence checklist for release decision
+
+- [ ] Distinct immutable tag/build identifier recorded for both candidates (baseline and optimized)
+- [ ] Baseline candidate is documented as instrumentation-only (no optimization logic)
+- [ ] Raw Playwright harness output preserved for each candidate (attach to release notes/PR discussion or release artifacts)
+- [ ] At least one Chrome DevTools Performance trace preserved for each candidate
+- [ ] Measured timings recorded:
     - [ ] `quests:time-to-list-visible`
     - [ ] `quests:time-to-snapshot-classification`
     - [ ] `quests:time-to-full-reconciliation`
-    - [ ] `quests:time-to-custom-merge` (if custom quests present)
-- [ ] Confirm required User Timing marks exist and are sensible in trace/log output:
+    - [ ] `quests:time-to-custom-merge` (optional; or documented approximation/omission)
+- [ ] Required timing marks verified:
     - [ ] `quests:list-hydration-start`
     - [ ] `quests:list-visible`
     - [ ] `quests:snapshot-classification-ready`
     - [ ] `quests:full-state-reconciliation-complete`
-    - [ ] `quests:custom-quests-merge-complete` (optional if no custom quests)
-- [ ] Review at least one Chrome DevTools Performance trace for `/quests` and confirm improved critical path
+    - [ ] `quests:custom-quests-merge-complete` (optional)
+- [ ] Run metadata recorded for each result set:
+    - [ ] candidate tag
+    - [ ] commit SHA
+    - [ ] date/time
+    - [ ] browser/device profile
+    - [ ] CPU slowdown factor
+    - [ ] cold or warm designation
+- [ ] Compared runs use the same seeded data, same account state, same route, and same slowdown/profile;
+      any different-device or different-condition runs are labeled as separate experiments
+- [ ] Acceptance decision is based on comparable cold-run results first (warm data tracked separately)
 - [ ] (Optional supporting audit) Run Lighthouse locally and attach summary, but do not use as sole gate
 
 ```bash


### PR DESCRIPTION
### Motivation
- Ensure the `/quests` TTI launch gate is semver-correct for the `v3.0.1` patch line and prescribes an operationally robust apples-to-apples comparison between an instrumented baseline and the optimized `HEAD` candidate. 
- Prevent invalid comparisons caused by in-place artifact mutation, warmed client state, or mismatched test conditions by making deploy, state-reset, and evidence requirements explicit. 
- Make the measurement contract explicit so the baseline branch is instrumentation-only and the timing names/measures are stable for comparability. 

### Description
- Added a dedicated `/quests` TTI subsection that requires exactly two immutable staging candidates: an instrumented baseline branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93` (measurement-only) and the optimized `HEAD` candidate. 
- Added exact required and optional User Timing marks and measures (marks: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`, optional `quests:custom-quests-merge-complete`; measures: `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`, optional `quests:time-to-custom-merge`). 
- Added a 9-step sequential procedure enforcing immutable deploys, pre-run health checks (`/config.json`, `/healthz`, `/livez`), explicit client-state resets (IndexedDB/localStorage/sessionStorage/service worker/cache), identical seeded/save/account/route/browser/CPU-slowdown conditions, trace capture, metadata recording, rollback readiness, and cold-run-first acceptance. 
- Added an evidence checklist requiring distinct candidate tags, preserved raw Playwright output, at least one DevTools trace per candidate, full run metadata, and guidance to omit or document optional-phase approximations on baseline. 

### Testing
- Ran the verification patterns `rg -n "v3\.0\.0\.1|3\.0\.0\.1" docs` and confirmed there are no remaining references to `v3.0.0.1`. 
- Verified timing names are present in the updated file with `rg -n "quests:list-hydration-start|quests:list-visible|quests:snapshot-classification-ready|quests:full-state-reconciliation-complete|quests:custom-quests-merge-complete|quests:time-to-list-visible|quests:time-to-snapshot-classification|quests:time-to-full-reconciliation|quests:time-to-custom-merge" docs/qa/v3.0.1.md` and confirmed matches. 
- Executed `node scripts/link-check.mjs` and confirmed all local markdown links resolved successfully. 
- Change is limited to `docs/qa/v3.0.1.md` and contains no code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74004fddc832f8f1c5bcecb5e38a8)