### PR TITLE
🐛 Fix /processes preview flicker (hide IDs until item metadata loads)

### DIFF
--- a/frontend/e2e/processes-item-metadata-loading.spec.ts
+++ b/frontend/e2e/processes-item-metadata-loading.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { clearUserData } from './test-helpers';
+
+test.describe('Processes item metadata loading', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('keeps preview item names blank until metadata resolves without blocking row details', async ({
+        page,
+    }) => {
+        await page.goto('/processes', { waitUntil: 'domcontentloaded' });
+
+        const firstRow = page.locator('article.process-row').first();
+        await expect(firstRow).toBeVisible();
+        await expect(firstRow.getByText('Duration')).toBeVisible();
+
+        const firstPreviewItemName = firstRow.getByTestId('preview-item-name').first();
+        await expect(firstPreviewItemName).toHaveText('', { timeout: 5000 });
+        await expect(firstPreviewItemName).not.toHaveText('', { timeout: 10000 });
+    });
+});

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -19,12 +19,14 @@
         const metadata = metadataMap?.get(entryId);
         const count = Number(entry?.count);
         const countLabel = Number.isFinite(count) ? count : 0;
+        const hasMetadata = Boolean(metadata);
 
         return {
             id: entryId,
             countLabel,
-            name: metadata?.name || entry?.name || entryId || 'Unknown item',
-            image: metadata?.image || '/favicon.ico',
+            name: hasMetadata ? metadata?.name || entry?.name || 'Unknown item' : '',
+            image: hasMetadata ? metadata?.image || '/favicon.ico' : '',
+            hasMetadata,
         };
     };
 
