### PR TITLE
Improve /processes list performance with summary-first rows

### DIFF
--- a/frontend/__tests__/manageActionButtons.test.js
+++ b/frontend/__tests__/manageActionButtons.test.js
@@ -6,10 +6,6 @@ import ManageQuests from '../src/pages/quests/svelte/ManageQuests.svelte';
 import ManageProcesses from '../src/pages/processes/svelte/ManageProcesses.svelte';
 import Processes from '../src/pages/processes/Processes.svelte';
 
-vi.mock('../src/pages/process/[slug]/ProcessView.svelte', () => ({
-    default: {},
-}));
-
 vi.mock('../src/generated/processes.json', () => ({
     default: [
         {

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,0 +1,74 @@
+<script>
+    export let process;
+
+    const toCount = (items = []) => (Array.isArray(items) ? items.length : 0);
+
+    const summarize = (label, items = []) => {
+        const count = toCount(items);
+        return `${label}: ${count}`;
+    };
+
+    $: processId = String(process?.id ?? '').trim();
+    $: title = process?.title ?? processId;
+    $: duration = process?.duration ?? 'Unknown';
+    $: requireSummary = summarize('Requires', process?.requireItems);
+    $: consumeSummary = summarize('Consumes', process?.consumeItems);
+    $: createSummary = summarize('Creates', process?.createItems);
+</script>
+
+<article class="process-row" data-process-id={processId}>
+    <div class="summary">
+        <h2>{title}</h2>
+        <p class="duration">Duration: {duration}</p>
+        <p class="io-summary">{requireSummary} • {consumeSummary} • {createSummary}</p>
+    </div>
+    <div class="actions">
+        {#if process?.custom}
+            <span class="badge">Custom</span>
+        {/if}
+        <a class="details-link" href={`/processes/${processId}`}>View details</a>
+    </div>
+</article>
+
+<style>
+    .process-row {
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+        padding: 14px 16px;
+        display: flex;
+        gap: 12px;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    .summary h2 {
+        margin: 0;
+        font-size: 1.1rem;
+    }
+
+    .duration,
+    .io-summary {
+        margin: 4px 0 0;
+    }
+
+    .actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .badge {
+        border: 1px solid #9ec9a3;
+        border-radius: 999px;
+        padding: 2px 8px;
+        font-size: 0.8rem;
+    }
+
+    .details-link {
+        color: #fff;
+        text-decoration: underline;
+        font-weight: 600;
+    }
+</style>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -1,9 +1,11 @@
 <script>
     import { onMount } from 'svelte';
     import Chip from '../../components/svelte/Chip.svelte';
-    import processes from '../../generated/processes.json';
+    import generatedProcesses from '../../generated/processes.json';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
-    import ProcessView from '../process/[slug]/ProcessView.svelte';
+    import ProcessListRow from './ProcessListRow.svelte';
+
+    export let builtInProcesses = null;
 
     let mounted = false;
     let customProcesses = [];
@@ -15,25 +17,41 @@
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
+    const builtInsFromGenerated = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map(
+        (process) => ({
+            ...process,
+            custom: false,
+        })
+    );
+
+    const builtInsFromProps = (Array.isArray(builtInProcesses) ? builtInProcesses : [])
+        .map((process) => ({
+            ...process,
+            custom: false,
+        }))
+        .filter((process) => normalizeProcessId(process?.id));
+
+    $: resolvedBuiltIns = builtInsFromProps.length ? builtInsFromProps : builtInsFromGenerated;
+
+    $: allProcesses = [...resolvedBuiltIns, ...(Array.isArray(customProcesses) ? customProcesses : [])]
+        .filter((process) => normalizeProcessId(process?.id))
+        .filter((process, index, list) => {
+            const processId = normalizeProcessId(process?.id);
+            return list.findIndex((entry) => normalizeProcessId(entry?.id) === processId) === index;
+        });
+
     onMount(async () => {
         mounted = true;
+
         try {
-            customProcesses = (await db.list(ENTITY_TYPES.PROCESS)) ?? [];
+            customProcesses = ((await db.list(ENTITY_TYPES.PROCESS)) ?? []).filter(
+                (process) => normalizeProcessId(process?.id)
+            );
         } catch (error) {
             console.error('Failed to load custom processes:', error);
             customProcesses = [];
         }
     });
-
-    const builtInProcesses = (Array.isArray(processes) ? processes : []).map((process) => ({
-        ...process,
-        custom: false,
-    }));
-
-    $: allProcesses = [
-        ...builtInProcesses,
-        ...(Array.isArray(customProcesses) ? customProcesses : []),
-    ].filter(Boolean);
 </script>
 
 <div class="processes-page" data-hydrated={mounted ? 'true' : 'false'}>
@@ -43,22 +61,15 @@
         {/each}
     </div>
 
-    {#if mounted}
-        <div class="processes-list">
-            {#if allProcesses.length === 0}
-                <div class="no-processes">No processes found</div>
-            {:else}
-                {#each allProcesses as process (normalizeProcessId(process?.id))}
-                    {@const processId = normalizeProcessId(process?.id)}
-                    <div class="process-row" data-process-id={processId}>
-                        <ProcessView slug={processId} />
-                    </div>
-                {/each}
-            {/if}
-        </div>
-    {:else}
-        <div class="loading">Loading processes...</div>
-    {/if}
+    <div class="processes-list">
+        {#if allProcesses.length === 0}
+            <div class="no-processes">No processes found</div>
+        {:else}
+            {#each allProcesses as process (normalizeProcessId(process?.id))}
+                <ProcessListRow {process} />
+            {/each}
+        {/if}
+    </div>
 </div>
 
 <style>
@@ -78,18 +89,10 @@
     .processes-list {
         display: flex;
         flex-direction: column;
-        gap: 20px;
+        gap: 12px;
     }
 
-    .process-row {
-        background: #2c5837;
-        border-radius: 12px;
-        border: 2px solid #007006;
-        padding: 15px;
-    }
-
-    .no-processes,
-    .loading {
+    .no-processes {
         text-align: center;
         padding: 40px;
         background: #2c5837;

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -1,8 +1,14 @@
 ---
 import Page from '../../components/Page.astro';
 import Processes from './Processes.svelte';
+import generatedProcesses from '../../generated/processes.json';
+
+const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => ({
+    ...process,
+    custom: false,
+}));
 ---
 
 <Page title="Processes" columns="1">
-    <Processes client:load />
+    <Processes builtInProcesses={builtInProcesses} client:load />
 </Page>

--- a/frontend/tests/processViewDetailActions.test.ts
+++ b/frontend/tests/processViewDetailActions.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ProcessView from '../src/pages/process/[slug]/ProcessView.svelte';
+import { buyItems } from '../src/utils/gameState/inventory.js';
+
+vi.mock('../src/components/svelte/Process.svelte', () => ({
+    default: () => null,
+}));
+
+vi.mock('../src/generated/processes.json', () => ({
+    default: [
+        {
+            id: 'launch-rocket',
+            title: 'Launch Rocket',
+            duration: '5m',
+            requireItems: [{ id: 'rocket-fuel', count: 2 }],
+            consumeItems: [],
+            createItems: [],
+        },
+    ],
+}));
+
+vi.mock('../src/pages/inventory/json/items', () => ({
+    default: [{ id: 'rocket-fuel', price: '12 dUSD' }],
+}));
+
+vi.mock('../src/utils/gameState/inventory.js', () => ({
+    buyItems: vi.fn(),
+    getItemCount: vi.fn(() => 0),
+}));
+
+vi.mock('../src/utils.js', () => ({
+    getPriceStringComponents: vi.fn((price: string) => ({ price: Number.parseInt(price, 10) || null })),
+}));
+
+vi.mock('../src/utils/customcontent.js', () => ({
+    getProcess: vi.fn().mockResolvedValue(null),
+}));
+
+describe('ProcessView detail actions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('keeps Buy required items action on detail view and buys missing requirements', async () => {
+        render(ProcessView, { props: { slug: 'launch-rocket' } });
+
+        const button = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(button.hasAttribute('disabled')).toBe(false);
+
+        await fireEvent.click(button);
+
+        expect(buyItems).toHaveBeenCalledWith([{ id: 'rocket-fuel', quantity: 2, price: 12 }]);
+        expect(screen.getByRole('status').textContent).toContain('Added 2 items to inventory');
+    });
+});

--- a/frontend/tests/processesListPresentation.test.ts
+++ b/frontend/tests/processesListPresentation.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Processes from '../src/pages/processes/Processes.svelte';
+import { db } from '../src/utils/customcontent.js';
+
+vi.mock('../src/generated/processes.json', () => ({
+    default: [
+        {
+            id: 'built-in-process',
+            title: 'Built In Process',
+            duration: '15m',
+            requireItems: [{ id: 'item-1', count: 1 }],
+            consumeItems: [{ id: 'item-2', count: 2 }],
+            createItems: [{ id: 'item-3', count: 3 }],
+        },
+    ],
+}));
+
+vi.mock('../src/utils/customcontent.js', () => ({
+    db: {
+        list: vi.fn().mockResolvedValue([]),
+    },
+    ENTITY_TYPES: {
+        PROCESS: 'process',
+    },
+}));
+
+describe('Processes list presentation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders built-in summary rows immediately without a loading gate', () => {
+        render(Processes);
+
+        expect(screen.getByText('Built In Process')).not.toBeNull();
+        expect(screen.getByText('Duration: 15m')).not.toBeNull();
+        expect(screen.queryByText('Loading processes...')).toBeNull();
+    });
+
+    it('does not render ProcessView in list rows', () => {
+        render(Processes);
+
+        expect(screen.getByRole('link', { name: 'View details' }).getAttribute('href')).toBe(
+            '/processes/built-in-process'
+        );
+        expect(screen.queryByRole('button', { name: 'Buy required items' })).toBeNull();
+    });
+
+    it('merges custom processes asynchronously after mount', async () => {
+        vi.mocked(db.list).mockResolvedValueOnce([
+            {
+                id: 'custom-process',
+                title: 'Custom Process',
+                duration: '1h',
+                requireItems: [],
+                consumeItems: [],
+                createItems: [],
+                custom: true,
+            },
+        ]);
+
+        render(Processes);
+
+        expect(await screen.findByText('Custom Process')).not.toBeNull();
+        expect(screen.getByText('Custom')).not.toBeNull();
+        const detailLinks = screen.getAllByRole('link', { name: 'View details' });
+        const hrefs = detailLinks.map((link) => link.getAttribute('href'));
+        expect(hrefs).toContain('/processes/built-in-process');
+        expect(hrefs).toContain('/processes/custom-process');
+    });
+});


### PR DESCRIPTION
### Motivation
- Reduce `/processes` initial paint and per-row hydration cost by removing detail-grade mounts from the list view. 
- Make the list summary-first and primarily navigational while preserving all existing detail-route gameplay semantics. 
- Ensure built-in processes are visible immediately during SSR and allow custom processes to merge asynchronously after mount.

### Description
- Add a lightweight summary row component `frontend/src/pages/processes/ProcessListRow.svelte` and use it for list rendering so rows no longer mount `ProcessView`/`Process`. 
- Update `frontend/src/pages/processes/index.astro` to pass built-in process data into the list component so built-ins render immediately on first paint. 
- Refactor `frontend/src/pages/processes/Processes.svelte` to render built-ins SSR-first, asynchronously `db.list(ENTITY_TYPES.PROCESS)`-merge custom processes after `onMount`, normalize/deduplicate IDs for stable ordering, and avoid rendering detail-only CTAs on the list. 
- Preserve `frontend/src/pages/process/[slug]/ProcessView.svelte` and `frontend/src/components/svelte/Process.svelte` for full runtime controls (including “Buy required items”) on the detail route; no gameplay semantics changed. 
- Scope kept intentionally small and localized to the `/processes` surface and a few focused tests; optional design-doc follow-ups (virtualization, new search/filter UX, manifest pipeline, telemetry, etc.) were not implemented.

### Testing
- Ran targeted component tests: `frontend/tests/processesListPresentation.test.ts` and `frontend/tests/processViewDetailActions.test.ts` with Vitest and both passed. 
- Ran `node scripts/link-check.mjs` and it succeeded with all local markdown links resolved. 
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run build` and the site build completed successfully. 
- `npm run type-check` failed due to a pre-existing unrelated TypeScript test error: `tests/runRemoteCompletionistAwardIIIResolver.test.ts(132,34): TS2493: Tuple type '[]' of length '0' has no element at index '0'`. 
- Running the full root `node run-tests.js` suite timed out in this environment (environment constraint), so only the focused tests above were executed and verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d755054d40832fa69a77dc76fe583f)