### PR TITLE
Update built-in processes status to completed

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -202,7 +202,7 @@ Required marks/measures:
 - [ ] `/processes` renders summary rows (title, duration, requires/consumes/creates counts)
 - [ ] List route keeps detail controls out of rows (`Start`, `Pause`, `Resume`, `Collect`,
       `Buy required items` are not shown in list rows)
-- [ ] Built-in processes appear immediately on list load
+- [x] Built-in processes appear immediately on list load
 
 ### 5.2 Custom process merge and coexistence (critical)
 


### PR DESCRIPTION
This pull request makes a minor documentation update to the QA checklist for version 3.0.1. The change marks the requirement that "Built-in processes appear immediately on list load" as completed.