### PR TITLE
📝 docs: refresh v3.0.1 QA checklist and add v3.0.1 changelog addendum

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,9 +1,6 @@
-# DSPACE v3.0.1 QA Checklist (urgent patch line)
+# DSPACE v3.0.1 QA Checklist
 
-> Scope: `v3.0.1` is for urgent bugfixes and small improvements only.
-> It is **not** a feature release track.
-
-Use this checklist for rapid but safe patch promotion from staging to prod.
+> Release target: patch validation for all deltas merged after `v3.0.0` (`3ec45a5517a35c96767f6b946c01104e6ec88f93`).
 
 Related docs:
 
@@ -11,227 +8,223 @@ Related docs:
 - [Release and promotion procedure](../merge-plan.md)
 - [Staging runbook](../k3s-sugarkube-staging.md)
 - [Prod runbook](../k3s-sugarkube-prod.md)
-- [Feature-track QA checklist (v3.1)](./v3.1.md)
+- [v3.0.1 `/quests` design](../design/quests-tti-optimization.md)
+- [v3.0.1 `/processes` design](../design/processes-list-performance-and-presentation.md)
+- [v3.0.1 `/docs` design](../design/docs-index-performance-and-presentation.md)
 
 ---
 
-## 0) Release metadata
+## 0) Patch scope summary (from `v3.0.0` → `v3.0.1`)
+
+`v3.0.1` launch QA must cover these shipped themes together (not just `/quests`):
+
+- `/quests`: list-path performance and stability changes (manifest/snapshot/classification path + delayed custom merge behavior).
+- `/processes`: list refactor to summary-first rows, with detail route behavior retained.
+- `/docs`: lightweight initial payload + deferred full-text corpus loading for keyword search.
+- `/chat`: regression checks for docs-backed retrieval quality (because `/chat` depends on docs corpus behavior).
+- Release safety updates touching smoke/deploy confidence (health checks and route smoke expectations).
+
+---
+
+## 1) Release metadata and sign-off (required)
 
 - [ ] Target version: `v3.0.1`
 - [ ] Candidate tag under test: `________________`
-- [ ] Commit SHA: `________________`
-- [ ] Change scope summary (bugfix/small improvements only): `________________`
-- [ ] Staging sign-off owner + timestamp: `________________`
+- [ ] Candidate commit SHA: `________________`
+- [ ] QA owner + timestamp: `________________`
+- [ ] Staging deploy owner + timestamp: `________________`
 - [ ] Production deploy owner + timestamp: `________________`
 - [ ] Previous known-good rollback tag: `________________`
+- [ ] Evidence location (logs/traces/screenshots): `________________`
 
 ---
 
-## 1) Patch-scope gate (must pass before broader QA)
+## 2) Required automated checks (launch gates)
 
-- [ ] Every change is bugfix/small improvement scoped
-- [ ] No new feature flag or major UX flow introduced without explicit approval
-- [ ] No unrelated refactor included
-- [ ] Release notes drafted with user-visible deltas only
-
----
-
-## 2) Automated checks (required)
+Run from repo root unless noted.
 
 ```bash
 npm run lint
-```
-
-```bash
 npm run type-check
+npm run build
+npm test
+node scripts/link-check.mjs
 ```
+
+Targeted evidence for this patch line:
 
 ```bash
-npm run link-check
+npm --prefix frontend run perf:quests
+npm --prefix frontend run test -- quests-tti-behavior.spec.ts quests-tti-metrics.spec.ts
+npm --prefix frontend run test -- src/components/__tests__/DocsIndexSearch.spec.ts src/pages/docs/__tests__/index.spec.ts
 ```
 
-```bash
-node run-tests.js
-```
-
-If full test runtime is constrained, record the exception and run at least targeted validation:
-
-```bash
-npm run qa:smoke
-```
+- [ ] All required commands pass, or exceptions are documented with owner + mitigation.
 
 ---
 
