### PR TITLE
docs: refresh v3.0.1 QA checklist and add v3.0.1 changelog addendum

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,9 +1,9 @@
-# DSPACE v3.0.1 QA Checklist (urgent patch line)
+# DSPACE v3.0.1 QA Checklist
 
-> Scope: `v3.0.1` is for urgent bugfixes and small improvements only.
-> It is **not** a feature release track.
-
-Use this checklist for rapid but safe patch promotion from staging to prod.
+> Patch line: **v3.0.1**
+> 
+> This checklist is scoped to the real delta merged after `v3.0.0`
+> (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) through the current release candidate.
 
 Related docs:
 
@@ -11,32 +11,52 @@ Related docs:
 - [Release and promotion procedure](../merge-plan.md)
 - [Staging runbook](../k3s-sugarkube-staging.md)
 - [Prod runbook](../k3s-sugarkube-prod.md)
-- [Feature-track QA checklist (v3.1)](./v3.1.md)
+- [Quest TTI design](../design/quests-tti-optimization.md)
+- [Processes list design](../design/processes-list-performance-and-presentation.md)
+- [Docs index design](../design/docs-index-performance-and-presentation.md)
 
 ---
 
-## 0) Release metadata
+## 0) Patch scope summary (required context)
+
+`v3.0.1` launch QA must cover these patch themes (not just `/quests`):
+
+1. **`/quests` TTI + list correctness**
+   - list manifest/snapshot-first rendering
+   - delayed custom-quest merge behavior
+   - built-in/custom coexistence correctness
+2. **`/processes` summary-first list refactor**
+   - built-in process summaries visible immediately
+   - custom process merge after load
+   - detail page behavior parity (including `Buy required items`)
+3. **`/docs` deferred full-text corpus**
+   - lightweight initial payload for browse/default view
+   - first keyword search lazy-loads corpus
+   - `has:` operators and snippet behavior preserved
+4. **`/chat` regression checks tied to docs-backed retrieval (RAG)**
+   - ensure docs-backed grounding quality is not degraded by deferred corpus behavior
+5. **Release-safety checks**
+   - remote smoke / migration harness changes that affect launch confidence
+
+---
+
+## 1) Release metadata and signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `________________`
-- [ ] Commit SHA: `________________`
-- [ ] Change scope summary (bugfix/small improvements only): `________________`
-- [ ] Staging sign-off owner + timestamp: `________________`
-- [ ] Production deploy owner + timestamp: `________________`
+- [ ] Candidate immutable tag: `________________`
+- [ ] Candidate commit SHA: `________________`
+- [ ] Audit range confirmed: `3ec45a5517a35c96767f6b946c01104e6ec88f93..________________`
+- [ ] QA owner + timestamp: `________________`
+- [ ] Deploy owner + timestamp: `________________`
 - [ ] Previous known-good rollback tag: `________________`
 
 ---
 
-## 1) Patch-scope gate (must pass before broader QA)
+## 2) Required launch gates
 
-- [ ] Every change is bugfix/small improvement scoped
-- [ ] No new feature flag or major UX flow introduced without explicit approval
-- [ ] No unrelated refactor included
-- [ ] Release notes drafted with user-visible deltas only
+## 2.1 Automated checks (required)
 
----
-
-## 2) Automated checks (required)
+Run from repo root unless noted:
 
 ```bash
 npm run lint
@@ -54,25 +74,39 @@ npm run link-check
 node run-tests.js
 ```
 
-If full test runtime is constrained, record the exception and run at least targeted validation:
+Targeted checks for patch surfaces (if full suite is constrained, record exception):
+
+```bash
+npm --prefix frontend run test -- e2e/quests-tti-behavior.spec.ts
+```
+
+```bash
+npm --prefix frontend run test -- e2e/quests-tti-metrics.spec.ts
+```
+
+```bash
+npm --prefix frontend run test -- frontend/src/components/__tests__/DocsIndexSearch.spec.ts
+```
+
+```bash
+npm --prefix frontend run test -- frontend/src/pages/docs/__tests__/index.spec.ts
+```
 
 ```bash
 npm run qa:smoke
 ```
 
