### PR TITLE
📝 docs: align v3.0.1 QA checklist and add changelog addendum (June 1, 2026)

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -31,6 +31,27 @@ Related docs:
 
 ---
 
+### 0.1 Commit-range audit (required before checklist execution)
+
+Derive this checklist from the audited patch delta first, then execute QA against that scoped delta.
+Run these exact commands and attach output to release evidence:
+
+```bash
+git log --oneline 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
+```
+
+```bash
+git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
+```
+
+```bash
+git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
+```
+
+- [ ] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+
+---
+
 ## 1) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
@@ -152,8 +173,10 @@ Required marks/measures:
 
 - [ ] Custom quests still load from local custom content storage
 - [ ] Custom quest section appears only after merge completion, without displacing built-in cards
+- [ ] Custom content must continue to function correctly alongside built-in content
 - [ ] Built-in and custom quest cards coexist correctly (no duplicate IDs, no missing built-ins)
 - [ ] Custom quests remain navigable and usable from list to detail and through interaction flow
+- [ ] Mixed-state scenario: use an account with built-in quest progress already in-flight, then import/load custom quests and confirm both sets remain actionable through refresh + navigation
 
 ---
 
@@ -169,8 +192,10 @@ Required marks/measures:
 ### 5.2 Custom process merge and coexistence (critical)
 
 - [ ] Custom processes merge after list load and are labeled/identifiable as custom
+- [ ] Custom content must continue to function correctly alongside built-in content
 - [ ] Built-in + custom processes coexist without duplicate-row corruption (ID collisions do not hide built-ins)
 - [ ] `View details` links resolve correctly for both built-in and custom processes
+- [ ] Mixed-state scenario: with active built-in process progress present, load/import custom processes and confirm list rows + detail routing work for both sets in the same session
 
 ### 5.3 Detail-route behavior unchanged
 
@@ -200,20 +225,21 @@ Suggested manual checks:
 
 ## 7) `/chat` regression checks (required due to docs/RAG dependency)
 
-Goal: confirm docs-backed retrieval still produces grounded responses after `/docs` corpus changes.
+Goal: confirm docs-backed retrieval still produces grounded responses after `/docs` deferred-corpus changes.
+
+Prerequisite: execute this section only after Section 6 validates `/docs` browse behavior and first-keyword deferred corpus load from `/docs/full-text-corpus.json`.
 
 - [ ] Chat UI loads/hydrates normally on `/chat`
-- [ ] Docs-grounded prompts still return relevant, non-empty responses
+- [ ] Launch-check prompts grounded in existing docs still return relevant, non-empty responses
 - [ ] Responses continue to reference expected docs topics/pages when appropriate
 - [ ] No obvious delayed-index/empty-corpus failure pattern appears in chat responses
 
-Suggested prompts/scenarios:
+Suggested docs-backed launch prompts:
 
-1. “What is the difference between cloud sync and backups in DSPACE?”
-2. “How do I submit custom content bundles?”
-3. “Which docs explain quest schema requirements?”
-4. Ask a docs-backed question, then repeat with slightly different wording to check retrieval
-   consistency.
+1. “From the docs, what is the difference between Cloud Sync and Backups, and when should I use each?”
+2. “From `/docs/custom-content-bundles`, what fields are required before submitting a bundle?”
+3. “From `/docs/quest-submission`, what are the minimum quest JSON structure requirements?”
+4. Re-run one of the prompts with slightly different wording and confirm answer quality remains docs-grounded after corpus warm-up.
 
 Record brief transcript snippets and whether responses appear grounded vs generic.
 
@@ -250,7 +276,7 @@ curl -fsS https://democratized.space/livez
 - [ ] Re-run prod health checks
 - [ ] Log incident notes and keep `v3.0.1` open until replacement candidate is validated
 
