### PR TITLE
📝 docs: refresh v3.0.1 QA checklist and add June 1, 2026 changelog addendum

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,9 +1,7 @@
-# DSPACE v3.0.1 QA Checklist (urgent patch line)
+# DSPACE v3.0.1 QA Checklist (patch release)
 
-> Scope: `v3.0.1` is for urgent bugfixes and small improvements only.
-> It is **not** a feature release track.
-
-Use this checklist for rapid but safe patch promotion from staging to prod.
+> Scope lock: `v3.0.1` validates the patch delta from `v3.0.0` tag commit
+> `3ec45a5517a35c96767f6b946c01104e6ec88f93` to the promoted candidate.
 
 Related docs:
 
@@ -11,32 +9,61 @@ Related docs:
 - [Release and promotion procedure](../merge-plan.md)
 - [Staging runbook](../k3s-sugarkube-staging.md)
 - [Prod runbook](../k3s-sugarkube-prod.md)
-- [Feature-track QA checklist (v3.1)](./v3.1.md)
+- [`/quests` TTI design](../design/quests-tti-optimization.md)
+- [`/processes` list design](../design/processes-list-performance-and-presentation.md)
+- [`/docs` index design](../design/docs-index-performance-and-presentation.md)
 
 ---
 
-## 0) Release metadata
+## 0) Patch-scope summary (required)
+
+`v3.0.1` is no longer `/quests`-only. QA must cover these patch themes from the
+`3ec45a5..HEAD` range:
+
+- `/quests`: TTI optimization + deterministic custom-quest merge + list correctness.
+- `/processes`: summary-first list rows with detail behavior preserved on `/processes/:slug`.
+- `/docs`: deferred full-text corpus loading with lightweight initial payload.
+- `/chat`: regression safety because docs indexing/search feeds docs-backed retrieval quality.
+- Release safety: smoke/migration harness hardening and workflow guard updates.
+
+### 0.1 Commit-range audit evidence (required before sign-off)
+
+Run and attach outputs:
+
+```bash
+git log --oneline 3ec45a5517a35c96767f6b946c01104e6ec88f93..HEAD
+```
+
+```bash
+git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..HEAD
+```
+
+```bash
+git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..HEAD
+```
+
+- [ ] Audit outputs attached to release ticket/PR
+- [ ] QA scope confirmed against touched `/quests`, `/processes`, `/docs`, `/chat` surfaces
+
+---
+
+## 1) Release metadata + signoff (required)
 
 - [ ] Target version: `v3.0.1`
 - [ ] Candidate tag under test: `________________`
-- [ ] Commit SHA: `________________`
-- [ ] Change scope summary (bugfix/small improvements only): `________________`
-- [ ] Staging sign-off owner + timestamp: `________________`
+- [ ] Candidate commit SHA: `________________`
+- [ ] Date/time of validation window: `________________`
+- [ ] QA owner: `________________`
+- [ ] Staging approver + timestamp: `________________`
 - [ ] Production deploy owner + timestamp: `________________`
 - [ ] Previous known-good rollback tag: `________________`
+- [ ] Go/No-go decision recorded with links to evidence
 
 ---
 
-## 1) Patch-scope gate (must pass before broader QA)
+## 2) Automated checks
 
-- [ ] Every change is bugfix/small improvement scoped
-- [ ] No new feature flag or major UX flow introduced without explicit approval
-- [ ] No unrelated refactor included
-- [ ] Release notes drafted with user-visible deltas only
-
----
-
-## 2) Automated checks (required)
+### 2.1 Required launch gates
 
 ```bash
 npm run lint
@@ -47,6 +74,10 @@ npm run type-check
 ```
 
 ```bash
+npm run build
+```
+
+```bash
 npm run link-check
 ```
 
