### PR TITLE
Split /docs payload; defer full-text corpus to local endpoint

### DIFF
--- a/frontend/__tests__/DocsIndex.test.js
+++ b/frontend/__tests__/DocsIndex.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 
@@ -33,6 +33,10 @@ const SECTIONS_FIXTURE = [
 ];
 
 describe('DocsIndex component', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -43,6 +47,11 @@ describe('DocsIndex component', () => {
     });
 
     it('filters links using the search query', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => ({ bySlug: {} }),
+        });
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });

--- a/frontend/__tests__/docsIndexPage.test.js
+++ b/frontend/__tests__/docsIndexPage.test.js
@@ -13,11 +13,10 @@ describe('docs index.astro', () => {
         const sections = JSON.parse(fs.readFileSync(docsSectionsFile, 'utf8'));
         const content = fs.readFileSync(docsIndexFile, 'utf8');
 
-        // Using import assertions for JSON imports
-        expect(content).toMatch(
-            /import sections from '\.\/json\/sections\.json' assert { type: 'json' }/
-        );
+        expect(content).toMatch(/import sections from '\.\/json\/sections\.json'/);
         expect(content).toMatch(/sections\.map/);
+        expect(content).toMatch(/fullTextCorpusUrl="\/docs\/json\/fullTextCorpus\.json"/);
+        expect(content).not.toMatch(/bodyText/);
 
         const allLinks = sections.flatMap((section) => section.links);
         const codexPromptLink = allLinks.find((link) => link.href === '/docs/prompts-codex');

--- a/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+++ b/frontend/src/components/__tests__/DocsIndexSearch.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DocsIndex from '../svelte/DocsIndex.svelte';
 
@@ -17,12 +17,14 @@ const SECTIONS_FIXTURE = [
             {
                 title: 'Quest Development Guidelines',
                 href: '/docs/quest-guidelines',
+                slug: 'quest-guidelines',
                 keywords: ['quest'],
                 features: ['link'],
             },
             {
                 title: 'Quest Schema Requirements',
                 href: '/docs/quest-schema',
+                slug: 'quest-schema',
                 keywords: ['schema', 'quest'],
                 features: ['link', 'image'],
             },
@@ -31,6 +33,10 @@ const SECTIONS_FIXTURE = [
 ];
 
 describe('DocsIndex search operators', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('renders an accessible search box for docs', () => {
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
@@ -41,6 +47,16 @@ describe('DocsIndex search operators', () => {
     });
 
     it('filters links using the search query', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                bySlug: {
+                    'quest-guidelines': 'Quest development playbook.',
+                    'quest-schema': 'Quest schema requirements.',
+                },
+            }),
+        } as Response);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
@@ -49,7 +65,7 @@ describe('DocsIndex search operators', () => {
 
         expect(screen.queryByRole('link', { name: 'About' })).toBeNull();
         expect(
-            screen.getByRole('link', {
+            await screen.findByRole('link', {
                 name: 'Quest Development Guidelines',
             })
         ).not.toBeNull();
@@ -67,12 +83,26 @@ describe('DocsIndex search operators', () => {
     });
 
     it('combines text queries with has:image operator filters', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                bySlug: {
+                    'quest-schema': 'Schema docs include quest rewards and structure.',
+                },
+            }),
+        } as Response);
+
         render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
 
         const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
 
         await fireEvent.input(searchBox, { target: { value: 'quest has:image' } });
 
+        expect(
+            await screen.findByRole('link', {
+                name: 'Quest Schema Requirements',
+            })
+        ).not.toBeNull();
         expect(
             screen.getByRole('link', {
                 name: 'Quest Schema Requirements',
@@ -83,5 +113,40 @@ describe('DocsIndex search operators', () => {
                 name: 'Quest Development Guidelines',
             })
         ).toBeNull();
+    });
+
+    it('applies has:image without loading deferred full-text corpus', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'has:image' } });
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(screen.getByRole('link', { name: 'Quest Schema Requirements' })).not.toBeNull();
+    });
+
+    it('loads deferred corpus for first keyword query and reuses it for later queries', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                bySlug: {
+                    'quest-schema': 'Use durable quest schema constraints for deterministic validation.',
+                },
+            }),
+        } as Response);
+
+        render(DocsIndex, { props: { sections: SECTIONS_FIXTURE } });
+
+        const searchBox = screen.getByRole('searchbox', { name: /search docs/i });
+        await fireEvent.input(searchBox, { target: { value: 'deterministic' } });
+
+        expect(await screen.findByRole('link', { name: 'Quest Schema Requirements' })).not.toBeNull();
+        expect(await screen.findByText(/deterministic/i)).not.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await fireEvent.input(searchBox, { target: { value: 'validation' } });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(await screen.findByText(/validation/i)).not.toBeNull();
     });
 });

--- a/frontend/src/components/svelte/DocsIndex.svelte
+++ b/frontend/src/components/svelte/DocsIndex.svelte
@@ -6,6 +6,7 @@
      * @property {string[]=} keywords
      * @property {boolean=} external
      * @property {string[]=} features