-Rollback command template:
+Rollback command template (from prod runbook):
 
 ```bash
 cd ~/sugarkube

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,4 +1,4 @@
-# DSPACE v3.0.1 QA Checklist (patch addendum line)
+# DSPACE v3.0.1 QA Checklist (patch delta validation)
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
@@ -23,7 +23,7 @@ Related docs:
 - `/quests`: TTI-focused list-path optimization and regression hardening, including delayed custom
   quest merge behavior, built-in list correctness, and custom coexistence.
 - `/processes`: summary-first list refactor (`/processes`) with detail behavior retained on
-  `/processes/:slug`.
+  `/processes/:processId` (legacy alias: `/process/:slug`).
 - `/docs`: deferred full-text corpus loading for keyword search while keeping browse and `has:`
   query behavior stable.
 - `/chat`: regression checks for docs-backed retrieval quality because docs corpus behavior changed.
@@ -76,7 +76,7 @@ npm --prefix frontend run test -- src/components/__tests__/DocsIndexSearch.spec.
 ```
 
 ```bash
-npm --prefix frontend run test:e2e -- quests-tti-behavior.spec.ts quests-tti-metrics.spec.ts
+BASE_URL=https://staging.democratized.space npm --prefix frontend run test:e2e -- quests-tti-behavior.spec.ts quests-tti-metrics.spec.ts
 ```
 
 ```bash
@@ -103,7 +103,8 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-- [ ] `/config.json` reflects expected version/env
+- [ ] `/healthz` or `/livez` reflects the expected `version` and `env`
+- [ ] `/config.json` reflects expected feature-flag/runtime-config values
 - [ ] `/healthz` and `/livez` return success
 - [ ] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
 - [ ] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
@@ -173,7 +174,8 @@ Required marks/measures:
 
 ### 5.3 Detail-route behavior unchanged
 
-- [ ] `/processes/:slug` still provides full interactive process runtime controls
+- [ ] `/processes/:processId` still provides full interactive process runtime controls
+      (legacy alias `/process/:slug`, if still supported, also resolves correctly)
 - [ ] `Buy required items` still behaves correctly on detail route where requirements are purchasable
 - [ ] No regression in start/cancel/collect lifecycle on detail page
 

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,9 +1,7 @@
-# DSPACE v3.0.1 QA Checklist (urgent patch line)
+# DSPACE v3.0.1 QA Checklist (patch addendum line)
 
-> Scope: `v3.0.1` is for urgent bugfixes and small improvements only.
-> It is **not** a feature release track.
-
-Use this checklist for rapid but safe patch promotion from staging to prod.
+> Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
+> (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
 
 Related docs:
 
@@ -12,31 +10,44 @@ Related docs:
 - [Staging runbook](../k3s-sugarkube-staging.md)
 - [Prod runbook](../k3s-sugarkube-prod.md)
 - [Feature-track QA checklist (v3.1)](./v3.1.md)
+- [`/quests` TTI optimization design](../design/quests-tti-optimization.md)
+- [`/processes` list performance design](../design/processes-list-performance-and-presentation.md)
+- [`/docs` index payload design](../design/docs-index-performance-and-presentation.md)
 
 ---
 
-## 0) Release metadata
+## 0) Patch scope summary (required read before testing)
+
+`v3.0.1` patch themes to validate end-to-end:
+
+- `/quests`: TTI-focused list-path optimization and regression hardening, including delayed custom
+  quest merge behavior, built-in list correctness, and custom coexistence.
+- `/processes`: summary-first list refactor (`/processes`) with detail behavior retained on
+  `/processes/:slug`.
+- `/docs`: deferred full-text corpus loading for keyword search while keeping browse and `has:`
+  query behavior stable.
+- `/chat`: regression checks for docs-backed retrieval quality because docs corpus behavior changed.
+- Release-safety: smoke/remote-smoke and migration harness updates that affect launch confidence.
+
+---
+
+## 1) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
 - [ ] Candidate tag under test: `________________`
 - [ ] Commit SHA: `________________`
-- [ ] Change scope summary (bugfix/small improvements only): `________________`
+- [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
+- [ ] QA owner + timestamp: `________________`
 - [ ] Staging sign-off owner + timestamp: `________________`
 - [ ] Production deploy owner + timestamp: `________________`
 - [ ] Previous known-good rollback tag: `________________`
+- [ ] Release notes include only user-visible patch deltas
 
 ---
 
-## 1) Patch-scope gate (must pass before broader QA)
+## 2) Automated checks (required launch gates)
 
-- [ ] Every change is bugfix/small improvement scoped
-- [ ] No new feature flag or major UX flow introduced without explicit approval
-- [ ] No unrelated refactor included
-- [ ] Release notes drafted with user-visible deltas only
-
----
-
-## 2) Automated checks (required)
+Run from repo root unless noted:
 
 ```bash
 npm run lint
@@ -47,32 +58,38 @@ npm run type-check
 ```
 
 ```bash
-npm run link-check
+npm run build
 ```
 
 ```bash
-node run-tests.js
+npm test
 ```
-
-If full test runtime is constrained, record the exception and run at least targeted validation:
 
 ```bash
