### PR TITLE
📝 chore: add v3.0.1-rc.1 to releases and QA docs

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,6 +1,6 @@
 # DSPACE v3.0.1 QA Checklist (patch delta validation)
 
-> Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
+> Release intent: `v3.0.1-rc.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
 
 Related docs:
@@ -54,8 +54,8 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 
 ## 1) Release metadata + signoff
 
-- [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `________________`
+- [ ] Target version: `v3.0.1-rc.1`
+- [ ] Candidate tag under test: `v3.0.1-rc.1`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,6 +17,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.0-rc.2` | Release candidate | [`v3.0.0-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.2) |
 | `v3.0.0-rc.3` | Release candidate | [`v3.0.0-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.3) |
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
+| `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 
 ## QA checklists tracked separately (not a tag list)
 


### PR DESCRIPTION
### Motivation
- Add `v3.0.1-rc.1` to the canonical release table and align the v3.0.1 QA metadata so QA can validate the exact release candidate.

### Description
- Updated `docs/releases.md` to include a `v3.0.1-rc.1` row and updated `docs/qa/v3.0.1.md` to target `v3.0.1-rc.1` in the release intent and metadata fields.

### Testing
- Ran `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` with no errors; this is a docs-only change so no build or unit tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8af1be1b8832fa0d5149accba0f5d)