### PR TITLE
🧪 Backport /quests TTI measurement harness to baseline branch

### DIFF
--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { purgeClientState, waitForHydration } from './test-helpers';
+
+type PerfEntrySummary = {
+    name: string;
+    startTime: number;
+    duration: number;
+};
+
+const REQUIRED_MARKS = [
+    'quests:list-hydration-start',
+    'quests:list-visible',
+    'quests:snapshot-classification-ready',
+    'quests:full-state-reconciliation-complete',
+] as const;
+
+const REQUIRED_MEASURES = [
+    'quests:time-to-list-visible',
+    'quests:time-to-snapshot-classification',
+    'quests:time-to-full-reconciliation',
+] as const;
+
+function parseCpuSlowdownFromEnv(): number {
+    const rawValue = process.env.QUESTS_TTI_CPU_SLOWDOWN;
+    const parsed = Number(rawValue ?? '1');
+
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return 1;
+    }
+
+    return parsed;
+}
+
+test.describe('Quests TTI metrics', () => {
+    test.beforeEach(async ({ page }) => {
+        await purgeClientState(page);
+    });
+
+    test('captures required User Timing marks/measures for /quests', async ({
+        page,
+        browserName,
+    }) => {
+        test.skip(browserName !== 'chromium', 'CPU throttling harness targets chromium only.');
+
+        const cpuSlowdown = parseCpuSlowdownFromEnv();
+
+        if (cpuSlowdown > 1) {
+            const cdpSession = await page.context().newCDPSession(page);
+            await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: cpuSlowdown });
+        }
+
+        await page.goto('/quests');
+        await waitForHydration(page);
+        await expect(page.getByTestId('quests-grid')).toBeVisible();
+
+        await page.waitForFunction(
+            ({ requiredMarks, requiredMeasures }) => {
+                const hasMark = (name: string) =>
+                    performance.getEntriesByName(name, 'mark').length > 0;
+                const hasMeasure = (name: string) =>
+                    performance.getEntriesByName(name, 'measure').length > 0;
+
+                return (
+                    requiredMarks.every((name: string) => hasMark(name)) &&
+                    requiredMeasures.every((name: string) => hasMeasure(name))
+                );
+            },
+            {
+                requiredMarks: [...REQUIRED_MARKS],
+                requiredMeasures: [...REQUIRED_MEASURES],
+            }
+        );
+
+        const payload = await page.evaluate(
+            ({ requiredMarks, requiredMeasures, cpuSlowdown: rate }) => {
+                const marks = performance
+                    .getEntriesByType('mark')
+                    .filter((entry) => requiredMarks.includes(entry.name))
+                    .map((entry) => ({
+                        name: entry.name,
+                        startTime: entry.startTime,
+                        duration: entry.duration,
+                    }));
+
+                const measures = performance
+                    .getEntriesByType('measure')
+                    .filter((entry) => requiredMeasures.includes(entry.name))
+                    .map((entry) => ({
+                        name: entry.name,
+                        startTime: entry.startTime,
+                        duration: entry.duration,
+                    }));
+
+                return {
+                    url: window.location.href,
+                    cpuSlowdown: rate,
+                    marks,
+                    measures,
+                };
+            },
+            {
+                requiredMarks: [...REQUIRED_MARKS],
+                requiredMeasures: [...REQUIRED_MEASURES],
+                cpuSlowdown,
+            }
+        );
+
+        for (const markName of REQUIRED_MARKS) {
+            expect(payload.marks.some((mark) => mark.name === markName)).toBeTruthy();
+        }
+
+        for (const measureName of REQUIRED_MEASURES) {
+            const measure = payload.measures.find((entry) => entry.name === measureName);
+            expect(measure).toBeDefined();
+            expect(Number.isFinite(measure?.duration)).toBeTruthy();
+            expect((measure?.duration ?? -1) >= 0).toBeTruthy();
+        }
+
+        console.log(`QUESTS_TTI_METRICS ${JSON.stringify(payload)}`);
+    });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,8 @@
         "seed:custom": "node scripts/seed-custom-content.js",
         "benchmark:db": "node scripts/db-benchmark.js",
         "loadtest:custom-content": "node scripts/custom-content-load-test.js",
