### PR TITLE
⚡ split /processes list from detail rendering

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,0 +1,70 @@
+<script>
+    export let process = {};
+
+    const toCount = (value) => (Array.isArray(value) ? value.length : 0);
+    const formatCount = (label, value) => `${label} ${toCount(value)}`;
+
+    $: processId = String(process?.id ?? '').trim();
+    $: title = process?.title || processId || 'Untitled process';
+    $: duration = process?.duration || 'Unknown';
+    $: requiresSummary = formatCount('Requires', process?.requireItems);
+    $: consumesSummary = formatCount('Consumes', process?.consumeItems);
+    $: createsSummary = formatCount('Creates', process?.createItems);
+</script>
+
+<article
+    class="process-list-row"
+    data-process-id={processId}
+    data-custom={process?.custom ? 'true' : 'false'}
+>
+    <div class="header">
+        <h2>{title}</h2>
+        {#if process?.custom}
+            <span class="custom-badge">Custom</span>
+        {/if}
+    </div>
+    <div class="meta">Duration: {duration}</div>
+    <div class="summary">{requiresSummary} • {consumesSummary} • {createsSummary}</div>
+    <a class="detail-link" href={`/processes/${processId}`}>View details</a>
+</article>
+
+<style>
+    .process-list-row {
+        background: #2c5837;
+        border-radius: 12px;
+        border: 2px solid #007006;
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.05rem;
+    }
+
+    .meta,
+    .summary {
+        font-size: 0.95rem;
+    }
+
+    .custom-badge {
+        font-size: 0.75rem;
+        background: #153320;
+        border: 1px solid #8fcc9a;
+        padding: 2px 6px;
+        border-radius: 999px;
+    }
+
+    .detail-link {
+        width: fit-content;
+        color: white;
+    }
+</style>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -3,7 +3,7 @@
     import Chip from '../../components/svelte/Chip.svelte';
     import processes from '../../generated/processes.json';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
-    import ProcessView from '../process/[slug]/ProcessView.svelte';
+    import ProcessListRow from './ProcessListRow.svelte';
 
     let mounted = false;
     let customProcesses = [];
@@ -15,6 +15,16 @@
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
+    const builtInProcesses = (Array.isArray(processes) ? processes : [])
+        .filter(Boolean)
+        .map((process) => ({
+            ...process,
+            custom: false,
+        }));
+
+    const processKey = (process, index) =>
+        `${normalizeProcessId(process?.id)}:${process?.custom ? 'custom' : 'builtin'}:${index}`;
+
     onMount(async () => {
         mounted = true;
         try {
@@ -25,15 +35,10 @@
         }
     });
 
-    const builtInProcesses = (Array.isArray(processes) ? processes : []).map((process) => ({
-        ...process,
-        custom: false,
-    }));
-
     $: allProcesses = [
         ...builtInProcesses,
         ...(Array.isArray(customProcesses) ? customProcesses : []),
-    ].filter(Boolean);
+    ].filter((process) => normalizeProcessId(process?.id).length > 0);
 </script>
 
 <div class="processes-page" data-hydrated={mounted ? 'true' : 'false'}>
@@ -43,22 +48,15 @@
         {/each}
     </div>
 
