### PR TITLE
Defer /docs full-text corpus loading behind first keyword search

### DIFF
--- a/frontend/__tests__/DocsIndex.test.js
+++ b/frontend/__tests__/DocsIndex.test.js
@@ -34,7 +34,9 @@ const SECTIONS_FIXTURE = [
 
 describe('DocsIndex component', () => {
     it('renders an accessible search box for docs', () => {
-        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        render(DocsIndex, {
+            props: { sections: SECTIONS_FIXTURE, loadFullTextCorpus: async () => ({}) },
+        });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
@@ -43,7 +45,9 @@ describe('DocsIndex component', () => {
     });
 
     it('filters links using the search query', async () => {
-        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        render(DocsIndex, {
+            props: { sections: SECTIONS_FIXTURE, loadFullTextCorpus: async () => ({}) },
+        });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 

--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -13,11 +13,9 @@ describe('docs index.astro', () => {
         const sections = JSON.parse(fs.readFileSync(docsSectionsFile, 'utf8'));
         const content = fs.readFileSync(docsIndexFile, 'utf8');
 
-        // Using import assertions for JSON imports
-        expect(content).toMatch(
-            /import sections from '\.\/json\/sections\.json' assert { type: 'json' }/
-        );
+        expect(content).toMatch(/import sections from '\.\/json\/sections\.json';/);
         expect(content).toMatch(/sections\.map/);
+        expect(content).not.toMatch(/bodyText/);
 
         const allLinks = sections.flatMap((section) => section.links);
         const codexPromptLink = allLinks.find((link) => link.href === '/docs/prompts-codex');

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import DocsIndex from '../svelte/DocsIndex.svelte';
 
@@ -19,12 +19,14 @@ const SECTIONS_FIXTURE = [
                 href: '/docs/quest-guidelines',
                 keywords: ['quest'],
                 features: ['link'],
+                bodyText: 'Quest development starts with narrative goals.',
             },
             {
                 title: 'Quest Schema Requirements',
                 href: '/docs/quest-schema',
                 keywords: ['schema', 'quest'],
                 features: ['link', 'image'],
+                bodyText: 'Schema guides include image and link examples.',
             },
         ],
     },
@@ -41,7 +43,9 @@ describe('DocsIndex search operators', () => {
     });
 
     it('filters links using the search query', async () => {
-        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        render(DocsIndex, {
+            props: { sections: SECTIONS_FIXTURE, loadFullTextCorpus: async () => ({}) },
+        });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
@@ -56,7 +60,8 @@ describe('DocsIndex search operators', () => {
     });
 
     it('applies has:link operator filters', async () => {
-        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        const loadFullTextCorpus = vi.fn(async () => ({}));
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE, loadFullTextCorpus } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
@@ -64,10 +69,13 @@ describe('DocsIndex search operators', () => {
 
         expect(screen.getByRole('link', { name: 'About' })).not.toBeNull();
         expect(screen.queryByRole('link', { name: 'Mission' })).toBeNull();
+        expect(loadFullTextCorpus).not.toHaveBeenCalled();
     });
 
     it('combines text queries with has:image operator filters', async () => {
-        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        render(DocsIndex, {
+            props: { sections: SECTIONS_FIXTURE, loadFullTextCorpus: async () => ({}) },
+        });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
@@ -83,5 +91,33 @@ describe('DocsIndex search operators', () => {
                 name: 'Quest Development Guidelines',
             })
         ).toBeNull();
+    });
+
+    it('loads deferred full-text corpus once for keyword searches and reuses it', async () => {
+        const loadFullTextCorpus = vi.fn(async () => ({
+            '/docs/about': 'The mission includes turbine planning notes.',
+            '/docs/mission': 'Wind turbine output forecasts.',
+        }));
+        const sections = [
+            {
+                title: 'The basics',
+                links: [
+                    { title: 'About', href: '/docs/about', features: [] },
+                    { title: 'Mission', href: '/docs/mission', features: [] },
+                ],
+            },
+        ];
+        render(DocsIndex, { props: { sections, loadFullTextCorpus } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'turbine' } });
+
+        expect(loadFullTextCorpus).toHaveBeenCalledTimes(1);
+        expect(await screen.findByRole('link', { name: 'Mission' })).not.toBeNull();
+        expect(await screen.findByTitle(/wind turbine output forecasts/i)).not.toBeNull();
+
+        await fireEvent.input(searchBox, { target: { value: 'wind' } });
+        expect(loadFullTextCorpus).toHaveBeenCalledTimes(1);
+        expect(await screen.findByRole('link', { name: 'Mission' })).not.toBeNull();
     });
 });

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -19,8 +19,23 @@
 
     /** @type {DocsSection[]} */
     export let sections = [];
+    /** @type {() => Promise<Record<string, string>>} */
+    export let loadFullTextCorpus = async () => {
+        const response = await fetch('/docs/full-text-corpus.json');
+
+        if (!response.ok) {
+            throw new Error(`Failed to load docs full-text corpus (${response.status})`);
+        }
+
+        return response.json();
+    };
 
     let query = '';
+    /** @type {Record<string, string> | null} */
+    let fullTextCorpus = null;
+    let fullTextCorpusPromise = null;
+    let isLoadingFullTextCorpus = false;
+    let filteredSections = [];
 
     const normalize = (value) => value.toLowerCase().trim();
 
@@ -39,14 +54,49 @@
         return operators.every((operator) => normalizedFeatures.includes(operator));
     };
 
-    const matchLink = (link, parsedQuery) => {
+    const ensureFullTextCorpus = async () => {
+        if (fullTextCorpus) {
+            return fullTextCorpus;
+        }
+
+        if (!fullTextCorpusPromise) {
+            isLoadingFullTextCorpus = true;
+            fullTextCorpusPromise = loadFullTextCorpus()
+                .then((corpus) => {
+                    fullTextCorpus = corpus ?? {};
+                    return fullTextCorpus;
+                })
+                .catch((error) => {
+                    console.error('Failed to load docs full-text corpus', error);
+                    fullTextCorpus = {};
+                    return fullTextCorpus;
+                })
+                .finally(() => {
+                    isLoadingFullTextCorpus = false;
+                });
+        }
+
+        return fullTextCorpusPromise;
+    };
+
+    const getBodyText = (link, corpus = fullTextCorpus) => {
+        if (typeof link.bodyText === 'string') {
+            return link.bodyText;
+        }
+
+        if (!corpus) {
+            return '';
+        }
+
+        return corpus[normalize(link.href ?? '')] ?? '';
+    };
+
+    const matchLink = (link, parsedQuery, corpus = fullTextCorpus) => {
         if (!parsedQuery.operators.length && !parsedQuery.keywords.length) {
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), link.bodyText ?? ''].map(
-            normalize
-        );
+        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link, corpus)].map(normalize);
 
         return (
             matchesWords(parsedQuery.keywords, searchableValues) &&
@@ -55,20 +105,33 @@
     };
 
     $: parsedQuery = parseDocsQuery(query);
-    $: filteredSections = sections
-        .map((section) => ({
-            title: section.title,
-            links: section.links
-                .filter((link) => matchLink(link, parsedQuery))
-                .map((link) => ({
-                    ...link,
-                    snippet:
-                        parsedQuery.keywords.length && !parsedQuery.isHasPredicate
-                            ? findDocSnippet(link, parsedQuery.keywords)
-                            : null,
-                })),
-        }))
-        .filter((section) => section.links.length > 0);
+    $: if (parsedQuery.keywords.length > 0) {
+        void ensureFullTextCorpus();
+    }
+    $: {
+        const corpus = fullTextCorpus;
+
+        filteredSections = sections
+            .map((section) => ({
+                title: section.title,
+                links: section.links
+                    .filter((link) => matchLink(link, parsedQuery, corpus))
+                    .map((link) => ({
+                        ...link,
+                        snippet:
+                            parsedQuery.keywords.length && !parsedQuery.isHasPredicate
+                                ? findDocSnippet(
+                                      {
+                                          ...link,
+                                          bodyText: getBodyText(link, corpus),
+                                      },
+                                      parsedQuery.keywords
+                                  )
+                                : null,
+                    })),
+            }))
+            .filter((section) => section.links.length > 0);
+    }
 
     $: totalResults = filteredSections.reduce((count, section) => count + section.links.length, 0);
 </script>
@@ -83,7 +146,9 @@
         aria-label="Search docs"
     />
 
-    {#if parsedQuery.normalized && totalResults === 0}
+    {#if parsedQuery.keywords.length > 0 && isLoadingFullTextCorpus}
+        <p class="empty-state">Loading docs index…</p>
+    {:else if parsedQuery.normalized && totalResults === 0}
         <p class="empty-state">No docs found for "{query}".</p>
     {:else}
         <div class="docs-grid" data-testid="docs-grid">

--- a/frontend/src/pages/docs/full-text-corpus.json.ts
+++ b/frontend/src/pages/docs/full-text-corpus.json.ts
@@ -1,0 +1,87 @@
+import type { APIRoute } from 'astro';
+
+import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
+
+const docModules = import.meta.glob('./md/**/*.md', {
+    eager: true,
+});
+
+const normalizeHref = (value: string) => {
+    if (!value) {
+        return '';
+    }
+
+    const clean = value.split('#')[0].split('?')[0];
+
+    if (!clean.startsWith('/docs/')) {
+        return '';
+    }
+
+    return clean.replace(/\/?$/, '').toLowerCase();
+};
+
+const buildCorpus = async () => {
+    const entries = await Promise.all(
+        Object.values(docModules).map(async (doc) => {
+            const slug = String(
+                (doc as { frontmatter?: { slug?: string } })?.frontmatter?.slug ?? ''
+            )
+                .toLowerCase()
+                .trim();
+
+            if (!slug) {
+                return null;
+            }
+
+            const href = normalizeHref(`/docs/${slug}`);
+
+            if (!href) {
+                return null;
+            }
+
+            try {
+                let content = '';
+                const markdownDoc = doc as {
+                    rawContent?: () => Promise<string>;
+                    compiledContent?: () => Promise<string>;
+                };
+
+                if (typeof markdownDoc.rawContent === 'function') {
+                    content = await markdownDoc.rawContent();
+                } else if (typeof markdownDoc.compiledContent === 'function') {
+                    content = await markdownDoc.compiledContent();
+                }
+
+                return [href, stripMarkdownToText(content)];
+            } catch (error) {
+                console.error(`Failed to build docs full-text corpus for ${href}`, error);
+                return [href, ''];
+            }
+        })
+    );
+
+    return Object.fromEntries(
+        entries.filter((entry): entry is [string, string] => Array.isArray(entry))
+    );
+};
+
+let cachedCorpusPromise: Promise<Record<string, string>> | null = null;
+
+const getCorpus = () => {
+    if (!cachedCorpusPromise) {
+        cachedCorpusPromise = buildCorpus();
+    }
+
+    return cachedCorpusPromise;
+};
+
+export const GET: APIRoute = async () => {
+    const corpus = await getCorpus();
+
+    return new Response(JSON.stringify(corpus), {
+        headers: {
+            'content-type': 'application/json; charset=utf-8',
+            'cache-control': 'public, max-age=31536000, immutable',
+        },
+    });
+};

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -3,7 +3,6 @@ import Page from '../../components/Page.astro';
 import DocsIndex from '../../components/svelte/DocsIndex.svelte';
 import sections from './json/sections.json';
 import { detectDocFeatures } from '../../utils/docsSearchFeatures.js';
-import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../../utils/docsSkillsIndex.js';
 
 const docModules = await Astro.glob('./md/**/*.md');
@@ -32,7 +31,6 @@ const buildDocIndex = async () => {
                     slug,
                     {
                         features: detectDocFeatures(content),
-                        bodyText: stripMarkdownToText(content),
                     },
                 ];
             } catch (error) {
@@ -42,7 +40,7 @@ const buildDocIndex = async () => {
                     throw error;
                 }
 
-                return [slug, { features: [], bodyText: '' }];
+                return [slug, { features: [] }];
             }
         })
     );
@@ -87,7 +85,6 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
         const docData = docSearchIndex.get(tree) ?? null;
         const missingDoc = !docData;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
         if (missingDoc) {
             console.warn(`Quest tree '${tree}' is missing matching docs page at ${href}`);
@@ -98,7 +95,6 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
             href,
             keywords: missingDoc ? [tree, 'missing-doc'] : [tree],
             features,
-            bodyText,
         };
     });
 