----
+## 2.2 Staging deploy + health (required)
 
-## 3) Staging deploy + validation
+Deploy approved immutable candidate to `https://staging.democratized.space`:
 
-Deploy approved immutable candidate to staging (`staging.democratized.space`) and validate:
+- [ ] `/config.json` is healthy and shows expected candidate metadata
+- [ ] `/healthz` succeeds
+- [ ] `/livez` succeeds
+- [ ] Core nav pages load: `/quests`, `/processes`, `/docs`, `/chat`
+- [ ] QA Cheats enabled in staging (`DSPACE_ENV=staging`)
 
-- [ ] `/config.json` returns expected runtime config
-- [ ] `/healthz` and `/livez` return success
-- [ ] Patch issue reproduction is fixed in staging
-- [ ] No regression in core nav/routes relevant to touched areas
-- [ ] QA Cheats remain enabled in staging (`DSPACE_ENV=staging`)
-
-Suggested smoke commands:
+Smoke commands:
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json
@@ -86,113 +120,153 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-### 3.1 `/quests` TTI performance launch gate (required for this optimization)
+---
 
-This gate compares **exactly two candidates** on `staging.democratized.space`:
+## 3) Feature-surface validation (required)
 
-1. **Instrumented baseline candidate** branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
-2. **Optimized HEAD candidate** for `v3.0.1`
+### 3.1 `/quests` validation (required)
 
-Baseline policy (strict):
+#### A) TTI gate: baseline vs optimized
 
-- The baseline branch is **measurement-only instrumentation**.
-- It must emit the required marks/measures, but **must not include optimization logic** from the
-  HEAD implementation.
-- If baseline internals differ from optimized internals, preserve the exact timing names for
-  comparability, keep instrumentation honest, and if an optional phase is not meaningfully
-  separable, omit it or explicitly document the approximation in recorded results.
+Compare exactly two immutable staging candidates:
 
-Primary validation stack for this gate (required):
+1. Baseline (instrumentation-only) from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
+2. Optimized v3.0.1 candidate
 
-1. Playwright `/quests` TTI measurement harness (raw output retained)
-2. `/quests` User Timing marks/measures
-3. Chrome DevTools Performance trace review (at least one trace per candidate)
-
-Lighthouse is supplementary only and cannot replace the required evidence above.
-
-#### Procedure (run sequentially on the same staging environment)
-
-1. Deploy the **baseline** as a distinct immutable build/tag (do not mutate artifacts in place).
-2. Confirm rollback path before any candidate swap.
-3. Verify staging health for this candidate: use `/config.json` as a config sanity check, and confirm deployed candidate `version`/`env` via `/healthz` or `/livez` output.
-4. Reset browser/client state before measurement (clear IndexedDB, localStorage,
-   sessionStorage, service worker/cache storage, and any persisted quest state).
-5. Run Playwright harness on `/quests` with the chosen profile/slowdown.
-6. Capture at least one Chrome DevTools performance trace for `/quests`.
-7. Record metadata and results for this run, including:
-   - candidate tag
-   - commit SHA
-   - date/time
-   - browser/device profile
-   - CPU slowdown factor
-   - seeded save / test account state
-   - route
-   - cold vs warm
-8. Deploy the **optimized HEAD** as a second distinct immutable build/tag.
-9. Repeat steps 3-7 under identical seeded state, route, browser/device profile, and CPU slowdown.
-10. Compare results and make go/no-go decision.
-
-Required harness command:
+Run:
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-Optional recommended slow-CPU companion run (use the same factor for both candidates; `perf:quests:slowcpu` applies `QUESTS_TTI_CPU_SLOWDOWN=4`):
+Optional companion run (same slowdown for both candidates):
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-Required timing marks/measures to verify and record:
+Required marks/measures to confirm:
 
