### PR TITLE
📝 docs: add v3.0.1-rc.1 release candidate references

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -1,6 +1,6 @@
 # DSPACE v3.0.1 QA Checklist (patch delta validation)
 
-> Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
+> Release intent: `v3.0.1-rc.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion.
 
 Related docs:
@@ -54,8 +54,8 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 
 ## 1) Release metadata + signoff
 
-- [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `________________`
+- [ ] Target version: `v3.0.1-rc.1`
+- [ ] Candidate tag under test: `v3.0.1-rc.1`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`
@@ -288,7 +288,7 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
 ### 9.2 Release closeout
 
-- [ ] Final release git tag created and pushed (`v3.0.1`)
+- [ ] Final release git tag created and pushed (`v3.0.1`) after `v3.0.1-rc.1` validation
 - [ ] `v3.0.1` patch-note addendum published in changelog
 - [ ] Deployed immutable tag + SHA recorded in release notes
 - [ ] Evidence links attached (perf outputs, traces, smoke logs, key manual QA notes)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,14 +9,15 @@ This is the canonical list of all historical DSPACE release tags.
 
 ## Tagged releases
 
-| Tag | Channel | GitHub release page |
-| --- | --- | --- |
-| `v1.0.0` | Stable release | [`v1.0.0`](https://github.com/democratizedspace/dspace/releases/tag/v1.0.0) |
-| `v2.1.0` | Stable release | [`v2.1.0`](https://github.com/democratizedspace/dspace/releases/tag/v2.1.0) |
+| Tag           | Channel           | GitHub release page                                                                   |
+| ------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| `v1.0.0`      | Stable release    | [`v1.0.0`](https://github.com/democratizedspace/dspace/releases/tag/v1.0.0)           |
+| `v2.1.0`      | Stable release    | [`v2.1.0`](https://github.com/democratizedspace/dspace/releases/tag/v2.1.0)           |
 | `v3.0.0-rc.1` | Release candidate | [`v3.0.0-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.1) |
 | `v3.0.0-rc.2` | Release candidate | [`v3.0.0-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.2) |
 | `v3.0.0-rc.3` | Release candidate | [`v3.0.0-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.3) |
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
+| `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 
 ## QA checklists tracked separately (not a tag list)
 


### PR DESCRIPTION
### Motivation
- Make `v3.0.1-rc.1` visible in the canonical release history so the candidate is tracked for QA and promotion.
- Ensure the `v3.0.1` QA checklist explicitly targets the RC candidate and documents the RC-to-release closeout expectation.

### Description
- Add a `v3.0.1-rc.1` row to the tagged releases table in `docs/releases.md` with a GitHub release link.
- Update `docs/qa/v3.0.1.md` to change the release intent and metadata fields to `v3.0.1-rc.1` and to note that the final `v3.0.1` tag follows RC validation.
- Run Prettier formatting on the modified files to normalize table alignment and style.

### Testing
- Ran `npx prettier --check docs/releases.md docs/qa/v3.0.1.md` and fixed formatting with `npx prettier --write` until the check passed.
- Ran `git diff --cached | ./scripts/scan-secrets.py` against the staged changes and the scan produced no findings.
- Verified the modified files in a local diff and ensured Prettier reports "All matched files use Prettier code style!".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8af1be1b8832fa0d5149accba0f5d)