### PR TITLE
Add v3.0.1-rc.1 to release and QA docs

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,6 +1,6 @@
 # DSPACE v3.0.1 QA Checklist (patch delta validation)
 
-> Release intent: `v3.0.1-rc.1` validates the patch delta merged after `v3.0.0`
+> Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
 
 Related docs:

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,7 +1,8 @@
 # DSPACE v3.0.1 QA Checklist (patch delta validation)
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
-> (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
+> (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
+> current candidate under validation: `v3.0.1-rc.1`.
 
 Related docs:
 

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,6 +1,6 @@
 # DSPACE v3.0.1 QA Checklist (patch delta validation)
 
-> Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
+> Release intent: `v3.0.1-rc.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
 
 Related docs:
@@ -55,7 +55,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ## 1) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `________________`
+- [ ] Candidate tag under test: `v3.0.1-rc.1`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,6 +17,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.0-rc.2` | Release candidate | [`v3.0.0-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.2) |
 | `v3.0.0-rc.3` | Release candidate | [`v3.0.0-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.3) |
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
+| `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 
 ## QA checklists tracked separately (not a tag list)
 


### PR DESCRIPTION
### Motivation
- Prepare the canonical release history and the v3.0.1 QA checklist so the `v3.0.1-rc.1` candidate can be validated by QA.

### Description
- Add a `v3.0.1-rc.1` row to `docs/releases.md` and update `docs/qa/v3.0.1.md` to reference `v3.0.1-rc.1` in the release intent and prefill the "Candidate tag under test" field.

### Testing
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py`; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8af1be1b8832fa0d5149accba0f5d)