### PR TITLE
Backport baseline /quests TTI measurement harness and timing marks

### DIFF
--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+const PERF_MARKS = [
+    'quests:list-hydration-start',
+    'quests:list-visible',
+    'quests:snapshot-classification-ready',
+    'quests:full-state-reconciliation-complete',
+    'quests:custom-quests-merge-complete',
+];
+
+test.describe('quests performance marks', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('collects /quests user timing milestones', async ({ page, browserName, baseURL }) => {
+        test.skip(browserName !== 'chromium', 'Measurement harness is Chromium-focused');
+
+        const cpuSlowdown = Number(process.env.QUESTS_TTI_CPU_SLOWDOWN ?? '1');
+        if (cpuSlowdown > 1) {
+            const session = await page.context().newCDPSession(page);
+            await session.send('Emulation.setCPUThrottlingRate', { rate: cpuSlowdown });
+        }
+
+        await page.goto('/quests');
+        await page.waitForLoadState('networkidle');
+
+        const configuredBaseUrl =
+            process.env.QUESTS_PERF_BASE_URL || process.env.BASE_URL || baseURL || page.url();
+        const configuredOrigin = new URL(configuredBaseUrl).origin;
+        const loadedUrl = new URL(page.url());
+
+        expect(loadedUrl.origin).toBe(configuredOrigin);
+        expect(loadedUrl.pathname).toBe('/quests');
+        await expect(page.getByRole('heading', { name: 'Quests', exact: true })).toBeVisible();
+        await expect(page.getByTestId('quests-grid')).toBeVisible();
+
+        const metrics = await page.evaluate((marks) => {
+            const allMarks = performance.getEntriesByType('mark');
+            const allMeasures = performance.getEntriesByType('measure');
+
+            const markTimes = Object.fromEntries(
+                marks.map((name) => {
+                    const entry = allMarks.find((mark) => mark.name === name);
+                    return [name, entry ? Number(entry.startTime.toFixed(2)) : null];
+                })
+            );
+
+            const measureTimes = Object.fromEntries(
+                allMeasures
+                    .filter((entry) => entry.name.startsWith('quests:time-to-'))
+                    .map((entry) => [entry.name, Number(entry.duration.toFixed(2))])
+            );
+
+            return { markTimes, measureTimes };
+        }, PERF_MARKS);
+
+        for (const markName of PERF_MARKS.slice(0, 4)) {
+            expect(metrics.markTimes[markName]).not.toBeNull();
+        }
+
+        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+    });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,9 @@
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js",
-        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell"
+        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell",
+        "perf:quests": "npm run setup-test-env && node scripts/run-quests-perf.mjs",
+        "perf:quests:slowcpu": "npm run setup-test-env && cross-env QUESTS_TTI_CPU_SLOWDOWN=4 node scripts/run-quests-perf.mjs"
     },
     "devDependencies": {
         "@astrojs/svelte": "^6.0.0",

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const baseEnv = { ...process.env };
+const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
+
+if (requestedBaseUrl) {
+    baseEnv.BASE_URL = requestedBaseUrl;
+    baseEnv.REMOTE_SMOKE = '1';
+}
+
+const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
+if (cpuSlowdown) {
+    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
+}
+
+const result = spawnSync(
+    'playwright',
+    ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
+    {
+        cwd: new URL('..', import.meta.url),
+        stdio: 'inherit',
+        env: baseEnv,
+        shell: true,
+    }
+);
+
+if (typeof result.status === 'number') {
+    process.exit(result.status);
+}
+
+process.exit(1);

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -5,6 +5,7 @@
     import { questFinished, canStartQuest } from '../../../utils/gameState.js';
     import { listCustomQuests } from '../../../utils/customcontent.js';
     import { loadGameState, state, ready } from '../../../utils/gameState/common.js';
+    import { isBrowser } from '../../../utils/ssr.js';
 
     export let quests = [];
     let filteredQuests = [];
@@ -15,6 +16,25 @@
     let normalizedCustomQuests = [];
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
+    let hasMarkedListVisible = false;
+
+    const markPerf = (name) => {
+        if (!isBrowser || typeof performance?.mark !== 'function') {
+            return;
+        }
+        performance.mark(name);
+    };
+
+    const measurePerf = (name, start, end) => {
+        if (!isBrowser || typeof performance?.measure !== 'function') {
+            return;
+        }
+        try {
+            performance.measure(name, start, end);
+        } catch {
+            // no-op
+        }
+    };
 
     const normalizeQuest = (entry) => {
         if (!entry) {
@@ -86,10 +106,28 @@
     };
 
     onMount(async () => {
+        markPerf('quests:list-hydration-start');
         await ready;
         mounted = true;
         const initialState = loadGameState();
         showQuestGraphVisualizer = Boolean(initialState.settings?.showQuestGraphVisualizer);
+
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        if (!hasMarkedListVisible) {
+            hasMarkedListVisible = true;
+            markPerf('quests:list-visible');
+            markPerf('quests:snapshot-classification-ready');
+            measurePerf(
+                'quests:time-to-list-visible',
+                'quests:list-hydration-start',
+                'quests:list-visible'
+            );
+            measurePerf(
+                'quests:time-to-snapshot-classification',
+                'quests:list-hydration-start',
+                'quests:snapshot-classification-ready'
+            );
+        }
 
         unsubscribeState = state.subscribe((value) => {
             showQuestGraphVisualizer = Boolean(value?.settings?.showQuestGraphVisualizer);
@@ -101,6 +139,13 @@
         } catch (error) {
             console.error('Unable to load custom quests for listing:', error);
             customQuestRecords = [];
+        } finally {
+            markPerf('quests:full-state-reconciliation-complete');
+            measurePerf(
+                'quests:time-to-full-reconciliation',
+                'quests:list-hydration-start',
+                'quests:full-state-reconciliation-complete'
+            );
         }
     });
 


### PR DESCRIPTION
### Motivation
- Provide a minimal Playwright-based measurement harness so the v3.0.0 baseline can produce `/quests` TTI user-timing marks for apples-to-apples comparison with the optimized HEAD. 
- Keep the baseline behavior identical to v3.0.0 and avoid backporting any performance optimizations or architecture changes; this change is measurement-only. 
- Emit timing names that match `docs/qa/v3.0.1.md` so downstream analysis and tooling can consume the same metric keys.

### Description
- Added a Chromium-focused Playwright spec `frontend/e2e/quests-tti-metrics.spec.ts` that collects the required user-timing marks and measures and logs the JSON output for analysis. 
- Added a perf runner script `frontend/scripts/run-quests-perf.mjs` that invokes the new spec and wires optional env vars for `QUESTS_PERF_BASE_URL` and `QUESTS_TTI_CPU_SLOWDOWN`. 
- Wired `frontend/package.json` with two convenience scripts: `perf:quests` and `perf:quests:slowcpu` that run the perf harness after `setup-test-env`. 
- Inserted minimal, honest User Timing instrumentation into the baseline list path in `frontend/src/pages/quests/svelte/Quests.svelte` to emit marks and measures: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete` and the measures `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`. 
- Maintained scope control by not backporting snapshot-first rendering, manifest generation, classifier refactors, custom-quest deferral, or any other perf logic; optional custom-merge timing was intentionally omitted on the baseline.

### Testing
- Ran `npm install` which completed successfully in this environment. 
- Ran `npm --prefix frontend run setup-test-env` which completed and produced the expected test artifacts/placeholders. 
- Attempted `npm --prefix frontend run perf:quests` and `QUESTS_TTI_CPU_SLOWDOWN=4 npm --prefix frontend run perf:quests:slowcpu`, but these failed here due to Playwright browser/dependency installation being blocked by network/apt restrictions in the execution environment. 
- Ran `npm run lint` which failed in this environment due to `@typescript-eslint/parser` resolution errors surfaced by ESLint (environment-specific parser resolution issue). 
- Ran `npm run type-check` which failed due to a pre-existing TypeScript test error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` unrelated to this instrumentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73f032120832fa66312c5f2eeb0cd)