### PR TITLE
⚡ docs: defer /docs full-text corpus load

### DIFF
--- a/frontend/__tests__/DocsIndex.test.js
+++ b/frontend/__tests__/DocsIndex.test.js
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 import DocsIndex from '../src/components/svelte/DocsIndex.svelte';
 
@@ -33,6 +33,10 @@ const SECTIONS_FIXTURE = [
 ];
 
 describe('DocsIndex component', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -42,18 +46,34 @@ describe('DocsIndex component', () => {
         expect(searchBox).toHaveAttribute('id', 'docs-search-input');
     });
 
-    it('filters links using the search query', async () => {
+    it('filters links using deferred corpus data', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    corpus: {
+                        about: 'General overview',
+                        'quest-guidelines': 'Quest authoring handbook',
+                        'quest-schema': 'Quest schema specs',
+                    },
+                }),
+            })
+        );
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
-        await fireEvent.input(searchBox, { target: { value: 'quest' } });
+        await fireEvent.input(searchBox, { target: { value: 'authoring' } });
 
-        expect(screen.queryByRole('link', { name: 'About' })).not.toBeInTheDocument();
-        expect(
-            screen.getByRole('link', {
-                name: 'Quest Development Guidelines',
-            })
-        ).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.queryByRole('link', { name: 'About' })).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('link', {
+                    name: 'Quest Development Guidelines',
+                })
+            ).toBeInTheDocument();
+        });
     });
 });