-- Required marks:
-    - `quests:list-hydration-start`
-    - `quests:list-visible`
-    - `quests:snapshot-classification-ready`
-    - `quests:full-state-reconciliation-complete`
-- Optional mark:
-    - `quests:custom-quests-merge-complete`
-- Required measures:
-    - `quests:time-to-list-visible`
-    - `quests:time-to-snapshot-classification`
-    - `quests:time-to-full-reconciliation`
-- Optional measure:
-    - `quests:time-to-custom-merge`
+- `quests:list-hydration-start`
+- `quests:list-visible`
+- `quests:snapshot-classification-ready`
+- `quests:full-state-reconciliation-complete`
+- `quests:time-to-list-visible`
+- `quests:time-to-snapshot-classification`
+- `quests:time-to-full-reconciliation`
 
-Acceptance and evidence checklist:
+- [ ] Raw Playwright metric output retained for both candidates
+- [ ] At least one DevTools trace captured per candidate
+- [ ] Cold-run data compared first; warm-run data labeled separately
 
-- [ ] Comparison includes exactly two immutable candidates: baseline-from-3ec45a5517a35c96767f6b946c01104e6ec88f93 and optimized HEAD
-- [ ] Baseline candidate confirmed instrumentation-only (no optimization behavior merged)
-- [ ] Candidates tested sequentially on same staging environment, with no in-place artifact mutation
-- [ ] Same seeded save/test account state, same `/quests` route, same browser/device profile, same CPU slowdown
-- [ ] Browser/app state reset between candidates (including storage + service worker/cache storage)
-- [ ] Raw Playwright harness output preserved for both candidates
-- [ ] At least one Chrome DevTools performance trace captured for each candidate
-- [ ] Attach raw Playwright output and DevTools traces to release artifacts, or link both from release notes / PR discussion for both candidates
-- [ ] Recorded per run: candidate tag, commit SHA, date/time, profile, CPU slowdown, cold/warm flag
-- [ ] Go/no-go decision based on comparable **cold-run** data first (warm-run data tracked separately only)
-- [ ] Runs from different devices/slowdown/seeded data are labeled as separate experiments and not compared directly
-- [ ] Logs/traces attached as release artifacts or linked in release notes/PR discussion
+#### B) Built-in quest correctness
 
-- [ ] (Optional supporting audit) Run Lighthouse against staging and attach summary, but do not use as sole gate
+- [ ] `/quests` shows actionable built-in quests without broken statuses
+- [ ] Completed built-in quests remain in completed section
+- [ ] Locked/unavailable built-ins are not incorrectly shown as actionable
+- [ ] Clicking built-in quest cards still navigates and progresses normally
 
-```bash
-npx lighthouse https://staging.democratized.space/quests --preset=desktop --view
-```
+#### C) Custom quest regression checks
 
