### PR TITLE
🛡️ Sanitize custom quest list href targets

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -175,6 +175,12 @@ describe('Quests Component', () => {
                 route: '//evil.example/phish',
                 custom: true,
             },
+            {
+                id: 'custom/backslash',
+                title: 'Backslash Route Quest',
+                route: '/\\evil.example/phish',
+                custom: true,
+            },
         ]);
 
         try {
@@ -187,6 +193,9 @@ describe('Quests Component', () => {
 
             const externalQuestLink = host.querySelector("a[data-questid='custom/external']");
             expect(externalQuestLink?.getAttribute('href')).toBe('/quests/custom/external');
+
+            const backslashQuestLink = host.querySelector("a[data-questid='custom/backslash']");
+            expect(backslashQuestLink?.getAttribute('href')).toBe('/quests/custom/backslash');
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -156,4 +156,39 @@ describe('Quests Component', () => {
             vi.useRealTimers();
         }
     });
+
+    it('falls back to safe internal quest routes for custom quests with unsafe hrefs', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => ({ ...quest, status: 'available' }))
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            {
+                id: 'custom/unsafe',
+                title: 'Unsafe Route Quest',
+                route: 'javascript:alert(1)',
+                custom: true,
+            },
+            {
+                id: 'custom/external',
+                title: 'External Route Quest',
+                route: '//evil.example/phish',
+                custom: true,
+            },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const unsafeQuestLink = host.querySelector("a[data-questid='custom/unsafe']");
+            expect(unsafeQuestLink?.getAttribute('href')).toBe('/quests/custom/unsafe');
+
+            const externalQuestLink = host.querySelector("a[data-questid='custom/external']");
+            expect(externalQuestLink?.getAttribute('href')).toBe('/quests/custom/external');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -142,6 +142,7 @@ forward.
 ### Patch notes
 
 - **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior.
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
 - **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
 - **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
 - **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -55,7 +55,7 @@
             return fallbackRoute;
         }
 
-        if (normalizedRoute.startsWith('//')) {
+        if (normalizedRoute.startsWith('//') || normalizedRoute.startsWith('/\\')) {
             return fallbackRoute;
         }
 

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -44,6 +44,24 @@
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
 
+    const normalizeQuestRoute = (route, id) => {
+        const fallbackRoute = `/quests/${id}`;
+        if (typeof route !== 'string') {
+            return fallbackRoute;
+        }
+
+        const normalizedRoute = route.trim();
+        if (!normalizedRoute.startsWith('/')) {
+            return fallbackRoute;
+        }
+
+        if (normalizedRoute.startsWith('//')) {
+            return fallbackRoute;
+        }
+
+        return normalizedRoute;
+    };
+
     const normalizeQuest = (questData) => {
         if (!questData || typeof questData !== 'object' || !questData.id) {
             return null;
@@ -66,7 +84,7 @@
             description: typeof questData.description === 'string' ? questData.description : '',
             image: typeof questData.image === 'string' ? questData.image : '',
             requiresQuests,
-            route: typeof questData.route === 'string' ? questData.route : `/quests/${id}`,
+            route: normalizeQuestRoute(questData.route, id),
         };
     };
 


### PR DESCRIPTION
### Motivation
- Fix a stored XSS / open-redirect vector where imported custom quest data could set a `route` like `javascript:` or an external URL and that value was used directly in anchor `href`s in the quest list.
- Ensure quest tiles only navigate to safe internal app paths to prevent click-triggered exfiltration or code execution while preserving normal internal routing behavior.
- Provide a minimal, targeted remediation that normalizes untrusted `route` values without changing built-in quest behavior.

### Description
- Added `normalizeQuestRoute(route, id)` to `frontend/src/pages/quests/svelte/Quests.svelte` which trims the input and falls back to `/quests/{id}` for non-string values, values not starting with `/`, and protocol-relative URLs that start with `//`.
- Updated `normalizeQuest` to call `normalizeQuestRoute` so all rendered quest `route` fields are safe before being used as anchor `href` targets.
- Added a regression test in `frontend/__tests__/Quests.test.js` that loads mocked custom quests with `javascript:` and `//...` routes and asserts the links fallback to `/quests/{id}`.

### Testing
- Ran `npm run test:root -- frontend/__tests__/Quests.test.js` and the updated `Quests.test.js` suite passed.
- Ran `npm run lint` in the frontend workspace and lint completed without blocking errors.
- The staged changes were scanned with `git diff --cached | ./scripts/scan-secrets.py` as part of pre-commit checks with no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c0dd6ee8832fb1289a09d7d77ade)