### PR TITLE
Backport /quests TTI measurement harness to quests-tti-baseline

### DIFF
--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -49,25 +49,28 @@ test.describe('quests performance marks', () => {
             PERF_MARKS
         );
 
-        const metrics = await page.evaluate((marks) => {
-            const allMarks = performance.getEntriesByType('mark');
-            const allMeasures = performance.getEntriesByType('measure');
+        const metrics = await page.evaluate(
+            (marks) => {
+                const allMarks = performance.getEntriesByType('mark');
+                const allMeasures = performance.getEntriesByType('measure');
 
-            const markTimes = Object.fromEntries(
-                marks.map((name) => {
-                    const entry = allMarks.find((mark) => mark.name === name);
-                    return [name, entry ? Number(entry.startTime.toFixed(2)) : null];
-                })
-            );
+                const markTimes = Object.fromEntries(
+                    marks.map((name) => {
+                        const entry = allMarks.find((mark) => mark.name === name);
+                        return [name, entry ? Number(entry.startTime.toFixed(2)) : null];
+                    })
+                );
 
-            const measureTimes = Object.fromEntries(
-                allMeasures
-                    .filter((entry) => entry.name.startsWith('quests:time-to-'))
-                    .map((entry) => [entry.name, Number(entry.duration.toFixed(2))])
-            );
+                const measureTimes = Object.fromEntries(
+                    allMeasures
+                        .filter((entry) => entry.name.startsWith('quests:time-to-'))
+                        .map((entry) => [entry.name, Number(entry.duration.toFixed(2))])
+                );
 
-            return { markTimes, measureTimes };
-        }, [...PERF_MARKS, ...OPTIONAL_PERF_MARKS]);
+                return { markTimes, measureTimes };
+            },
+            [...PERF_MARKS, ...OPTIONAL_PERF_MARKS]
+        );
 
         for (const markName of PERF_MARKS) {
             expect(metrics.markTimes[markName]).not.toBeNull();

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -6,8 +6,8 @@ const PERF_MARKS = [
     'quests:list-visible',
     'quests:snapshot-classification-ready',
     'quests:full-state-reconciliation-complete',
-    'quests:custom-quests-merge-complete',
 ];
+const OPTIONAL_PERF_MARKS = ['quests:custom-quests-merge-complete'];
 
 test.describe('quests performance marks', () => {
     test.beforeEach(async ({ page }) => {
@@ -35,6 +35,13 @@ test.describe('quests performance marks', () => {
         expect(loadedUrl.pathname).toBe('/quests');
         await expect(page.getByRole('heading', { name: 'Quests', exact: true })).toBeVisible();
         await expect(page.getByTestId('quests-grid')).toBeVisible();
+        await page.waitForFunction(
+            (requiredMarks) =>
+                requiredMarks.every((name) =>
+                    performance.getEntriesByName(name, 'mark').some(Boolean)
+                ),
+            PERF_MARKS
+        );
 
         const metrics = await page.evaluate((marks) => {
             const allMarks = performance.getEntriesByType('mark');
@@ -54,9 +61,9 @@ test.describe('quests performance marks', () => {
             );
 
             return { markTimes, measureTimes };
-        }, PERF_MARKS);
+        }, [...PERF_MARKS, ...OPTIONAL_PERF_MARKS]);
 
-        for (const markName of PERF_MARKS.slice(0, 4)) {
+        for (const markName of PERF_MARKS) {
             expect(metrics.markTimes[markName]).not.toBeNull();
         }
 

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+const PERF_MARKS = [
+    'quests:list-hydration-start',
+    'quests:list-visible',
+    'quests:snapshot-classification-ready',
+    'quests:full-state-reconciliation-complete',
+    'quests:custom-quests-merge-complete',
+];
+
+test.describe('quests performance marks', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('collects /quests user timing milestones', async ({ page, browserName, baseURL }) => {
+        test.skip(browserName !== 'chromium', 'Measurement harness is Chromium-focused');
+
+        const cpuSlowdown = Number(process.env.QUESTS_TTI_CPU_SLOWDOWN ?? '1');
+        if (cpuSlowdown > 1) {
+            const session = await page.context().newCDPSession(page);
+            await session.send('Emulation.setCPUThrottlingRate', { rate: cpuSlowdown });
+        }
+
+        await page.goto('/quests');
+        await page.waitForLoadState('networkidle');
+
+        const configuredBaseUrl =
+            process.env.QUESTS_PERF_BASE_URL || process.env.BASE_URL || baseURL || page.url();
+        const configuredOrigin = new URL(configuredBaseUrl).origin;
+        const loadedUrl = new URL(page.url());
+
+        expect(loadedUrl.origin).toBe(configuredOrigin);
+        expect(loadedUrl.pathname).toBe('/quests');
+        await expect(page.getByRole('heading', { name: 'Quests', exact: true })).toBeVisible();
+        await expect(page.getByTestId('quests-grid')).toBeVisible();
+
+        const metrics = await page.evaluate((marks) => {
+            const allMarks = performance.getEntriesByType('mark');
+            const allMeasures = performance.getEntriesByType('measure');
+
+            const markTimes = Object.fromEntries(
+                marks.map((name) => {
+                    const entry = allMarks.find((mark) => mark.name === name);
+                    return [name, entry ? Number(entry.startTime.toFixed(2)) : null];
+                })
+            );
+
+            const measureTimes = Object.fromEntries(
+                allMeasures
+                    .filter((entry) => entry.name.startsWith('quests:time-to-'))
+                    .map((entry) => [entry.name, Number(entry.duration.toFixed(2))])
+            );
+
+            return { markTimes, measureTimes };
+        }, PERF_MARKS);
+
+        for (const markName of PERF_MARKS.slice(0, 4)) {
+            expect(metrics.markTimes[markName]).not.toBeNull();
+        }
+
+        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+    });
+});

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -7,6 +7,7 @@ const PERF_MARKS = [
     'quests:snapshot-classification-ready',
     'quests:full-state-reconciliation-complete',
 ];
+// Intentionally not emitted on this baseline; kept for comparable JSON shape vs v3.0.1.
 const OPTIONAL_PERF_MARKS = ['quests:custom-quests-merge-complete'];
 
 test.describe('quests performance marks', () => {
@@ -28,6 +29,11 @@ test.describe('quests performance marks', () => {
 
         const configuredBaseUrl =
             process.env.QUESTS_PERF_BASE_URL || process.env.BASE_URL || baseURL || page.url();
+        if (!/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(configuredBaseUrl)) {
+            throw new Error(
+                `Invalid quests perf base URL "${configuredBaseUrl}": include scheme (e.g. http:// or https://).`
+            );
+        }
         const configuredOrigin = new URL(configuredBaseUrl).origin;
         const loadedUrl = new URL(page.url());
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,9 @@
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js",
-        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell"
+        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell",
+        "perf:quests": "npm run setup-test-env && node scripts/run-quests-perf.mjs",
+        "perf:quests:slowcpu": "npm run setup-test-env && cross-env QUESTS_TTI_CPU_SLOWDOWN=4 node scripts/run-quests-perf.mjs"
     },
     "devDependencies": {
         "@astrojs/svelte": "^6.0.0",

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -10,11 +10,6 @@ if (requestedBaseUrl) {
     baseEnv.REMOTE_SMOKE = '1';
 }
 
-const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
-if (cpuSlowdown) {
-    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
-}
-
 const frontendRoot = fileURLToPath(new URL('..', import.meta.url));
 
 const result = spawnSync(

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const baseEnv = { ...process.env };
 const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
@@ -14,11 +15,13 @@ if (cpuSlowdown) {
     baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
 }
 
+const frontendRoot = fileURLToPath(new URL('..', import.meta.url));
+
 const result = spawnSync(
     'playwright',
     ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
     {
-        cwd: new URL('..', import.meta.url),
+        cwd: frontendRoot,
         stdio: 'inherit',
         env: baseEnv,
         shell: true,

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const baseEnv = { ...process.env };
+const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
+
+if (requestedBaseUrl) {
+    baseEnv.BASE_URL = requestedBaseUrl;
+    baseEnv.REMOTE_SMOKE = '1';
+}
+
+const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
+if (cpuSlowdown) {
+    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
+}
+
+const result = spawnSync(
+    'playwright',
+    ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
+    {
+        cwd: new URL('..', import.meta.url),
+        stdio: 'inherit',
+        env: baseEnv,
+        shell: true,
+    }
+);
+
+if (typeof result.status === 'number') {
+    process.exit(result.status);
+}
+
+process.exit(1);

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -188,6 +188,7 @@ const TEST_GROUPS = [
     {
         name: 'Quest Tests',
         files: [
+            'quests-tti-metrics.spec.ts',
             'test-quest-chat.spec.ts',
             'custom-quest-chat.spec.ts',
             'tutorial-quest.spec.ts',

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -1,7 +1,7 @@
 <script>
     import Quest from './Quest.svelte';
     import Chip from '../../../components/svelte/Chip.svelte';
-    import { onDestroy, onMount } from 'svelte';
+    import { onDestroy, onMount, tick } from 'svelte';
     import { questFinished, canStartQuest } from '../../../utils/gameState.js';
     import { listCustomQuests } from '../../../utils/customcontent.js';
     import { loadGameState, state, ready } from '../../../utils/gameState/common.js';
@@ -15,6 +15,24 @@
     let normalizedCustomQuests = [];
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
+
+    const markPerf = (name) => {
+        if (typeof window === 'undefined' || typeof performance?.mark !== 'function') {
+            return;
+        }
+        performance.mark(name);
+    };
+
+    const measurePerf = (name, start, end) => {
+        if (typeof window === 'undefined' || typeof performance?.measure !== 'function') {
+            return;
+        }
+        try {
+            performance.measure(name, start, end);
+        } catch {
+            // no-op for missing marks
+        }
+    };
 
     const normalizeQuest = (entry) => {
         if (!entry) {
@@ -86,8 +104,25 @@
     };
 
     onMount(async () => {
+        markPerf('quests:list-hydration-start');
         await ready;
         mounted = true;
+        await tick();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        markPerf('quests:list-visible');
+        measurePerf(
+            'quests:time-to-list-visible',
+            'quests:list-hydration-start',
+            'quests:list-visible'
+        );
+
+        markPerf('quests:snapshot-classification-ready');
+        measurePerf(
+            'quests:time-to-snapshot-classification',
+            'quests:list-hydration-start',
+            'quests:snapshot-classification-ready'
+        );
+
         const initialState = loadGameState();
         showQuestGraphVisualizer = Boolean(initialState.settings?.showQuestGraphVisualizer);
 
@@ -101,6 +136,14 @@
         } catch (error) {
             console.error('Unable to load custom quests for listing:', error);
             customQuestRecords = [];
+        } finally {
+            await tick();
+            markPerf('quests:full-state-reconciliation-complete');
+            measurePerf(
+                'quests:time-to-full-reconciliation',
+                'quests:list-hydration-start',
+                'quests:full-state-reconciliation-complete'
+            );
         }
     });
 

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -14,6 +14,7 @@
     let normalizedBuiltInQuests = [];
     let normalizedCustomQuests = [];
     let showQuestGraphVisualizer = false;
+    let hasMarkedSnapshotClassification = false;
     let unsubscribeState;
 
     const markPerf = (name) => {
@@ -110,20 +111,12 @@
         void (async () => {
             await tick();
             await new Promise((resolve) => requestAnimationFrame(resolve));
+            // Baseline milestone: list has been rendered visibly (distinct from classification work).
             markPerf('quests:list-visible');
             measurePerf(
                 'quests:time-to-list-visible',
                 'quests:list-hydration-start',
                 'quests:list-visible'
-            );
-
-            // Baseline intentionally emits this alongside list-visible because there is
-            // no separate deferred snapshot classification phase in v3.
-            markPerf('quests:snapshot-classification-ready');
-            measurePerf(
-                'quests:time-to-snapshot-classification',
-                'quests:list-hydration-start',
-                'quests:snapshot-classification-ready'
             );
         })();
 
@@ -170,6 +163,15 @@
                 filteredQuests.push(quest);
             }
         });
+        if (!hasMarkedSnapshotClassification) {
+            hasMarkedSnapshotClassification = true;
+            markPerf('quests:snapshot-classification-ready');
+            measurePerf(
+                'quests:time-to-snapshot-classification',
+                'quests:list-hydration-start',
+                'quests:snapshot-classification-ready'
+            );
+        }
     }
 
     // Define buttons for easy expansion

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -107,21 +107,25 @@
         markPerf('quests:list-hydration-start');
         await ready;
         mounted = true;
-        await tick();
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        markPerf('quests:list-visible');
-        measurePerf(
-            'quests:time-to-list-visible',
-            'quests:list-hydration-start',
-            'quests:list-visible'
-        );
+        void (async () => {
+            await tick();
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            markPerf('quests:list-visible');
+            measurePerf(
+                'quests:time-to-list-visible',
+                'quests:list-hydration-start',
+                'quests:list-visible'
+            );
 
-        markPerf('quests:snapshot-classification-ready');
-        measurePerf(
-            'quests:time-to-snapshot-classification',
-            'quests:list-hydration-start',
-            'quests:snapshot-classification-ready'
-        );
+            // Baseline intentionally emits this alongside list-visible because there is
+            // no separate deferred snapshot classification phase in v3.
+            markPerf('quests:snapshot-classification-ready');
+            measurePerf(
+                'quests:time-to-snapshot-classification',
+                'quests:list-hydration-start',
+                'quests:snapshot-classification-ready'
+            );
+        })();
 
         const initialState = loadGameState();
         showQuestGraphVisualizer = Boolean(initialState.settings?.showQuestGraphVisualizer);


### PR DESCRIPTION
### Motivation
- Add only the minimal instrumentation and harness needed to measure `/quests` TTI on the v3.0.0 baseline so it can be compared to optimized `main` without backporting any optimization work.
- Preserve baseline behavior and UX while emitting the specific User Timing names required by QA so apples-to-apples comparisons are possible.

### Description
- Added a focused Playwright metrics spec at `frontend/e2e/quests-tti-metrics.spec.ts` that collects the required marks/measures and supports CPU slowdown via `QUESTS_TTI_CPU_SLOWDOWN` and optional `QUESTS_PERF_BASE_URL` wiring.
- Added a perf runner script at `frontend/scripts/run-quests-perf.mjs` that invokes the focused Chromium Playwright job with the above env wiring.
- Wired two frontend npm scripts in `frontend/package.json`: `perf:quests` and `perf:quests:slowcpu` to run the harness (`npm run setup-test-env && node scripts/run-quests-perf.mjs`).
- Inserted minimal User Timing instrumentation in the baseline list flow (`frontend/src/pages/quests/svelte/Quests.svelte`) to emit the required marks/measures without changing load order or implementing any of the optimizations from `main` (emitted marks: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`; emitted measures: `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`).
- Intentionally did not add the optional `quests:custom-quests-merge-complete`/`quests:time-to-custom-merge` because the baseline has no distinct deferred custom-merge phase; the harness tolerates that omission (it requires the first four marks).

### Testing
- Ran `npm install` successfully in this workspace and `npm --prefix frontend run setup-test-env` which completed and built the frontend artifacts successfully.
- Attempted `npm --prefix frontend run perf:quests` and `QUESTS_TTI_CPU_SLOWDOWN=4 npm --prefix frontend run perf:quests:slowcpu`, but both failed in this execution environment because Playwright browser/system dependencies could not be downloaded (network/apt reachability), so the Chromium test run could not start in-container.
- Ran `npm run lint` which surfaced environment-specific ESLint parser resolution errors (`@typescript-eslint/parser` not resolvable in this container) unrelated to the instrumentation changes.
- Ran `npm run type-check` which failed on a pre-existing TypeScript test typing error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` unrelated to this diff.
- Started `node run-tests.js` (full test harness) which began running but did not complete within the container execution window; this run was not blocked by the instrumentation changes.

Notes: To run the measurement locally/CI where network and Playwright browser install are available, use the new scripts: `npm --prefix frontend run perf:quests` and `npm --prefix frontend run perf:quests:slowcpu` (the latter sets `QUESTS_TTI_CPU_SLOWDOWN=4`). For staging deployment of an immutable baseline candidate use the repository's staging runbook, for example:
```
cd ~/sugarkube
just helm-oci-install \
  release=dspace namespace=dspace \
  chart=oci://ghcr.io/democratizedspace/charts/dspace \
  values=docs/examples/dspace.values.staging.yaml \
  version_file=docs/apps/dspace.version \
  default_tag=v3-REPLACE_SHORTSHA
```
Replace `REPLACE_SHORTSHA` with the published `v3-<shortsha>` tag; then verify with `curl -fsS https://staging.democratized.space/config.json` (see `docs/k3s-sugarkube-staging.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73f032120832fa66312c5f2eeb0cd)