-npm run qa:smoke
+node scripts/link-check.mjs
 ```
+
+Targeted patch checks (required evidence for this patch line):
+
+```bash
+npm --prefix frontend run test -- src/components/__tests__/DocsIndexSearch.spec.ts src/pages/docs/__tests__/index.spec.ts src/pages/processes/__tests__/Processes.spec.ts src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+```
+
+```bash
+npm --prefix frontend run test:e2e -- quests-tti-behavior.spec.ts quests-tti-metrics.spec.ts
+```
+
+```bash
+npm run qa:remote-smoke -- --baseURL=https://staging.democratized.space --chat-mode=ui --safe
+```
+
+- [ ] All required commands pass, or any exception is explicitly documented with owner + follow-up
 
 ---
 
-## 3) Staging deploy + validation
+## 3) Staging deploy + health validation (required)
 
-Deploy approved immutable candidate to staging (`staging.democratized.space`) and validate:
-
-- [ ] `/config.json` returns expected runtime config
-- [ ] `/healthz` and `/livez` return success
-- [ ] Patch issue reproduction is fixed in staging
-- [ ] No regression in core nav/routes relevant to touched areas
-- [ ] QA Cheats remain enabled in staging (`DSPACE_ENV=staging`)
-
-Suggested smoke commands:
+Deploy the immutable candidate to `https://staging.democratized.space`.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json
@@ -86,113 +103,126 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-### 3.1 `/quests` TTI performance launch gate (required for this optimization)
+- [ ] `/config.json` reflects expected version/env
+- [ ] `/healthz` and `/livez` return success
+- [ ] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
+- [ ] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
 
-This gate compares **exactly two candidates** on `staging.democratized.space`:
+---
 
-1. **Instrumented baseline candidate** branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
-2. **Optimized HEAD candidate** for `v3.0.1`
+## 4) `/quests` validation (required)
 
-Baseline policy (strict):
+### 4.1 Performance gate (baseline vs optimized)
 
-- The baseline branch is **measurement-only instrumentation**.
-- It must emit the required marks/measures, but **must not include optimization logic** from the
-  HEAD implementation.
-- If baseline internals differ from optimized internals, preserve the exact timing names for
-  comparability, keep instrumentation honest, and if an optional phase is not meaningfully
-  separable, omit it or explicitly document the approximation in recorded results.
+Run a strict two-candidate comparison on staging:
 
-Primary validation stack for this gate (required):
-
-1. Playwright `/quests` TTI measurement harness (raw output retained)
-2. `/quests` User Timing marks/measures
-3. Chrome DevTools Performance trace review (at least one trace per candidate)
-
-Lighthouse is supplementary only and cannot replace the required evidence above.
-
-#### Procedure (run sequentially on the same staging environment)
-
-1. Deploy the **baseline** as a distinct immutable build/tag (do not mutate artifacts in place).
-2. Confirm rollback path before any candidate swap.
-3. Verify staging health for this candidate: use `/config.json` as a config sanity check, and confirm deployed candidate `version`/`env` via `/healthz` or `/livez` output.
-4. Reset browser/client state before measurement (clear IndexedDB, localStorage,
-   sessionStorage, service worker/cache storage, and any persisted quest state).
-5. Run Playwright harness on `/quests` with the chosen profile/slowdown.
-6. Capture at least one Chrome DevTools performance trace for `/quests`.
-7. Record metadata and results for this run, including:
-   - candidate tag
-   - commit SHA
-   - date/time
-   - browser/device profile
-   - CPU slowdown factor
-   - seeded save / test account state
-   - route
-   - cold vs warm
-8. Deploy the **optimized HEAD** as a second distinct immutable build/tag.
-9. Repeat steps 3-7 under identical seeded state, route, browser/device profile, and CPU slowdown.
-10. Compare results and make go/no-go decision.
-
-Required harness command:
+1. Instrumented baseline candidate branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
+2. Optimized `v3.0.1` candidate
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-Optional recommended slow-CPU companion run (use the same factor for both candidates; `perf:quests:slowcpu` applies `QUESTS_TTI_CPU_SLOWDOWN=4`):
-
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-Required timing marks/measures to verify and record:
+Required marks/measures:
 
