### PR TITLE
Split /processes into SSR summary rows and client-side custom merge

### DIFF
--- a/frontend/__tests__/manageActionButtons.test.js
+++ b/frontend/__tests__/manageActionButtons.test.js
@@ -1,14 +1,11 @@
 /** @jest-environment jsdom */
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { render, screen } from '@testing-library/svelte';
 import ManageItems from '../src/pages/inventory/svelte/ManageItems.svelte';
 import ManageQuests from '../src/pages/quests/svelte/ManageQuests.svelte';
 import ManageProcesses from '../src/pages/processes/svelte/ManageProcesses.svelte';
-import Processes from '../src/pages/processes/Processes.svelte';
-
-vi.mock('../src/pages/process/[slug]/ProcessView.svelte', () => ({
-    default: {},
-}));
 
 vi.mock('../src/generated/processes.json', () => ({
     default: [
@@ -88,12 +85,13 @@ describe('Manage pages action buttons', () => {
         expect(viewButton).toHaveAttribute('href', '/processes');
     });
 
-    it('shows create and manage buttons on the processes page', async () => {
-        render(Processes);
-        const createButton = await screen.findByRole('link', { name: 'Create a new process' });
-        const manageButton = await screen.findByRole('link', { name: 'Manage processes' });
+    it('keeps create/manage action buttons on the processes page route scaffold', () => {
+        const indexPath = path.join(__dirname, '../src/pages/processes/index.astro');
+        const source = readFileSync(indexPath, 'utf8');
 
-        expect(createButton).toHaveAttribute('href', '/processes/create');
-        expect(manageButton).toHaveAttribute('href', '/processes/manage');
+        expect(source).toContain('Create a new process');
+        expect(source).toContain('/processes/create');
+        expect(source).toContain('Manage processes');
+        expect(source).toContain('/processes/manage');
     });
 });

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,0 +1,79 @@
+<script>
+    export let process;
+
+    const normalizedDuration = (duration) => {
+        if (typeof duration === 'string' && duration.trim().length > 0) {
+            return duration;
+        }
+        return 'Unknown';
+    };
+
+    const toCountSummary = (items) => {
+        if (!Array.isArray(items) || items.length === 0) {
+            return 'None';
+        }
+
+        const total = items.reduce((sum, item) => sum + Number(item?.count ?? 0), 0);
+        return `${items.length} type${items.length === 1 ? '' : 's'} (${total} total)`;
+    };
+</script>
+
+<article class="process-list-row" data-process-id={process?.id ?? ''}>
+    <div class="process-header">
+        <h3>{process?.title || process?.id || 'Untitled process'}</h3>
+        {#if process?.custom}
+            <span class="custom-badge">Custom</span>
+        {/if}
+    </div>
+    <p class="duration">Duration: {normalizedDuration(process?.duration)}</p>
+    <p class="summary">Requires: {toCountSummary(process?.requireItems)}</p>
+    <p class="summary">Consumes: {toCountSummary(process?.consumeItems)}</p>
+    <p class="summary">Creates: {toCountSummary(process?.createItems)}</p>
+    <a class="details-link" href={`/processes/${process?.id ?? ''}`}>View details</a>
+</article>
+
+<style>
+    .process-list-row {
+        background: #2c5837;
+        border: 2px solid #007006;
+        border-radius: 12px;
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .process-header {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        line-height: 1.3;
+    }
+
+    .custom-badge {
+        background: #175cd3;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: 2px 8px;
+        white-space: nowrap;
+    }
+
+    .duration,
+    .summary {
+        margin: 0;
+    }
+
+    .details-link {
+        align-self: flex-start;
+        color: #fff;
+        font-weight: 600;
+        text-decoration: underline;
+    }
+</style>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -1,17 +1,10 @@
 <script>
     import { onMount } from 'svelte';
-    import Chip from '../../components/svelte/Chip.svelte';
-    import processes from '../../generated/processes.json';
+    import ProcessListRow from './ProcessListRow.svelte';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
-    import ProcessView from '../process/[slug]/ProcessView.svelte';
 
     let mounted = false;
     let customProcesses = [];
-
-    const actionButtons = [
-        { text: 'Create a new process', href: '/processes/create' },
-        { text: 'Manage processes', href: '/processes/manage' },
-    ];
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
@@ -25,76 +18,37 @@
         }
     });
 
-    const builtInProcesses = (Array.isArray(processes) ? processes : []).map((process) => ({
-        ...process,
-        custom: false,
-    }));
-
-    $: allProcesses = [
-        ...builtInProcesses,
-        ...(Array.isArray(customProcesses) ? customProcesses : []),
-    ].filter(Boolean);
+    $: allCustomProcesses = (Array.isArray(customProcesses) ? customProcesses : [])
+        .filter(Boolean)
+        .map((process) => ({
+            ...process,
+            custom: process?.custom ?? true,
+        }));
 </script>
 
-<div class="processes-page" data-hydrated={mounted ? 'true' : 'false'}>
-    <div class="action-buttons">
-        {#each actionButtons as button}
-            <Chip text={button.text} href={button.href} inverted={true} />
-        {/each}
-    </div>
-
-    {#if mounted}
+<div class="custom-processes" data-hydrated={mounted ? 'true' : 'false'}>
+    {#if allCustomProcesses.length > 0}
+        <h2>Custom processes</h2>
         <div class="processes-list">
-            {#if allProcesses.length === 0}
-                <div class="no-processes">No processes found</div>
-            {:else}
-                {#each allProcesses as process (normalizeProcessId(process?.id))}
-                    {@const processId = normalizeProcessId(process?.id)}
-                    <div class="process-row" data-process-id={processId}>
-                        <ProcessView slug={processId} />
-                    </div>
-                {/each}
-            {/if}
+            {#each allCustomProcesses as process (normalizeProcessId(process?.id))}
+                <ProcessListRow {process} />
+            {/each}
         </div>
-    {:else}
-        <div class="loading">Loading processes...</div>
     {/if}
 </div>
 
 <style>
-    .processes-page {
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 20px;
+    .custom-processes {
+        margin-top: 20px;
     }
 
-    .action-buttons {
-        display: flex;
-        justify-content: center;
-        gap: 10px;
-        margin-bottom: 20px;
+    h2 {
+        margin: 0 0 10px;
     }
 
     .processes-list {
         display: flex;
         flex-direction: column;
-        gap: 20px;
-    }
-
-    .process-row {
-        background: #2c5837;
-        border-radius: 12px;
-        border: 2px solid #007006;
-        padding: 15px;
-    }
-
-    .no-processes,
-    .loading {
-        text-align: center;
-        padding: 40px;
-        background: #2c5837;
-        border-radius: 12px;
-        border: 2px solid #007006;
-        color: white;
+        gap: 12px;
     }
 </style>

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -1,8 +1,60 @@
 ---
 import Page from '../../components/Page.astro';
+import Chip from '../../components/svelte/Chip.svelte';
+import processes from '../../generated/processes.json';
+import ProcessListRow from './ProcessListRow.svelte';
 import Processes from './Processes.svelte';
+
+const builtInProcesses = (Array.isArray(processes) ? processes : []).map((process) => ({
+    ...process,
+    custom: false,
+}));
+
+const actionButtons = [
+    { text: 'Create a new process', href: '/processes/create' },
+    { text: 'Manage processes', href: '/processes/manage' },
+];
 ---
 
 <Page title="Processes" columns="1">
-    <Processes client:load />
+    <div class="processes-page">
+        <div class="action-buttons">
+            {
+                actionButtons.map((button) => (
+                    <Chip text={button.text} href={button.href} inverted={true} />
+                ))
+            }
+        </div>
+
+        <div class="processes-list" data-built-in-count={builtInProcesses.length}>
+            {
+                builtInProcesses.map((process) => (
+                    <ProcessListRow process={process} />
+                ))
+            }
+        </div>
+
+        <Processes client:load />
+    </div>
 </Page>
+
+<style>
+    .processes-page {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .action-buttons {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+        margin-bottom: 20px;
+    }
+
+    .processes-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+</style>

--- a/frontend/tests/processesListContract.test.ts
+++ b/frontend/tests/processesListContract.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { render, screen } from '@testing-library/svelte';
+import Processes from '../src/pages/processes/Processes.svelte';
+
+const { listMock } = vi.hoisted(() => ({
+    listMock: vi.fn(),
+}));
+
+vi.mock('../src/utils/customcontent.js', () => ({
+    db: {
+        list: listMock,
+    },
+    ENTITY_TYPES: {
+        PROCESS: 'process',
+    },
+}));
+
+describe('Processes list/detail contract', () => {
+    beforeEach(() => {
+        listMock.mockReset();
+    });
+
+    it('does not use ProcessView/detail rendering on the list component path', () => {
+        const componentPath = path.join(__dirname, '../src/pages/processes/Processes.svelte');
+        const source = readFileSync(componentPath, 'utf8');
+
+        expect(source).not.toContain('ProcessView');
+        expect(source).toContain('ProcessListRow');
+        expect(source).not.toContain('Loading processes...');
+    });
+
+    it('renders custom processes asynchronously without blocking initial render', async () => {
+        listMock.mockResolvedValue([
+            {
+                id: 'custom-oxygen-cycle',
+                title: 'Custom oxygen cycle',
+                duration: '2m',
+                requireItems: [{ id: 'tank', count: 1 }],
+                consumeItems: [],
+                createItems: [{ id: 'oxygen', count: 1 }],
+            },
+        ]);
+
+        render(Processes);
+
+        expect(screen.queryByText('Loading processes...')).toBeNull();
+        expect(screen.queryByText('Custom oxygen cycle')).toBeNull();
+
+        expect(await screen.findByText('Custom oxygen cycle')).toBeTruthy();
+        const detailsLink = await screen.findByRole('link', { name: 'View details' });
+        expect(detailsLink.getAttribute('href')).toBe('/processes/custom-oxygen-cycle');
+        expect(screen.getByText('Custom')).toBeTruthy();
+    });
+
+    it('renders built-in process rows from the route scaffold and keeps action links', () => {
+        const indexPath = path.join(__dirname, '../src/pages/processes/index.astro');
+        const source = readFileSync(indexPath, 'utf8');
+
+        expect(source).toContain('builtInProcesses.map');
+        expect(source).toContain('<ProcessListRow process={process} />');
+        expect(source).toContain('data-built-in-count={builtInProcesses.length}');
+        expect(source).toContain('Create a new process');
+        expect(source).toContain('/processes/create');
+        expect(source).toContain('Manage processes');
+        expect(source).toContain('/processes/manage');
+    });
+});


### PR DESCRIPTION
### Motivation
- The `/processes` list was mounting detail-grade components per row, causing hydration gating and large client work; the change implements the v3.0.1 must-have core to reduce list rendering cost and improve first meaningful paint.
- Keep gameplay semantics and the existing detail route behavior intact while making the list summary-first and navigational.

### Description
- Introduce a lightweight summary row component `frontend/src/pages/processes/ProcessListRow.svelte` that renders title, duration, compact requires/consumes/creates summaries, an optional `Custom` badge, and a `View details` link to `/processes/:id` (no runtime controls or timers).
- Change `frontend/src/pages/processes/index.astro` to SSR-render built-in process rows immediately using `ProcessListRow`, and preserve Create/Manage action links on the route scaffold for immediate visibility.
- Rework `frontend/src/pages/processes/Processes.svelte` to stop mounting `ProcessView`/`Process` per row and to only perform client-side async merge of custom processes after `onMount`, rendering custom rows via `ProcessListRow` (so built-ins are visible without the full-page loading gate).
- Preserve `frontend/src/pages/process/[slug]/ProcessView.svelte` as the full-detail runtime surface (including `Buy required items`, Start/Pause/Collect semantics) so all runtime actions remain on the detail route.
- Add/adjust focused tests: new `frontend/tests/processesListContract.test.ts` to assert the list/detail contract and updated `frontend/__tests__/manageActionButtons.test.js` to keep Create/Manage checks against the SSR scaffold only.
- The change is intentionally scoped to the `/processes` list/detail surface and related minimal tests; optional follow-ups from the design doc (virtualization, new filters, broad card refactor, build-manifest optimizations, telemetry) were not implemented.

### Testing
- Ran targeted unit tests: `frontend/tests/processesListContract.test.ts` and `frontend/tests/containerProcesses.test.ts`, both passed.
- Ran repository checks: `node scripts/link-check.mjs` (passed), `npm run lint` (passed), and `npm run build` (passed).
- Ran `npm run type-check` which failed due to a pre-existing unrelated TypeScript test error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts`; this failure is unrelated to the `/processes` changes.
- Ran the full pre-PR harness (`node run-tests.js`) which progressed successfully through the unit/test phases, but end-to-end browser setup failed in this environment due to a network error downloading Playwright browsers (`ENETUNREACH`); this is an environment-level failure and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d755054d40832fa69a77dc76fe583f)