### PR TITLE
📊 Backport /quests TTI measurement harness to quests-tti-baseline

### DIFF
--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+const PERF_MARKS = [
+    'quests:list-hydration-start',
+    'quests:list-visible',
+    'quests:snapshot-classification-ready',
+    'quests:full-state-reconciliation-complete',
+    'quests:custom-quests-merge-complete',
+];
+
+test.describe('quests performance marks', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('collects /quests user timing milestones', async ({ page, browserName, baseURL }) => {
+        test.skip(browserName !== 'chromium', 'Measurement harness is Chromium-focused');
+
+        const cpuSlowdown = Number(process.env.QUESTS_TTI_CPU_SLOWDOWN ?? '1');
+        if (cpuSlowdown > 1) {
+            const session = await page.context().newCDPSession(page);
+            await session.send('Emulation.setCPUThrottlingRate', { rate: cpuSlowdown });
+        }
+
+        await page.goto('/quests');
+        await page.waitForLoadState('networkidle');
+
+        const configuredBaseUrl =
+            process.env.QUESTS_PERF_BASE_URL || process.env.BASE_URL || baseURL || page.url();
+        const configuredOrigin = new URL(configuredBaseUrl).origin;
+        const loadedUrl = new URL(page.url());
+
+        expect(loadedUrl.origin).toBe(configuredOrigin);
+        expect(loadedUrl.pathname).toBe('/quests');
+        await expect(page.getByRole('heading', { name: 'Quests', exact: true })).toBeVisible();
+        await expect(page.getByTestId('quests-grid')).toBeVisible();
+
+        const metrics = await page.evaluate((marks) => {
+            const allMarks = performance.getEntriesByType('mark');
+            const allMeasures = performance.getEntriesByType('measure');
+
+            const markTimes = Object.fromEntries(
+                marks.map((name) => {
+                    const entry = allMarks.find((mark) => mark.name === name);
+                    return [name, entry ? Number(entry.startTime.toFixed(2)) : null];
+                })
+            );
+
+            const measureTimes = Object.fromEntries(
+                allMeasures
+                    .filter((entry) => entry.name.startsWith('quests:time-to-'))
+                    .map((entry) => [entry.name, Number(entry.duration.toFixed(2))])
+            );
+
+            return { markTimes, measureTimes };
+        }, PERF_MARKS);
+
+        for (const markName of PERF_MARKS.slice(0, 4)) {
+            expect(metrics.markTimes[markName]).not.toBeNull();
+        }
+
+        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+    });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,9 @@
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js",
-        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell"
+        "playwright:install": "playwright install --with-deps chromium chromium-headless-shell",
+        "perf:quests": "npm run setup-test-env && node scripts/run-quests-perf.mjs",
+        "perf:quests:slowcpu": "npm run setup-test-env && cross-env QUESTS_TTI_CPU_SLOWDOWN=4 node scripts/run-quests-perf.mjs"
     },
     "devDependencies": {
         "@astrojs/svelte": "^6.0.0",

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const baseEnv = { ...process.env };
+const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
+
+if (requestedBaseUrl) {
+    baseEnv.BASE_URL = requestedBaseUrl;
+    baseEnv.REMOTE_SMOKE = '1';
+}
+
+const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
+if (cpuSlowdown) {
+    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
+}
+
+const result = spawnSync(
+    'playwright',
+    ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
+    {
+        cwd: new URL('..', import.meta.url),
+        stdio: 'inherit',
+        env: baseEnv,
+        shell: true,
+    }
+);
+
+if (typeof result.status === 'number') {
+    process.exit(result.status);
+}
+
+process.exit(1);

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -1,7 +1,7 @@
 <script>
     import Quest from './Quest.svelte';
     import Chip from '../../../components/svelte/Chip.svelte';
-    import { onDestroy, onMount } from 'svelte';
+    import { onDestroy, onMount, tick } from 'svelte';
     import { questFinished, canStartQuest } from '../../../utils/gameState.js';
     import { listCustomQuests } from '../../../utils/customcontent.js';
     import { loadGameState, state, ready } from '../../../utils/gameState/common.js';
@@ -15,6 +15,23 @@
     let normalizedCustomQuests = [];
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
+    let didMarkSnapshotClassificationReady = false;
+    let didMarkFullReconciliation = false;
+    let customQuestsLoadSettled = false;
+
+    const markPerformance = (name) => {
+        if (typeof performance === 'undefined') {
+            return;
+        }
+        performance.mark(name);
+    };
+
+    const measurePerformance = (name, start, end) => {
+        if (typeof performance === 'undefined') {
+            return;
+        }
+        performance.measure(name, start, end);
+    };
 
     const normalizeQuest = (entry) => {
         if (!entry) {
@@ -86,8 +103,16 @@
     };
 
     onMount(async () => {
+        markPerformance('quests:list-hydration-start');
         await ready;
         mounted = true;
+        await tick();
+        markPerformance('quests:list-visible');
+        measurePerformance(
+            'quests:time-to-list-visible',
+            'quests:list-hydration-start',
+            'quests:list-visible'
+        );
         const initialState = loadGameState();
         showQuestGraphVisualizer = Boolean(initialState.settings?.showQuestGraphVisualizer);
 
@@ -98,9 +123,17 @@
         try {
             const questsFromStorage = await listCustomQuests();
             customQuestRecords = Array.isArray(questsFromStorage) ? questsFromStorage : [];
+            markPerformance('quests:custom-quests-merge-complete');
+            measurePerformance(
+                'quests:time-to-custom-merge',
+                'quests:list-hydration-start',
+                'quests:custom-quests-merge-complete'
+            );
         } catch (error) {
             console.error('Unable to load custom quests for listing:', error);
             customQuestRecords = [];
+        } finally {
+            customQuestsLoadSettled = true;
         }
     });
 
@@ -123,6 +156,30 @@
                 filteredQuests.push(quest);
             }
         });