@@ -119,9 +115,8 @@ const docsSections = sections.map((section) => ({
         const slug = getSlugFromHref(link.href);
         const docData = slug ? docSearchIndex.get(slug) ?? null : null;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
-        return { ...link, features, bodyText };
+        return { ...link, features };
     }),
 }));
 


### PR DESCRIPTION
### Motivation
- The `/docs` landing page currently ships full `bodyText` for every doc which inflates the initial payload and increases client-side hydration and per-keystroke work. 
- The change implements the minimal `v3.0.1` core from the design doc: ship a light browse payload and defer heavy full-text data until first keyword search. 
- Preserve existing search semantics and the `has:` operators while reducing initial cost and keeping SSR/offline friendliness.

### Description
- Stop attaching `bodyText` to the initial sections payload in `frontend/src/pages/docs/index.astro` and keep only metadata needed for browsing and `has:` filters (`title`, `href`, `keywords`, `features`).
- Add a same-origin deferred corpus endpoint at `frontend/src/pages/docs/full-text-corpus.json.ts` which returns a JSON object of normalized doc href → stripped body text and is memoized and served with long cache headers.
- Update `frontend/src/components/svelte/DocsIndex.svelte` to keep browse behavior unchanged, preserve `has:link`/`has:image` filtering without loading the corpus, lazily fetch and cache the corpus on the first non-empty keyword query, and then use the existing `findDocSnippet` logic for snippets once the corpus is available.
- Make minimal test and fixture changes to assert the new lazy-load contract (tests updated: `frontend/src/components/__tests__/DocsIndexSearch.spec.ts` and small adjustments to `frontend/__tests__/DocsIndex.test.js` and `frontend/__tests__/docsIndexPage.test.js`).