@@ -54,25 +85,41 @@ npm run link-check
 node run-tests.js
 ```
 
-If full test runtime is constrained, record the exception and run at least targeted validation:
+```bash
+node scripts/link-check.mjs
+```
+
+- [ ] All required commands pass (or exception explicitly approved by release owner)
+
+### 2.2 Recommended targeted evidence (strongly recommended)
+
+```bash
+npm --prefix frontend run test:e2e -- quests-tti-behavior.spec.ts
+```
+
+```bash
+npm --prefix frontend run test:e2e -- quests-tti-metrics.spec.ts
+```
+
+```bash
+npm --prefix frontend run test -- src/components/__tests__/DocsIndexSearch.spec.ts src/pages/docs/__tests__/index.spec.ts
+```
 
 ```bash
 npm run qa:smoke
 ```
 
+```bash
+npm run qa:remote-migration
+```
+
+- [ ] Targeted checks captured for changed patch surfaces
+
 ---
 
-## 3) Staging deploy + validation
+## 3) Staging deploy + health validation (required)
 
-Deploy approved immutable candidate to staging (`staging.democratized.space`) and validate:
-
-- [ ] `/config.json` returns expected runtime config
-- [ ] `/healthz` and `/livez` return success
-- [ ] Patch issue reproduction is fixed in staging
-- [ ] No regression in core nav/routes relevant to touched areas
-- [ ] QA Cheats remain enabled in staging (`DSPACE_ENV=staging`)
-
-Suggested smoke commands:
+Deploy immutable candidate to `staging.democratized.space`.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json
@@ -86,113 +133,122 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-### 3.1 `/quests` TTI performance launch gate (required for this optimization)
+- [ ] `/config.json` exposes expected build/version metadata
+- [ ] `/healthz` and `/livez` are healthy
+- [ ] Core nav routes load (`/quests`, `/processes`, `/docs`, `/chat`, `/changelog`)
 
-This gate compares **exactly two candidates** on `staging.democratized.space`:
+---
 
-1. **Instrumented baseline candidate** branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
-2. **Optimized HEAD candidate** for `v3.0.1`
+## 4) `/quests` validation (required)
 
-Baseline policy (strict):
+### 4.1 TTI baseline-vs-optimized gate (required)
 
-- The baseline branch is **measurement-only instrumentation**.
-- It must emit the required marks/measures, but **must not include optimization logic** from the
-  HEAD implementation.
-- If baseline internals differ from optimized internals, preserve the exact timing names for
-  comparability, keep instrumentation honest, and if an optional phase is not meaningfully
-  separable, omit it or explicitly document the approximation in recorded results.
+Compare exactly two immutable candidates on staging:
 
-Primary validation stack for this gate (required):
-
-1. Playwright `/quests` TTI measurement harness (raw output retained)
-2. `/quests` User Timing marks/measures
-3. Chrome DevTools Performance trace review (at least one trace per candidate)
-
-Lighthouse is supplementary only and cannot replace the required evidence above.
-
-#### Procedure (run sequentially on the same staging environment)
-
-1. Deploy the **baseline** as a distinct immutable build/tag (do not mutate artifacts in place).
-2. Confirm rollback path before any candidate swap.
-3. Verify staging health for this candidate: use `/config.json` as a config sanity check, and confirm deployed candidate `version`/`env` via `/healthz` or `/livez` output.
-4. Reset browser/client state before measurement (clear IndexedDB, localStorage,
-   sessionStorage, service worker/cache storage, and any persisted quest state).
-5. Run Playwright harness on `/quests` with the chosen profile/slowdown.
-6. Capture at least one Chrome DevTools performance trace for `/quests`.
-7. Record metadata and results for this run, including:
-   - candidate tag
-   - commit SHA
-   - date/time
-   - browser/device profile
-   - CPU slowdown factor
-   - seeded save / test account state
-   - route
-   - cold vs warm
-8. Deploy the **optimized HEAD** as a second distinct immutable build/tag.
-9. Repeat steps 3-7 under identical seeded state, route, browser/device profile, and CPU slowdown.
-10. Compare results and make go/no-go decision.
-
-Required harness command:
+1. Baseline instrumentation-only build from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
+2. Optimized `v3.0.1` candidate
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests
 ```
 
