### PR TITLE
Improve /processes list with cached lightweight item previews

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,10 +1,85 @@
 <script>
+    import { onDestroy, onMount } from 'svelte';
+    import { getItemMap } from '../../utils/itemResolver.js';
+    import { prettyPrintNumber } from '../../utils.js';
+
     export let process;
 
+    const PREVIEW_LIMIT = 3;
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
     const formatItemSummary = (types, total) =>
         Number(types) > 0 ? `${types} item${types === 1 ? '' : 's'} (${total})` : 'none';
+
+    const normalizePreviewItem = (item, metadata = null) => {
+        const itemId = String(item?.id ?? '');
+        const parsedCount = Number(item?.count ?? 0);
+
+        return {
+            id: itemId,
+            count: Number.isFinite(parsedCount) ? parsedCount : 0,
+            name: metadata?.name ?? item?.name ?? `Item ${itemId}`,
+            image: metadata?.image ?? item?.image ?? '/favicon.ico',
+            releaseImage: metadata?.releaseImage ?? null,
+        };
+    };
+
+    const toPreviewList = (entries = []) =>
+        Array.isArray(entries) ? entries.slice(0, PREVIEW_LIMIT).map((entry) => normalizePreviewItem(entry)) : [];
+
+    const releaseImages = (items = []) => {
+        items.forEach((item) => item?.releaseImage?.());
+    };
+
+    let isMounted = false;
+    let previewRequestId = 0;
+    let requireItemsPreview = [];
+    let consumeItemsPreview = [];
+    let createItemsPreview = [];
+
+    async function loadPreviewItems() {
+        const requestId = ++previewRequestId;
+        const previewEntries = [
+            ...(process?.requireItems ?? []).slice(0, PREVIEW_LIMIT),
+            ...(process?.consumeItems ?? []).slice(0, PREVIEW_LIMIT),
+            ...(process?.createItems ?? []).slice(0, PREVIEW_LIMIT),
+        ];
+        const ids = previewEntries.map((entry) => String(entry?.id ?? '')).filter((id) => id.length > 0);
+        const metadataById = ids.length > 0 ? await getItemMap(ids) : new Map();
+
+        if (!isMounted || requestId !== previewRequestId) {
+            releaseImages(Array.from(metadataById.values()));
+            return;
+        }
+
+        releaseImages(requireItemsPreview);
+        releaseImages(consumeItemsPreview);
+        releaseImages(createItemsPreview);
+
+        requireItemsPreview = (process?.requireItems ?? [])
+            .slice(0, PREVIEW_LIMIT)
+            .map((entry) => normalizePreviewItem(entry, metadataById.get(String(entry?.id ?? ''))));
+        consumeItemsPreview = (process?.consumeItems ?? [])
+            .slice(0, PREVIEW_LIMIT)
+            .map((entry) => normalizePreviewItem(entry, metadataById.get(String(entry?.id ?? ''))));
+        createItemsPreview = (process?.createItems ?? [])
+            .slice(0, PREVIEW_LIMIT)
+            .map((entry) => normalizePreviewItem(entry, metadataById.get(String(entry?.id ?? ''))));
+    }
+
+    onMount(() => {
+        isMounted = true;
+        if (process?.custom) {
+            loadPreviewItems();
+        }
+    });
+
+    onDestroy(() => {
+        isMounted = false;
+        releaseImages(requireItemsPreview);
+        releaseImages(consumeItemsPreview);
+        releaseImages(createItemsPreview);
+    });
 
     $: processId = normalizeProcessId(process?.id);
     $: processTitle = process?.title || processId || 'Untitled process';
@@ -12,9 +87,27 @@
     $: requireSummary = formatItemSummary(process?.requireItemTypes, process?.requireItemTotal);
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
+    $: serverRequirePreview = toPreviewList(process?.requireItemsPreview);
+    $: serverConsumePreview = toPreviewList(process?.consumeItemsPreview);
+    $: serverCreatePreview = toPreviewList(process?.createItemsPreview);
+    $: resolvedRequirePreview = process?.custom ? requireItemsPreview : serverRequirePreview;
+    $: resolvedConsumePreview = process?.custom ? consumeItemsPreview : serverConsumePreview;
+    $: resolvedCreatePreview = process?.custom ? createItemsPreview : serverCreatePreview;
+    $: requirePreviewRemainder = Math.max(
+        Number(process?.requireItemsPreviewRemainder ?? (process?.requireItems?.length ?? 0) - PREVIEW_LIMIT),
+        0
+    );
+    $: consumePreviewRemainder = Math.max(
+        Number(process?.consumeItemsPreviewRemainder ?? (process?.consumeItems?.length ?? 0) - PREVIEW_LIMIT),
+        0
+    );
+    $: createPreviewRemainder = Math.max(
+        Number(process?.createItemsPreviewRemainder ?? (process?.createItems?.length ?? 0) - PREVIEW_LIMIT),
+        0
+    );
 </script>
 