@@ -63,8 +65,16 @@
                     <ul class="item-preview-list">
                         {#each requirePreviewLines as item, index (`require-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
-                                <span>{item.countLabel}x {item.name}</span>
+                                {#if item.hasMetadata}
+                                    <img src={item.image} alt={item.name} />
+                                {:else}
+                                    <span class="preview-icon-placeholder" aria-hidden="true"
+                                    ></span>
+                                {/if}
+                                <span
+                                    >{item.countLabel}x
+                                    <span data-testid="preview-item-name">{item.name}</span></span
+                                >
                             </li>
                         {/each}
                     </ul>
@@ -79,8 +89,16 @@
                     <ul class="item-preview-list">
                         {#each consumePreviewLines as item, index (`consume-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
-                                <span>{item.countLabel}x {item.name}</span>
+                                {#if item.hasMetadata}
+                                    <img src={item.image} alt={item.name} />
+                                {:else}
+                                    <span class="preview-icon-placeholder" aria-hidden="true"
+                                    ></span>
+                                {/if}
+                                <span
+                                    >{item.countLabel}x
+                                    <span data-testid="preview-item-name">{item.name}</span></span
+                                >
                             </li>
                         {/each}
                     </ul>
@@ -95,8 +113,16 @@
                     <ul class="item-preview-list">
                         {#each createPreviewLines as item, index (`create-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
-                                <span>{item.countLabel}x {item.name}</span>
+                                {#if item.hasMetadata}
+                                    <img src={item.image} alt={item.name} />
+                                {:else}
+                                    <span class="preview-icon-placeholder" aria-hidden="true"
+                                    ></span>
+                                {/if}
+                                <span
+                                    >{item.countLabel}x
+                                    <span data-testid="preview-item-name">{item.name}</span></span
+                                >
                             </li>
                         {/each}
                     </ul>
@@ -179,6 +205,13 @@
         height: 16px;
         border-radius: 50%;
         object-fit: cover;
+        flex-shrink: 0;
+    }
+
+    .preview-icon-placeholder {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
         flex-shrink: 0;
     }
 

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -25,17 +25,17 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [{ id: 'dwatt', count: 1000 }],
         };
 
-        const { getByText, getAllByRole } = render(ProcessListRow, {
+        const { container, getAllByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: metadataMap },
         });
 
-        expect(getByText('1x Smart Plug')).toBeTruthy();
-        expect(getByText('0.18x dUSD')).toBeTruthy();
-        expect(getByText('1000x dWatt')).toBeTruthy();
+        expect(container.textContent).toContain('1x Smart Plug');
+        expect(container.textContent).toContain('0.18x dUSD');
+        expect(container.textContent).toContain('1000x dWatt');
         expect(getAllByRole('img')).toHaveLength(3);
     });
 
-    test('falls back to entry ids when metadata is missing', () => {
+    test('leaves preview item names blank when metadata is still loading', () => {
         const process = {
             id: 'process-with-missing-item',
             title: 'Missing item metadata',
@@ -51,14 +51,17 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByText } = render(ProcessListRow, {
+        const { getByText, getByTestId } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByText('2x unknown-item')).toBeTruthy();
+        expect(getByText('Duration')).toBeTruthy();
+        expect(getByText('1 item (1)')).toBeTruthy();
+        expect(getByText('2x', { exact: false })).toBeTruthy();
+        expect(getByTestId('preview-item-name').textContent).toBe('');
     });
 
-    test('does not render untrusted preview images when metadata is missing', () => {
+    test('does not render preview images before metadata is available', () => {
         const process = {
             id: 'process-with-untrusted-image',
             title: 'Untrusted image',
@@ -76,11 +79,12 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByAltText } = render(ProcessListRow, {
+        const { container, queryByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByAltText('unknown-item').getAttribute('src')).toBe('/favicon.ico');
+        expect(queryByRole('img')).toBeNull();
+        expect(container.querySelector('.preview-icon-placeholder')).toBeTruthy();
     });
 
     test('updates preview lines when metadata map changes after mount', async () => {
@@ -99,12 +103,12 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByText, rerender, queryByText } = render(ProcessListRow, {
+        const { container, getByText, rerender } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByText('1x smart-plug')).toBeTruthy();
-        expect(queryByText('1x Smart Plug')).toBeNull();
+        expect(getByText('1x', { exact: false })).toBeTruthy();
+        expect(container.textContent).not.toContain('1x Smart Plug');
 
         await rerender({
             process,
@@ -113,6 +117,6 @@ describe('ProcessListRow', () => {
             ]),
         });
 
-        expect(getByText('1x Smart Plug')).toBeTruthy();
+        expect(container.textContent).toContain('1x Smart Plug');
     });
 });

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -180,9 +180,11 @@ describe('Processes list route contract', () => {
         expect(screen.queryByRole('button', { name: 'Start' })).toBeNull();
         expect(screen.getAllByRole('link', { name: 'View details' })).toHaveLength(2);
 
-        expect(await screen.findByText('1x Shared Item')).toBeTruthy();
-        expect(screen.getByText('3x Fuel Cell')).toBeTruthy();
-        expect(screen.getByText('3x Byproduct')).toBeTruthy();
+        const listText = await screen.findByText('Built In Process');
+        expect(listText).toBeTruthy();
+        expect(document.body.textContent).toContain('1x Shared Item');
+        expect(document.body.textContent).toContain('3x Fuel Cell');
+        expect(document.body.textContent).toContain('3x Byproduct');
 
         expect(getItemMapMock).toHaveBeenCalledTimes(1);
         expect(getItemMapMock).toHaveBeenCalledWith(
@@ -193,7 +195,7 @@ describe('Processes list route contract', () => {
         );
     });
 
-    it('falls back to preview entry ids when at least one route-level preview metadata record is missing', async () => {
+    it('keeps preview names blank when metadata records are still unavailable', async () => {
         customListMock.mockResolvedValue([]);
         getItemMapMock.mockResolvedValue(
             new Map([['known-item', { id: 'known-item', name: 'Known Item', image: '/known.png' }]])
@@ -221,7 +223,10 @@ describe('Processes list route contract', () => {
             },
         });
 
-        expect(await screen.findByText('1x Known Item')).toBeTruthy();
-        expect(screen.getByText('2x missing-item')).toBeTruthy();
+        await screen.findByText('Fallback Process');
+        expect(document.body.textContent).toContain('1x Known Item');
+        expect(screen.getByText('2x', { exact: false })).toBeTruthy();
+        const previewNames = screen.getAllByTestId('preview-item-name');
+        expect(previewNames[previewNames.length - 1].textContent).toBe('');
     });
 });


### PR DESCRIPTION
### Motivation

- The processes list briefly displayed raw item IDs before their metadata (name/image) finished loading, producing a flicker during refresh. 
- The intent is to avoid showing transient IDs while still allowing the rest of the process row (duration and item totals) to render immediately.

### Description

- Update `ProcessListRow.svelte` to treat preview entries as metadata-driven and to leave the preview name/image blank until metadata is available by adding a `hasMetadata` flag and only rendering `name`/`image` when present. 
- Render an icon/name placeholder (`.preview-icon-placeholder` and an empty `data-testid="preview-item-name"`) for entries whose metadata is not yet resolved so the layout stays stable. 
- Adjust `getPreviewLines`/`toPreviewLine` logic to return blank `name`/`image` when metadata is absent so previews don’t display raw IDs. 
- Update unit tests in `frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts` and `frontend/src/pages/processes/__tests__/Processes.spec.ts` to cover blank-name behavior, no preview images before metadata, and runtime update after metadata arrival. 
- Add a Playwright regression E2E test `frontend/e2e/processes-item-metadata-loading.spec.ts` that asserts preview names are blank on initial render and populated later without blocking row details.

### Testing

- Ran the component/unit suite with `npx vitest run -c vitest.config.mts frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts frontend/src/pages/processes/__tests__/Processes.spec.ts` and all tests passed. 
- Added the Playwright regression `frontend/e2e/processes-item-metadata-loading.spec.ts` and attempted `cd frontend && npm run test:e2e -- processes-item-metadata-loading.spec.ts`, but the Playwright run failed in this environment due to inability to download browser/system dependencies (network/apt connectivity), not due to the tests themselves.
- Formatting/lint checks were run (Prettier) during development to keep frontend style consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4df6d8cc832f93820b39f44b513d)