### PR TITLE
Split /processes list rendering from detail runtime (v3.0.1 core)

### DIFF
--- a/frontend/e2e/remote-release-smoke.spec.ts
+++ b/frontend/e2e/remote-release-smoke.spec.ts
@@ -128,24 +128,20 @@ async function runProcessLifecycle(page: Page): Promise<void> {
     await page.goto('/processes');
     await waitForHydration(page);
 
-    const processRow = page
-        .locator('tr, .process-row, [data-testid="process-row"], li, article, section, div')
-        .filter({ has: page.locator('button').filter({ hasText: /start/i }) })
-        .first();
-    const startButton = processRow.locator('button').filter({ hasText: /start/i }).first();
+    const detailLink = page.getByRole('link', { name: /view details/i }).first();
+    await expect(detailLink, 'Expected at least one process details link').toBeVisible();
+    await detailLink.click();
+    await expect(page).toHaveURL(/\/processes\/(?!manage$|create$)[^/]+$/);
+
+    const processContainer = page.locator('.process-view, main').first();
+    const startButton = processContainer.getByRole('button', { name: /start/i }).first();
 
     await expect(startButton, 'Expected at least one process start button').toBeVisible();
     await startButton.click();
 
-    const cancelButton = processRow
-        .locator('button')
-        .filter({ hasText: /cancel/i })
-        .first();
+    const cancelButton = processContainer.getByRole('button', { name: /cancel/i }).first();
 
-    const collectButton = processRow
-        .locator('button')
-        .filter({ hasText: /collect/i })
-        .first();
+    const collectButton = processContainer.getByRole('button', { name: /collect/i }).first();
 
     if (await cancelButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
         await cancelButton.click();
@@ -159,7 +155,7 @@ async function runProcessLifecycle(page: Page): Promise<void> {
         return;
     }
 
-    const activeMarker = processRow.locator(
+    const activeMarker = processContainer.locator(
         '[data-status="active"], .process-running, :text("In progress")'
     );
     const state = await Promise.race([

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ProcessView from '../ProcessView.svelte';
+
+const { buyItemsMock, getItemCountMock } = vi.hoisted(() => ({
+    buyItemsMock: vi.fn(),
+    getItemCountMock: vi.fn(),
+}));
+
+vi.mock('../../../../generated/processes.json', () => ({
+    default: [
+        {
+            id: 'detail-process',
+            title: 'Detail Process',
+            requireItems: [{ id: 'req-item', count: 2 }],
+            consumeItems: [],
+            createItems: [],
+        },
+    ],
+}));
+
+vi.mock('../../../inventory/json/items', () => ({
+    default: [
+        {
+            id: 'req-item',
+            price: '5 dUSD',
+        },
+    ],
+}));
+
+vi.mock('../../../../utils/gameState/inventory.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        buyItems: buyItemsMock,
+        getItemCount: getItemCountMock,
+    };
+});
+
+vi.mock('../../../../utils/customcontent.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        getProcess: vi.fn().mockResolvedValue(null),
+    };
+});
+
+describe('ProcessView detail controls', () => {
+    beforeEach(() => {
+        buyItemsMock.mockReset();
+        getItemCountMock.mockReset();
+        getItemCountMock.mockReturnValue(0);
+    });
+
+    it('keeps Buy required items on detail route and purchases missing requirements', async () => {
+        render(ProcessView, { props: { slug: 'detail-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).toBeNull();
+
+        await fireEvent.click(buyButton);
+
+        expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
+        expect((await screen.findByRole('status')).textContent).toContain('Added 2 items to inventory');
+    });
+});

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -58,9 +58,18 @@ describe('ProcessView detail controls', () => {
         const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
         expect(buyButton.getAttribute('disabled')).toBeNull();
 
-        await fireEvent.click(buyButton);
+        vi.useFakeTimers();
+        try {
+            await fireEvent.click(buyButton);
 
-        expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
-        expect((await screen.findByRole('status')).textContent).toContain('Added 2 items to inventory');
+            expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
+            expect((await screen.findByRole('status')).textContent).toContain(
+                'Added 2 items to inventory'
+            );
+
+            vi.runAllTimers();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,0 +1,111 @@
+<script>
+    export let process;
+
+    const normalizeProcessId = (id) => String(id ?? '').trim();
+
+    const summarizeEntries = (entries = []) => {
+        if (!Array.isArray(entries) || entries.length === 0) {
+            return 'none';
+        }
+
+        const totalCount = entries.reduce((sum, entry) => {
+            const count = Number(entry?.count);
+            return sum + (Number.isFinite(count) ? count : 0);
+        }, 0);
+
+        return `${entries.length} item${entries.length === 1 ? '' : 's'} (${totalCount})`;
+    };
+
+    $: processId = normalizeProcessId(process?.id);
+    $: processTitle = process?.title || processId || 'Untitled process';
+    $: duration = process?.duration || '—';
+    $: requireSummary = summarizeEntries(process?.requireItems);
+    $: consumeSummary = summarizeEntries(process?.consumeItems);
+    $: createSummary = summarizeEntries(process?.createItems);
+</script>
+
+<article class="process-row" data-process-id={processId}>
+    <div class="process-row__header">
+        <h2>{processTitle}</h2>
+        {#if process?.custom}
+            <span class="custom-badge">Custom</span>
+        {/if}
+    </div>
+
+    <dl class="process-row__summary">
+        <div>
+            <dt>Duration</dt>
+            <dd>{duration}</dd>
+        </div>
+        <div>
+            <dt>Requires</dt>
+            <dd>{requireSummary}</dd>
+        </div>
+        <div>
+            <dt>Consumes</dt>
+            <dd>{consumeSummary}</dd>
+        </div>
+        <div>
+            <dt>Creates</dt>
+            <dd>{createSummary}</dd>
+        </div>
+    </dl>
+
+    <a class="details-link" href={`/processes/${processId}`}>View details</a>
+</article>
+
+<style>
+    .process-row {
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+        padding: 15px;
+    }
+
+    .process-row__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.1rem;
+    }
+
+    .custom-badge {
+        border: 1px solid #e8e8e8;
+        border-radius: 999px;
+        padding: 2px 10px;
+        font-size: 0.75rem;
+    }
+
+    .process-row__summary {
+        margin: 0 0 12px;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 6px 12px;
+    }
+
+    .process-row__summary div {
+        display: flex;
+        justify-content: space-between;
+        gap: 6px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+        padding-bottom: 2px;
+        font-size: 0.9rem;
+    }
+
+    dt,
+    dd {
+        margin: 0;
+    }
+
+    .details-link {
+        display: inline-block;
+        color: #fff;
+        text-decoration: underline;
+    }
+</style>

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -3,25 +3,15 @@
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
-    const summarizeEntries = (entries = []) => {
-        if (!Array.isArray(entries) || entries.length === 0) {
-            return 'none';
-        }
-
-        const totalCount = entries.reduce((sum, entry) => {
-            const count = Number(entry?.count);
-            return sum + (Number.isFinite(count) ? count : 0);
-        }, 0);
-
-        return `${entries.length} item${entries.length === 1 ? '' : 's'} (${totalCount})`;
-    };
+    const formatItemSummary = (types, total) =>
+        Number(types) > 0 ? `${types} item${types === 1 ? '' : 's'} (${total})` : 'none';
 
     $: processId = normalizeProcessId(process?.id);
     $: processTitle = process?.title || processId || 'Untitled process';
     $: duration = process?.duration || '—';
-    $: requireSummary = summarizeEntries(process?.requireItems);
-    $: consumeSummary = summarizeEntries(process?.consumeItems);
-    $: createSummary = summarizeEntries(process?.createItems);
+    $: requireSummary = formatItemSummary(process?.requireItemTypes, process?.requireItemTotal);
+    $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
+    $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
 </script>
 
 <article class="process-row" data-process-id={processId}>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -1,11 +1,12 @@
 <script>
     import { onMount } from 'svelte';
     import Chip from '../../components/svelte/Chip.svelte';
-    import processes from '../../generated/processes.json';
+    import generatedProcesses from '../../generated/processes.json';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
-    import ProcessView from '../process/[slug]/ProcessView.svelte';
+    import ProcessListRow from './ProcessListRow.svelte';
 
-    let mounted = false;
+    export let builtInProcesses = null;
+
     let customProcesses = [];
 
     const actionButtons = [
@@ -15,8 +16,36 @@
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
+    const withBuiltinFlag = (process) => ({
+        ...process,
+        custom: Boolean(process?.custom),
+    });
+
+    const defaultBuiltIns = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map(
+        (process) => ({
+            ...process,
+            custom: false,
+        })
+    );
+
+    $: resolvedBuiltIns = (
+        Array.isArray(builtInProcesses) && builtInProcesses.length > 0
+            ? builtInProcesses
+            : defaultBuiltIns
+    ).map(withBuiltinFlag);
+
+    $: allProcesses = [
+        ...resolvedBuiltIns,
+        ...(Array.isArray(customProcesses) ? customProcesses : []),
+    ]
+        .map(withBuiltinFlag)
+        .filter((process) => normalizeProcessId(process?.id).length > 0)
+        .filter((process, index, list) => {
+            const processId = normalizeProcessId(process?.id);
+            return list.findIndex((entry) => normalizeProcessId(entry?.id) === processId) === index;
+        });
+
     onMount(async () => {
-        mounted = true;
         try {
             customProcesses = (await db.list(ENTITY_TYPES.PROCESS)) ?? [];
         } catch (error) {
@@ -24,41 +53,24 @@
             customProcesses = [];
         }
     });
-
-    const builtInProcesses = (Array.isArray(processes) ? processes : []).map((process) => ({
-        ...process,
-        custom: false,
-    }));
-
-    $: allProcesses = [
-        ...builtInProcesses,
-        ...(Array.isArray(customProcesses) ? customProcesses : []),
-    ].filter(Boolean);
 </script>
 
-<div class="processes-page" data-hydrated={mounted ? 'true' : 'false'}>
+<div class="processes-page">
     <div class="action-buttons">
         {#each actionButtons as button}
             <Chip text={button.text} href={button.href} inverted={true} />
         {/each}
     </div>
 
-    {#if mounted}
-        <div class="processes-list">
-            {#if allProcesses.length === 0}
-                <div class="no-processes">No processes found</div>
-            {:else}
-                {#each allProcesses as process (normalizeProcessId(process?.id))}
-                    {@const processId = normalizeProcessId(process?.id)}
-                    <div class="process-row" data-process-id={processId}>
-                        <ProcessView slug={processId} />
-                    </div>
-                {/each}
-            {/if}
-        </div>
-    {:else}
-        <div class="loading">Loading processes...</div>
-    {/if}
+    <div class="processes-list">
+        {#if allProcesses.length === 0}
+            <div class="no-processes">No processes found</div>
+        {:else}
+            {#each allProcesses as process (normalizeProcessId(process.id))}
+                <ProcessListRow {process} />
+            {/each}
+        {/if}
+    </div>
 </div>
 
 <style>
@@ -78,18 +90,10 @@
     .processes-list {
         display: flex;
         flex-direction: column;
-        gap: 20px;
+        gap: 12px;
     }
 
-    .process-row {
-        background: #2c5837;
-        border-radius: 12px;
-        border: 2px solid #007006;
-        padding: 15px;
-    }
-
-    .no-processes,
-    .loading {
+    .no-processes {
         text-align: center;
         padding: 40px;
         background: #2c5837;

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -1,11 +1,10 @@
 <script>
     import { onMount } from 'svelte';
     import Chip from '../../components/svelte/Chip.svelte';
-    import generatedProcesses from '../../generated/processes.json';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
     import ProcessListRow from './ProcessListRow.svelte';
 
-    export let builtInProcesses = null;
+    export let builtInProcesses = [];
 
     let customProcesses = [];
 
@@ -16,34 +15,67 @@
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
-    const withBuiltinFlag = (process) => ({
-        ...process,
-        custom: Boolean(process?.custom),
-    });
+    const summarizeEntries = (entries = []) => {
+        if (!Array.isArray(entries) || entries.length === 0) {
+            return { types: 0, total: 0 };
+        }
 
-    const defaultBuiltIns = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map(
-        (process) => ({
+        return entries.reduce(
+            (summary, entry) => {
+                const count = Number(entry?.count);
+                const normalizedCount = Number.isFinite(count) ? count : 0;
+                return {
+                    types: summary.types + 1,
+                    total: summary.total + normalizedCount,
+                };
+            },
+            { types: 0, total: 0 }
+        );
+    };
+
+    const toListProcess = (process, fallbackCustom = false) => {
+        const requireSummary = summarizeEntries(process?.requireItems);
+        const consumeSummary = summarizeEntries(process?.consumeItems);
+        const createSummary = summarizeEntries(process?.createItems);
+
+        return {
             ...process,
-            custom: false,
-        })
+            custom: Boolean(process?.custom ?? fallbackCustom),
+            requireItemTypes: Number(process?.requireItemTypes ?? requireSummary.types),
+            requireItemTotal: Number(process?.requireItemTotal ?? requireSummary.total),
+            consumeItemTypes: Number(process?.consumeItemTypes ?? consumeSummary.types),
+            consumeItemTotal: Number(process?.consumeItemTotal ?? consumeSummary.total),
+            createItemTypes: Number(process?.createItemTypes ?? createSummary.types),
+            createItemTotal: Number(process?.createItemTotal ?? createSummary.total),
+        };
+    };
+
+    const dedupeByNormalizedId = (processes) => {
+        const seenIds = new Set();
+        const deduped = [];
+
+        for (const process of processes) {
+            const processId = normalizeProcessId(process?.id);
+            if (processId.length === 0 || seenIds.has(processId)) {
+                continue;
+            }
+            seenIds.add(processId);
+            deduped.push(process);
+        }
+
+        return deduped;
+    };
+
+    $: resolvedBuiltIns = (Array.isArray(builtInProcesses) ? builtInProcesses : []).map((process) =>
+        toListProcess(process, false)
     );
 
-    $: resolvedBuiltIns = (
-        Array.isArray(builtInProcesses) && builtInProcesses.length > 0
-            ? builtInProcesses
-            : defaultBuiltIns
-    ).map(withBuiltinFlag);
-
-    $: allProcesses = [
+    $: allProcesses = dedupeByNormalizedId([
         ...resolvedBuiltIns,
-        ...(Array.isArray(customProcesses) ? customProcesses : []),
-    ]
-        .map(withBuiltinFlag)
-        .filter((process) => normalizeProcessId(process?.id).length > 0)
-        .filter((process, index, list) => {
-            const processId = normalizeProcessId(process?.id);
-            return list.findIndex((entry) => normalizeProcessId(entry?.id) === processId) === index;
-        });
+        ...(Array.isArray(customProcesses) ? customProcesses : []).map((process) =>
+            toListProcess(process, true)
+        ),
+    ]);
 
     onMount(async () => {
         try {

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -6,19 +6,6 @@ const { customListMock } = vi.hoisted(() => ({
     customListMock: vi.fn(),
 }));
 
-vi.mock('../../../generated/processes.json', () => ({
-    default: [
-        {
-            id: 'built-in-1',
-            title: 'Built In Process',
-            duration: '10m',
-            requireItems: [{ id: 'a', count: 1 }],
-            consumeItems: [{ id: 'b', count: 2 }],
-            createItems: [{ id: 'c', count: 3 }],
-        },
-    ],
-}));
-
 vi.mock('../../../utils/customcontent.js', () => ({
     db: {
         list: customListMock,
@@ -29,13 +16,28 @@ vi.mock('../../../utils/customcontent.js', () => ({
 }));
 
 describe('Processes list route contract', () => {
+    const builtInProcesses = [
+        {
+            id: 'built-in-1',
+            title: 'Built In Process',
+            duration: '10m',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 1,
+            consumeItemTotal: 2,
+            createItemTypes: 1,
+            createItemTotal: 3,
+            custom: false,
+        },
+    ];
+
     beforeEach(() => {
         customListMock.mockReset();
     });
 
     it('renders built-in summary rows immediately and keeps navigation controls', () => {
         customListMock.mockResolvedValue([]);
-        render(Processes);
+        render(Processes, { props: { builtInProcesses } });
 
         expect(screen.getByText('Built In Process')).toBeTruthy();
         expect(screen.queryByText('Loading processes...')).toBeNull();
@@ -65,7 +67,7 @@ describe('Processes list route contract', () => {
             },
         ]);
 
-        render(Processes);
+        render(Processes, { props: { builtInProcesses } });
 
         expect(await screen.findByText('Custom Process')).toBeTruthy();
         expect(screen.getByText('Custom')).toBeTruthy();
@@ -73,5 +75,25 @@ describe('Processes list route contract', () => {
         const detailLinks = screen.getAllByRole('link', { name: 'View details' });
         expect(detailLinks.length).toBe(2);
         expect(detailLinks[1].getAttribute('href')).toBe('/processes/custom-1');
+    });
+
+    it('de-dupes by normalized id and keeps built-ins when custom ids collide', async () => {
+        customListMock.mockResolvedValue([
+            {
+                id: ' built-in-1 ',
+                title: 'Overriding Custom Process',
+                duration: '99m',
+                custom: true,
+                requireItems: [],
+                consumeItems: [],
+                createItems: [],
+            },
+        ]);
+
+        render(Processes, { props: { builtInProcesses } });
+
+        await screen.findByText('Built In Process');
+        expect(screen.queryByText('Overriding Custom Process')).toBeNull();
+        expect(screen.getAllByRole('link', { name: 'View details' })).toHaveLength(1);
     });
 });

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -64,9 +64,9 @@ describe('Processes list route contract', () => {
         customListMock.mockResolvedValue([]);
         render(Processes, { props: { builtInProcesses } });
 
-        expect(screen.getByRole('link', { name: 'Create a new process' }).getAttribute('href')).toBe(
-            '/processes/create'
-        );
+        expect(
+            screen.getByRole('link', { name: 'Create a new process' }).getAttribute('href')
+        ).toBe('/processes/create');
         expect(screen.getByRole('link', { name: 'Manage processes' }).getAttribute('href')).toBe(
             '/processes/manage'
         );

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Processes from '../Processes.svelte';
+
+const { customListMock } = vi.hoisted(() => ({
+    customListMock: vi.fn(),
+}));
+
+vi.mock('../../../generated/processes.json', () => ({
+    default: [
+        {
+            id: 'built-in-1',
+            title: 'Built In Process',
+            duration: '10m',
+            requireItems: [{ id: 'a', count: 1 }],
+            consumeItems: [{ id: 'b', count: 2 }],
+            createItems: [{ id: 'c', count: 3 }],
+        },
+    ],
+}));
+
+vi.mock('../../../utils/customcontent.js', () => ({
+    db: {
+        list: customListMock,
+    },
+    ENTITY_TYPES: {
+        PROCESS: 'process',
+    },
+}));
+
+describe('Processes list route contract', () => {
+    beforeEach(() => {
+        customListMock.mockReset();
+    });
+
+    it('renders built-in summary rows immediately and keeps navigation controls', () => {
+        customListMock.mockResolvedValue([]);
+        render(Processes);
+
+        expect(screen.getByText('Built In Process')).toBeTruthy();
+        expect(screen.queryByText('Loading processes...')).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Buy required items' })).toBeNull();
+
+        expect(screen.getByRole('link', { name: 'Create a new process' }).getAttribute('href')).toBe(
+            '/processes/create'
+        );
+        expect(screen.getByRole('link', { name: 'Manage processes' }).getAttribute('href')).toBe(
+            '/processes/manage'
+        );
+        expect(screen.getByRole('link', { name: 'View details' }).getAttribute('href')).toBe(
+            '/processes/built-in-1'
+        );
+    });
+
+    it('merges custom processes asynchronously after mount', async () => {
+        customListMock.mockResolvedValue([
+            {
+                id: 'custom-1',
+                title: 'Custom Process',
+                duration: '20m',
+                custom: true,
+                requireItems: [],
+                consumeItems: [],
+                createItems: [],
+            },
+        ]);
+
+        render(Processes);
+
+        expect(await screen.findByText('Custom Process')).toBeTruthy();
+        expect(screen.getByText('Custom')).toBeTruthy();
+
+        const detailLinks = screen.getAllByRole('link', { name: 'View details' });
+        expect(detailLinks.length).toBe(2);
+        expect(detailLinks[1].getAttribute('href')).toBe('/processes/custom-1');
+    });
+});

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -35,13 +35,34 @@ describe('Processes list route contract', () => {
         customListMock.mockReset();
     });
 
-    it('renders built-in summary rows immediately and keeps navigation controls', () => {
-        customListMock.mockResolvedValue([]);
+    it('renders built-in summary rows from initial output before custom merge resolves', () => {
+        let resolveCustomProcesses;
+        const pendingCustomProcesses = new Promise((resolve) => {
+            resolveCustomProcesses = resolve;
+        });
+        customListMock.mockReturnValue(pendingCustomProcesses);
+
         render(Processes, { props: { builtInProcesses } });
 
         expect(screen.getByText('Built In Process')).toBeTruthy();
-        expect(screen.queryByText('Loading processes...')).toBeNull();
-        expect(screen.queryByRole('button', { name: 'Buy required items' })).toBeNull();
+        expect(screen.getByText('Duration')).toBeTruthy();
+        expect(screen.queryByText('No processes found')).toBeNull();
+
+        resolveCustomProcesses([]);
+    });
+
+    it('keeps list route summary-only without detail runtime controls', () => {
+        customListMock.mockResolvedValue([]);
+        render(Processes, { props: { builtInProcesses } });
+
+        for (const control of ['Buy required items', 'Start', 'Pause', 'Resume', 'Collect']) {
+            expect(screen.queryByRole('button', { name: control })).toBeNull();
+        }
+    });
+
+    it('keeps create and manage navigation affordances on the list route', () => {
+        customListMock.mockResolvedValue([]);
+        render(Processes, { props: { builtInProcesses } });
 
         expect(screen.getByRole('link', { name: 'Create a new process' }).getAttribute('href')).toBe(
             '/processes/create'

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -1,8 +1,14 @@
 ---
 import Page from '../../components/Page.astro';
+import generatedProcesses from '../../generated/processes.json';
 import Processes from './Processes.svelte';
+
+const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => ({
+    ...process,
+    custom: false,
+}));
 ---
 
 <Page title="Processes" columns="1">
-    <Processes client:load />
+    <Processes builtInProcesses={builtInProcesses} client:load />
 </Page>

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -3,10 +3,39 @@ import Page from '../../components/Page.astro';
 import generatedProcesses from '../../generated/processes.json';
 import Processes from './Processes.svelte';
 
-const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => ({
-    ...process,
-    custom: false,
-}));
+const summarizeEntries = (entries = []) =>
+    Array.isArray(entries)
+        ? entries.reduce(
+              (summary, entry) => {
+                  const count = Number(entry?.count);
+                  const normalizedCount = Number.isFinite(count) ? count : 0;
+                  return {
+                      types: summary.types + 1,
+                      total: summary.total + normalizedCount,
+                  };
+              },
+              { types: 0, total: 0 }
+          )
+        : { types: 0, total: 0 };
+
+const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => {
+    const requireSummary = summarizeEntries(process?.requireItems);
+    const consumeSummary = summarizeEntries(process?.consumeItems);
+    const createSummary = summarizeEntries(process?.createItems);
+
+    return {
+        id: process?.id,
+        title: process?.title,
+        duration: process?.duration,
+        custom: false,
+        requireItemTypes: requireSummary.types,
+        requireItemTotal: requireSummary.total,
+        consumeItemTypes: consumeSummary.types,
+        consumeItemTotal: consumeSummary.total,
+        createItemTypes: createSummary.types,
+        createItemTotal: createSummary.total,
+    };
+});
 ---
 
 <Page title="Processes" columns="1">


### PR DESCRIPTION
### Motivation
- Reduce initial render/hydration cost on `/processes` by avoiding mounting detail-grade runtime components for every list row. 
- Make the list summary-first and primarily navigational so built-in processes appear immediately via SSR. 
- Preserve all gameplay semantics and keep full runtime controls (including “Buy required items”) on the detail route only. 

### Description
- Added a lightweight summary row component `frontend/src/pages/processes/ProcessListRow.svelte` that renders compact metadata and a `View details` link. 
- Changed `frontend/src/pages/processes/index.astro` to pass SSR-built `builtInProcesses` into the client component so built-ins render immediately. 
- Reworked `frontend/src/pages/processes/Processes.svelte` to render `ProcessListRow` for each process, remove the full-page loading gate, and perform an asynchronous `db.list(ENTITY_TYPES.PROCESS)` merge of custom processes on `onMount` with dedupe by normalized id. 
- Preserved `frontend/src/pages/process/[slug]/ProcessView.svelte` and `frontend/src/components/svelte/Process.svelte` for the detail route so all runtime controls (start/cancel/pause/resume/collect/Buy required items) remain unchanged. 
- Added focused tests exercising the new contract: `frontend/src/pages/processes/__tests__/Processes.spec.ts` and `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts`.

### Testing
- Ran targeted unit tests with `npx vitest run frontend/src/pages/processes/__tests__/Processes.spec.ts frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` and they passed. 
- Ran link verification with `node scripts/link-check.mjs` and it passed. 
- Ran lint with `npm run lint` and it passed. 
- Ran `npm run build` and the site built successfully. 
- `npm run type-check` failed due to a pre-existing unrelated TypeScript test error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts`; this failure is external to the `/processes` changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d755054d40832fa69a77dc76fe583f)