-## 3) Staging deploy + validation
+## 3) Staging deploy + platform health (required)
 
-Deploy approved immutable candidate to staging (`staging.democratized.space`) and validate:
-
-- [ ] `/config.json` returns expected runtime config
-- [ ] `/healthz` and `/livez` return success
-- [ ] Patch issue reproduction is fixed in staging
-- [ ] No regression in core nav/routes relevant to touched areas
-- [ ] QA Cheats remain enabled in staging (`DSPACE_ENV=staging`)
-
-Suggested smoke commands:
+Deploy the immutable candidate to `staging.democratized.space`.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json
-```
-
-```bash
 curl -fsS https://staging.democratized.space/healthz
-```
-
-```bash
 curl -fsS https://staging.democratized.space/livez
 ```
 
-### 3.1 `/quests` TTI performance launch gate (required for this optimization)
+- [ ] `/config.json` returns expected version/env.
+- [ ] `/healthz` and `/livez` return success.
+- [ ] Core routes load: `/`, `/quests`, `/processes`, `/docs`, `/chat`, `/changelog`.
+- [ ] QA Cheats policy verified for staging (`DSPACE_ENV=staging`).
 
-This gate compares **exactly two candidates** on `staging.democratized.space`:
+---
 
-1. **Instrumented baseline candidate** branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
-2. **Optimized HEAD candidate** for `v3.0.1`
+## 4) `/quests` validation (required launch gate)
 
-Baseline policy (strict):
+### 4.1 TTI baseline vs optimized comparison (required)
 
-- The baseline branch is **measurement-only instrumentation**.
-- It must emit the required marks/measures, but **must not include optimization logic** from the
-  HEAD implementation.
-- If baseline internals differ from optimized internals, preserve the exact timing names for
-  comparability, keep instrumentation honest, and if an optional phase is not meaningfully
-  separable, omit it or explicitly document the approximation in recorded results.
+Compare exactly two immutable candidates on staging:
 
-Primary validation stack for this gate (required):
-
-1. Playwright `/quests` TTI measurement harness (raw output retained)
-2. `/quests` User Timing marks/measures
-3. Chrome DevTools Performance trace review (at least one trace per candidate)
-
-Lighthouse is supplementary only and cannot replace the required evidence above.
-
-#### Procedure (run sequentially on the same staging environment)
-
-1. Deploy the **baseline** as a distinct immutable build/tag (do not mutate artifacts in place).
-2. Confirm rollback path before any candidate swap.
-3. Verify staging health for this candidate: use `/config.json` as a config sanity check, and confirm deployed candidate `version`/`env` via `/healthz` or `/livez` output.
-4. Reset browser/client state before measurement (clear IndexedDB, localStorage,
-   sessionStorage, service worker/cache storage, and any persisted quest state).
-5. Run Playwright harness on `/quests` with the chosen profile/slowdown.
-6. Capture at least one Chrome DevTools performance trace for `/quests`.
-7. Record metadata and results for this run, including:
-   - candidate tag
-   - commit SHA
-   - date/time
-   - browser/device profile
-   - CPU slowdown factor
-   - seeded save / test account state
-   - route
-   - cold vs warm
-8. Deploy the **optimized HEAD** as a second distinct immutable build/tag.
-9. Repeat steps 3-7 under identical seeded state, route, browser/device profile, and CPU slowdown.
-10. Compare results and make go/no-go decision.
-
-Required harness command:
+1. Instrumented baseline from `3ec45a5517a35c96767f6b946c01104e6ec88f93` (instrumentation-only).
+2. Optimized `v3.0.1` candidate.
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
-```
-
-Optional recommended slow-CPU companion run (use the same factor for both candidates; `perf:quests:slowcpu` applies `QUESTS_TTI_CPU_SLOWDOWN=4`):
-
-```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-Required timing marks/measures to verify and record:
+Required marks/measures to capture:
 
-- Required marks:
-    - `quests:list-hydration-start`
-    - `quests:list-visible`
-    - `quests:snapshot-classification-ready`
-    - `quests:full-state-reconciliation-complete`
-- Optional mark:
-    - `quests:custom-quests-merge-complete`
-- Required measures:
-    - `quests:time-to-list-visible`
-    - `quests:time-to-snapshot-classification`
-    - `quests:time-to-full-reconciliation`
-- Optional measure:
-    - `quests:time-to-custom-merge`
+- Marks: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`
+- Optional mark: `quests:custom-quests-merge-complete`
+- Measures: `quests:time-to-list-visible`, `quests:time-to-snapshot-classification`, `quests:time-to-full-reconciliation`
+- Optional measure: `quests:time-to-custom-merge`
 
