### PR TITLE
Improve /processes list summaries with cached item previews

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,10 +1,88 @@
 <script>
+    import { onDestroy, onMount } from 'svelte';
+    import { getItemMap } from '../../utils/itemResolver.js';
+
     export let process;
+
+    const PREVIEW_LIMIT = 2;
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
     const formatItemSummary = (types, total) =>
         Number(types) > 0 ? `${types} item${types === 1 ? '' : 's'} (${total})` : 'none';
+
+    const normalizeListEntries = (entries = []) => {
+        if (!Array.isArray(entries) || entries.length === 0) {
+            return [];
+        }
+
+        return entries
+            .map((entry) => {
+                const id = String(entry?.id ?? '').trim();
+                if (!id) {
+                    return null;
+                }
+
+                const count = Number(entry?.count);
+                return {
+                    id,
+                    count: Number.isFinite(count) ? count : 0,
+                };
+            })
+            .filter(Boolean);
+    };
+
+    const toPreviewItems = (entries, itemMap) =>
+        entries.map((entry) => {
+            const item = itemMap.get(entry.id);
+            return {
+                id: entry.id,
+                count: entry.count,
+                name: item?.name ?? 'Unknown item',
+                image: item?.image ?? '/favicon.ico',
+                releaseImage: item?.releaseImage ?? null,
+            };
+        });
+
+    const releasePreviewItems = (items) => {
+        items.forEach((item) => item?.releaseImage?.());
+    };
+
+    const loadPreviews = async () => {
+        const requireEntries = normalizeListEntries(process?.requireItems).slice(0, PREVIEW_LIMIT);
+        const consumeEntries = normalizeListEntries(process?.consumeItems).slice(0, PREVIEW_LIMIT);
+        const createEntries = normalizeListEntries(process?.createItems).slice(0, PREVIEW_LIMIT);
+
+        const ids = [...requireEntries, ...consumeEntries, ...createEntries].map((entry) => entry.id);
+        if (ids.length === 0) {
+            requirePreview = [];
+            consumePreview = [];
+            createPreview = [];
+            return;
+        }
+
+        const requestId = ++previewRequestId;
+        const uniqueIds = Array.from(new Set(ids));
+        const itemMap = await getItemMap(uniqueIds);
+
+        if (requestId !== previewRequestId) {
+            releasePreviewItems(Array.from(itemMap.values()));
+            return;
+        }
+
+        releasePreviewItems(requirePreview);
+        releasePreviewItems(consumePreview);
+        releasePreviewItems(createPreview);
+
+        requirePreview = toPreviewItems(requireEntries, itemMap);
+        consumePreview = toPreviewItems(consumeEntries, itemMap);
+        createPreview = toPreviewItems(createEntries, itemMap);
+    };
+
+    let requirePreview = [];
+    let consumePreview = [];
+    let createPreview = [];
+    let previewRequestId = 0;
 
     $: processId = normalizeProcessId(process?.id);
     $: processTitle = process?.title || processId || 'Untitled process';
@@ -12,6 +90,26 @@
     $: requireSummary = formatItemSummary(process?.requireItemTypes, process?.requireItemTotal);
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
+    $: previewKey = [
+        processId,
+        JSON.stringify(process?.requireItems ?? []),
+        JSON.stringify(process?.consumeItems ?? []),
+        JSON.stringify(process?.createItems ?? []),
+    ].join('|');
+
+    $: if (previewKey) {
+        loadPreviews();
+    }
+
+    onMount(() => {
+        loadPreviews();
+    });
+
+    onDestroy(() => {
+        releasePreviewItems(requirePreview);
+        releasePreviewItems(consumePreview);
+        releasePreviewItems(createPreview);
+    });
 </script>
 
 <article class="process-row" data-process-id={processId}>
@@ -31,14 +129,56 @@
             <dt>Requires</dt>
             <dd>{requireSummary}</dd>
         </div>
