### PR TITLE
Improve /processes cards with lightweight item name/image previews

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,5 +1,6 @@
 <script>
     export let process;
+    export let itemMetadataMap = new Map();
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
@@ -12,6 +13,33 @@
     $: requireSummary = formatItemSummary(process?.requireItemTypes, process?.requireItemTotal);
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
+
+    const toPreviewLine = (entry) => {
+        const entryId = normalizeProcessId(entry?.id);
+        const metadata = itemMetadataMap?.get(entryId);
+        const count = Number(entry?.count);
+        const normalizedCount = Number.isFinite(count) ? count : 0;
+        const countLabel = Number.isFinite(count) ? normalizedCount : 0;
+
+        return {
+            id: entryId,
+            countLabel,
+            name: metadata?.name || entry?.name || entryId || 'Unknown item',
+            image: metadata?.image || entry?.image || '/favicon.ico',
+        };
+    };
+
+    const getPreviewLines = (entries = []) =>
+        Array.isArray(entries)
+            ? entries
+                  .filter((entry) => entry?.id !== undefined && entry?.id !== null)
+                  .slice(0, 2)
+                  .map((entry) => toPreviewLine(entry))
+            : [];
+
+    $: requirePreviewLines = getPreviewLines(process?.requirePreviewEntries);
+    $: consumePreviewLines = getPreviewLines(process?.consumePreviewEntries);
+    $: createPreviewLines = getPreviewLines(process?.createPreviewEntries);
 </script>
 
 <article class="process-row" data-process-id={processId}>
@@ -30,14 +58,44 @@
         <div>
             <dt>Requires</dt>
             <dd>{requireSummary}</dd>