-- Required marks:
-    - `quests:list-hydration-start`
-    - `quests:list-visible`
-    - `quests:snapshot-classification-ready`
-    - `quests:full-state-reconciliation-complete`
-- Optional mark:
-    - `quests:custom-quests-merge-complete`
-- Required measures:
-    - `quests:time-to-list-visible`
-    - `quests:time-to-snapshot-classification`
-    - `quests:time-to-full-reconciliation`
-- Optional measure:
-    - `quests:time-to-custom-merge`
+- `quests:list-hydration-start`
+- `quests:list-visible`
+- `quests:snapshot-classification-ready`
+- `quests:full-state-reconciliation-complete`
+- `quests:time-to-list-visible`
+- `quests:time-to-snapshot-classification`
+- `quests:time-to-full-reconciliation`
 
-Acceptance and evidence checklist:
+- [ ] Same seeded account, route, browser profile, and CPU settings across both candidates
+- [ ] Raw harness output + at least one DevTools trace per candidate attached to release evidence
+- [ ] Go/no-go decision is based on comparable cold-run data
 
-- [ ] Comparison includes exactly two immutable candidates: baseline-from-3ec45a5517a35c96767f6b946c01104e6ec88f93 and optimized HEAD
-- [ ] Baseline candidate confirmed instrumentation-only (no optimization behavior merged)
-- [ ] Candidates tested sequentially on same staging environment, with no in-place artifact mutation
-- [ ] Same seeded save/test account state, same `/quests` route, same browser/device profile, same CPU slowdown
-- [ ] Browser/app state reset between candidates (including storage + service worker/cache storage)
-- [ ] Raw Playwright harness output preserved for both candidates
-- [ ] At least one Chrome DevTools performance trace captured for each candidate
-- [ ] Attach raw Playwright output and DevTools traces to release artifacts, or link both from release notes / PR discussion for both candidates
-- [ ] Recorded per run: candidate tag, commit SHA, date/time, profile, CPU slowdown, cold/warm flag
-- [ ] Go/no-go decision based on comparable **cold-run** data first (warm-run data tracked separately only)
-- [ ] Runs from different devices/slowdown/seeded data are labeled as separate experiments and not compared directly
-- [ ] Logs/traces attached as release artifacts or linked in release notes/PR discussion
+### 4.2 Built-in quest correctness
 
-- [ ] (Optional supporting audit) Run Lighthouse against staging and attach summary, but do not use as sole gate
+- [ ] `/quests` shows only actionable built-in quests in the primary grid (no locked built-ins in the active grid)
+- [ ] Completed built-ins remain in the completed section
+- [ ] No incorrect optimistic `Start`/`Continue` affordance appears before authoritative reconciliation
 
-```bash
-npx lighthouse https://staging.democratized.space/quests --preset=desktop --view
-```
+### 4.3 Custom quest regressions and coexistence (critical)
 
-If you must run Lighthouse locally, ensure the local build exactly mirrors the candidate under test and label results as local-only supplementary evidence.
+- [ ] Custom quests still load from local custom content storage
+- [ ] Custom quest section appears only after merge completion, without displacing built-in cards
+- [ ] Built-in and custom quest cards coexist correctly (no duplicate IDs, no missing built-ins)
+- [ ] Custom quests remain navigable and usable from list to detail and through interaction flow
 
 ---
 
-## 4) Production promotion gate
+## 5) `/processes` validation (required)
 
-- [ ] Promote only the exact immutable tag validated in staging
-- [ ] Confirm rollback tag and command are prepared before prod deploy
-- [ ] Confirm prod values file and host target are correct (`democratized.space`)
-- [ ] Confirm QA Cheats remain OFF in prod (`DSPACE_ENV=prod`)
+### 5.1 Summary-first list behavior
 