+        "perf:quests": "node scripts/run-quests-perf.mjs",
+        "perf:quests:slowcpu": "node scripts/run-quests-perf.mjs --slowcpu",
         "check": "npm run lint && npm run format:check",
         "sync": "node scripts/sync-package.js",
         "postinstall": "node scripts/postinstall.js",

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendDir = path.resolve(__dirname, '..');
+const playwrightCli = path.join(frontendDir, 'node_modules', '@playwright', 'test', 'cli.js');
+
+if (!fs.existsSync(playwrightCli)) {
+    console.error('Playwright CLI not found. Run npm install in frontend first.');
+    process.exit(1);
+}
+
+const cpuSlowdownFromEnv = Number(process.env.QUESTS_TTI_CPU_SLOWDOWN ?? '1');
+const hasSlowCpuFlag = process.argv.includes('--slowcpu');
+const cpuSlowdown =
+    Number.isFinite(cpuSlowdownFromEnv) && cpuSlowdownFromEnv > 0
+        ? cpuSlowdownFromEnv
+        : hasSlowCpuFlag
+          ? 4
+          : 1;
+
+const env = {
+    ...process.env,
+    QUESTS_TTI_CPU_SLOWDOWN: String(cpuSlowdown),
+};
+
+const args = [
+    playwrightCli,
+    'test',
+    'e2e/quests-tti-metrics.spec.ts',
+    '--project=chromium',
+    '--workers=1',
+    '--reporter=line',
+];
+
+console.log(`[quests-perf] Running with QUESTS_TTI_CPU_SLOWDOWN=${cpuSlowdown}`);
+
+const result = spawnSync(process.execPath, args, {
+    cwd: frontendDir,
+    env,
+    encoding: 'utf8',
+});
+
+if (result.stdout) {
+    process.stdout.write(result.stdout);
+}
+if (result.stderr) {
+    process.stderr.write(result.stderr);
+}
+
+const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+const metricsLine = output
+    .split(/\r?\n/)
+    .find((line) => line.trimStart().startsWith('QUESTS_TTI_METRICS '));
+
+if (metricsLine) {
+    const jsonPayload = metricsLine.trimStart().replace('QUESTS_TTI_METRICS ', '');
+
+    try {
+        const parsed = JSON.parse(jsonPayload);
+        const format = (value) => `${Math.round(value * 100) / 100}ms`;
+        const measures = Array.isArray(parsed?.measures) ? parsed.measures : [];
+
+        console.log('\n[quests-perf] Summary');
+        for (const entry of measures) {
+            console.log(`- ${entry.name}: ${format(entry.duration)}`);
+        }
+    } catch (error) {
+        console.warn('[quests-perf] Unable to parse metrics payload as JSON:', error);
+    }
+} else {
+    console.warn('[quests-perf] Metrics payload not found in Playwright output.');
+}
+
+if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+}

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -1,7 +1,7 @@
 <script>
     import Quest from './Quest.svelte';
     import Chip from '../../../components/svelte/Chip.svelte';
-    import { onDestroy, onMount } from 'svelte';
+    import { onDestroy, onMount, tick } from 'svelte';
     import { questFinished, canStartQuest } from '../../../utils/gameState.js';
     import { listCustomQuests } from '../../../utils/customcontent.js';
     import { loadGameState, state, ready } from '../../../utils/gameState/common.js';