-If you must run Lighthouse locally, ensure the local build exactly mirrors the candidate under test and label results as local-only supplementary evidence.
+- [ ] Existing custom quests still load and display after merge completes
+- [ ] Custom quest cards are usable (open, progress, complete flow as expected)
+- [ ] Delayed merge does not break built-in list rendering or route navigation
+
+#### D) Built-in + custom coexistence (critical)
+
+- [ ] Built-in quests remain visible/usable while custom merge occurs
+- [ ] Custom quests appear alongside built-ins without duplicates or ID collisions
+- [ ] No regression where one content source suppresses the other
+
+### 3.2 `/processes` validation (required)
+
+#### A) Summary-first list behavior
+
+- [ ] `/processes` list renders summary rows (title/duration/IO summary)
+- [ ] Built-in process rows are visible immediately
+- [ ] Rows include working `View details` links
+
+#### B) Custom process regression + coexistence (critical)
+
+- [ ] Custom processes still load after mount and merge into list
+- [ ] Built-in + custom rows coexist correctly (no duplicates/missing IDs)
+- [ ] Custom badge and summary values render correctly for custom rows
+
+#### C) Detail route parity
+
+- [ ] Opening `/processes/:id` for built-in process still supports start/cancel/collect
+- [ ] Opening custom process detail route still resolves correctly
+- [ ] `Buy required items` behavior remains unchanged on detail page
+- [ ] No obvious process runtime control regressions from list refactor
+
+### 3.3 `/docs` validation (required)
+
+- [ ] Default `/docs` browse view works before full body corpus is loaded
+- [ ] Operator-only queries (for example `has:link`, `has:image`) still work
+- [ ] First keyword query triggers deferred corpus load successfully
+- [ ] Subsequent keyword searches reuse loaded corpus (no repeated fetch churn)
+- [ ] Snippet rendering still highlights matching terms and wraps long tokens safely
+- [ ] No regressions in docs search result quality vs pre-patch behavior
+
+### 3.4 `/chat` regression checks (required because docs power RAG)
+
+Run at least these manual prompts in staging and review for grounding quality:
+
+1. **Docs lookup sanity**
+   - Prompt: `What does the About page say DSPACE is?`
+   - Expected: answer references `/docs/about` content accurately.
+2. **Process/doc grounding sanity**
+   - Prompt: `How do processes work in DSPACE? Cite the docs page name.`
+   - Expected: grounded answer with relevant docs concept/page.
+3. **Quest/doc grounding sanity**
+   - Prompt: `Where can I read about quest submission requirements?`
+   - Expected: points to quest submission docs and describes key requirement(s).
+4. **No-empty-retrieval sanity**
+   - Prompt: `Summarize cloud sync behavior in one short paragraph.`
+   - Expected: non-empty, coherent docs-backed response (not blank/fallback-only).
+
+Checklist:
+
+- [ ] `/chat` still returns grounded docs-backed answers
+- [ ] Responses still point to the right docs/content when expected
+- [ ] No obvious empty-results or delayed-index regression from deferred corpus behavior
 
 ---
 
-## 4) Production promotion gate
+## 4) Recommended manual sanity checks (strongly recommended)
 
-- [ ] Promote only the exact immutable tag validated in staging
-- [ ] Confirm rollback tag and command are prepared before prod deploy
-- [ ] Confirm prod values file and host target are correct (`democratized.space`)
-- [ ] Confirm QA Cheats remain OFF in prod (`DSPACE_ENV=prod`)
+- [ ] Run remote smoke harness against staging with current defaults
 
-Suggested prod smoke commands:
+```bash
+npm run qa:remote-smoke -- --baseURL https://staging.democratized.space
+```
+
+- [ ] Run remote migration harness if release risk includes legacy-save users
+
+```bash
+npm run qa:remote-migration -- --baseURL https://staging.democratized.space
+```
+
+- [ ] Capture screenshots/video for `/quests`, `/processes`, `/docs`, `/chat` validation evidence
+
+---
+
+## 5) Optional supplementary evidence
+
+- [ ] Lighthouse snapshot for `/quests` and `/docs` (supplementary only)
+- [ ] Additional low-end CPU throttled perf runs beyond required harness
+- [ ] Extra chat prompt set for regression confidence
+
+---
+
+## 6) Production promotion gate
+
+- [ ] Promote only exact immutable tag validated in staging
+- [ ] Confirm rollback command and rollback tag before deployment
+- [ ] Verify prod target host is `https://democratized.space`
+- [ ] Confirm QA Cheats OFF in prod (`DSPACE_ENV=prod`)
+
+Prod smoke:
 
 ```bash
 curl -fsS https://democratized.space/config.json
@@ -208,16 +282,16 @@ curl -fsS https://democratized.space/livez
 
 ---
 
-## 5) Rollback notes
+## 7) Rollback
 
 If production verification fails:
 
 - [ ] Roll back immediately to previous known-good immutable tag
-- [ ] Re-run prod health checks
-- [ ] Log incident notes and follow-up fix scope
+- [ ] Re-run prod smoke endpoints and route checks
+- [ ] Record incident summary + replacement candidate scope
 - [ ] Keep `v3.0.1` open until replacement candidate is validated
 
-Rollback command template:
+Rollback template:
 
 ```bash
 cd ~/sugarkube