-Suggested prod smoke commands:
+- [ ] `/processes` renders summary rows (title, duration, requires/consumes/creates counts)
+- [ ] List route keeps detail controls out of rows (`Start`, `Pause`, `Resume`, `Collect`,
+      `Buy required items` are not shown in list rows)
+- [ ] Built-in processes appear immediately on list load
+
+### 5.2 Custom process merge and coexistence (critical)
+
+- [ ] Custom processes merge after list load and are labeled/identifiable as custom
+- [ ] Built-in + custom processes coexist without duplicate-row corruption (ID collisions do not hide built-ins)
+- [ ] `View details` links resolve correctly for both built-in and custom processes
+
+### 5.3 Detail-route behavior unchanged
+
+- [ ] `/processes/:slug` still provides full interactive process runtime controls
+- [ ] `Buy required items` still behaves correctly on detail route where requirements are purchasable
+- [ ] No regression in start/cancel/collect lifecycle on detail page
+
+---
+
+## 6) `/docs` validation (required)
+
+- [ ] Default browse view loads and is useful without full body text in initial payload
+- [ ] `has:` operator searches (for example `has:link`, `has:image`) still work without corpus fetch
+- [ ] First keyword search triggers deferred corpus load from `/docs/full-text-corpus.json`
+- [ ] Corpus fetch failures degrade gracefully and recover on retry
+- [ ] Snippet rendering still works (including long-token wrapping/title behavior)
+- [ ] No docs-search regression in result quality for existing known docs queries
+
+Suggested manual checks:
+
+- Query `has:link`
+- Query `quest has:image`
+- Query a keyword expected only in doc body text (not title/keywords) to confirm deferred corpus usage
+
+---
+
+## 7) `/chat` regression checks (required due to docs/RAG dependency)
+
+Goal: confirm docs-backed retrieval still produces grounded responses after `/docs` corpus changes.
+
+- [ ] Chat UI loads/hydrates normally on `/chat`
+- [ ] Docs-grounded prompts still return relevant, non-empty responses
+- [ ] Responses continue to reference expected docs topics/pages when appropriate
+- [ ] No obvious delayed-index/empty-corpus failure pattern appears in chat responses
+
+Suggested prompts/scenarios:
+
+1. “What is the difference between cloud sync and backups in DSPACE?”
+2. “How do I submit custom content bundles?”
+3. “Which docs explain quest schema requirements?”
+4. Ask a docs-backed question, then repeat with slightly different wording to check retrieval
+   consistency.
+
+Record brief transcript snippets and whether responses appear grounded vs generic.
+
+---
+
+## 8) Production promotion gate
+
+- [ ] Promote only the exact immutable artifact validated in staging
+- [ ] Confirm rollback tag/command before deploy
+- [ ] Confirm production target + values are correct (`democratized.space`)
+- [ ] Confirm QA Cheats are OFF in prod (`DSPACE_ENV=prod`)
 
 ```bash
 curl -fsS https://democratized.space/config.json
@@ -206,16 +236,17 @@ curl -fsS https://democratized.space/healthz
 curl -fsS https://democratized.space/livez
 ```
 
+- [ ] `/quests`, `/processes`, `/docs`, and `/chat` pass spot-checks on prod immediately after deploy
+
 ---
 
-## 5) Rollback notes
+## 9) Rollback + closeout
 
-If production verification fails:
+### 9.1 Rollback (if any required gate fails)
 
 - [ ] Roll back immediately to previous known-good immutable tag
 - [ ] Re-run prod health checks
-- [ ] Log incident notes and follow-up fix scope
-- [ ] Keep `v3.0.1` open until replacement candidate is validated
+- [ ] Log incident notes and keep `v3.0.1` open until replacement candidate is validated
 
 Rollback command template:
 
@@ -227,11 +258,20 @@ cd ~/sugarkube
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=<rollback-immutable-tag>
 ```
 
----
-
-## 6) Release close-out
+### 9.2 Release closeout
 
 - [ ] Final release git tag created and pushed (`v3.0.1`)
-- [ ] Changelog/release notes updated
-- [ ] Deployed immutable tag and SHA recorded in release notes
-- [ ] Any deferred non-patch work moved to `v3.1.x` planning
+- [ ] `v3.0.1` patch-note addendum published in changelog
+- [ ] Deployed immutable tag + SHA recorded in release notes
+- [ ] Evidence links attached (perf outputs, traces, smoke logs, key manual QA notes)
+- [ ] Confirmed that deferred/future work is tracked in `v3.1+`, not carried silently in patch scope
+
+---
+
+## 10) Optional supplementary evidence (recommended, not blocking)
+
+- Lighthouse run for `/quests`, `/processes`, and `/docs` as trend-only evidence (not release gate)
+- Short screen recordings showing:
+  - `/quests` built-in-first render + delayed custom merge stability
+  - `/processes` summary-first list then detail interaction
+  - `/docs` first-keyword deferred corpus load behavior

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -137,21 +137,11 @@ forward.
 
 ## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
 
-`v3.0.1` is a focused patch on top of the April 1 v3 release, centered on launch safety,
-list-path performance, and regression hardening.
+`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening.
 
-### What changed in v3.0.1
+### Patch notes
 