### Testing
- Ran link validation with `node scripts/link-check.mjs` and it succeeded. 
- Ran linting with `npm run lint` and it succeeded. 
- Built the site with `npm run build` and the build completed successfully. 
- Ran targeted unit/component tests with `npm run test:root -- frontend/src/components/__tests__/DocsIndexSearch.spec.ts frontend/__tests__/DocsIndex.test.js frontend/__tests__/docsIndexPage.test.js frontend/src/lib/__tests__/fullTextSearch.test.ts` and the updated docs-search tests passed. 
- `npm run type-check` surfaced an unrelated existing TypeScript test failure (`tests/runRemoteCompletionistAwardIIIResolver.test.ts`) so full type-check of the repo did not pass in this run. 
- E2E docs search (`cd frontend && npm run test:e2e -- e2e/docs-search.spec.ts`) was attempted but blocked in this environment due to Playwright browser download/network restrictions. 

Notes: the deferred corpus is located at `GET /docs/full-text-corpus.json` served by `frontend/src/pages/docs/full-text-corpus.json.ts` and has the shape `{ [normalizedDocsHref: string]: strippedBodyText }`; `has:` operator filtering continues to work from the initial light payload and does not trigger corpus load. Optional follow-ups from the design doc (workers, advanced index shaping, ranking changes) were intentionally not implemented in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d753430bf8832fa36c4d727b505072)