@@ -15,6 +15,41 @@
     let normalizedCustomQuests = [];
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
+    let hasMarkedListVisible = false;
+    let hasMarkedReconciliation = false;
+    const emittedMarks = new Set();
+    const emittedMeasures = new Set();
+
+    const supportsPerformanceApi = typeof performance !== 'undefined';
+
+    const markOnce = (name) => {
+        if (!supportsPerformanceApi || emittedMarks.has(name)) {
+            return;
+        }
+
+        performance.mark(name);
+        emittedMarks.add(name);
+    };
+
+    const measureOnce = (name, startMark, endMark) => {
+        if (
+            !supportsPerformanceApi ||
+            emittedMeasures.has(name) ||
+            !emittedMarks.has(startMark) ||
+            !emittedMarks.has(endMark)
+        ) {
+            return;
+        }
+
+        performance.measure(name, startMark, endMark);
+        emittedMeasures.add(name);
+    };
+
+    const markListVisible = async () => {
+        await tick();
+        markOnce('quests:list-visible');
+        measureOnce('quests:time-to-list-visible', 'quests:list-hydration-start', 'quests:list-visible');
+    };
 
     const normalizeQuest = (entry) => {
         if (!entry) {
@@ -86,6 +121,7 @@
     };
 
     onMount(async () => {
+        markOnce('quests:list-hydration-start');
         await ready;
         mounted = true;
         const initialState = loadGameState();
@@ -123,6 +159,27 @@
                 filteredQuests.push(quest);
             }
         });
+
+        if (!hasMarkedReconciliation) {
+            hasMarkedReconciliation = true;
+            markOnce('quests:snapshot-classification-ready');
+            measureOnce(
+                'quests:time-to-snapshot-classification',
+                'quests:list-hydration-start',
+                'quests:snapshot-classification-ready'
+            );
+            markOnce('quests:full-state-reconciliation-complete');
+            measureOnce(
+                'quests:time-to-full-reconciliation',
+                'quests:list-hydration-start',
+                'quests:full-state-reconciliation-complete'
+            );
+        }
+    }
+
+    $: if (mounted && !hasMarkedListVisible) {
+        hasMarkedListVisible = true;
+        void markListVisible();
     }
 
     // Define buttons for easy expansion


### PR DESCRIPTION
### Motivation
- Provide a minimal, honest measurement baseline for `/quests` TTI so v3.0.0 can be compared against the optimized `main` without backporting any performance optimizations. 
- Keep changes narrowly scoped to instrumentation and harness wiring so baseline behavior/UX remains unchanged.

### Description
- Add a Playwright measurement spec at `frontend/e2e/quests-tti-metrics.spec.ts` that collects required User Timing marks/measures and emits a machine-readable `QUESTS_TTI_METRICS` payload. 
- Add a perf runner `frontend/scripts/run-quests-perf.mjs` to run the TTI spec with optional CPU slowdown propagation and a simple summary printer. 
- Wire two npm scripts in `frontend/package.json` (`perf:quests` and `perf:quests:slowcpu`) to run the perf harness. 
- Insert minimal, one-time User Timing instrumentation in `frontend/src/pages/quests/svelte/Quests.svelte` to emit the required marks/measures: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`, and the measures `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, and `quests:time-to-full-reconciliation`; the optional `custom-merge` timing is intentionally omitted because the baseline has no distinct merge phase.

### Testing
- `npm install` completed successfully in this environment. 
- `npm --prefix frontend run setup-test-env` completed successfully and built the Astro artifacts. 
- `npm --prefix frontend run perf:quests` (and `perf:quests:slowcpu`) attempted to run Playwright but failed in this environment because Playwright browser/system dependency installation and browser downloads were blocked by network (Playwright could not download Chromium), so the harness wiring is present but could not be executed end-to-end here. 
- `npm run lint` failed in this environment due to ESLint resolving issues (`@typescript-eslint/parser` resolution in this environment), and `npm run type-check` failed due to a pre-existing TypeScript test typing error unrelated to these changes; `node run-tests.js` also timed out in this environment while running the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73f032120832fa66312c5f2eeb0cd)