-Optional recommended slow-CPU companion run (use the same factor for both candidates; `perf:quests:slowcpu` applies `QUESTS_TTI_CPU_SLOWDOWN=4`):
+Optional slow-CPU companion (same profile/seed for both):
 
 ```bash
 QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu
 ```
 
-Required timing marks/measures to verify and record:
+- [ ] Same browser/device/CPU profile across both candidates
+- [ ] Browser state reset between runs (IndexedDB/localStorage/sw/cache)
+- [ ] Required marks present: `quests:list-hydration-start`, `quests:list-visible`, `quests:snapshot-classification-ready`, `quests:full-state-reconciliation-complete`
+- [ ] Raw perf output + at least one DevTools trace per candidate attached
 
-- Required marks:
-    - `quests:list-hydration-start`
-    - `quests:list-visible`
-    - `quests:snapshot-classification-ready`
-    - `quests:full-state-reconciliation-complete`
-- Optional mark:
-    - `quests:custom-quests-merge-complete`
-- Required measures:
-    - `quests:time-to-list-visible`
-    - `quests:time-to-snapshot-classification`
-    - `quests:time-to-full-reconciliation`
-- Optional measure:
-    - `quests:time-to-custom-merge`
+### 4.2 Built-in quest correctness (required)
 
-Acceptance and evidence checklist:
+- [ ] Built-in list appears promptly and stays stable after hydration
+- [ ] Completed quests remain correctly marked
+- [ ] Locked/available status is not optimistic when state is uncertain
+- [ ] Opening a built-in quest route and progressing still works
 
-- [ ] Comparison includes exactly two immutable candidates: baseline-from-3ec45a5517a35c96767f6b946c01104e6ec88f93 and optimized HEAD
-- [ ] Baseline candidate confirmed instrumentation-only (no optimization behavior merged)
-- [ ] Candidates tested sequentially on same staging environment, with no in-place artifact mutation
-- [ ] Same seeded save/test account state, same `/quests` route, same browser/device profile, same CPU slowdown
-- [ ] Browser/app state reset between candidates (including storage + service worker/cache storage)
-- [ ] Raw Playwright harness output preserved for both candidates
-- [ ] At least one Chrome DevTools performance trace captured for each candidate
-- [ ] Attach raw Playwright output and DevTools traces to release artifacts, or link both from release notes / PR discussion for both candidates
-- [ ] Recorded per run: candidate tag, commit SHA, date/time, profile, CPU slowdown, cold/warm flag
-- [ ] Go/no-go decision based on comparable **cold-run** data first (warm-run data tracked separately only)
-- [ ] Runs from different devices/slowdown/seeded data are labeled as separate experiments and not compared directly
-- [ ] Logs/traces attached as release artifacts or linked in release notes/PR discussion
+### 4.3 Custom quest regression + coexistence (required)
 
-- [ ] (Optional supporting audit) Run Lighthouse against staging and attach summary, but do not use as sole gate
-
-```bash
-npx lighthouse https://staging.democratized.space/quests --preset=desktop --view
-```
-
-If you must run Lighthouse locally, ensure the local build exactly mirrors the candidate under test and label results as local-only supplementary evidence.
+- [ ] Custom quests still load from local content and remain playable
+- [ ] No custom quests are dropped during delayed merge
+- [ ] Built-in quests remain visible/usable while custom quests merge
+- [ ] Built-in + custom sections coexist without built-in tile displacement regressions
+- [ ] Mixed saves (built-in progress + custom quests) preserve status accuracy
 
 ---
 
-## 4) Production promotion gate
+## 5) `/processes` validation (required)
 