+     * @property {string=} slug
      * @property {string=} bodyText
      */
 
@@ -19,8 +20,15 @@
 
     /** @type {DocsSection[]} */
     export let sections = [];
+    export let fullTextCorpusUrl = '/docs/json/fullTextCorpus.json';
 
     let query = '';
+    let isCorpusLoading = false;
+    let corpusLoaded = false;
+    /** @type {Promise<void> | null} */
+    let corpusLoadPromise = null;
+    /** @type {Record<string, string>} */
+    let deferredBodyTextBySlug = {};
 
     const normalize = (value) => value.toLowerCase().trim();
 
@@ -39,12 +47,14 @@
         return operators.every((operator) => normalizedFeatures.includes(operator));
     };
 
+    const getBodyText = (link) => link.bodyText ?? deferredBodyTextBySlug[link.slug ?? ''] ?? '';
+
     const matchLink = (link, parsedQuery) => {
         if (!parsedQuery.operators.length && !parsedQuery.keywords.length) {
             return true;
         }
 
-        const searchableValues = [link.title, ...(link.keywords ?? []), link.bodyText ?? ''].map(
+        const searchableValues = [link.title, ...(link.keywords ?? []), getBodyText(link)].map(
             normalize
         );
 
@@ -54,7 +64,42 @@
         );
     };
 
+    const ensureFullTextCorpusLoaded = async () => {
+        if (corpusLoaded || corpusLoadPromise) {
+            return corpusLoadPromise;
+        }
+
+        const corpusUrl =
+            typeof window !== 'undefined'
+                ? new URL(fullTextCorpusUrl, window.location.href).toString()
+                : fullTextCorpusUrl;
+
+        isCorpusLoading = true;
+        corpusLoadPromise = fetch(corpusUrl)
+            .then(async (response) => {
+                if (!response.ok) {
+                    throw new Error(`Failed to load docs search corpus: ${response.status}`);
+                }
+
+                const payload = await response.json();
+                deferredBodyTextBySlug = payload?.bySlug ?? {};
+                corpusLoaded = true;
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+            .finally(() => {
+                isCorpusLoading = false;
+            });
+
+        return corpusLoadPromise;
+    };
+
     $: parsedQuery = parseDocsQuery(query);
+    $: needsDeferredCorpus = parsedQuery.keywords.length > 0;
+    $: if (needsDeferredCorpus) {
+        void ensureFullTextCorpusLoaded();
+    }
     $: filteredSections = sections
         .map((section) => ({
             title: section.title,
@@ -63,8 +108,16 @@
                 .map((link) => ({
                     ...link,
                     snippet:
-                        parsedQuery.keywords.length && !parsedQuery.isHasPredicate
-                            ? findDocSnippet(link, parsedQuery.keywords)
+                        parsedQuery.keywords.length &&
+                        !parsedQuery.isHasPredicate &&
+                        (link.bodyText || corpusLoaded)
+                            ? findDocSnippet(
+                                  {
+                                      ...link,
+                                      bodyText: getBodyText(link),
+                                  },
+                                  parsedQuery.keywords
+                              )
                             : null,
                 })),
         }))
@@ -83,7 +136,9 @@
         aria-label="Search docs"
     />
 
-    {#if parsedQuery.normalized && totalResults === 0}
+    {#if needsDeferredCorpus && isCorpusLoading}
+        <p class="empty-state">Loading docs search index…</p>
+    {:else if parsedQuery.normalized && totalResults === 0}
         <p class="empty-state">No docs found for "{query}".</p>
     {:else}
         <div class="docs-grid" data-testid="docs-grid">

--- a/frontend/src/pages/docs/index.astro
+++ b/frontend/src/pages/docs/index.astro
@@ -3,7 +3,6 @@ import Page from '../../components/Page.astro';
 import DocsIndex from '../../components/svelte/DocsIndex.svelte';
 import sections from './json/sections.json';
 import { detectDocFeatures } from '../../utils/docsSearchFeatures.js';
-import { stripMarkdownToText } from '../../lib/docs/fullTextSearch';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../../utils/docsSkillsIndex.js';
 
 const docModules = await Astro.glob('./md/**/*.md');
@@ -32,7 +31,6 @@ const buildDocIndex = async () => {
                     slug,
                     {
                         features: detectDocFeatures(content),
-                        bodyText: stripMarkdownToText(content),
                     },
                 ];
             } catch (error) {
@@ -42,7 +40,7 @@ const buildDocIndex = async () => {
                     throw error;
                 }
 
-                return [slug, { features: [], bodyText: '' }];
+                return [slug, { features: [] }];
             }
         })
     );
