### PR TITLE
🛡️ fix: reject unknown item containers

### DIFF
--- a/frontend/src/utils/gameState/itemContainers.js
+++ b/frontend/src/utils/gameState/itemContainers.js
@@ -38,12 +38,7 @@ const normalizePositiveCount = (count) => {
 
 const getContainerItem = (containerItemId) => getItemMap().get(containerItemId);
 
-const getAllowedStoredItemIds = (containerItemId) => {
-    if (!isValidId(containerItemId)) {
-        return [];
-    }
-
-    const containerItem = getContainerItem(containerItemId);
+const getAllowedStoredItemIdsFromContainerItem = (containerItem) => {
     if (
         !containerItem ||
         typeof containerItem.itemCounts !== 'object' ||
@@ -53,6 +48,14 @@ const getAllowedStoredItemIds = (containerItemId) => {
     }
 
     return Object.keys(containerItem.itemCounts);
+};
+
+const getAllowedStoredItemIds = (containerItemId) => {
+    if (!isValidId(containerItemId)) {
+        return [];
+    }
+
+    return getAllowedStoredItemIdsFromContainerItem(getContainerItem(containerItemId));
 };
 
 const ensureContainerMap = (gameState, containerItemId) => {
@@ -80,7 +83,8 @@ export const canStoreItemInContainer = (containerItemId, storedItemId) => {
         return false;
     }
 
-    return getAllowedStoredItemIds(containerItemId).includes(storedItemId);
+    const allowedIds = getAllowedStoredItemIdsFromContainerItem(containerItem);
+    return allowedIds.includes(storedItemId);
 };
 
 export const getStateStoredItemCounts = (gameState, containerItemId) => {
@@ -94,7 +98,7 @@ export const getStateStoredItemCounts = (gameState, containerItemId) => {
     const allowedIds = getAllowedStoredItemIds(containerItemId);
 
     return allowedIds.reduce((acc, storedItemId) => {
-        acc[storedItemId] = Number(containerMap[storedItemId] ?? 0);
+        acc[storedItemId] = normalizePositiveCount(containerMap[storedItemId]);
         return acc;
     }, {});
 };

--- a/frontend/src/utils/gameState/itemContainers.js
+++ b/frontend/src/utils/gameState/itemContainers.js
@@ -77,8 +77,7 @@ export const canStoreItemInContainer = (containerItemId, storedItemId) => {
 
     const containerItem = getContainerItem(containerItemId);
     if (!containerItem) {
-        // Allow custom container definitions that may not be loaded yet from IndexedDB.
-        return true;
+        return false;
     }
 
     return getAllowedStoredItemIds(containerItemId).includes(storedItemId);
@@ -92,15 +91,9 @@ export const getStateStoredItemCounts = (gameState, containerItemId) => {
     }
 
     const containerMap = gameState.itemContainerCounts?.[containerItemId] ?? {};
-    const allowedIds = new Set(getAllowedStoredItemIds(containerItemId));
+    const allowedIds = getAllowedStoredItemIds(containerItemId);
 
-    Object.keys(containerMap).forEach((storedItemId) => {
-        if (isValidId(storedItemId)) {
-            allowedIds.add(storedItemId);
-        }
-    });
-
-    return Array.from(allowedIds).reduce((acc, storedItemId) => {
+    return allowedIds.reduce((acc, storedItemId) => {
         acc[storedItemId] = Number(containerMap[storedItemId] ?? 0);
         return acc;
     }, {});

--- a/frontend/tests/itemContainers.test.ts
+++ b/frontend/tests/itemContainers.test.ts
@@ -81,6 +81,24 @@ describe('itemContainers helpers', () => {
         expect(removeAllStoredItems(jarId, dusdId)).toBe(0);
     });
 
+
+    test('normalizes malformed persisted counts to non-negative finite values', () => {
+        mockGameState.itemContainerCounts[jarId] = {
+            [dusdId]: Number.NaN,
+        };
+        expect(getStoredItemCounts(jarId)).toEqual({ [dusdId]: 0 });
+
+        mockGameState.itemContainerCounts[jarId] = {
+            [dusdId]: -3,
+        };
+        expect(getStoredItemCounts(jarId)).toEqual({ [dusdId]: 0 });
+
+        mockGameState.itemContainerCounts[jarId] = {
+            [dusdId]: Infinity,
+        };
+        expect(getStoredItemCounts(jarId)).toEqual({ [dusdId]: 0 });
+    });
+
     test('does not expose invalid stored item ids from persisted state', () => {
         mockGameState.itemContainerCounts[jarId] = {
             [dusdId]: 4,

--- a/frontend/tests/itemContainers.test.ts
+++ b/frontend/tests/itemContainers.test.ts
@@ -81,7 +81,6 @@ describe('itemContainers helpers', () => {
         expect(removeAllStoredItems(jarId, dusdId)).toBe(0);
     });
 
-
     test('normalizes malformed persisted counts to non-negative finite values', () => {
         mockGameState.itemContainerCounts[jarId] = {
             [dusdId]: Number.NaN,

--- a/frontend/tests/itemContainers.test.ts
+++ b/frontend/tests/itemContainers.test.ts
@@ -55,6 +55,7 @@ describe('itemContainers helpers', () => {
     test('rejects invalid container-item pairs and invalid counts', () => {
         expect(canStoreItemInContainer('', dusdId)).toBe(false);
         expect(canStoreItemInContainer(jarId, '')).toBe(false);
+        expect(canStoreItemInContainer('missing-container', dusdId)).toBe(false);
         expect(canStoreItemInContainer(jarId, 'invalid-item')).toBe(false);
         expect(addStoredItems(jarId, 'invalid-item', 5)).toBe(false);
         expect(addStoredItems(jarId, dusdId, -1)).toBe(false);
@@ -78,5 +79,14 @@ describe('itemContainers helpers', () => {
         expect(removeAllStoredItems(jarId, dusdId)).toBe(12.5);
         expect(getStoredItemCount(jarId, dusdId)).toBe(0);
         expect(removeAllStoredItems(jarId, dusdId)).toBe(0);
+    });
+
+    test('does not expose invalid stored item ids from persisted state', () => {
+        mockGameState.itemContainerCounts[jarId] = {
+            [dusdId]: 4,
+            'unexpected-item-id': 10,
+        };
+
+        expect(getStoredItemCounts(jarId)).toEqual({ [dusdId]: 4 });
     });
 });


### PR DESCRIPTION
### Motivation
- A recent regression treated missing container definitions as valid in `canStoreItemInContainer`, which allowed arbitrary stored-item IDs to be written into `itemContainerCounts` and persist in state.
- This change restores the previous allowlist-only behavior so container restrictions cannot be bypassed by unresolved or malformed IDs.

### Description
- Update `canStoreItemInContainer` in `frontend/src/utils/gameState/itemContainers.js` to return `false` when the container item cannot be resolved instead of allowing it.
- Update `getStateStoredItemCounts` to return counts only for IDs from the container's defined allowlist returned by `getAllowedStoredItemIds` and stop merging arbitrary persisted keys.
- Add regression tests in `frontend/tests/itemContainers.test.ts` to assert that missing containers are rejected and that unexpected persisted stored-item IDs are not exposed.

### Testing
- Ran `npm run test:root -- frontend/tests/itemContainers.test.ts` and the tests in the file passed (4 tests passed).
- Ran `npm run lint` from the repo root and it completed successfully.
- Ran the staged-diff secret scan via `./scripts/scan-secrets.py` and it reported no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9dc9c6b6c832f9e3e4701fc2eeac2)