### PR TITLE
fix(ci): replace unpinned privileged binfmt runs with docker/setup-qemu-action@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
           exit 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           exit 1
 
       - name: Set up QEMU
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -347,7 +347,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -347,7 +347,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-to-raspi.yml
+++ b/.github/workflows/deploy-to-raspi.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        with:
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/deploy-to-raspi.yml
+++ b/.github/workflows/deploy-to-raspi.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -34,7 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        with:
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Verify credentials

--- a/.github/workflows/rpi-deploy.yml
+++ b/.github/workflows/rpi-deploy.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Verify credentials


### PR DESCRIPTION
### Motivation
- CI workflows were running `docker run --privileged --rm tonistiigi/binfmt --install arm64`, which pulls an unpinned upstream image and executes it with elevated privileges, creating a supply-chain risk that can exfiltrate secrets and tamper build artifacts. 
- The change aims to eliminate the direct unpinned privileged container invocation while preserving multi-arch/QEMU setup for builds and deployments.

### Description
- Replaced the direct `docker run --privileged --rm tonistiigi/binfmt --install arm64` steps with the maintained action `docker/setup-qemu-action@v3` to avoid pulling an unpinned image with `--privileged` execution. 
- Applied this change to the four affected workflows: `.github/workflows/build.yml`, `.github/workflows/ci-image.yml`, `.github/workflows/deploy-to-raspi.yml`, and `.github/workflows/rpi-deploy.yml`.
- Preserved existing buildx and registry login steps so multi-arch builds and GHCR login behavior remain unchanged.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Started `npm run test:ci` (the job was initiated but did not complete within the interaction window). 
- Executed the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` and observed no flagged secrets in the staged changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9dc9c9a10832f89ddd6542cf45459)