+            {#if requirePreviewLines.length > 0}
+                <ul class="item-preview-list">
+                    {#each requirePreviewLines as item, index (`require-${item.id}-${index}`)}
+                        <li>
+                            <img src={item.image} alt={item.name} />
+                            <span>{item.countLabel}x {item.name}</span>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
         </div>
         <div>
             <dt>Consumes</dt>
             <dd>{consumeSummary}</dd>
+            {#if consumePreviewLines.length > 0}
+                <ul class="item-preview-list">
+                    {#each consumePreviewLines as item, index (`consume-${item.id}-${index}`)}
+                        <li>
+                            <img src={item.image} alt={item.name} />
+                            <span>{item.countLabel}x {item.name}</span>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
         </div>
         <div>
             <dt>Creates</dt>
             <dd>{createSummary}</dd>
+            {#if createPreviewLines.length > 0}
+                <ul class="item-preview-list">
+                    {#each createPreviewLines as item, index (`create-${item.id}-${index}`)}
+                        <li>
+                            <img src={item.image} alt={item.name} />
+                            <span>{item.countLabel}x {item.name}</span>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
         </div>
     </dl>
 
@@ -80,8 +138,8 @@
     }
 
     .process-row__summary div {
-        display: flex;
-        justify-content: space-between;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
         gap: 6px;
         border-bottom: 1px solid rgba(255, 255, 255, 0.15);
         padding-bottom: 2px;
@@ -91,6 +149,31 @@
     dt,
     dd {
         margin: 0;
+    }
+
+    .item-preview-list {
+        grid-column: 1 / -1;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 3px;
+    }
+
+    .item-preview-list li {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.82rem;
+        opacity: 0.95;
+    }
+
+    .item-preview-list img {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        object-fit: cover;
+        flex-shrink: 0;
     }
 
     .details-link {

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -14,12 +14,11 @@
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
 
-    const toPreviewLine = (entry) => {
+    const toPreviewLine = (entry, metadataMap) => {
         const entryId = normalizeProcessId(entry?.id);
-        const metadata = itemMetadataMap?.get(entryId);
+        const metadata = metadataMap?.get(entryId);
         const count = Number(entry?.count);
-        const normalizedCount = Number.isFinite(count) ? count : 0;
-        const countLabel = Number.isFinite(count) ? normalizedCount : 0;
+        const countLabel = Number.isFinite(count) ? count : 0;
 
         return {
             id: entryId,
@@ -29,17 +28,18 @@
         };
     };
 
-    const getPreviewLines = (entries = []) =>
+    const getPreviewLines = (entries = [], metadataMap) =>
         Array.isArray(entries)
             ? entries
-                  .filter((entry) => entry?.id !== undefined && entry?.id !== null)
+                  .map((entry) => ({ ...entry, id: normalizeProcessId(entry?.id) }))
+                  .filter((entry) => entry.id.length > 0)
                   .slice(0, 2)
-                  .map((entry) => toPreviewLine(entry))
+                  .map((entry) => toPreviewLine(entry, metadataMap))
             : [];
 
-    $: requirePreviewLines = getPreviewLines(process?.requirePreviewEntries);
-    $: consumePreviewLines = getPreviewLines(process?.consumePreviewEntries);
-    $: createPreviewLines = getPreviewLines(process?.createPreviewEntries);
+    $: requirePreviewLines = getPreviewLines(process?.requirePreviewEntries, itemMetadataMap);
+    $: consumePreviewLines = getPreviewLines(process?.consumePreviewEntries, itemMetadataMap);
+    $: createPreviewLines = getPreviewLines(process?.createPreviewEntries, itemMetadataMap);
 </script>
 
 <article class="process-row" data-process-id={processId}>
@@ -57,45 +57,51 @@
         </div>
         <div>
             <dt>Requires</dt>
-            <dd>{requireSummary}</dd>
-            {#if requirePreviewLines.length > 0}
-                <ul class="item-preview-list">
-                    {#each requirePreviewLines as item, index (`require-${item.id}-${index}`)}
-                        <li>
-                            <img src={item.image} alt={item.name} />
-                            <span>{item.countLabel}x {item.name}</span>
-                        </li>
-                    {/each}
-                </ul>
-            {/if}
+            <dd>
+                {requireSummary}
+                {#if requirePreviewLines.length > 0}
+                    <ul class="item-preview-list">
+                        {#each requirePreviewLines as item, index (`require-${item.id}-${index}`)}
+                            <li>
+                                <img src={item.image} alt={item.name} />
+                                <span>{item.countLabel}x {item.name}</span>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
+            </dd>
         </div>
         <div>
             <dt>Consumes</dt>
-            <dd>{consumeSummary}</dd>
-            {#if consumePreviewLines.length > 0}
-                <ul class="item-preview-list">
-                    {#each consumePreviewLines as item, index (`consume-${item.id}-${index}`)}
-                        <li>
-                            <img src={item.image} alt={item.name} />
-                            <span>{item.countLabel}x {item.name}</span>
-                        </li>
-                    {/each}
-                </ul>
-            {/if}
+            <dd>
+                {consumeSummary}
+                {#if consumePreviewLines.length > 0}
+                    <ul class="item-preview-list">
+                        {#each consumePreviewLines as item, index (`consume-${item.id}-${index}`)}
+                            <li>
+                                <img src={item.image} alt={item.name} />
+                                <span>{item.countLabel}x {item.name}</span>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
+            </dd>
         </div>
         <div>
             <dt>Creates</dt>
-            <dd>{createSummary}</dd>
-            {#if createPreviewLines.length > 0}
-                <ul class="item-preview-list">
-                    {#each createPreviewLines as item, index (`create-${item.id}-${index}`)}
-                        <li>
-                            <img src={item.image} alt={item.name} />
-                            <span>{item.countLabel}x {item.name}</span>
-                        </li>
-                    {/each}
-                </ul>
-            {/if}
+            <dd>
+                {createSummary}
+                {#if createPreviewLines.length > 0}
+                    <ul class="item-preview-list">
+                        {#each createPreviewLines as item, index (`create-${item.id}-${index}`)}
+                            <li>
+                                <img src={item.image} alt={item.name} />
+                                <span>{item.countLabel}x {item.name}</span>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
+            </dd>
         </div>
     </dl>
 

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -2,11 +2,16 @@
     import { onMount } from 'svelte';
     import Chip from '../../components/svelte/Chip.svelte';
     import { db, ENTITY_TYPES } from '../../utils/customcontent.js';
+    import { getItemMap } from '../../utils/itemResolver.js';
     import ProcessListRow from './ProcessListRow.svelte';
 
     export let builtInProcesses = [];
 
     let customProcesses = [];
+    let itemMetadataMap = new Map();
+    let metadataRequestId = 0;
+    let isMounted = false;
+    let previousMetadataIdsKey = '';
 
     const actionButtons = [
         { text: 'Create a new process', href: '/processes/create' },
@@ -47,8 +52,39 @@
             consumeItemTotal: Number(process?.consumeItemTotal ?? consumeSummary.total),
             createItemTypes: Number(process?.createItemTypes ?? createSummary.types),
             createItemTotal: Number(process?.createItemTotal ?? createSummary.total),
+            requirePreviewEntries: Array.isArray(process?.requirePreviewEntries)
+                ? process.requirePreviewEntries
+                : (process?.requireItems ?? []),
+            consumePreviewEntries: Array.isArray(process?.consumePreviewEntries)
+                ? process.consumePreviewEntries
+                : (process?.consumeItems ?? []),
+            createPreviewEntries: Array.isArray(process?.createPreviewEntries)
+                ? process.createPreviewEntries
+                : (process?.createItems ?? []),
         };
     };
+
+    const releaseMapImages = (map) => {
+        if (!map) {
+            return;
+        }
+        Array.from(map.values()).forEach((item) => item?.releaseImage?.());
+    };
+
+    const getPreviewIds = (processes) =>
+        processes.flatMap((process) =>
+            [
+                ...(process?.requirePreviewEntries ?? []),
+                ...(process?.consumePreviewEntries ?? []),
+                ...(process?.createPreviewEntries ?? []),
+            ]
+                .map((entry) =>
+                    typeof entry?.id === 'string' || typeof entry?.id === 'number'
+                        ? String(entry.id)
+                        : ''
+                )
+                .filter((id) => id.length > 0)
+        );
 
     const dedupeByNormalizedId = (processes) => {
         const seenIds = new Set();
@@ -78,13 +114,42 @@
     ]);
 
     onMount(async () => {
+        isMounted = true;
         try {
             customProcesses = (await db.list(ENTITY_TYPES.PROCESS)) ?? [];
         } catch (error) {
             console.error('Failed to load custom processes:', error);
             customProcesses = [];
         }
+
+        return () => {
+            isMounted = false;
+            releaseMapImages(itemMetadataMap);
+            itemMetadataMap = new Map();
+        };
     });
+
+    $: if (isMounted) {
+        const uniqueIds = Array.from(new Set(getPreviewIds(allProcesses)));
+        const nextMetadataIdsKey = uniqueIds.join('|');
+        if (nextMetadataIdsKey !== previousMetadataIdsKey) {
+            previousMetadataIdsKey = nextMetadataIdsKey;
+            const requestId = ++metadataRequestId;
+            getItemMap(uniqueIds)
+                .then((nextMap) => {
+                    if (!isMounted || requestId !== metadataRequestId) {
+                        releaseMapImages(nextMap);
+                        return;
+                    }
+
+                    releaseMapImages(itemMetadataMap);
+                    itemMetadataMap = nextMap;
+                })
+                .catch((error) => {
+                    console.error('Failed to load process item metadata:', error);
+                });
+        }
+    }
 </script>
 
 <div class="processes-page">
@@ -99,7 +164,7 @@
             <div class="no-processes">No processes found</div>
         {:else}
             {#each allProcesses as process (normalizeProcessId(process.id))}
-                <ProcessListRow {process} />
+                <ProcessListRow {process} {itemMetadataMap} />
             {/each}
         {/if}
     </div>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -71,20 +71,18 @@
         Array.from(map.values()).forEach((item) => item?.releaseImage?.());
     };
 
+    const collectSectionPreviewIds = (entries = []) =>
+        (Array.isArray(entries) ? entries : [])
+            .map((entry) => normalizeProcessId(entry?.id))
+            .filter((id) => id.length > 0)
+            .slice(0, 2);
+
     const getPreviewIds = (processes) =>
-        processes.flatMap((process) =>
-            [
-                ...(process?.requirePreviewEntries ?? []),
-                ...(process?.consumePreviewEntries ?? []),
-                ...(process?.createPreviewEntries ?? []),
-            ]
-                .map((entry) =>
-                    typeof entry?.id === 'string' || typeof entry?.id === 'number'
-                        ? String(entry.id)
-                        : ''
-                )
-                .filter((id) => id.length > 0)
-        );
+        processes.flatMap((process) => [
+            ...collectSectionPreviewIds(process?.requirePreviewEntries),
+            ...collectSectionPreviewIds(process?.consumePreviewEntries),
+            ...collectSectionPreviewIds(process?.createPreviewEntries),
+        ]);
 
     const dedupeByNormalizedId = (processes) => {
         const seenIds = new Set();
@@ -113,14 +111,16 @@
         ),
     ]);
 
-    onMount(async () => {
+    onMount(() => {
         isMounted = true;
-        try {
-            customProcesses = (await db.list(ENTITY_TYPES.PROCESS)) ?? [];
-        } catch (error) {
-            console.error('Failed to load custom processes:', error);
-            customProcesses = [];
-        }
+        (async () => {
+            try {
+                customProcesses = (await db.list(ENTITY_TYPES.PROCESS)) ?? [];
+            } catch (error) {
+                console.error('Failed to load custom processes:', error);
+                customProcesses = [];
+            }
+        })();
 
         return () => {
             isMounted = false;
@@ -133,7 +133,6 @@
         const uniqueIds = Array.from(new Set(getPreviewIds(allProcesses)));
         const nextMetadataIdsKey = uniqueIds.join('|');
         if (nextMetadataIdsKey !== previousMetadataIdsKey) {
-            previousMetadataIdsKey = nextMetadataIdsKey;
             const requestId = ++metadataRequestId;
             getItemMap(uniqueIds)
                 .then((nextMap) => {
@@ -144,9 +143,13 @@
 
                     releaseMapImages(itemMetadataMap);
                     itemMetadataMap = nextMap;
+                    previousMetadataIdsKey = nextMetadataIdsKey;
                 })
                 .catch((error) => {
                     console.error('Failed to load process item metadata:', error);
+                    if (requestId === metadataRequestId) {
+                        previousMetadataIdsKey = '';
+                    }
                 });
         }
     }

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import ProcessListRow from '../ProcessListRow.svelte';
+
+describe('ProcessListRow', () => {
+    test('renders item preview metadata for requires, consumes, and creates entries', () => {
+        const metadataMap = new Map([
+            ['smart-plug', { id: 'smart-plug', name: 'Smart Plug', image: '/smart-plug.png' }],
+            ['dusd', { id: 'dusd', name: 'dUSD', image: '/dusd.png' }],
+            ['dwatt', { id: 'dwatt', name: 'dWatt', image: '/dwatt.png' }],
+        ]);
+
+        const process = {
+            id: 'buy-electricity',
+            title: 'Buy electricity',
+            duration: '5s',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 1,
+            consumeItemTotal: 0.18,
+            createItemTypes: 1,
+            createItemTotal: 1000,
+            requirePreviewEntries: [{ id: 'smart-plug', count: 1 }],
+            consumePreviewEntries: [{ id: 'dusd', count: 0.18 }],
+            createPreviewEntries: [{ id: 'dwatt', count: 1000 }],
+        };
+
+        const { getByText, getAllByRole } = render(ProcessListRow, {
+            props: { process, itemMetadataMap: metadataMap },
+        });
+
+        expect(getByText('1x Smart Plug')).toBeTruthy();
+        expect(getByText('0.18x dUSD')).toBeTruthy();
+        expect(getByText('1000x dWatt')).toBeTruthy();
+        expect(getAllByRole('img')).toHaveLength(3);
+    });
+
+    test('falls back to entry ids when metadata is missing', () => {
+        const process = {
+            id: 'process-with-missing-item',
+            title: 'Missing item metadata',
+            duration: '1s',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 0,
+            consumeItemTotal: 0,
+            createItemTypes: 0,
+            createItemTotal: 0,
+            requirePreviewEntries: [{ id: 'unknown-item', count: 2 }],
+            consumePreviewEntries: [],
+            createPreviewEntries: [],
+        };
+
+        const { getByText } = render(ProcessListRow, {
+            props: { process, itemMetadataMap: new Map() },
+        });
+
+        expect(getByText('2x unknown-item')).toBeTruthy();
+    });
+});

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -57,4 +57,37 @@ describe('ProcessListRow', () => {
 
         expect(getByText('2x unknown-item')).toBeTruthy();
     });
+
+    test('updates preview lines when metadata map changes after mount', async () => {
+        const process = {
+            id: 'delayed-metadata',
+            title: 'Delayed metadata',
+            duration: '1s',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 0,
+            consumeItemTotal: 0,
+            createItemTypes: 0,
+            createItemTotal: 0,
+            requirePreviewEntries: [{ id: 'smart-plug', count: 1 }],
+            consumePreviewEntries: [],
+            createPreviewEntries: [],
+        };
+
+        const { getByText, rerender, queryByText } = render(ProcessListRow, {
+            props: { process, itemMetadataMap: new Map() },
+        });
+
+        expect(getByText('1x smart-plug')).toBeTruthy();
+        expect(queryByText('1x Smart Plug')).toBeNull();
+
+        await rerender({
+            process,
+            itemMetadataMap: new Map([
+                ['smart-plug', { id: 'smart-plug', name: 'Smart Plug', image: '/smart-plug.png' }],
+            ]),
+        });
+
+        expect(getByText('1x Smart Plug')).toBeTruthy();
+    });
 });

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Processes from '../Processes.svelte';
 
-const { customListMock } = vi.hoisted(() => ({
+const { customListMock, getItemMapMock } = vi.hoisted(() => ({
     customListMock: vi.fn(),
+    getItemMapMock: vi.fn(),
 }));
 
 vi.mock('../../../utils/customcontent.js', () => ({
@@ -13,6 +14,10 @@ vi.mock('../../../utils/customcontent.js', () => ({
     ENTITY_TYPES: {
         PROCESS: 'process',
     },
+}));
+
+vi.mock('../../../utils/itemResolver.js', () => ({
+    getItemMap: getItemMapMock,
 }));
 
 describe('Processes list route contract', () => {
@@ -33,6 +38,8 @@ describe('Processes list route contract', () => {
 
     beforeEach(() => {
         customListMock.mockReset();
+        getItemMapMock.mockReset();
+        getItemMapMock.mockResolvedValue(new Map());
     });
 
     it('renders built-in summary rows from initial output before custom merge resolves', () => {
@@ -116,5 +123,105 @@ describe('Processes list route contract', () => {
         await screen.findByText('Built In Process');
         expect(screen.queryByText('Overriding Custom Process')).toBeNull();
         expect(screen.getAllByRole('link', { name: 'View details' })).toHaveLength(1);
+    });
+
+    it('hydrates preview lines on the route list and dedupes metadata fetch ids across sections/processes', async () => {
+        customListMock.mockResolvedValue([]);
+        getItemMapMock.mockResolvedValue(
+            new Map([
+                ['shared-item', { id: 'shared-item', name: 'Shared Item', image: '/shared.png' }],
+                ['fuel-cell', { id: 'fuel-cell', name: 'Fuel Cell', image: '/fuel.png' }],
+                ['byproduct', { id: 'byproduct', name: 'Byproduct', image: '/byproduct.png' }],
+            ])
+        );
+
+        const routeShapedBuiltIns = [
+            {
+                id: 'built-in-1',
+                title: 'Built In Process',
+                duration: '10m',
+                requireItemTypes: 1,
+                requireItemTotal: 1,
+                consumeItemTypes: 2,
+                consumeItemTotal: 5,
+                createItemTypes: 1,
+                createItemTotal: 3,
+                requirePreviewEntries: [{ id: 'shared-item', count: 1 }],
+                consumePreviewEntries: [
+                    { id: 'shared-item', count: 2 },
+                    { id: 'fuel-cell', count: 3 },
+                ],
+                createPreviewEntries: [{ id: 'byproduct', count: 3 }],
+                custom: false,
+            },
+            {
+                id: 'built-in-2',
+                title: 'Secondary Process',
+                duration: '3m',
+                requireItemTypes: 1,
+                requireItemTotal: 2,
+                consumeItemTypes: 0,
+                consumeItemTotal: 0,
+                createItemTypes: 1,
+                createItemTotal: 1,
+                requirePreviewEntries: [{ id: 'shared-item', count: 2 }],
+                consumePreviewEntries: [],
+                createPreviewEntries: [{ id: 'fuel-cell', count: 1 }],
+                custom: false,
+            },
+        ];
+
+        render(Processes, { props: { builtInProcesses: routeShapedBuiltIns } });
+
+        expect(screen.getByText('Built In Process')).toBeTruthy();
+        expect(screen.getByText('Secondary Process')).toBeTruthy();
+        expect(screen.getAllByText('1 item (1)').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('1 item (3)').length).toBeGreaterThan(0);
+        expect(screen.queryByRole('button', { name: 'Start' })).toBeNull();
+        expect(screen.getAllByRole('link', { name: 'View details' })).toHaveLength(2);
+
+        expect(await screen.findByText('1x Shared Item')).toBeTruthy();
+        expect(screen.getByText('3x Fuel Cell')).toBeTruthy();
+        expect(screen.getByText('3x Byproduct')).toBeTruthy();
+
+        expect(getItemMapMock).toHaveBeenCalledTimes(1);
+        expect(getItemMapMock).toHaveBeenCalledWith(
+            expect.arrayContaining(['shared-item', 'fuel-cell', 'byproduct'])
+        );
+        expect(new Set(getItemMapMock.mock.calls[0][0]).size).toBe(
+            getItemMapMock.mock.calls[0][0].length
+        );
+    });
+
+    it('falls back to preview entry ids when at least one route-level preview metadata record is missing', async () => {
+        customListMock.mockResolvedValue([]);
+        getItemMapMock.mockResolvedValue(
+            new Map([['known-item', { id: 'known-item', name: 'Known Item', image: '/known.png' }]])
+        );
+
+        render(Processes, {
+            props: {
+                builtInProcesses: [
+                    {
+                        id: 'built-in-fallback',
+                        title: 'Fallback Process',
+                        duration: '8m',
+                        requireItemTypes: 1,
+                        requireItemTotal: 1,
+                        consumeItemTypes: 1,
+                        consumeItemTotal: 2,
+                        createItemTypes: 0,
+                        createItemTotal: 0,
+                        requirePreviewEntries: [{ id: 'known-item', count: 1 }],
+                        consumePreviewEntries: [{ id: 'missing-item', count: 2 }],
+                        createPreviewEntries: [],
+                        custom: false,
+                    },
+                ],
+            },
+        });
+
+        expect(await screen.findByText('1x Known Item')).toBeTruthy();
+        expect(screen.getByText('2x missing-item')).toBeTruthy();
     });
 });

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -18,6 +18,17 @@ const summarizeEntries = (entries = []) =>
           )
         : { types: 0, total: 0 };
 
+const toPreviewEntries = (entries = [], limit = 2) =>
+    Array.isArray(entries)
+        ? entries
+              .slice(0, limit)
+              .map((entry) => ({
+                  id: entry?.id,
+                  count: entry?.count,
+              }))
+              .filter((entry) => entry.id !== undefined && entry.id !== null)
+        : [];
+
 const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => {
     const requireSummary = summarizeEntries(process?.requireItems);
     const consumeSummary = summarizeEntries(process?.consumeItems);
@@ -34,6 +45,9 @@ const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses
         consumeItemTotal: consumeSummary.total,
         createItemTypes: createSummary.types,
         createItemTotal: createSummary.total,
+        requirePreviewEntries: toPreviewEntries(process?.requireItems),
+        consumePreviewEntries: toPreviewEntries(process?.consumeItems),
+        createPreviewEntries: toPreviewEntries(process?.createItems),
     };
 });
 ---

--- a/frontend/src/pages/processes/index.astro
+++ b/frontend/src/pages/processes/index.astro
@@ -21,12 +21,12 @@ const summarizeEntries = (entries = []) =>
 const toPreviewEntries = (entries = [], limit = 2) =>
     Array.isArray(entries)
         ? entries
+              .filter((entry) => entry?.id !== undefined && entry?.id !== null)
               .slice(0, limit)
               .map((entry) => ({
                   id: entry?.id,
                   count: entry?.count,
               }))
-              .filter((entry) => entry.id !== undefined && entry.id !== null)
         : [];
 
 const builtInProcesses = (Array.isArray(generatedProcesses) ? generatedProcesses : []).map((process) => {


### PR DESCRIPTION
### Motivation
- The v3.0.1 optimization reduced /processes list payloads too aggressively and removed glanceable item context (names/images) from process rows.
- We want to restore useful preview information without reverting to the original heavy per-row payloads or regressing list performance.

### Description
- Add a small SSR preview payload for built-in processes that includes the first two item refs (`id`, `count`) for `requires`, `consumes`, and `creates`, keeping existing aggregate summaries intact (`frontend/src/pages/processes/index.astro`).
- Hydrate item metadata client-side in the list view by deduping preview IDs and calling `getItemMap()` once per update, caching results and safely releasing object URLs when replaced/unmounted (`frontend/src/pages/processes/Processes.svelte`).
- Render compact preview lines (image + `count x name`) under Requires/Consumes/Creates in each process row with robust fallbacks when metadata is missing (`frontend/src/pages/processes/ProcessListRow.svelte`).
- Add focused unit tests for preview rendering and fallback behavior (`frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts`).

### Testing
- Ran `npm run lint` and the linter passed.
- Ran `npm run format:check` and formatting checks passed.
- Ran the focused component tests with `npm run test:root -- frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts` and the new tests passed.
- `npm run test:ci` was started in this environment and progressed through build steps but the run output was truncated in the session capture and did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89978115c832f858bfc2f2f00bc67)