@@ -229,9 +303,10 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
 ---
 
-## 6) Release close-out
+## 8) Release closeout
 
-- [ ] Final release git tag created and pushed (`v3.0.1`)
-- [ ] Changelog/release notes updated
-- [ ] Deployed immutable tag and SHA recorded in release notes
-- [ ] Any deferred non-patch work moved to `v3.1.x` planning
+- [ ] Final tag `v3.0.1` created and pushed
+- [ ] Release notes/changelog addendum published
+- [ ] Final deployed immutable tag + SHA recorded in release notes
+- [ ] Confirm no extra non-patch scope is bundled
+- [ ] Archive QA evidence links (metrics, traces, smoke logs, chat transcript snippets)

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,28 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+---
+
+## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
+
+`v3.0.1` is a focused stability + performance patch to the April v3 release.
+
+### What improved in this patch
+
+- **`/quests` list performance and correctness:** quest-list loading was optimized for faster first
+  meaningful render, with additional hardening around status classification and custom-quest merge
+  behavior so built-in and custom quests continue to work correctly together.
+- **`/processes` summary-first list rendering:** the `/processes` index now prioritizes lightweight
+  list summaries, shows built-in process rows immediately, and preserves custom-process merge and
+  detail-route workflows.
+- **`/docs` deferred full-text search payload:** docs browse/default view now starts from a
+  lighter payload and loads the full text corpus when needed for keyword search, while preserving
+  operators such as `has:link` and `has:image`.
+- **Release-safety regression coverage:** QA and smoke coverage for patch promotion was tightened
+  around docs/search behavior, quest/process list regressions, and migration/smoke confidence checks.
+
+### Player-visible outcome
+
+This patch keeps v3 feature scope intact while making high-traffic routes (`/quests`, `/processes`,
+`/docs`) more responsive and reducing regression risk for docs-backed chat behavior.


### PR DESCRIPTION
### Motivation

- Audit the commit range since `v3.0.0` and expand the `v3.0.1` QA checklist to reflect the real patch delta beyond the original `/quests` TTI work. 
- Ensure staging/prod launch gates explicitly cover `/quests`, `/processes`, `/docs`, and `/chat` surfaces and the critical built-in + custom coexistence checks. 
- Provide a compact, discoverable patch-note addendum for `v3.0.1` inside the existing April 1, 2026 changelog entry.

### Description

- Updated `docs/qa/v3.0.1.md` to a focused, operational launch checklist that documents the audited patch scope, required automated checks, staging TTI comparison procedure, `/quests` and `/processes` coexistence/regression checks, `/docs` deferred-corpus validation, `/chat` RAG sanity prompts, and promotion/rollback/closeout steps. 
- Appended a dated addendum section (`June 1, 2026 — DSPACE v3.0.1`) to `frontend/src/pages/docs/md/changelog/20260401.md` summarizing user-visible patch changes to `/quests`, `/processes`, `/docs`, and QA/smoke coverage. 
- Kept the change strictly documentation-only and limited the diff to the two files requested with no runtime or application code modifications. 

### Testing

- Audited the commit range using `git log` and `git diff` to enumerate the merged changes from `3ec45a5517a35c96767f6b946c01104e6ec88f93..HEAD`. 
- Verified local markdown links with `node scripts/link-check.mjs`, which returned "All local markdown links resolved.". 
- Ran the repo secret scan (`./scripts/scan-secrets.py` via the staged `git diff --cached` invocation) and confirmed no secrets were reported, and performed a final `git diff --stat` to confirm only the two documentation files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d888ab7af8832fa40d77fd516e5285)