+
+        if (!didMarkSnapshotClassificationReady) {
+            didMarkSnapshotClassificationReady = true;
+            markPerformance('quests:snapshot-classification-ready');
+            measurePerformance(
+                'quests:time-to-snapshot-classification',
+                'quests:list-hydration-start',
+                'quests:snapshot-classification-ready'
+            );
+        }
+
+        if (
+            didMarkSnapshotClassificationReady &&
+            !didMarkFullReconciliation &&
+            customQuestsLoadSettled
+        ) {
+            didMarkFullReconciliation = true;
+            markPerformance('quests:full-state-reconciliation-complete');
+            measurePerformance(
+                'quests:time-to-full-reconciliation',
+                'quests:list-hydration-start',
+                'quests:full-state-reconciliation-complete'
+            );
+        }
     }
 
     // Define buttons for easy expansion


### PR DESCRIPTION
### Motivation
- Provide a minimal, truthful measurement baseline so `/quests` TTI metrics can be collected and compared against the optimized `main` implementation without backporting any performance optimizations. 
- Instrumentation is measurement-only and emits QA-required names while avoiding any change to list rendering, snapshot-first behavior, classifier refactors, or custom-quest critical-path deferral.

### Description
- Backported the Playwright measurement spec as `frontend/e2e/quests-tti-metrics.spec.ts` and a runner script `frontend/scripts/run-quests-perf.mjs` to run the Chromium-focused perf test with optional `QUESTS_PERF_BASE_URL` and `QUESTS_TTI_CPU_SLOWDOWN` passthrough. 
- Added minimal npm script wiring in `frontend/package.json` (`perf:quests` and `perf:quests:slowcpu`) so the perf flow can be invoked with `npm --prefix frontend run perf:quests` and `npm --prefix frontend run perf:quests:slowcpu`. 
- Added small, local User Timing instrumentation to the baseline list flow in `frontend/src/pages/quests/svelte/Quests.svelte` that emits the required marks/measures `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete` and measures `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`, plus the optional `quests:custom-quests-merge-complete`/`quests:time-to-custom-merge` when custom quests are present; changed files: `frontend/e2e/quests-tti-metrics.spec.ts`, `frontend/scripts/run-quests-perf.mjs`, `frontend/package.json`, `frontend/src/pages/quests/svelte/Quests.svelte`. 
- To deploy the baseline candidate to staging use the existing sugarkube/helm runbook (replace `REPLACE_SHORTSHA` with the candidate immutable tag): `cd ~/sugarkube && just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=v3-REPLACE_SHORTSHA`.

### Testing
- `npm install` completed successfully in this environment. 
- `npm --prefix frontend run setup-test-env` completed and built Astro artifacts for test harness creation. 
- `npm --prefix frontend run perf:quests` and `QUESTS_TTI_CPU_SLOWDOWN=4 npm --prefix frontend run perf:quests:slowcpu` were exercised but failed to complete here because Playwright/Chromium system/browser downloads were blocked by network/apt reachability in this container (browsers could not be fetched), so the spec wiring ran but Chromium could not be launched. 
- `npm run lint` and `npm run type-check` were run and reported pre-existing environment/dependency and typing issues (missing parser resolution for ESLint and an existing TS tuple index error in tests) that are unrelated to the measurement backport.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73f032120832fa66312c5f2eeb0cd)