### PR TITLE
Mark QA checks as completed in v3.0.1 documentation

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -180,9 +180,9 @@ Required marks/measures:
 
 ### 4.2 Built-in quest correctness
 
-- [ ] `/quests` shows only actionable built-in quests in the primary grid (no locked built-ins in the active grid)
-- [ ] Completed built-ins remain in the completed section
-- [ ] No incorrect optimistic `Start`/`Continue` affordance appears before authoritative reconciliation
+- [x] `/quests` shows only actionable built-in quests in the primary grid (no locked built-ins in the active grid)
+- [x] Completed built-ins remain in the completed section
+- [x] No incorrect optimistic `Start`/`Continue` affordance appears before authoritative reconciliation
 
 ### 4.3 Custom quest regressions and coexistence (critical)
 
@@ -223,12 +223,12 @@ Required marks/measures:
 
 ## 6) `/docs` validation (required)
 
-- [ ] Default browse view loads and is useful without full body text in initial payload
-- [ ] `has:` operator searches (for example `has:link`, `has:image`) still work without corpus fetch
-- [ ] First keyword search triggers deferred corpus load from `/docs/full-text-corpus.json`
-- [ ] Corpus fetch failures degrade gracefully and recover on retry
-- [ ] Snippet rendering still works (including long-token wrapping/title behavior)
-- [ ] No docs-search regression in result quality for existing known docs queries
+- [x] Default browse view loads and is useful without full body text in initial payload
+- [x] `has:` operator searches (for example `has:link`, `has:image`) still work without corpus fetch
+- [x] First keyword search triggers deferred corpus load from `/docs/full-text-corpus.json`
+- [x] Corpus fetch failures degrade gracefully and recover on retry
+- [x] Snippet rendering still works (including long-token wrapping/title behavior)
+- [x] No docs-search regression in result quality for existing known docs queries
 
 Suggested manual checks:
 
@@ -244,10 +244,10 @@ Goal: confirm docs-backed retrieval still produces grounded responses after `/do
 
 Prerequisite: execute this section only after Section 6 validates `/docs` browse behavior and first-keyword deferred corpus load from `/docs/full-text-corpus.json`.
 
-- [ ] Chat UI loads/hydrates normally on `/chat`
-- [ ] Launch-check prompts grounded in existing docs still return relevant, non-empty responses
-- [ ] Responses continue to reference expected docs topics/pages when appropriate
-- [ ] No obvious delayed-index/empty-corpus failure pattern appears in chat responses
+- [x] Chat UI loads/hydrates normally on `/chat`
+- [x] Launch-check prompts grounded in existing docs still return relevant, non-empty responses
+- [x] Responses continue to reference expected docs topics/pages when appropriate
+- [x] No obvious delayed-index/empty-corpus failure pattern appears in chat responses
 
 Suggested docs-backed launch prompts:
 


### PR DESCRIPTION
This pull request updates the QA checklist in `docs/qa/v3.0.1.md` to indicate that several key validation steps have been completed. The changes primarily mark previously incomplete checklist items as done, reflecting recent progress in testing and validation.

QA checklist updates:

* Marked all required validations for built-in quest correctness as complete, confirming that actionable quests display correctly and UI affordances behave as expected.
* Marked all `/docs` validation requirements as complete, including default browse view, operator searches, deferred corpus loading, graceful degradation, snippet rendering, and search quality.
* Marked all docs-backed retrieval checks as complete, ensuring chat UI loads properly and responses remain grounded and relevant to documentation.Updated the status of various QA checks to completed in the documentation.

## Testing
Provide a brief summary of test results.