-    {#if mounted}
-        <div class="processes-list">
-            {#if allProcesses.length === 0}
-                <div class="no-processes">No processes found</div>
-            {:else}
-                {#each allProcesses as process (normalizeProcessId(process?.id))}
-                    {@const processId = normalizeProcessId(process?.id)}
-                    <div class="process-row" data-process-id={processId}>
-                        <ProcessView slug={processId} />
-                    </div>
-                {/each}
-            {/if}
-        </div>
-    {:else}
-        <div class="loading">Loading processes...</div>
-    {/if}
+    <div class="processes-list">
+        {#if allProcesses.length === 0}
+            <div class="no-processes">No processes found</div>
+        {:else}
+            {#each allProcesses as process, index (processKey(process, index))}
+                <ProcessListRow {process} />
+            {/each}
+        {/if}
+    </div>
 </div>
 
 <style>
@@ -78,18 +76,10 @@
     .processes-list {
         display: flex;
         flex-direction: column;
-        gap: 20px;
+        gap: 12px;
     }
 
-    .process-row {
-        background: #2c5837;
-        border-radius: 12px;
-        border: 2px solid #007006;
-        padding: 15px;
-    }
-
-    .no-processes,
-    .loading {
+    .no-processes {
         text-align: center;
         padding: 40px;
         background: #2c5837;

--- a/frontend/tests/processesListPresentation.test.ts
+++ b/frontend/tests/processesListPresentation.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Processes from '../src/pages/processes/Processes.svelte';
+
+const { mockList } = vi.hoisted(() => ({ mockList: vi.fn() }));
+
+vi.mock('../src/generated/processes.json', () => ({
+    default: [
+        {
+            id: 'test-process',
+            title: 'Test Process',
+            duration: '1h',
+            requireItems: [{ id: 'r1', count: 1 }],
+            consumeItems: [],
+            createItems: [{ id: 'c1', count: 1 }],
+        },
+    ],
+}));
+
+vi.mock('../src/utils/customcontent.js', () => ({
+    db: {
+        list: mockList,
+    },
+    ENTITY_TYPES: {
+        PROCESS: 'process',
+    },
+}));
+
+describe('/processes list presentation contract', () => {
+    beforeEach(() => {
+        mockList.mockReset();
+        mockList.mockResolvedValue([]);
+    });
+
+    it('renders built-in summary rows immediately with navigation controls', async () => {
+        render(Processes);
+
+        expect(screen.getByText('Test Process')).toBeTruthy();
+        expect(screen.queryByText('Loading processes...')).toBeNull();
+        expect(screen.queryByText('Buy required items')).toBeNull();
+
+        expect(
+            screen.getByRole('link', { name: 'Create a new process' }).getAttribute('href')
+        ).toBe('/processes/create');
+        expect(screen.getByRole('link', { name: 'Manage processes' }).getAttribute('href')).toBe(
+            '/processes/manage'
+        );
+        expect(screen.getByRole('link', { name: 'View details' }).getAttribute('href')).toBe(
+            '/processes/test-process'
+        );
+
+        expect(await screen.findByText('Test Process')).toBeTruthy();
+    });
+
+    it('merges custom processes asynchronously after first paint', async () => {
+        mockList.mockResolvedValueOnce([
+            {
+                id: 'custom-process',
+                title: 'Custom Process',
+                duration: '2h',
+                requireItems: [],
+                consumeItems: [],
+                createItems: [],
+                custom: true,
+            },
+        ]);
+
+        render(Processes);
+
+        expect(screen.getByText('Test Process')).toBeTruthy();
+        expect(await screen.findByText('Custom Process')).toBeTruthy();
+        expect(await screen.findByText('Custom')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
### Motivation
- The list route was mounting detail-grade components for every row which inflated hydration cost and delayed meaningful list paint. 
- Implement the v3.0.1 must-have core from the design doc: make `/processes` summary-first, navigational, and render built-ins immediately while preserving detail semantics. 

### Description
- Replaced per-row `ProcessView` mounts with a lightweight, summary-only `ProcessListRow.svelte` at `frontend/src/pages/processes/ProcessListRow.svelte`. 
- Updated `frontend/src/pages/processes/Processes.svelte` to SSR-render built-in rows immediately and to merge custom processes asynchronously after mount, removing the full-page "Loading processes..." gate. 
- Left `frontend/src/pages/process/[slug]/ProcessView.svelte` unchanged so detail-route behavior (runtime controls and “Buy required items”) remains intact. 
- Added focused presentation contract tests in `frontend/tests/processesListPresentation.test.ts` to assert summary-first rendering, absence of detail CTAs on the list, navigation links, and async merge of custom processes. 

### Testing
- Ran the focused unit tests: `frontend/tests/processesListPresentation.test.ts` and `frontend/src/components/__tests__/Process.spec.ts`, and both suites passed. 
- Ran `node scripts/link-check.mjs`, `npm run lint`, and `npm run build`, and each step completed successfully. 
- Ran `npm run type-check` which failed due to a pre-existing, unrelated TypeScript error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` and is not caused by these changes. 
- Executed the project test harness (`node run-tests.js`) which progressed through the root unit suites (many tests passed) and validation checks in this environment; the change-specific tests introduced by this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d755054d40832fa69a77dc76fe583f)