-Acceptance and evidence checklist:
+- [ ] Same seed/account/profile/CPU for both candidates.
+- [ ] Raw Playwright perf output attached for both candidates.
+- [ ] At least one DevTools trace per candidate attached.
+- [ ] Go/no-go based on comparable cold-run data.
 
-- [ ] Comparison includes exactly two immutable candidates: baseline-from-3ec45a5517a35c96767f6b946c01104e6ec88f93 and optimized HEAD
-- [ ] Baseline candidate confirmed instrumentation-only (no optimization behavior merged)
-- [ ] Candidates tested sequentially on same staging environment, with no in-place artifact mutation
-- [ ] Same seeded save/test account state, same `/quests` route, same browser/device profile, same CPU slowdown
-- [ ] Browser/app state reset between candidates (including storage + service worker/cache storage)
-- [ ] Raw Playwright harness output preserved for both candidates
-- [ ] At least one Chrome DevTools performance trace captured for each candidate
-- [ ] Attach raw Playwright output and DevTools traces to release artifacts, or link both from release notes / PR discussion for both candidates
-- [ ] Recorded per run: candidate tag, commit SHA, date/time, profile, CPU slowdown, cold/warm flag
-- [ ] Go/no-go decision based on comparable **cold-run** data first (warm-run data tracked separately only)
-- [ ] Runs from different devices/slowdown/seeded data are labeled as separate experiments and not compared directly
-- [ ] Logs/traces attached as release artifacts or linked in release notes/PR discussion
+### 4.2 Built-in quest correctness (required)
 
-- [ ] (Optional supporting audit) Run Lighthouse against staging and attach summary, but do not use as sole gate
+- [ ] `/quests` shows only actionable built-in quests in the main grid (locked built-ins not incorrectly shown as startable).
+- [ ] Completed built-in quests remain in the completed section.
+- [ ] No incorrect `Start`/`Continue` affordance appears during uncertain snapshot/loading states.
 
-```bash
-npx lighthouse https://staging.democratized.space/quests --preset=desktop --view
-```
+### 4.3 Custom quest regression + coexistence (required)
 
-If you must run Lighthouse locally, ensure the local build exactly mirrors the candidate under test and label results as local-only supplementary evidence.
+- [ ] Existing custom quests still load and appear in `Custom Quests`.
+- [ ] Custom quest cards remain usable (open route, progress, complete path where applicable).
+- [ ] Built-in and custom quests coexist correctly in one session (neither set hides or corrupts the other).
+- [ ] Delayed custom merge does not break built-in grid stability or interaction.
 
 ---
 
-## 4) Production promotion gate
+## 5) `/processes` validation (required launch gate)
 
-- [ ] Promote only the exact immutable tag validated in staging
-- [ ] Confirm rollback tag and command are prepared before prod deploy
-- [ ] Confirm prod values file and host target are correct (`democratized.space`)
-- [ ] Confirm QA Cheats remain OFF in prod (`DSPACE_ENV=prod`)
+### 5.1 Summary-first list behavior
 