-- [ ] Promote only the exact immutable tag validated in staging
-- [ ] Confirm rollback tag and command are prepared before prod deploy
-- [ ] Confirm prod values file and host target are correct (`democratized.space`)
-- [ ] Confirm QA Cheats remain OFF in prod (`DSPACE_ENV=prod`)
+### 5.1 Summary-first list behavior (required)
 
-Suggested prod smoke commands:
+- [ ] `/processes` initially shows summary rows (not detail-grade controls in every row)
+- [ ] Built-in process rows are visible immediately
+- [ ] Each row retains clear navigation to `View details`
+
+### 5.2 Custom process regression + coexistence (required)
+
+- [ ] Custom processes merge after load without replacing/hiding built-ins
+- [ ] Custom rows are identifiable and clickable
+- [ ] Built-in + custom process rows coexist in one usable list
+
+### 5.3 Detail route parity (required)
+
+- [ ] `/processes/:slug` behavior unchanged for built-in processes
+- [ ] `/processes/:slug` works for custom processes
+- [ ] `Buy required items` still appears/works where requirements apply
+- [ ] Start/cancel/collect flow remains functional from detail route
+
+---
+
+## 6) `/docs` validation (required)
+
+- [ ] Default docs browse view loads correctly from lightweight payload
+- [ ] Initial docs payload does not require full body text to render lists
+- [ ] `has:link` and `has:image` operators still behave correctly
+- [ ] First keyword query triggers deferred corpus fetch and returns expected matches
+- [ ] Snippet rendering remains correct after deferred corpus load
+- [ ] No regression in docs search empty-state/error fallback behavior
+
+Suggested manual checks:
+
+- `/docs` then query `has:link`
+- `/docs` then query a body-text keyword that is not in title/keywords
+- Repeat keyword query to confirm corpus retry/fallback behavior is sane
+
+---
+
+## 7) `/chat` docs-backed regression validation (required)
+
+Because `/chat` uses docs-backed retrieval context, run a manual RAG sanity sweep after `/docs`
+changes.
+
+### 7.1 Grounding checks
+
+- [ ] Chat answers at least 3 docs-grounded gameplay questions correctly
+- [ ] Responses point to the expected docs concepts/pages (no obvious off-topic retrieval)
+- [ ] No obvious empty-results or delayed-index symptoms after first docs search/corpus load
+
+### 7.2 Suggested prompts (manual)
+
+Use prompts like:
+
+1. `How do I submit a custom content bundle in DSPACE?`
+2. `What does has:image do in docs search and when should I use it?`
+3. `How do process requirements and Buy required items work?`
+4. `Where can I find migration/backup guidance for older saves?`
+
+- [ ] Answers are coherent, grounded, and consistent with docs content
+
+---
+
+## 8) Production promotion gate (required)
+
+- [ ] Promote only the exact immutable candidate validated in staging
+- [ ] Rollback command prepared before deploy
+- [ ] Prod env/settings verified (`democratized.space`, `DSPACE_ENV=prod`)
 
 ```bash
 curl -fsS https://democratized.space/config.json
@@ -206,18 +262,20 @@ curl -fsS https://democratized.space/healthz
 curl -fsS https://democratized.space/livez
 ```
 
+- [ ] Post-deploy smoke confirms `/quests`, `/processes`, `/docs`, `/chat` route health
+
 ---
 
-## 5) Rollback notes
+## 9) Rollback plan (required)
 
-If production verification fails:
+If any required gate fails in production:
 
 - [ ] Roll back immediately to previous known-good immutable tag
-- [ ] Re-run prod health checks
-- [ ] Log incident notes and follow-up fix scope
-- [ ] Keep `v3.0.1` open until replacement candidate is validated
+- [ ] Re-run prod health/smoke checks
+- [ ] Log incident summary + follow-up owner
+- [ ] Keep `v3.0.1` open until replacement candidate passes full checklist
 