-- **`/quests` list path:** improved time-to-interactive behavior and strengthened correctness around
-  built-in quest classification, delayed custom-quest merge timing, and built-in/custom coexistence.
-- **`/processes` list path:** refactored to a summary-first list that renders quickly and links to
-  detail pages, while preserving full runtime controls on `/processes/:processId`.
-- **`/docs` search payload:** moved full body-text corpus loading to deferred fetch on first keyword
-  search, so default docs browsing remains lighter while keeping full-text and `has:` search behavior.
-- **Release-safety regressions:** expanded smoke and targeted regression coverage around quests,
-  processes, docs search, and chat UI behavior.
-
-### Patch outcome
-
-This patch keeps v3 feature scope unchanged while making high-traffic routes (`/quests`,
-`/processes`, `/docs`) more resilient and reducing risk for docs-backed chat workflows.
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior.
+- **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
+- **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
+- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,26 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+---
+
+## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
+
+`v3.0.1` is a focused patch on top of the April 1 v3 release, centered on launch safety,
+list-path performance, and regression hardening.
+
+### What changed in v3.0.1
+
+- **`/quests` list path:** improved time-to-interactive behavior and strengthened correctness around
+  built-in quest classification, delayed custom-quest merge timing, and built-in/custom coexistence.
+- **`/processes` list path:** refactored to a summary-first list that renders quickly and links to
+  detail pages, while preserving full runtime controls on `/processes/:slug`.
+- **`/docs` search payload:** moved full body-text corpus loading to deferred fetch on first keyword
+  search, so default docs browsing remains lighter while keeping full-text and `has:` search behavior.
+- **Release-safety regressions:** expanded smoke and targeted regression coverage around quests,
+  processes, docs search, and chat UI behavior.
+
+### Patch outcome
+
+This patch keeps v3 feature scope unchanged while making high-traffic routes (`/quests`,
+`/processes`, `/docs`) more resilient and reducing risk for docs-backed chat workflows.

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -145,7 +145,7 @@ list-path performance, and regression hardening.
 - **`/quests` list path:** improved time-to-interactive behavior and strengthened correctness around
   built-in quest classification, delayed custom-quest merge timing, and built-in/custom coexistence.
 - **`/processes` list path:** refactored to a summary-first list that renders quickly and links to
-  detail pages, while preserving full runtime controls on `/processes/:slug`.
+  detail pages, while preserving full runtime controls on `/processes/:processId`.
 - **`/docs` search payload:** moved full body-text corpus loading to deferred fetch on first keyword
   search, so default docs browsing remains lighter while keeping full-text and `has:` search behavior.
 - **Release-safety regressions:** expanded smoke and targeted regression coverage around quests,


### PR DESCRIPTION
### Motivation

- Audit the post-`v3.0.0` commit range and make `v3.0.1` QA guidance accurately reflect the real patch delta (not just the original `/quests` TTI work). 
- Cover the expanded launch-safety surface introduced in the delta: `/quests` TTI + built-in vs custom regressions, `/processes` summary-first list changes, `/docs` deferred full-text corpus behavior, and `/chat` RAG fallout. 
- Provide a concise, operational checklist that a human QA/Release engineer can follow to validate a staging candidate before promotion.

### Description

- Rewrote `docs/qa/v3.0.1.md` into a patch-accurate, operational QA checklist that includes release metadata, required automated checks, staging health, the `/quests` TTI baseline-vs-optimized measurement gate, explicit built-in+custom coexistence/regression checks, `/processes` summary-list + detail parity checks, `/docs` deferred-corpus and `has:` operator checks, `/chat` RAG regression prompts, and production promotion/rollback/closeout steps. 
- Appended a June 1, 2026 patch addendum for DSPACE v3.0.1 to the existing April 1 changelog at `frontend/src/pages/docs/md/changelog/20260401.md` summarizing user-visible patch items (`/quests`, `/processes`, `/docs`, and release-safety regression coverage). 
- Kept scope strictly to the two documentation files requested; no application code, tests, build artifacts, or scripts were modified.

### Testing

- Ran the repository link check with `node scripts/link-check.mjs`, which completed successfully (`All local markdown links resolved`).
- Ran the pre-commit secrets scan via `git diff --cached | ./scripts/scan-secrets.py` as part of staging the changes, which reported no issues.
- Performed the audit commands used to prepare the doc changes (`git log`, `git diff --name-only`, `git diff --stat`) and verified the final diff shows exactly the two intended files changed; no automated unit/e2e test suites were altered or run as part of this doc-only PR.

No runtime or application code changes were made in this PR; this is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d888ab7af8832fa40d77fd516e5285)