@@ -87,7 +85,6 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
         const docData = docSearchIndex.get(tree) ?? null;
         const missingDoc = !docData;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
         if (missingDoc) {
             console.warn(`Quest tree '${tree}' is missing matching docs page at ${href}`);
@@ -96,9 +93,9 @@ const questSkillLinks = getQuestTreesFromModulePaths(questTreeModules).map((tree
         return {
             title: TITLE_OVERRIDES[tree] ?? toTitleCase(tree),
             href,
+            slug: tree,
             keywords: missingDoc ? [tree, 'missing-doc'] : [tree],
             features,
-            bodyText,
         };
     });
 
@@ -119,9 +116,8 @@ const docsSections = sections.map((section) => ({
         const slug = getSlugFromHref(link.href);
         const docData = slug ? docSearchIndex.get(slug) ?? null : null;
         const features = docData?.features ?? [];
-        const bodyText = docData?.bodyText ?? '';
 
-        return { ...link, features, bodyText };
+        return { ...link, slug, features };
     }),
 }));
 
@@ -142,7 +138,11 @@ const docsSectionsWithAllSkills = docsSections.map((section) => {
 ---
 
 <Page title="Docs">
-    <DocsIndex sections={docsSectionsWithAllSkills} client:load />
+    <DocsIndex
+        sections={docsSectionsWithAllSkills}
+        fullTextCorpusUrl="/docs/json/fullTextCorpus.json"
+        client:load
+    />
 </Page>
 
 <style>

--- a/frontend/src/pages/docs/json/fullTextCorpus.json.ts
+++ b/frontend/src/pages/docs/json/fullTextCorpus.json.ts
@@ -1,0 +1,55 @@
+import { stripMarkdownToText } from '../../../lib/docs/fullTextSearch';
+
+type DocModule = {
+    frontmatter?: { slug?: string };
+    rawContent?: () => Promise<string>;
+    compiledContent?: () => Promise<string>;
+};
+
+const docModules = import.meta.glob('../md/**/*.md');
+
+const buildFullTextCorpus = async () => {
+    const entries = await Promise.all(
+        Object.values(docModules).map(async (loadModule) => {
+            const doc = (await loadModule()) as DocModule;
+            const slug = String(doc?.frontmatter?.slug ?? '').toLowerCase();
+
+            if (!slug) {
+                return null;
+            }
+
+            try {
+                let content = '';
+
+                if (typeof doc.rawContent === 'function') {
+                    content = await doc.rawContent();
+                } else if (typeof doc.compiledContent === 'function') {
+                    content = await doc.compiledContent();
+                }
+
+                return [slug, stripMarkdownToText(content)] as const;
+            } catch (error) {
+                console.error(`Failed to build deferred docs corpus for doc slug ${slug}`, error);
+
+                if (import.meta.env?.DEV) {
+                    throw error;
+                }
+
+                return [slug, ''] as const;
+            }
+        })
+    );
+
+    return Object.fromEntries(entries.filter((entry) => Array.isArray(entry)));
+};
+
+export const GET = async () => {
+    const bySlug = await buildFullTextCorpus();
+
+    return new Response(JSON.stringify({ bySlug }), {
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Cache-Control': 'public, max-age=31536000, immutable',
+        },
+    });
+};


### PR DESCRIPTION
### Motivation

- Reduce the initial hydrated payload for `/docs` by removing large per-doc `bodyText` while preserving browse and operator behavior. 
- Preserve existing full-text search and snippet semantics after the corpus is available and keep `has:` operator filters working from the light payload. 

### Description

- Stop attaching `bodyText` to the initial `sections` prop in `frontend/src/pages/docs/index.astro` and instead include `slug` plus metadata (`title`, `href`, `keywords`, `features`) needed for browsing and operator filters. 
- Add a same-origin deferred full-text corpus endpoint at `frontend/src/pages/docs/json/fullTextCorpus.json` (implemented in `fullTextCorpus.json.ts`) that returns the shape `{ bySlug: { "<slug>": "<plain body text>" } }` by stripping markdown at build/route time. 
- Update `frontend/src/components/svelte/DocsIndex.svelte` to lazily fetch the deferred corpus on the first non-empty keyword query, join body text by `slug`, reuse the loaded corpus for the session, and keep `has:` operator filtering working without loading the corpus; snippet generation reuses the existing `findDocSnippet` logic once body text is available. 
- Update tests and page-shape assertions to cover the lazy-load contract and ensure the initial hydrated page no longer contains `bodyText`. 

### Testing

- Ran `npm run test:root -- frontend/src/components/__tests__/DocsIndexSearch.spec.ts` and the updated docs search unit tests passed. 
- Ran `node scripts/link-check.mjs` and link validation succeeded. 
- Ran `npm run lint` and linting passed. 
- Ran `npm run type-check` which failed due to an existing unrelated TypeScript test typing error (`tests/runRemoteCompletionistAwardIIIResolver.test.ts`), not introduced by this change. 
- Ran `npm run build` and the Astro build completed successfully. 
- Attempted E2E `cd frontend && npm run test:e2e -- docs-search.spec.ts` but it was blocked in this environment by Playwright browser download/network errors (Chromium download `ENETUNREACH`). 

Note: optional follow-ups from the design doc (query-time caching beyond simple in-memory reuse, build-time index shaping, worker-based search, new UX or ranking changes) were intentionally not implemented in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d753430bf8832fa36c4d727b505072)