-<article class="process-row" data-process-id={processId}>
+<article class="process-row" data-process-id={processId} data-testid="process-row">
     <div class="process-row__header">
         <h2>{processTitle}</h2>
         {#if process?.custom}
@@ -30,14 +123,53 @@
         <div>
             <dt>Requires</dt>
             <dd>{requireSummary}</dd>
+            {#if resolvedRequirePreview.length > 0}
+                <div class="item-preview-list">
+                    {#each resolvedRequirePreview as item (item.id)}
+                        <a class="item-preview" href={`/inventory/item/${item.id}`}>
+                            <img src={item.image} alt={item.name} loading="lazy" />
+                            <span>{prettyPrintNumber(item.count)}x {item.name}</span>
+                        </a>
+                    {/each}
+                    {#if requirePreviewRemainder > 0}
+                        <span class="preview-overflow">+{requirePreviewRemainder} more</span>
+                    {/if}
+                </div>
+            {/if}
         </div>
         <div>
             <dt>Consumes</dt>
             <dd>{consumeSummary}</dd>
+            {#if resolvedConsumePreview.length > 0}
+                <div class="item-preview-list">
+                    {#each resolvedConsumePreview as item (item.id)}
+                        <a class="item-preview" href={`/inventory/item/${item.id}`}>
+                            <img src={item.image} alt={item.name} loading="lazy" />
+                            <span>{prettyPrintNumber(item.count)}x {item.name}</span>
+                        </a>
+                    {/each}
+                    {#if consumePreviewRemainder > 0}
+                        <span class="preview-overflow">+{consumePreviewRemainder} more</span>
+                    {/if}
+                </div>
+            {/if}
         </div>
         <div>
             <dt>Creates</dt>
             <dd>{createSummary}</dd>
+            {#if resolvedCreatePreview.length > 0}
+                <div class="item-preview-list">
+                    {#each resolvedCreatePreview as item (item.id)}
+                        <a class="item-preview" href={`/inventory/item/${item.id}`}>
+                            <img src={item.image} alt={item.name} loading="lazy" />
+                            <span>{prettyPrintNumber(item.count)}x {item.name}</span>
+                        </a>
+                    {/each}
+                    {#if createPreviewRemainder > 0}
+                        <span class="preview-overflow">+{createPreviewRemainder} more</span>
+                    {/if}
+                </div>
+            {/if}
         </div>
     </dl>
 
@@ -80,17 +212,51 @@
     }
 
     .process-row__summary div {
-        display: flex;
-        justify-content: space-between;
+        display: grid;
+        grid-template-columns: auto 1fr;
         gap: 6px;
         border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-        padding-bottom: 2px;
+        padding-bottom: 8px;
         font-size: 0.9rem;
     }
 
     dt,
     dd {
         margin: 0;
+    }
+    dd {
+        text-align: right;
+    }
+
+    .item-preview-list {
+        grid-column: 1 / -1;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+
+    .item-preview {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        text-decoration: none;
+        color: inherit;
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 999px;
+        padding: 2px 8px 2px 3px;
+    }
+
+    .item-preview img {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+    .preview-overflow {
+        font-size: 0.8rem;
+        opacity: 0.9;
+        align-self: center;
     }
 
     .details-link {

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -6,6 +6,10 @@ const { customListMock } = vi.hoisted(() => ({
     customListMock: vi.fn(),
 }));
 
+const { getItemMapMock } = vi.hoisted(() => ({
+    getItemMapMock: vi.fn(async () => new Map()),
+}));
+
 vi.mock('../../../utils/customcontent.js', () => ({
     db: {
         list: customListMock,
@@ -13,6 +17,10 @@ vi.mock('../../../utils/customcontent.js', () => ({
     ENTITY_TYPES: {
         PROCESS: 'process',
     },
+}));
+
+vi.mock('../../../utils/itemResolver.js', () => ({
+    getItemMap: getItemMapMock,
 }));
 
 describe('Processes list route contract', () => {
@@ -27,12 +35,16 @@ describe('Processes list route contract', () => {
             consumeItemTotal: 2,
             createItemTypes: 1,
             createItemTotal: 3,
+            requireItemsPreview: [{ id: '1', count: 1, name: 'Smart Plug', image: '/smart-plug.png' }],
+            consumeItemsPreview: [{ id: '2', count: 2, name: 'dUSD', image: '/dusd.png' }],
+            createItemsPreview: [{ id: '3', count: 3, name: 'dWatt', image: '/dwatt.png' }],
             custom: false,
         },
     ];
 
     beforeEach(() => {
         customListMock.mockReset();
+        getItemMapMock.mockClear();
     });
 
     it('renders built-in summary rows from initial output before custom merge resolves', () => {
@@ -46,6 +58,9 @@ describe('Processes list route contract', () => {
 
         expect(screen.getByText('Built In Process')).toBeTruthy();
         expect(screen.getByText('Duration')).toBeTruthy();
+        expect(screen.getByText('1x Smart Plug')).toBeTruthy();
+        expect(screen.getByText('2x dUSD')).toBeTruthy();
+        expect(screen.getByText('3x dWatt')).toBeTruthy();
         expect(screen.queryByText('No processes found')).toBeNull();
 
         resolveCustomProcesses([]);

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -1,7 +1,19 @@
 ---
 import Page from '../../components/Page.astro';
 import generatedProcesses from '../../generated/processes.json';
+import items from '../inventory/json/items';
 import Processes from './Processes.svelte';
+
+const ITEM_PREVIEW_LIMIT = 3;
+const itemMetadataById = new Map(
+    (Array.isArray(items) ? items : []).map((item) => [
+        String(item?.id ?? ''),
+        {
+            name: item?.name?.trim() || `Item ${item?.id ?? ''}`,
+            image: item?.image || '/favicon.ico',
+        },
+    ])
+);
 
 const summarizeEntries = (entries = []) =>
     Array.isArray(entries)
@@ -18,10 +30,31 @@ const summarizeEntries = (entries = []) =>
           )
         : { types: 0, total: 0 };
 
+const createItemPreview = (entries = []) => {
+    if (!Array.isArray(entries) || entries.length === 0) {
+        return [];
+    }
+
+    return entries.slice(0, ITEM_PREVIEW_LIMIT).map((entry) => {
+        const entryId = String(entry?.id ?? '');
+        const metadata = itemMetadataById.get(entryId);
+
+        return {
+            id: entryId,
+            count: Number(entry?.count ?? 0),
+            name: metadata?.name ?? `Item ${entryId}`,
+            image: metadata?.image ?? '/favicon.ico',
+        };
+    });
+};
+
 const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => {
     const requireSummary = summarizeEntries(process?.requireItems);
     const consumeSummary = summarizeEntries(process?.consumeItems);
     const createSummary = summarizeEntries(process?.createItems);
+    const requireItemsPreview = createItemPreview(process?.requireItems);
+    const consumeItemsPreview = createItemPreview(process?.consumeItems);
+    const createItemsPreview = createItemPreview(process?.createItems);
 
     return {
         id: process?.id,
@@ -34,6 +67,21 @@ const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses
         consumeItemTotal: consumeSummary.total,
         createItemTypes: createSummary.types,
         createItemTotal: createSummary.total,
+        requireItemsPreview,
+        requireItemsPreviewRemainder: Math.max(
+            (process?.requireItems?.length ?? 0) - requireItemsPreview.length,
+            0
+        ),
+        consumeItemsPreview,
+        consumeItemsPreviewRemainder: Math.max(
+            (process?.consumeItems?.length ?? 0) - consumeItemsPreview.length,
+            0
+        ),
+        createItemsPreview,
+        createItemsPreviewRemainder: Math.max(
+            (process?.createItems?.length ?? 0) - createItemsPreview.length,
+            0
+        ),
     };
 });
 ---


### PR DESCRIPTION
### Motivation
- The recent `/processes` optimization removed per-row context (item names/images) which hurt usability while improving load performance.
- Restore a small, high-value amount of context for Requires/Consumes/Creates without reverting to the previous heavy runtime data fetch.

### Description
- Add server-side, build-time preview metadata for built-in processes in `frontend/src/pages/processes/index.astro` and attach capped preview lists (`requireItemsPreview`, `consumeItemsPreview`, `createItemsPreview`) to the built-in process objects.  
- Render compact item preview chips in `frontend/src/pages/processes/ProcessListRow.svelte` showing image, name and count (capped to 3 items per section) while keeping the original summary counts and “View details” flow.  
- Lazily hydrate previews for custom processes on mount using the cached resolver `getItemMap()` so custom rows populate names/images asynchronously without blocking initial render, and ensure image release/cleanup to avoid leaks.  
- Extend `frontend/src/pages/processes/__tests__/Processes.spec.ts` to mock `getItemMap` and assert the new preview text renders for built-in rows.

### Testing
- Ran the focused unit test file with `npm run test:root -- frontend/src/pages/processes/__tests__/Processes.spec.ts` and all tests passed (`5 tests` passed).  
- Ran lint with `npm run lint` and it completed successfully.  
- The build pretest step (`frontend/scripts/build-processes.mjs`) ran as part of the test invocation and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89978115c832f858bfc2f2f00bc67)