-Suggested prod smoke commands:
+- [ ] `/processes` shows summary rows (duration/requires/consumes/creates + details link) without rendering detail controls for every row.
+- [ ] Built-in process summaries are visible immediately on load.
+- [ ] Custom processes merge in after load and are clearly labeled/usable.
+
+### 5.2 Built-in + custom coexistence (required)
+
+- [ ] Mixed built-in/custom process catalogs render without duplicate-ID corruption.
+- [ ] Custom process detail links resolve correctly.
+- [ ] Built-in process detail links resolve correctly.
+
+### 5.3 Detail route parity (required)
+
+For representative built-in and custom process IDs:
+
+- [ ] `/processes/{id}` behavior is unchanged for runtime controls (start/cancel/pause/resume/collect as applicable).
+- [ ] `Buy required items` button still appears only when appropriate and remains functional.
+- [ ] No regression in requirement display, item counts, or toast/status feedback.
+
+---
+
+## 6) `/docs` validation (required launch gate)
+
+- [ ] Default `/docs` browse view loads correctly without full body text in initial payload.
+- [ ] `has:` operators (for example `has:link`, `has:image`) still work before any deferred corpus fetch.
+- [ ] First keyword search triggers deferred corpus load and returns expected matches.
+- [ ] Subsequent keyword searches reuse corpus without repeated failures.
+- [ ] Snippets render correctly (including long-token wrapping/highlighting).
+- [ ] No docs-search parity regressions vs v3 expectations.
+
+Suggested quick manual queries:
+
+- `has:link`
+- `has:image`
+- `quest has:image`
+- `cloud sync`
+
+---
+
+## 7) `/chat` docs-backed regression checks (required for v3.0.1)
+
+Because `/chat` retrieval depends on docs content/search corpus behavior, run manual sanity prompts in staging.
+
+- [ ] `/chat` returns grounded answers for docs-covered topics.
+- [ ] Answers reference the correct docs concepts/pages when expected (not empty or unrelated responses).
+- [ ] No obvious regression where first retrieval appears empty due to delayed docs corpus behavior.
+
+Suggested prompts:
+
+- `How do I submit a custom content bundle in DSPACE?`
+- `Where can I read about cloud sync and backups?`
+- `What does has:image mean in docs search?`
+- `What should I do before promoting a release to production?`
+
+Recommended checks:
+
+- [ ] Ask each prompt in a fresh chat and a follow-up turn.
+- [ ] Verify response quality stays stable after visiting `/docs` and retrying prompts.
+- [ ] Capture 2-3 transcript snippets as release evidence.
+
+---
+
+## 8) Production promotion, rollback, and closeout
+
+### 8.1 Promotion gate (required)
+
+- [ ] Promote only the exact immutable tag validated in staging.
+- [ ] Confirm rollback command/tag before production deploy.
+- [ ] Confirm production host/values target (`democratized.space`).
+- [ ] Confirm QA Cheats OFF in production (`DSPACE_ENV=prod`).
 
 ```bash
 curl -fsS https://democratized.space/config.json
-```
-
-```bash
 curl -fsS https://democratized.space/healthz
-```
-
-```bash
 curl -fsS https://democratized.space/livez
 ```
 
----
+### 8.2 Rollback plan (required)
 
-## 5) Rollback notes
+If any launch gate fails in production:
 
-If production verification fails:
-
-- [ ] Roll back immediately to previous known-good immutable tag
-- [ ] Re-run prod health checks
-- [ ] Log incident notes and follow-up fix scope
-- [ ] Keep `v3.0.1` open until replacement candidate is validated
-
-Rollback command template:
+- [ ] Roll back immediately to the previous known-good immutable tag.
+- [ ] Re-run production health checks.
+- [ ] Log incident + follow-up scope before reattempting.
 
 ```bash
 cd ~/sugarkube
-```
-
-```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=<rollback-immutable-tag>
 ```
 