--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -7,17 +7,16 @@ const docsIndexFile = path.join(__dirname, '../src/pages/docs/index.astro');
 const docsSectionsFile = path.join(__dirname, '../src/pages/docs/json/sections.json');
 
 describe('docs index.astro', () => {
-    it('renders docs navigation from JSON sections', () => {
+    it('renders docs navigation from JSON sections with deferred full text corpus', () => {
         expect(fs.existsSync(docsSectionsFile)).toBe(true);
 
         const sections = JSON.parse(fs.readFileSync(docsSectionsFile, 'utf8'));
         const content = fs.readFileSync(docsIndexFile, 'utf8');
 
-        // Using import assertions for JSON imports
-        expect(content).toMatch(
-            /import sections from '\.\/json\/sections\.json' assert { type: 'json' }/
-        );
-        expect(content).toMatch(/sections\.map/);
+        expect(content).toMatch(/import sections from '\.\/json\/sections\.json'/);
+        expect(content).toMatch(/fullTextCorpusHref="\/docs\/json\/full-text-corpus\.json"/);
+        expect(content).toMatch(/return \{ \.\.\.link, features \};/);
+        expect(content).not.toMatch(/bodyText/);
 
         const allLinks = sections.flatMap((section) => section.links);
         const codexPromptLink = allLinks.find((link) => link.href === '/docs/prompts-codex');

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import DocsIndex from '../svelte/DocsIndex.svelte';
 
@@ -30,7 +30,19 @@ const SECTIONS_FIXTURE = [
     },
 ];
 
+const CORPUS_FIXTURE = {
+    corpus: {
+        about: 'Learn about the dSpace mission and long-term roadmap.',
+        'quest-guidelines': 'Quest writing covers drafting and testing guidance.',
+        'quest-schema': 'The quest schema requires start, middle, and completion nodes.',
+    },
+};
+
 describe('DocsIndex search operators', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -40,22 +52,36 @@ describe('DocsIndex search operators', () => {
         expect(searchBox.getAttribute('id')).toBe('docs-search-input');
     });
 
-    it('filters links using the search query', async () => {
+    it('filters links using the search query after deferred corpus load', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => CORPUS_FIXTURE,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
-        await fireEvent.input(searchBox, { target: { value: 'quest' } });
+        await fireEvent.input(searchBox, { target: { value: 'drafting' } });
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(
+                screen.getByRole('link', {
+                    name: 'Quest Development Guidelines',
+                })
+            ).not.toBeNull();
+        });
 
         expect(screen.queryByRole('link', { name: 'About' })).toBeNull();
-        expect(
-            screen.getByRole('link', {
-                name: 'Quest Development Guidelines',
-            })
-        ).not.toBeNull();
+        expect(screen.getByText(/writing covers/i)).not.toBeNull();
     });
 
-    it('applies has:link operator filters', async () => {
+    it('applies has:link operator filters without loading deferred corpus', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
@@ -64,24 +90,59 @@ describe('DocsIndex search operators', () => {
 
         expect(screen.getByRole('link', { name: 'About' })).not.toBeNull();
         expect(screen.queryByRole('link', { name: 'Mission' })).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('combines text queries with has:image operator filters', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => CORPUS_FIXTURE,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
-        await fireEvent.input(searchBox, { target: { value: 'quest has:image' } });
+        await fireEvent.input(searchBox, { target: { value: 'completion has:image' } });
 
-        expect(
-            screen.getByRole('link', {
-                name: 'Quest Schema Requirements',
-            })
-        ).not.toBeNull();
+        await waitFor(() => {
+            expect(
+                screen.getByRole('link', {
+                    name: 'Quest Schema Requirements',
+                })
+            ).not.toBeNull();
+        });
+
         expect(
             screen.queryByRole('link', {
                 name: 'Quest Development Guidelines',
             })
         ).toBeNull();
+    });
+
+    it('reuses deferred corpus across subsequent keyword searches', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => CORPUS_FIXTURE,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+
+        await fireEvent.input(searchBox, { target: { value: 'drafting' } });
+        await waitFor(() => {
+            expect(
+                screen.getByRole('link', { name: 'Quest Development Guidelines' })
+            ).not.toBeNull();
+        });
+
+        await fireEvent.input(searchBox, { target: { value: 'completion' } });
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: 'Quest Schema Requirements' })).not.toBeNull();
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -1,4 +1,6 @@
 <script>
+    import { findDocSnippet, parseDocsQuery } from '../../lib/docs/fullTextSearch';
+
     /**
      * @typedef {Object} DocLink
      * @property {string} title
@@ -15,14 +17,79 @@
      * @property {DocLink[]} links
      */
 
-    import { findDocSnippet, parseDocsQuery } from '../../lib/docs/fullTextSearch';
-
     /** @type {DocsSection[]} */
     export let sections = [];
 
+    export let fullTextCorpusHref = '/docs/json/full-text-corpus.json';
+
     let query = '';
+    let isLoadingCorpus = false;
+    let isCorpusLoaded = false;
+    let fullTextCorpusBySlug = new Map();
+    let corpusLoadPromise = null;
 
     const normalize = (value) => value.toLowerCase().trim();
+
+    const getSlugFromHref = (href = '') => {
+        const clean = href.split('#')[0].split('?')[0];
+
+        if (!clean.startsWith('/docs/')) {
+            return '';
+        }
+
+        return clean
+            .replace(/^\/docs\//, '')
+            .replace(/\/?$/, '')
+            .toLowerCase();
+    };
+
+    const getBodyText = (link) => {
+        if (typeof link.bodyText === 'string' && link.bodyText) {
+            return link.bodyText;
+        }
+
+        if (!isCorpusLoaded) {
+            return '';
+        }
+
+        const slug = getSlugFromHref(link.href);
+        return slug ? (fullTextCorpusBySlug.get(slug) ?? '') : '';
+    };
+
+    const loadFullTextCorpus = async () => {
+        if (isCorpusLoaded) {
+            return;
+        }
+
+        if (!corpusLoadPromise) {
+            isLoadingCorpus = true;
+            corpusLoadPromise = fetch(fullTextCorpusHref)
+                .then(async (response) => {
+                    if (!response.ok) {
+                        throw new Error(
+                            `Failed to load docs full-text corpus (${response.status})`
+                        );
+                    }
+
+                    const payload = await response.json();
+                    const corpusEntries = Object.entries(payload?.corpus ?? {});
+                    fullTextCorpusBySlug = new Map(
+                        corpusEntries.filter(
+                            ([slug, text]) => typeof slug === 'string' && typeof text === 'string'
+                        )
+                    );
+                    isCorpusLoaded = true;
+                })
+                .catch((error) => {
+                    console.error(error);
+                })
+                .finally(() => {
+                    isLoadingCorpus = false;
+                });
+        }
+
+        await corpusLoadPromise;
+    };
 
     // Note: `keywords` may be an empty array for operator-only queries (e.g. "has:link").
     // In that case, `every()` returns `true` by design, so word matching does not filter out
@@ -44,9 +111,8 @@
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), link.bodyText ?? ''].map(
-            normalize
-        );
+        const bodyText = getBodyText(link);
+        const searchableValues = [link.title, ...(link.keywords ?? []), bodyText].map(normalize);
 
         return (
             matchesWords(parsedQuery.keywords, searchableValues) &&
@@ -55,20 +121,36 @@
     };
 
     $: parsedQuery = parseDocsQuery(query);
-    $: filteredSections = sections
-        .map((section) => ({
-            title: section.title,
-            links: section.links
-                .filter((link) => matchLink(link, parsedQuery))
-                .map((link) => ({
-                    ...link,
-                    snippet:
-                        parsedQuery.keywords.length && !parsedQuery.isHasPredicate
-                            ? findDocSnippet(link, parsedQuery.keywords)
-                            : null,
-                })),
-        }))
-        .filter((section) => section.links.length > 0);
+    $: requiresDeferredCorpus = parsedQuery.keywords.length > 0;
+    $: if (requiresDeferredCorpus && !isCorpusLoaded) {
+        void loadFullTextCorpus();
+    }
+
+    $: filteredSections =
+        requiresDeferredCorpus && !isCorpusLoaded
+            ? []
+            : sections
+                  .map((section) => ({
+                      title: section.title,
+                      links: section.links
+                          .filter((link) => matchLink(link, parsedQuery))
+                          .map((link) => {
+                              const bodyText = getBodyText(link);
+
+                              return {
+                                  ...link,
+                                  bodyText,
+                                  snippet:
+                                      parsedQuery.keywords.length && !parsedQuery.isHasPredicate
+                                          ? findDocSnippet(
+                                                { ...link, bodyText },
+                                                parsedQuery.keywords
+                                            )
+                                          : null,
+                              };
+                          }),
+                  }))
+                  .filter((section) => section.links.length > 0);
 
     $: totalResults = filteredSections.reduce((count, section) => count + section.links.length, 0);
 </script>
@@ -83,7 +165,9 @@
         aria-label="Search docs"
     />
 
-    {#if parsedQuery.normalized && totalResults === 0}
+    {#if requiresDeferredCorpus && isLoadingCorpus}
+        <p class="loading-state">Loading docs search index...</p>
+    {:else if parsedQuery.normalized && totalResults === 0}
         <p class="empty-state">No docs found for "{query}".</p>
     {:else}
         <div class="docs-grid" data-testid="docs-grid">
@@ -230,7 +314,8 @@
         opacity: 1;
     }
 
-    .empty-state {
+    .empty-state,
+    .loading-state {
         background-color: #2f5b2f;
         border-radius: 2rem;
         padding: 1.5rem;

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -3,12 +3,11 @@ import Page from '../../components/Page.astro';
 import DocsIndex from '../../components/svelte/DocsIndex.svelte';
 import sections from './json/sections.json';
 import { detectDocFeatures } from '../../utils/docsSearchFeatures.js';
-import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../../utils/docsSkillsIndex.js';
 
 const docModules = await Astro.glob('./md/**/*.md');
 
-const buildDocIndex = async () => {
+const buildDocFeatureIndex = async () => {
     const entries = await Promise.all(
         docModules.map(async (doc) => {
             const slug = String(doc?.frontmatter?.slug ?? '').toLowerCase();
@@ -32,7 +31,6 @@ const buildDocIndex = async () => {
                     slug,
                     {
                         features: detectDocFeatures(content),
-                        bodyText: stripMarkdownToText(content),
                     },
                 ];
             } catch (error) {
@@ -42,7 +40,7 @@ const buildDocIndex = async () => {
                     throw error;
                 }
 
-                return [slug, { features: [], bodyText: '' }];
+                return [slug, { features: [] }];
             }
         })
     );
@@ -51,7 +49,7 @@ const buildDocIndex = async () => {
     return new Map(filteredEntries);
 };
 
-const docSearchIndex = await buildDocIndex();
+const docFeatureIndex = await buildDocFeatureIndex();
 const questTreeModules = Object.keys(import.meta.glob('../quests/json/*/*.json'));
 
 const TITLE_OVERRIDES = {
@@ -83,24 +81,22 @@ const toTitleCase = (value = '') =>
         .join(' ');
 
 const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree) => {
-        const href = `/docs/${tree}`;
-        const docData = docSearchIndex.get(tree) ?? null;
-        const missingDoc = !docData;
-        const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
+    const href = `/docs/${tree}`;
+    const docData = docFeatureIndex.get(tree) ?? null;
+    const missingDoc = !docData;
+    const features = docData?.features ?? [];
 
-        if (missingDoc) {
-            console.warn(`Quest tree '${tree}' is missing matching docs page at ${href}`);
-        }
+    if (missingDoc) {
+        console.warn(`Quest tree '${tree}' is missing matching docs page at ${href}`);
+    }
 
-        return {
-            title: TITLE_OVERRIDES[tree] ?? toTitleCase(tree),
-            href,
-            keywords: missingDoc ? [tree, 'missing-doc'] : [tree],
-            features,
-            bodyText,
-        };
-    });
+    return {
+        title: TITLE_OVERRIDES[tree] ?? toTitleCase(tree),
+        href,
+        keywords: missingDoc ? [tree, 'missing-doc'] : [tree],
+        features,
+    };
+});
 
 const getSlugFromHref = (href = '') => {
     const clean = href.split('#')[0].split('?')[0];
@@ -117,11 +113,10 @@ const docsSections = sections.map((section) => ({
     title: section.title,
     links: section.links.map((link) => {
         const slug = getSlugFromHref(link.href);
-        const docData = slug ? docSearchIndex.get(slug) ?? null : null;
+        const docData = slug ? docFeatureIndex.get(slug) ?? null : null;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
-        return { ...link, features, bodyText };
+        return { ...link, features };
     }),
 }));
 
@@ -142,7 +137,7 @@ const docsSectionsWithAllSkills = docsSections.map((section) => {
 ---
 
 <Page title="Docs">
-    <DocsIndex sections={docsSectionsWithAllSkills} client:load />
+    <DocsIndex sections={docsSectionsWithAllSkills} fullTextCorpusHref="/docs/json/full-text-corpus.json" client:load />
 </Page>
 
 <style>

--- a/frontend/src/pages/docs/json/full-text-corpus.json.ts
+++ b/frontend/src/pages/docs/json/full-text-corpus.json.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from 'astro';
+
+import { stripMarkdownToText } from '../../../lib/docs/fullTextSearch';
+
+const docModules = import.meta.glob('../md/**/*.md');
+
+const getDocContent = async (modulePath: string) => {
+    const loader = docModules[modulePath];
+
+    if (!loader) {
+        return null;
+    }
+
+    const doc = await loader();
+    const slug = String(doc?.frontmatter?.slug ?? '').toLowerCase();
+
+    if (!slug) {
+        return null;
+    }
+
+    let content;
+
+    if (typeof doc.rawContent === 'function') {
+        content = await doc.rawContent();
+    } else if (typeof doc.compiledContent === 'function') {
+        content = await doc.compiledContent();
+    } else {
+        throw new Error(`No content loader found for doc slug ${slug}`);
+    }
+
+    return [slug, stripMarkdownToText(content)] as const;
+};
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+    const entries = await Promise.all(
+        Object.keys(docModules).map(async (modulePath) => {
+            try {
+                return await getDocContent(modulePath);
+            } catch (error) {
+                console.error(`Failed to build docs full-text corpus for ${modulePath}`, error);
+                return null;
+            }
+        })
+    );
+
+    const corpus = Object.fromEntries(
+        entries.filter((entry): entry is readonly [string, string] => !!entry)
+    );
+
+    return new Response(JSON.stringify({ corpus }), {
+        headers: {
+            'content-type': 'application/json; charset=utf-8',
+            'cache-control': 'public, max-age=3600, stale-while-revalidate=86400',
+        },
+    });
+};


### PR DESCRIPTION
### Motivation
- Reduce `/docs` initial hydrated payload by removing full `bodyText` while preserving existing search semantics and `has:` operators.
- Ship a minimal same-origin deferred corpus to enable full-text/snippet parity on first keyword search without changing ranking or adding backend services.

### Description
- Stop attaching `bodyText` in `frontend/src/pages/docs/index.astro` and build a light feature-only index used for browse and `has:` operator filtering. 
- Add a deferred, prerendered endpoint `frontend/src/pages/docs/json/full-text-corpus.json.ts` that serves `{ corpus: { '<slug>': '<stripped body text>' } }` at `/docs/json/full-text-corpus.json`.
- Update `frontend/src/components/svelte/DocsIndex.svelte` to lazy-load and cache the corpus on first non-empty keyword query, preserve `has:link`/`has:image` behavior from the light payload, and call existing `findDocSnippet` to retain snippet formatting once body text is available.
- Make minimal test adjustments and add assertions ensuring the initial hydrated payload excludes `bodyText`, that `has:` queries do not trigger corpus fetch, and that the corpus is fetched once and reused.
- Intentionally do not implement optional follow-ups from the design doc (no ranking changes, no worker-based search, no extra index shaping).

### Testing
- Ran focused unit tests: `npx vitest run -c vitest.config.mts frontend/src/components/__tests__/DocsIndexSearch.spec.ts`, `frontend/src/lib/__tests__/fullTextSearch.test.ts`, `frontend/__tests__/DocsIndex.test.js`, and `frontend/__tests__/docsIndexPage.test.js` and verified the docs-search-related assertions (unit tests passed after a small test matcher adjustment).
- Verified internal links with `node scripts/link-check.mjs` (All local markdown links resolved).
- Ran `npm run lint` (frontend lint/format checks ran) and `npm run build` (Astro build completed successfully).
- Ran `npm run type-check` which failed due to an unrelated existing TypeScript test typing error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` (not introduced by this change).
- Attempted E2E run `cd frontend && npm run test:e2e -- e2e/docs-search.spec.ts` but Playwright browser install failed in this environment due to network `ENETUNREACH`, so full E2E execution could not be completed here.

If reviewers want, the next follow-up PR can add a tiny loading UX tweak, work-itemize query-time memoization, or shape the deferred corpus fields for narrower payloads; none of those are included in this minimal patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d753430bf8832fa36c4d727b505072)