+        {#if requirePreview.length > 0}
+            <div class="item-preview-row">
+                <dd>
+                    <ul class="item-preview-list" aria-label="Requires item preview">
+                        {#each requirePreview as item}
+                            <li>
+                                <img src={item.image} alt={`${item.name} icon`} loading="lazy" width="20" height="20" />
+                                <span>{item.name} ({item.count})</span>
+                            </li>
+                        {/each}
+                    </ul>
+                </dd>
+            </div>
+        {/if}
         <div>
             <dt>Consumes</dt>
             <dd>{consumeSummary}</dd>
         </div>
+        {#if consumePreview.length > 0}
+            <div class="item-preview-row">
+                <dd>
+                    <ul class="item-preview-list" aria-label="Consumes item preview">
+                        {#each consumePreview as item}
+                            <li>
+                                <img src={item.image} alt={`${item.name} icon`} loading="lazy" width="20" height="20" />
+                                <span>{item.name} ({item.count})</span>
+                            </li>
+                        {/each}
+                    </ul>
+                </dd>
+            </div>
+        {/if}
         <div>
             <dt>Creates</dt>
             <dd>{createSummary}</dd>
         </div>
+        {#if createPreview.length > 0}
+            <div class="item-preview-row">
+                <dd>
+                    <ul class="item-preview-list" aria-label="Creates item preview">
+                        {#each createPreview as item}
+                            <li>
+                                <img src={item.image} alt={`${item.name} icon`} loading="lazy" width="20" height="20" />
+                                <span>{item.name} ({item.count})</span>
+                            </li>
+                        {/each}
+                    </ul>
+                </dd>
+            </div>
+        {/if}
     </dl>
 
     <a class="details-link" href={`/processes/${processId}`}>View details</a>
@@ -86,6 +226,44 @@
         border-bottom: 1px solid rgba(255, 255, 255, 0.15);
         padding-bottom: 2px;
         font-size: 0.9rem;
+    }
+
+    .process-row__summary .item-preview-row {
+        grid-column: 1 / -1;
+        border-bottom: 0;
+        padding-bottom: 0;
+    }
+
+    .item-preview-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        list-style: none;
+        padding: 0;
+        margin: 2px 0 4px;
+    }
+
+    .item-preview-list li {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 8px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 999px;
+        font-size: 0.8rem;
+        max-width: 100%;
+    }
+
+    .item-preview-list img {
+        border-radius: 999px;
+        object-fit: cover;
+        flex-shrink: 0;
+    }
+
+    .item-preview-list span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     dt,

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Processes from '../Processes.svelte';
 
-const { customListMock } = vi.hoisted(() => ({
+const { customListMock, getItemMapMock } = vi.hoisted(() => ({
     customListMock: vi.fn(),
+    getItemMapMock: vi.fn(),
 }));
 
 vi.mock('../../../utils/customcontent.js', () => ({
@@ -13,6 +14,10 @@ vi.mock('../../../utils/customcontent.js', () => ({
     ENTITY_TYPES: {
         PROCESS: 'process',
     },
+}));
+
+vi.mock('../../../utils/itemResolver.js', () => ({
+    getItemMap: getItemMapMock,
 }));
 
 describe('Processes list route contract', () => {
@@ -33,6 +38,19 @@ describe('Processes list route contract', () => {
 
     beforeEach(() => {
         customListMock.mockReset();
+        getItemMapMock.mockReset();
+        getItemMapMock.mockImplementation(async (ids = []) => {
+            const map = new Map();
+            ids.forEach((id) => {
+                map.set(String(id), {
+                    id: String(id),
+                    name: `Item ${id}`,
+                    image: `/img/${id}.png`,
+                    releaseImage: null,
+                });
+            });
+            return map;
+        });
     });
 
     it('renders built-in summary rows from initial output before custom merge resolves', () => {
@@ -96,6 +114,35 @@ describe('Processes list route contract', () => {
         const detailLinks = screen.getAllByRole('link', { name: 'View details' });
         expect(detailLinks.length).toBe(2);
         expect(detailLinks[1].getAttribute('href')).toBe('/processes/custom-1');
+    });
+
+    it('loads lightweight item previews for requires, consumes, and creates', async () => {
+        customListMock.mockResolvedValue([]);
+        render(Processes, {
+            props: {
+                builtInProcesses: [
+                    {
+                        id: 'preview-process',
+                        title: 'Preview Process',
+                        duration: '5s',
+                        requireItemTypes: 1,
+                        requireItemTotal: 1,
+                        consumeItemTypes: 1,
+                        consumeItemTotal: 2,
+                        createItemTypes: 1,
+                        createItemTotal: 3,
+                        requireItems: [{ id: 'req-item', count: 1 }],
+                        consumeItems: [{ id: 'con-item', count: 2 }],
+                        createItems: [{ id: 'crt-item', count: 3 }],
+                    },
+                ],
+            },
+        });
+
+        expect(await screen.findByText('Item req-item (1)')).toBeTruthy();
+        expect(screen.getByText('Item con-item (2)')).toBeTruthy();
+        expect(screen.getByText('Item crt-item (3)')).toBeTruthy();
+        expect(getItemMapMock).toHaveBeenCalled();
     });
 
     it('de-dupes by normalized id and keeps built-ins when custom ids collide', async () => {


### PR DESCRIPTION
### Motivation
- The v3 list-only downgrade removed too much context from the `/processes` page making it harder to scan available actions and outputs. 
- The goal is to restore concise item-level context (names + icons + counts) without reverting to the heavier full-detail rendering path or harming initial interactive performance.

### Description
- Add lightweight, bounded item preview chips to each process row that asynchronously resolve up to two items per `Requires`, `Consumes`, and `Creates` section using the existing `getItemMap` resolver cache (file: `frontend/src/pages/processes/ProcessListRow.svelte`).
- Implement safe async behavior with a `previewRequestId` guard and release of image object URLs via `releaseImage` to avoid stale updates and memory leaks.
- Preserve the summary-first layout and `View details` navigation while keeping runtime process controls off the list route; previews load after paint to avoid blocking initial render.
- Add and update unit tests to mock `itemResolver` and verify preview rendering, summary-only contract, and dedupe semantics (file: `frontend/src/pages/processes/__tests__/Processes.spec.ts`).

### Testing
- Ran the targeted unit tests with `npx vitest run frontend/src/pages/processes/__tests__/Processes.spec.ts` and got `1 passed` file with `6 passed` tests.
- Ran repository linting via `npm run lint` (frontend lints) and it completed successfully after fixing image alt a11y issues.
- Attempted `prettier --config frontend/.prettierrc --write` for the Svelte file but encountered a Prettier Svelte plugin/API mismatch in this environment; the TypeScript test file was formatted successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89978115c832f858bfc2f2f00bc67)