### PR TITLE
🛠️ Fix preflight-check wind-evidence soft lock

### DIFF
--- a/frontend/src/pages/docs/md/rocketry.md
+++ b/frontend/src/pages/docs/md/rocketry.md
@@ -124,7 +124,7 @@ Rocketry quests build practical progression through the rocketry skill tree. Thi
     - `troubleshoot` enforces corrective actions and a mandatory re-test loop through `wind-readings`.
 - Grants:
     - Dialogue options/steps grantsItems:
-        - `wind-readings` → "Record both readings in the pad log." grants wind log ×1
+        - `wind-readings` declares wind log ×1 in quest JSON, but this `goto` option does not award items in the current UI runtime.
     - Quest-level `grantsItems`: None
 - Rewards:
     - rocket igniter ×10, hobbyist solid rocket motor ×5, Rocket Descent (animated) ×1

--- a/frontend/src/pages/docs/md/rocketry.md
+++ b/frontend/src/pages/docs/md/rocketry.md
@@ -118,7 +118,6 @@ Rocketry quests build practical progression through the rocketry skill tree. Thi
     - `requiresQuests`: `rocketry/parachute`
 - Dialogue `requiresItems` gates:
     - `supplies` → "All core gear is staged." — launch controller ×1, rocket igniter ×1, Model rocket launchpad ×1, rocket launch checklist ×1
-    - `wind-evidence` → "Both readings are documented. Time to interpret." — wind log ×1
     - `arm` → "Launch complete and post-flight check passed." — damaged model rocket ×1
 - Troubleshooting/safety branches:
     - `range-walk` and `scrub` paths can halt unsafe range conditions before arming.

--- a/frontend/src/pages/quests/json/rocketry/preflight-check.json
+++ b/frontend/src/pages/quests/json/rocketry/preflight-check.json
@@ -107,13 +107,7 @@
                 {
                     "type": "goto",
                     "goto": "interpret",
-                    "text": "Both readings are documented. Time to interpret.",
-                    "requiresItems": [
-                        {
-                            "id": "15e3dd7e-374b-4233-b8c9-117e3057f009",
-                            "count": 1
-                        }
-                    ]
+                    "text": "Both readings are documented. Time to interpret."
                 }
             ]
         },


### PR DESCRIPTION
### Motivation

- A `goto` option (`wind-readings`) carried `grantsItems` but the UI only awards items for options with `type: "grantsItems"`, so the wind-log reward was never granted. 
- The next step (`wind-evidence`) required that wind-log item, creating a soft lock in the rocketry quest chain that prevented normal progression.

### Description

- Removed the `requiresItems` gate from `wind-evidence` in `frontend/src/pages/quests/json/rocketry/preflight-check.json` so the dialogue flow no longer depends on an item that the UI does not grant. 
- Synchronized the Rocketry skills documentation by removing the obsolete `wind-evidence` item gate entry in `frontend/src/pages/docs/md/rocketry.md` to keep quest/docs parity. 
- The fix is intentionally minimal to preserve existing UI behavior and avoid changing option semantics across the codebase.

### Testing

- Ran `npm run lint` in the repo root which executed the frontend lint chain and completed successfully. 
- Ran `npm run link-check` which resolved all local markdown links successfully. 
- Ran bulk quest validation with `for f in frontend/src/pages/quests/json/*/*.json; do node scripts/validate-quest.js "$f" || exit 1; done` which completed without errors. 
- Ran the staged diff secret scan via `git diff --cached | ./scripts/scan-secrets.py` which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9dc9ce5dc832faf6dacaa0ea2cbf3)