-Rollback command template:
+Rollback template:
 
 ```bash
 cd ~/sugarkube
@@ -229,9 +287,15 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
 ---
 
-## 6) Release close-out
+## 10) Release closeout (required)
 
-- [ ] Final release git tag created and pushed (`v3.0.1`)
-- [ ] Changelog/release notes updated
-- [ ] Deployed immutable tag and SHA recorded in release notes
-- [ ] Any deferred non-patch work moved to `v3.1.x` planning
+- [ ] `v3.0.1` tag pushed and recorded
+- [ ] June 1, 2026 patch-note addendum published in changelog
+- [ ] Final deployed tag + SHA recorded in release notes
+- [ ] Explicit note recorded: no new feature work beyond patch scope
+
+### Optional supplementary evidence
+
+- Lighthouse summary for `/quests`, `/processes`, `/docs` (informational only)
+- Video capture of built-in/custom coexistence behavior for `/quests` and `/processes`
+- Remote smoke and migration harness reports attached for release archive

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,18 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+---
+
+## Addendum — June 1, 2026 (DSPACE v3.0.1)
+
+`v3.0.1` is a patch follow-up to v3 focused on performance, correctness, and release safety across high-traffic surfaces.
+
+### Patch highlights
+
+- **`/quests` list performance + correctness:** reduced time-to-meaningful content, hardened list status behavior, and improved built-in/custom quest coexistence so delayed custom merges do not destabilize built-in cards.
+- **`/processes` summary-first list update:** the main `/processes` page now prioritizes lightweight summaries and navigation, while full runtime controls stay on process detail pages.
+- **`/docs` search payload improvements:** `/docs` now ships a lighter initial payload and defers full-text corpus loading until keyword search needs it, while preserving existing `has:` operator behavior.
+- **Patch-line regression hardening:** expanded targeted QA/perf/smoke coverage around quests TTI, docs deferred corpus behavior, process list/detail contracts, and release smoke/migration safety checks.
+
+As a patch release, `v3.0.1` does **not** introduce a new major gameplay system; it tightens runtime behavior and launch reliability for existing v3 features.


### PR DESCRIPTION
### Motivation

- Audit and reconcile the actual patch delta since v3.0.0 so the v3.0.1 QA checklist matches what was merged and to make launch validation actionable. 
- Capture user-visible patch scope in the April 1, 2026 changelog entry by adding a June 1, 2026 v3.0.1 addendum. 
- Limit changes to documentation only and keep the PR small and focused on release validation.

### Description

- Updated `docs/qa/v3.0.1.md` to reflect the real v3.0.1 patch scope and to provide an operational, checklist-oriented runbook that includes: commit-range audit evidence, release metadata/signoff fields, required automated checks, staging deploy + health validation, an explicit `/quests` TTI baseline-vs-optimized gate and built-in vs custom coexistence checks, `/processes` summary-first and detail-route parity checks (including `Buy required items`), `/docs` deferred-corpus search checks (including `has:` operator behavior and snippet validation), `/chat` RAG grounding/regression scenarios, production promotion/rollback steps, and closeout items. 
- Appended a dated addendum to `frontend/src/pages/docs/md/changelog/20260401.md` titled “Addendum — June 1, 2026 (DSPACE v3.0.1)” that summarizes the patch (quests TTI & correctness, processes summary-first list behavior, docs deferred corpus improvements, and regression/QA hardening). 
- Scope-limited: only the two documentation files above were changed and no application code, tests, build artifacts, or release scripts were modified.

### Testing

- Ran the repository markdown link checker with `node scripts/link-check.mjs` and `npm run link-check`; both reported all local markdown links resolved. 
- Performed the required audit commands locally to list and inspect changed files and design/test surfaces (audit outputs attached to the release artifacts as part of the runbook step). 
- Executed the repo secret-scan hook after staging the doc changes (no secret findings). 

No runtime or application code was changed in this PR; this is documentation-only work to update QA coverage and the changelog addendum.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d888ab7af8832fa40d77fd516e5285)