+### 8.3 Closeout (required)
+
+- [ ] Final `v3.0.1` tag created and pushed.
+- [ ] Changelog addendum published.
+- [ ] Validated deployed tag + SHA recorded in release notes.
+- [ ] Any deferred non-patch work moved to `v3.1.x` planning.
+
 ---
 
-## 6) Release close-out
+## 9) Optional supplementary evidence (recommended, non-blocking)
 
-- [ ] Final release git tag created and pushed (`v3.0.1`)
-- [ ] Changelog/release notes updated
-- [ ] Deployed immutable tag and SHA recorded in release notes
-- [ ] Any deferred non-patch work moved to `v3.1.x` planning
+- [ ] Lighthouse snapshots for `/quests`, `/processes`, `/docs` (label as supplementary only).
+- [ ] Side-by-side screenshots of `/quests` and `/processes` before/after custom merge.
+- [ ] Brief QA summary comment linking artifacts used for sign-off.

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,29 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+---
+
+## Addendum — June 1, 2026: DSPACE v3.0.1
+
+`v3.0.1` is a focused patch release on performance, list correctness, and launch safety across
+core v3 surfaces.
+
+### What changed in v3.0.1
+
+- **`/quests` list-path improvements:** faster list rendering path and stronger correctness around
+  built-in quest visibility/status, with additional regression hardening for delayed custom quest
+  merges so built-in and custom quests continue to coexist cleanly.
+- **`/processes` list refactor:** `/processes` now prioritizes summary-first rows for quicker
+  scanning and lower list overhead, while process detail routes keep the existing interactive
+  behavior (including `Buy required items` where applicable).
+- **`/docs` search payload optimization:** default docs browsing now starts from a lightweight
+  payload, and full-text corpus data is loaded on first keyword search, preserving search/snippet
+  behavior while reducing initial load cost.
+- **Release-safety and regression coverage:** expanded QA and smoke coverage for list/detail route
+  contracts and docs-search edge cases to reduce patch-line deployment risk.
+
+### Why this patch matters
+
+This patch keeps v3 behavior familiar while improving responsiveness and reliability in the places
+players touch most: quest discovery, process browsing, docs search, and docs-backed chat workflows.


### PR DESCRIPTION
### Motivation
- Audit the full patch delta since v3.0.0 and expand the v3.0.1 QA checklist to reflect actual merged work beyond the original `/quests` TTI optimization. 
- Ensure launch validation explicitly covers `/quests`, `/processes`, `/docs`, and `/chat` regressions plus staging/prod promotion and rollback safety. 

### Description
- Replace and expand `docs/qa/v3.0.1.md` with an operational, checklist-oriented runbook that includes a concise patch-scope summary, release metadata/sign-off fields, required automated checks, staging health smoke commands, `/quests` TTI baseline-vs-optimized comparison guidance and custom-vs-built-in coexistence checks, `/processes` summary-first list and detail-parity checks (including `Buy required items`), `/docs` deferred-corpus and `has:` operator validation, `/chat` RAG sanity prompts, and promotion/rollback/closeout steps. 
- Add a dated addendum (June 1, 2026) for DSPACE v3.0.1 to `frontend/src/pages/docs/md/changelog/20260401.md` summarizing user-visible patch notes for `/quests`, `/processes`, `/docs`, and release-safety improvements, without creating a new changelog file. 
- Change scope limited to the two documentation files (`docs/qa/v3.0.1.md` and `frontend/src/pages/docs/md/changelog/20260401.md`) and does not modify application/runtime code. 

### Testing
- Ran `node scripts/link-check.mjs` and confirmed all local markdown links resolved successfully. 
- Executed the repository secret-scan via the staged diff check (`./scripts/scan-secrets.py`) as part of pre-commit validation and observed no findings. 
- Performed a repository diff/stat audit to confirm exactly the two targeted documentation files were modified and no other source files changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d888ab7af8832fa40d77fd516e5285)