### PR TITLE
Split /docs browse payload from deferred full-text corpus

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -496,7 +496,7 @@ Local-mode validation status (March 20, 2026):
 - [x] Docs landing search filters the manifest-driven index ([<docs-search.spec.ts:filters docs list by query and resets on clear>](../../frontend/e2e/docs-search.spec.ts#L12-L31))
 - [x] Docs search supports `has:` feature operators such as `has:link` and `has:image`
       ([<docs-search.spec.ts:supports has: feature operators for docs content>](../../frontend/e2e/docs-search.spec.ts#L31-L46),
-      [<DocsIndexSearch.spec.ts:combines text queries with has:image operator filters>](../../frontend/src/components/__tests__/DocsIndexSearch.spec.ts#L69-L86),
+      [<DocsIndexSearch.spec.ts:combines text queries with has:image operator filters>](../../frontend/src/components/__tests__/DocsIndexSearch.spec.ts#L154-L179),
       [<docsSearchFeatures.test.ts:reflects features from representative doc content>](../../tests/docsSearchFeatures.test.ts#L6-L35))
 - [x] `/docs/changelog` highlights the latest release entry and anchor
       ([<docs-changelog.spec.ts:lists recent release entries>](../../frontend/e2e/docs-changelog.spec.ts#L136))

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -496,7 +496,7 @@ Local-mode validation status (March 20, 2026):
 - [x] Docs landing search filters the manifest-driven index ([<docs-search.spec.ts:filters docs list by query and resets on clear>](../../frontend/e2e/docs-search.spec.ts#L12-L31))
 - [x] Docs search supports `has:` feature operators such as `has:link` and `has:image`
       ([<docs-search.spec.ts:supports has: feature operators for docs content>](../../frontend/e2e/docs-search.spec.ts#L31-L46),
-      [<DocsIndexSearch.spec.ts:combines text queries with has:image operator filters>](../../frontend/src/components/__tests__/DocsIndexSearch.spec.ts#L154-L179),
+      [<DocsIndexSearch.spec.ts:combines text queries with has:image operator filters>](../../frontend/src/components/__tests__/DocsIndexSearch.spec.ts#L223-L248),
       [<docsSearchFeatures.test.ts:reflects features from representative doc content>](../../tests/docsSearchFeatures.test.ts#L6-L35))
 - [x] `/docs/changelog` highlights the latest release entry and anchor
       ([<docs-changelog.spec.ts:lists recent release entries>](../../frontend/e2e/docs-changelog.spec.ts#L136))

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -125,6 +125,31 @@ describe('DocsIndex search operators', () => {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('uses cached body text immediately for later keyword searches', async () => {
+        const fetchSpy = vi.fn().mockImplementation(() =>
+            createFetchResponse({
+                'quest-guidelines': 'Cached turbine guidance for docs search.',
+            })
+        );
+        vi.stubGlobal('fetch', fetchSpy);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'cached' } });
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await fireEvent.input(searchBox, { target: { value: 'guidance' } });
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('retries corpus loading after an initial fetch failure', async () => {
         const fetchSpy = vi
             .fn()
@@ -149,6 +174,50 @@ describe('DocsIndex search operators', () => {
             await screen.findByRole('link', { name: 'Quest Development Guidelines' })
         ).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats non-ok corpus responses as retryable failures', async () => {
+        const fetchSpy = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 503,
+                json: () => Promise.resolve({ bodyBySlug: {} }),
+            })
+            .mockImplementationOnce(() =>
+                createFetchResponse({
+                    'quest-guidelines': 'Recovered corpus content after retry.',
+                })
+            );
+        vi.stubGlobal('fetch', fetchSpy);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'recoveredx' } });
+        expect(screen.queryByRole('link', { name: 'Quest Development Guidelines' })).toBeNull();
+
+        await fireEvent.input(searchBox, { target: { value: 'has:link' } });
+        await fireEvent.input(searchBox, { target: { value: 'recovered' } });
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips corpus fetch when fetch is unavailable in the runtime', async () => {
+        vi.stubGlobal('fetch', undefined);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'playbooks' } });
+
+        expect(screen.getByText('No docs found for "playbooks".')).not.toBeNull();
+
+        await fireEvent.input(searchBox, { target: { value: 'playbooks again' } });
+        expect(screen.getByText('No docs found for "playbooks again".')).not.toBeNull();
     });
 
     it('combines text queries with has:image operator filters', async () => {

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -45,6 +45,18 @@ describe('DocsIndex search operators', () => {
         vi.stubGlobal('fetch', vi.fn().mockImplementation(() => createFetchResponse()));
     });
 
+    it('renders default browse view from lightweight payload without fetching corpus', () => {
+        const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        expect(screen.getByRole('link', { name: 'About' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Mission' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Quest Schema Requirements' })).not.toBeNull();
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -83,13 +95,13 @@ describe('DocsIndex search operators', () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('loads deferred corpus on first keyword query and reuses it', async () => {
-        const fetchSpy = vi.fn().mockImplementation(
-            () =>
-                createFetchResponse({
-                    'quest-guidelines': 'Playbooks include turbine setup and validation.',
-                    'quest-schema': 'Schema docs describe quest image metadata.',
-                })
+    it('loads deferred corpus once and reuses it for subsequent keyword searches', async () => {
+        const fetchSpy = vi.fn().mockImplementation(() =>
+            createFetchResponse({
+                'quest-guidelines': 'Playbooks include turbine setup and after-action validation.',
+                'quest-schema':
+                    'Schema docs describe quest image metadata and docssearchsnippettokenwithoutbreakpoints.',
+            })
         );
         vi.stubGlobal('fetch', fetchSpy);
 
@@ -98,16 +110,11 @@ describe('DocsIndex search operators', () => {
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
         await fireEvent.input(searchBox, { target: { value: 'turbine' } });
-
-        expect(
-            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
-        ).not.toBeNull();
+        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-        await fireEvent.input(searchBox, { target: { value: 'schema' } });
-        expect(
-            await screen.findByRole('link', { name: 'Quest Schema Requirements' })
-        ).not.toBeNull();
+        await fireEvent.input(searchBox, { target: { value: 'after-action' } });
+        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -136,12 +143,11 @@ describe('DocsIndex search operators', () => {
     });
 
     it('combines text queries with has:image operator filters', async () => {
-        const fetchSpy = vi.fn().mockImplementation(
-            () =>
-                createFetchResponse({
-                    'quest-guidelines': 'Quest development procedures.',
-                    'quest-schema': 'Quest schema includes image requirements.',
-                })
+        const fetchSpy = vi.fn().mockImplementation(() =>
+            createFetchResponse({
+                'quest-guidelines': 'Quest development procedures.',
+                'quest-schema': 'Quest schema includes image requirements.',
+            })
         );
         vi.stubGlobal('fetch', fetchSpy);
 
@@ -182,6 +188,29 @@ describe('DocsIndex search operators', () => {
 
         await waitFor(() => expect(container.querySelector('.doc-snippet')).not.toBeNull());
         const snippet = container.querySelector('.doc-snippet');
-        expect(snippet.textContent?.toLowerCase()).toContain('playbooks');
+        expect(snippet?.textContent?.toLowerCase()).toContain('playbooks');
+    });
+
+    it('preserves long-token snippet behavior after deferred corpus loading', async () => {
+        const longToken = 'docssearchsnippettokenwithoutbreakpoints1234567890abcdefghijklmnopqrstuvwxyz';
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockImplementation(() =>
+                createFetchResponse({
+                    'quest-schema': `Token coverage ${longToken} remains visible in snippets.`,
+                })
+            )
+        );
+
+        const { container } = render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'docssearchsnippettokenwithoutbreakpoints' } });
+
+        await waitFor(() => expect(container.querySelector('.doc-snippet')).not.toBeNull());
+        const snippet = container.querySelector('.doc-snippet');
+        expect(snippet?.getAttribute('title')).toContain(longToken);
+        expect(snippet?.textContent).toContain('docssearchsnippettokenwithoutbreakpoints');
     });
 });

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DocsIndex from '../svelte/DocsIndex.svelte';
 
@@ -17,12 +17,14 @@ const SECTIONS_FIXTURE = [
             {
                 title: 'Quest Development Guidelines',
                 href: '/docs/quest-guidelines',
-                keywords: ['quest'],
+                slug: 'quest-guidelines',
+                keywords: ['quest', 'turbine'],
                 features: ['link'],
             },
             {
                 title: 'Quest Schema Requirements',
                 href: '/docs/quest-schema',
+                slug: 'quest-schema',
                 keywords: ['schema', 'quest'],
                 features: ['link', 'image'],
             },
@@ -30,7 +32,18 @@ const SECTIONS_FIXTURE = [
     },
 ];
 
+const createFetchResponse = (bodyBySlug = {}) =>
+    Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ bodyBySlug }),
+    });
+
 describe('DocsIndex search operators', () => {
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -56,6 +69,9 @@ describe('DocsIndex search operators', () => {
     });
 
     it('applies has:link operator filters', async () => {
+        const fetchSpy = vi.fn().mockImplementation(() => createFetchResponse());
+        vi.stubGlobal('fetch', fetchSpy);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
@@ -64,9 +80,47 @@ describe('DocsIndex search operators', () => {
 
         expect(screen.getByRole('link', { name: 'About' })).not.toBeNull();
         expect(screen.queryByRole('link', { name: 'Mission' })).toBeNull();
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('loads deferred corpus on first keyword query and reuses it', async () => {
+        const fetchSpy = vi.fn().mockImplementation(
+            () =>
+                createFetchResponse({
+                    'quest-guidelines': 'Playbooks include turbine setup and validation.',
+                    'quest-schema': 'Schema docs describe quest image metadata.',
+                })
+        );
+        vi.stubGlobal('fetch', fetchSpy);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'turbine' } });
+
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await fireEvent.input(searchBox, { target: { value: 'schema' } });
+        expect(
+            await screen.findByRole('link', { name: 'Quest Schema Requirements' })
+        ).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
     it('combines text queries with has:image operator filters', async () => {
+        const fetchSpy = vi.fn().mockImplementation(
+            () =>
+                createFetchResponse({
+                    'quest-guidelines': 'Quest development procedures.',
+                    'quest-schema': 'Quest schema includes image requirements.',
+                })
+        );
+        vi.stubGlobal('fetch', fetchSpy);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -42,7 +42,10 @@ describe('DocsIndex search operators', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
-        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => createFetchResponse()));
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockImplementation(() => createFetchResponse())
+        );
     });
 
     it('renders default browse view from lightweight payload without fetching corpus', () => {
@@ -110,11 +113,15 @@ describe('DocsIndex search operators', () => {
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
         await fireEvent.input(searchBox, { target: { value: 'turbine' } });
-        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
 
         await fireEvent.input(searchBox, { target: { value: 'after-action' } });
-        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -138,7 +145,9 @@ describe('DocsIndex search operators', () => {
 
         await fireEvent.input(searchBox, { target: { value: 'has:link' } });
         await fireEvent.input(searchBox, { target: { value: 'playbooks' } });
-        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
+        expect(
+            await screen.findByRole('link', { name: 'Quest Development Guidelines' })
+        ).not.toBeNull();
         expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -192,7 +201,8 @@ describe('DocsIndex search operators', () => {
     });
 
     it('preserves long-token snippet behavior after deferred corpus loading', async () => {
-        const longToken = 'docssearchsnippettokenwithoutbreakpoints1234567890abcdefghijklmnopqrstuvwxyz';
+        const longToken =
+            'docssearchsnippettokenwithoutbreakpoints1234567890abcdefghijklmnopqrstuvwxyz';
 
         vi.stubGlobal(
             'fetch',
@@ -206,7 +216,9 @@ describe('DocsIndex search operators', () => {
         const { container } = render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
-        await fireEvent.input(searchBox, { target: { value: 'docssearchsnippettokenwithoutbreakpoints' } });
+        await fireEvent.input(searchBox, {
+            target: { value: 'docssearchsnippettokenwithoutbreakpoints' },
+        });
 
         await waitFor(() => expect(container.querySelector('.doc-snippet')).not.toBeNull());
         const snippet = container.querySelector('.doc-snippet');

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DocsIndex from '../svelte/DocsIndex.svelte';
@@ -40,8 +40,9 @@ const createFetchResponse = (bodyBySlug = {}) =>
 
 describe('DocsIndex search operators', () => {
     beforeEach(() => {
-        vi.unstubAllGlobals();
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(() => createFetchResponse()));
     });
 
     it('renders an accessible search box for docs', () => {
@@ -69,8 +70,7 @@ describe('DocsIndex search operators', () => {
     });
 
     it('applies has:link operator filters', async () => {
-        const fetchSpy = vi.fn().mockImplementation(() => createFetchResponse());
-        vi.stubGlobal('fetch', fetchSpy);
+        const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
 
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -111,6 +111,30 @@ describe('DocsIndex search operators', () => {
         expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('retries corpus loading after an initial fetch failure', async () => {
+        const fetchSpy = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('temporary failure'))
+            .mockImplementationOnce(() =>
+                createFetchResponse({
+                    'quest-guidelines': 'Playbooks include turbine setup and validation.',
+                })
+            );
+        vi.stubGlobal('fetch', fetchSpy);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'playbooksx' } });
+        expect(screen.queryByRole('link', { name: 'Quest Development Guidelines' })).toBeNull();
+
+        await fireEvent.input(searchBox, { target: { value: 'has:link' } });
+        await fireEvent.input(searchBox, { target: { value: 'playbooks' } });
+        expect(await screen.findByRole('link', { name: 'Quest Development Guidelines' })).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
     it('combines text queries with has:image operator filters', async () => {
         const fetchSpy = vi.fn().mockImplementation(
             () =>
@@ -137,5 +161,27 @@ describe('DocsIndex search operators', () => {
                 name: 'Quest Development Guidelines',
             })
         ).toBeNull();
+    });
+
+    it('shows snippets for mixed keyword and has: queries', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockImplementation(() =>
+                createFetchResponse({
+                    'quest-guidelines':
+                        'Quest playbooks include turbine setup and guided link collections.',
+                })
+            )
+        );
+
+        const { container } = render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'playbooks has:link' } });
+
+        await waitFor(() => expect(container.querySelector('.doc-snippet')).not.toBeNull());
+        const snippet = container.querySelector('.doc-snippet');
+        expect(snippet.textContent?.toLowerCase()).toContain('playbooks');
     });
 });

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -93,9 +93,11 @@
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link, bodyBySlug)].map(
-            normalize
-        );
+        const searchableValues = [
+            link.title,
+            ...(link.keywords ?? []),
+            getBodyText(link, bodyBySlug),
+        ].map(normalize);
 
         return (
             matchesWords(parsedQuery.keywords, searchableValues) &&
@@ -116,16 +118,15 @@
                 .filter((link) => matchLink(link, parsedQuery, bodyTextBySlug))
                 .map((link) => ({
                     ...link,
-                    snippet:
-                        parsedQuery.keywords.length
-                            ? findDocSnippet(
-                                  {
-                                      ...link,
-                                      bodyText: getBodyText(link, bodyTextBySlug),
-                                  },
-                                  parsedQuery.keywords
-                              )
-                            : null,
+                    snippet: parsedQuery.keywords.length
+                        ? findDocSnippet(
+                              {
+                                  ...link,
+                                  bodyText: getBodyText(link, bodyTextBySlug),
+                              },
+                              parsedQuery.keywords
+                          )
+                        : null,
                 })),
         }))
         .filter((section) => section.links.length > 0);

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -43,12 +43,12 @@
         return operators.every((operator) => normalizedFeatures.includes(operator));
     };
 
-    const getBodyText = (link) => {
-        if (!bodyTextBySlug || !link.slug) {
+    const getBodyText = (link, bodyBySlug = bodyTextBySlug) => {
+        if (!bodyBySlug || !link.slug) {
             return '';
         }
 
-        return bodyTextBySlug[link.slug] ?? '';
+        return bodyBySlug[link.slug] ?? '';
     };
 
     const loadDeferredCorpus = async () => {
@@ -76,8 +76,9 @@
                     return bodyTextBySlug;
                 })
                 .catch(() => {
-                    bodyTextBySlug = {};
-                    return bodyTextBySlug;
+                    bodyTextBySlug = null;
+                    deferredCorpusPromise = null;
+                    return {};
                 })
                 .finally(() => {
                     isLoadingCorpus = false;
@@ -87,12 +88,12 @@
         return deferredCorpusPromise;
     };
 
-    const matchLink = (link, parsedQuery) => {
+    const matchLink = (link, parsedQuery, bodyBySlug) => {
         if (!parsedQuery.operators.length && !parsedQuery.keywords.length) {
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link)].map(
+        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link, bodyBySlug)].map(
             normalize
         );
 
@@ -112,15 +113,15 @@
         .map((section) => ({
             title: section.title,
             links: section.links
-                .filter((link) => matchLink(link, parsedQuery))
+                .filter((link) => matchLink(link, parsedQuery, bodyTextBySlug))
                 .map((link) => ({
                     ...link,
                     snippet:
-                        parsedQuery.keywords.length && !parsedQuery.isHasPredicate
+                        parsedQuery.keywords.length
                             ? findDocSnippet(
                                   {
                                       ...link,
-                                      bodyText: getBodyText(link),
+                                      bodyText: getBodyText(link, bodyTextBySlug),
                                   },
                                   parsedQuery.keywords
                               )

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -3,10 +3,10 @@
      * @typedef {Object} DocLink
      * @property {string} title
      * @property {string} href
+     * @property {string=} slug
      * @property {string[]=} keywords
      * @property {boolean=} external
      * @property {string[]=} features
-     * @property {string=} bodyText
      */
 
     /**
@@ -19,8 +19,12 @@
 
     /** @type {DocsSection[]} */
     export let sections = [];
+    export let deferredCorpusHref = '/docs/full-text-corpus.json';
 
     let query = '';
+    let bodyTextBySlug = null;
+    let deferredCorpusPromise = null;
+    let isLoadingCorpus = false;
 
     const normalize = (value) => value.toLowerCase().trim();
 
@@ -39,12 +43,56 @@
         return operators.every((operator) => normalizedFeatures.includes(operator));
     };
 
+    const getBodyText = (link) => {
+        if (!bodyTextBySlug || !link.slug) {
+            return '';
+        }
+
+        return bodyTextBySlug[link.slug] ?? '';
+    };
+
+    const loadDeferredCorpus = async () => {
+        if (bodyTextBySlug) {
+            return bodyTextBySlug;
+        }
+
+        if (typeof fetch !== 'function') {
+            bodyTextBySlug = {};
+            return bodyTextBySlug;
+        }
+
+        if (!deferredCorpusPromise) {
+            isLoadingCorpus = true;
+            deferredCorpusPromise = fetch(deferredCorpusHref)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(`Failed to load docs search corpus (${response.status})`);
+                    }
+
+                    return response.json();
+                })
+                .then((payload) => {
+                    bodyTextBySlug = payload?.bodyBySlug ?? {};
+                    return bodyTextBySlug;
+                })
+                .catch(() => {
+                    bodyTextBySlug = {};
+                    return bodyTextBySlug;
+                })
+                .finally(() => {
+                    isLoadingCorpus = false;
+                });
+        }
+
+        return deferredCorpusPromise;
+    };
+
     const matchLink = (link, parsedQuery) => {
         if (!parsedQuery.operators.length && !parsedQuery.keywords.length) {
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), link.bodyText ?? ''].map(
+        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link)].map(
             normalize
         );
 
@@ -55,6 +103,11 @@
     };
 
     $: parsedQuery = parseDocsQuery(query);
+    $: hasKeywordQuery = parsedQuery.keywords.length > 0;
+    $: if (hasKeywordQuery) {
+        loadDeferredCorpus();
+    }
+
     $: filteredSections = sections
         .map((section) => ({
             title: section.title,
@@ -64,7 +117,13 @@
                     ...link,
                     snippet:
                         parsedQuery.keywords.length && !parsedQuery.isHasPredicate
-                            ? findDocSnippet(link, parsedQuery.keywords)
+                            ? findDocSnippet(
+                                  {
+                                      ...link,
+                                      bodyText: getBodyText(link),
+                                  },
+                                  parsedQuery.keywords
+                              )
                             : null,
                 })),
         }))
@@ -83,7 +142,9 @@
         aria-label="Search docs"
     />
 
-    {#if parsedQuery.normalized && totalResults === 0}
+    {#if isLoadingCorpus && hasKeywordQuery && !bodyTextBySlug}
+        <p class="empty-state" role="status">Loading docs search index…</p>
+    {:else if parsedQuery.normalized && totalResults === 0}
         <p class="empty-state">No docs found for "{query}".</p>
     {:else}
         <div class="docs-grid" data-testid="docs-grid">

--- a/frontend/src/pages/docs/__tests__/index.spec.ts
+++ b/frontend/src/pages/docs/__tests__/index.spec.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const docsIndexFile = path.join(process.cwd(), 'frontend/src/pages/docs/index.astro');
+
+describe('/docs index page payload shape', () => {
+    it('keeps initial sections payload lightweight and points to deferred corpus', () => {
+        const content = fs.readFileSync(docsIndexFile, 'utf8');
+
+        expect(content).toContain('return { ...link, slug, features };');
+        expect(content).toContain('deferredCorpusHref="/docs/full-text-corpus.json"');
+        expect(content).not.toContain('bodyText');
+    });
+});

--- a/frontend/src/pages/docs/__tests__/index.spec.ts
+++ b/frontend/src/pages/docs/__tests__/index.spec.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import DocsIndex from '../../../components/svelte/DocsIndex.svelte';
 
 const docsIndexFile = path.join(process.cwd(), 'frontend/src/pages/docs/index.astro');
 
@@ -8,8 +11,34 @@ describe('/docs index page payload shape', () => {
     it('keeps initial sections payload lightweight and points to deferred corpus', () => {
         const content = fs.readFileSync(docsIndexFile, 'utf8');
 
-        expect(content).toMatch(/return\s*\{\s*\.\.\.link,\s*slug,\s*features\s*\};/);
         expect(content).toMatch(/deferredCorpusHref\s*=\s*["']\/docs\/full-text-corpus\.json["']/);
-        expect(content).not.toMatch(/return\s*\{[^}]*\bbodyText\b[^}]*\};/s);
+        expect(content).toMatch(/return\s*\{\s*\.\.\.link,\s*slug,\s*features\s*\};/);
+        expect(content).not.toMatch(/\bbodyText\s*:/);
+    });
+
+    it('renders and filters lightweight section links without bodyText in the initial payload', async () => {
+        const fetchSpy = vi.fn();
+        vi.stubGlobal('fetch', fetchSpy);
+
+        render(DocsIndex, {
+            props: {
+                sections: [
+                    {
+                        title: 'Docs',
+                        links: [
+                            { title: 'About', href: '/docs/about', features: ['link'] },
+                            { title: 'Mission', href: '/docs/mission', features: [] },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'has:link' } });
+
+        expect(screen.getByRole('link', { name: 'About' })).not.toBeNull();
+        expect(screen.queryByRole('link', { name: 'Mission' })).toBeNull();
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/pages/docs/__tests__/index.spec.ts
+++ b/frontend/src/pages/docs/__tests__/index.spec.ts
@@ -8,8 +8,8 @@ describe('/docs index page payload shape', () => {
     it('keeps initial sections payload lightweight and points to deferred corpus', () => {
         const content = fs.readFileSync(docsIndexFile, 'utf8');
 
-        expect(content).toContain('return { ...link, slug, features };');
-        expect(content).toContain('deferredCorpusHref="/docs/full-text-corpus.json"');
-        expect(content).not.toContain('bodyText');
+        expect(content).toMatch(/return\s*\{\s*\.\.\.link,\s*slug,\s*features\s*\};/);
+        expect(content).toMatch(/deferredCorpusHref\s*=\s*["']\/docs\/full-text-corpus\.json["']/);
+        expect(content).not.toMatch(/return\s*\{[^}]*\bbodyText\b[^}]*\};/s);
     });
 });

--- a/frontend/src/pages/docs/full-text-corpus.json.ts
+++ b/frontend/src/pages/docs/full-text-corpus.json.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro';
 import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
 
 const docModules = import.meta.glob('./md/**/*.md');
+let memoizedBodyBySlugPromise: Promise<Record<string, string>> | null = null;
 
 const readDocBodyBySlug = async () => {
     const entries = await Promise.all(
@@ -21,6 +22,8 @@ const readDocBodyBySlug = async () => {
                     content = await doc.rawContent();
                 } else if (typeof doc.compiledContent === 'function') {
                     content = await doc.compiledContent();
+                } else {
+                    throw new Error(`No supported content loader found for doc slug ${slug}`);
                 }
 
                 return [slug, stripMarkdownToText(content)];
@@ -39,8 +42,23 @@ const readDocBodyBySlug = async () => {
     return Object.fromEntries(entries.filter((entry) => Array.isArray(entry)));
 };
 
+const getBodyBySlug = async () => {
+    if (import.meta.env?.DEV) {
+        return readDocBodyBySlug();
+    }
+
+    if (!memoizedBodyBySlugPromise) {
+        memoizedBodyBySlugPromise = readDocBodyBySlug().catch((error) => {
+            memoizedBodyBySlugPromise = null;
+            throw error;
+        });
+    }
+
+    return memoizedBodyBySlugPromise;
+};
+
 export const GET: APIRoute = async () => {
-    const bodyBySlug = await readDocBodyBySlug();
+    const bodyBySlug = await getBodyBySlug();
 
     return new Response(JSON.stringify({ bodyBySlug }), {
         headers: {

--- a/frontend/src/pages/docs/full-text-corpus.json.ts
+++ b/frontend/src/pages/docs/full-text-corpus.json.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+
+import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
+
+const docModules = import.meta.glob('./md/**/*.md');
+
+const readDocBodyBySlug = async () => {
+    const entries = await Promise.all(
+        Object.values(docModules).map(async (loadModule) => {
+            const doc = await loadModule();
+            const slug = String(doc?.frontmatter?.slug ?? '').toLowerCase();
+
+            if (!slug) {
+                return null;
+            }
+
+            try {
+                let content = '';
+
+                if (typeof doc.rawContent === 'function') {
+                    content = await doc.rawContent();
+                } else if (typeof doc.compiledContent === 'function') {
+                    content = await doc.compiledContent();
+                }
+
+                return [slug, stripMarkdownToText(content)];
+            } catch (error) {
+                console.error(`Failed to build docs full-text corpus for doc slug ${slug}`, error);
+
+                if (import.meta.env?.DEV) {
+                    throw error;
+                }
+
+                return [slug, ''];
+            }
+        })
+    );
+
+    return Object.fromEntries(entries.filter((entry) => Array.isArray(entry)));
+};
+
+export const GET: APIRoute = async () => {
+    const bodyBySlug = await readDocBodyBySlug();
+
+    return new Response(JSON.stringify({ bodyBySlug }), {
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600',
+        },
+    });
+};

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -3,7 +3,6 @@ import Page from '../../components/Page.astro';
 import DocsIndex from '../../components/svelte/DocsIndex.svelte';
 import sections from './json/sections.json';
 import { detectDocFeatures } from '../../utils/docsSearchFeatures.js';
-import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../../utils/docsSkillsIndex.js';
 
 const docModules = await Astro.glob('./md/**/*.md');
@@ -28,13 +27,7 @@ const buildDocIndex = async () => {
                     throw new Error(`No content loader found for doc slug ${slug}`);
                 }
 
-                return [
-                    slug,
-                    {
-                        features: detectDocFeatures(content),
-                        bodyText: stripMarkdownToText(content),
-                    },
-                ];
+                return [slug, { features: detectDocFeatures(content) }];
             } catch (error) {
                 console.error(`Failed to build doc search data for doc slug ${slug}`, error);
 
@@ -42,7 +35,7 @@ const buildDocIndex = async () => {
                     throw error;
                 }
 
-                return [slug, { features: [], bodyText: '' }];
+                return [slug, { features: [] }];
             }
         })
     );
@@ -87,7 +80,6 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
         const docData = docSearchIndex.get(tree) ?? null;
         const missingDoc = !docData;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
         if (missingDoc) {
             console.warn(`Quest tree '${tree}' is missing matching docs page at ${href}`);
@@ -96,9 +88,9 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
         return {
             title: TITLE_OVERRIDES[tree] ?? toTitleCase(tree),
             href,
+            slug: tree,
             keywords: missingDoc ? [tree, 'missing-doc'] : [tree],
             features,
-            bodyText,
         };
     });
 
@@ -119,9 +111,8 @@ const docsSections = sections.map((section) => ({
         const slug = getSlugFromHref(link.href);
         const docData = slug ? docSearchIndex.get(slug) ?? null : null;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
-        return { ...link, features, bodyText };
+        return { ...link, slug, features };
     }),
 }));
 
@@ -142,7 +133,11 @@ const docsSectionsWithAllSkills = docsSections.map((section) => {
 ---
 
 <Page title="Docs">
-    <DocsIndex sections={docsSectionsWithAllSkills} client:load />
+    <DocsIndex
+        sections={docsSectionsWithAllSkills}
+        deferredCorpusHref="/docs/full-text-corpus.json"
+        client:load
+    />
 </Page>
 
 <style>


### PR DESCRIPTION
### Motivation
- Reduce initial `/docs` client payload and hydration cost by removing full `bodyText` from the server-hydrated sections while preserving existing search semantics.
- Keep `has:` operator behavior and default browse view fully functional from the light payload without loading the heavy corpus.
- Lazily load a same-origin, offline-friendly full-text corpus only when keyword full-text search is first requested, and reuse it for the session.

### Description
- Stopped attaching `bodyText` to links in the server-side payload and added `slug` so client can join against deferred corpus later by updating `frontend/src/pages/docs/index.astro`.
- Added a small same-origin endpoint `GET /docs/full-text-corpus.json` implemented in `frontend/src/pages/docs/full-text-corpus.json.ts` which returns `{ bodyBySlug: { <slug>: <stripped body text> } }` generated from existing markdown stripping logic.
- Updated `DocsIndex.svelte` to preserve `has:` filtering from the light payload, to lazily `fetch` and cache the deferred corpus on the first non-empty keyword query, to pass `bodyText` into existing snippet utilities once loaded, and to show a minimal loading state only while the corpus is being fetched.
- Adjusted/added focused tests and fixtures to validate the contract and lazy-load behavior by touching `frontend/src/components/__tests__/DocsIndexSearch.spec.ts` and adding `frontend/src/pages/docs/__tests__/index.spec.ts`.
- Changes are intentionally scoped to the `/docs` index/search surface and the minimal supporting files; no ranking, UX, or backend search services were added.

### Testing
- `node scripts/link-check.mjs` — passed.
- Unit/component tests run with `vitest` for the changed targets (`frontend/src/components/__tests__/DocsIndexSearch.spec.ts`, `frontend/src/pages/docs/__tests__/index.spec.ts`, and existing `frontend/src/lib/__tests__/fullTextSearch.test.ts`) — passed for the selected suite.
- `npm run lint` (frontend lint) — passed.
- `npm run type-check` — failed due to a pre-existing unrelated TS error (`tests/runRemoteCompletionistAwardIIIResolver.test.ts`); this is not caused by the `/docs` changes.
- `npm run build` — succeeded (Astro build completed).
- E2E (`npm run test:e2e` / Playwright) — could not complete in this environment because Playwright browser binaries could not be downloaded (`ENETUNREACH`); E2E tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d753430bf8832fa36c4d727b505072)