### PR TITLE
🐛 Fix transient item ID flash on /processes previews

### DIFF
--- a/frontend/e2e/processes-item-metadata-loading.spec.ts
+++ b/frontend/e2e/processes-item-metadata-loading.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+const CUSTOM_CONTENT_DB_VERSION = 3;
+
+async function seedCustomProcess(
+    page: import('@playwright/test').Page,
+    processRecord: Record<string, unknown>
+): Promise<void> {
+    await page.evaluate(
+        async ({ processRecord, dbVersion }) => {
+            const openDatabase = () =>
+                new Promise<IDBDatabase>((resolve, reject) => {
+                    const request = indexedDB.open('CustomContent', dbVersion);
+
+                    request.onupgradeneeded = () => {
+                        const db = request.result;
+                        if (!db.objectStoreNames.contains('meta')) {
+                            db.createObjectStore('meta');
+                        }
+                        if (!db.objectStoreNames.contains('items')) {
+                            db.createObjectStore('items', { keyPath: 'id' });
+                        }
+                        if (!db.objectStoreNames.contains('processes')) {
+                            db.createObjectStore('processes', { keyPath: 'id' });
+                        }
+                        if (!db.objectStoreNames.contains('quests')) {
+                            db.createObjectStore('quests', { keyPath: 'id' });
+                        }
+                    };
+
+                    request.onerror = () =>
+                        reject(
+                            request.error ??
+                                new Error('Failed to open IndexedDB for process seeding')
+                        );
+                    request.onsuccess = () => resolve(request.result);
+                });
+
+            const db = await openDatabase();
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    const tx = db.transaction('processes', 'readwrite');
+                    const store = tx.objectStore('processes');
+                    const request = store.put(processRecord);
+
+                    tx.oncomplete = () => resolve();
+                    tx.onerror = () =>
+                        reject(tx.error ?? new Error('Process seed transaction failed'));
+                    tx.onabort = () =>
+                        reject(tx.error ?? new Error('Process seed transaction aborted'));
+
+                    request.onerror = () =>
+                        reject(request.error ?? new Error('Failed to seed process record'));
+                });
+            } finally {
+                db.close();
+            }
+        },
+        { processRecord, dbVersion: CUSTOM_CONTENT_DB_VERSION }
+    );
+}
+
+test.describe('Processes metadata loading', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearUserData(page);
+    });
+
+    test('does not render transient item ids while metadata is loading', async ({ page }) => {
+        const missingItemId = `missing-item-${randomUUID()}`;
+        const processId = `custom-process-${randomUUID()}`;
+
+        await page.goto('/');
+
+        await seedCustomProcess(page, {
+            id: processId,
+            title: 'Metadata loading regression process',
+            duration: '30s',
+            requireItems: [{ id: missingItemId, count: 2 }],
+            consumeItems: [],
+            createItems: [],
+            custom: true,
+            entityType: 'process',
+            createdAt: new Date().toISOString(),
+        });
+
+        await page.addInitScript(
+            ({ targetItemId }) => {
+                const sightings: string[] = [];
+                const checkNode = (node: ParentNode | null) => {
+                    if (!node) {
+                        return;
+                    }
+                    const text = node.textContent ?? '';
+                    if (text.includes(targetItemId)) {
+                        sightings.push(text);
+                    }
+                };
+
+                const observer = new MutationObserver((mutations) => {
+                    for (const mutation of mutations) {
+                        checkNode(mutation.target as ParentNode);
+                        for (const addedNode of mutation.addedNodes) {
+                            if (addedNode.nodeType === Node.ELEMENT_NODE) {
+                                checkNode(addedNode as ParentNode);
+                            }
+                        }
+                    }
+                });
+
+                (
+                    window as unknown as { __processItemIdSightings?: string[] }
+                ).__processItemIdSightings = sightings;
+                observer.observe(document.documentElement, {
+                    childList: true,
+                    subtree: true,
+                    characterData: true,
+                });
+            },
+            { targetItemId: missingItemId }
+        );
+
+        await page.goto('/processes');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        await expect(page.getByText('Metadata loading regression process')).toBeVisible();
+        await expect(page.getByText(new RegExp(`2x\\s*${missingItemId}`))).toHaveCount(0);
+
+        const sightings = await page.evaluate(() => {
+            return (window as unknown as { __processItemIdSightings?: string[] })
+                .__processItemIdSightings;
+        });
+
+        expect(sightings ?? []).toHaveLength(0);
+    });
+});

--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -19,12 +19,13 @@
         const metadata = metadataMap?.get(entryId);
         const count = Number(entry?.count);
         const countLabel = Number.isFinite(count) ? count : 0;
+        const hasMetadata = Boolean(metadata && !metadata?.missing);
 
         return {
             id: entryId,
             countLabel,
-            name: metadata?.name || entry?.name || entryId || 'Unknown item',
-            image: metadata?.image || '/favicon.ico',
+            name: hasMetadata ? (metadata?.name ?? '') : '',
+            image: hasMetadata ? (metadata?.image ?? null) : null,
         };
     };
 
@@ -63,7 +64,9 @@
                     <ul class="item-preview-list">
                         {#each requirePreviewLines as item, index (`require-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
+                                {#if item.image}
+                                    <img src={item.image} alt={item.name} />
+                                {/if}
                                 <span>{item.countLabel}x {item.name}</span>
                             </li>
                         {/each}
@@ -79,7 +82,9 @@
                     <ul class="item-preview-list">
                         {#each consumePreviewLines as item, index (`consume-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
+                                {#if item.image}
+                                    <img src={item.image} alt={item.name} />
+                                {/if}
                                 <span>{item.countLabel}x {item.name}</span>
                             </li>
                         {/each}
@@ -95,7 +100,9 @@
                     <ul class="item-preview-list">
                         {#each createPreviewLines as item, index (`create-${item.id}-${index}`)}
                             <li>
-                                <img src={item.image} alt={item.name} />
+                                {#if item.image}
+                                    <img src={item.image} alt={item.name} />
+                                {/if}
                                 <span>{item.countLabel}x {item.name}</span>
                             </li>
                         {/each}

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -35,7 +35,7 @@ describe('ProcessListRow', () => {
         expect(getAllByRole('img')).toHaveLength(3);
     });
 
-    test('falls back to entry ids when metadata is missing', () => {
+    test('leaves preview name blank when metadata is still loading', () => {
         const process = {
             id: 'process-with-missing-item',
             title: 'Missing item metadata',
@@ -51,14 +51,15 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByText } = render(ProcessListRow, {
+        const { getByText, queryByText } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByText('2x unknown-item')).toBeTruthy();
+        expect(getByText(/^2x\s*$/)).toBeTruthy();
+        expect(queryByText('unknown-item')).toBeNull();
     });
 
-    test('does not render untrusted preview images when metadata is missing', () => {
+    test('does not render any preview image when metadata is missing', () => {
         const process = {
             id: 'process-with-untrusted-image',
             title: 'Untrusted image',
@@ -76,11 +77,11 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByAltText } = render(ProcessListRow, {
+        const { queryByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByAltText('unknown-item').getAttribute('src')).toBe('/favicon.ico');
+        expect(queryByRole('img')).toBeNull();
     });
 
     test('updates preview lines when metadata map changes after mount', async () => {
@@ -103,7 +104,7 @@ describe('ProcessListRow', () => {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByText('1x smart-plug')).toBeTruthy();
+        expect(getByText(/^1x\s*$/)).toBeTruthy();
         expect(queryByText('1x Smart Plug')).toBeNull();
 
         await rerender({

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -193,7 +193,7 @@ describe('Processes list route contract', () => {
         );
     });
 
-    it('falls back to preview entry ids when at least one route-level preview metadata record is missing', async () => {
+    it('keeps preview names blank until route-level preview metadata resolves', async () => {
         customListMock.mockResolvedValue([]);
         getItemMapMock.mockResolvedValue(
             new Map([['known-item', { id: 'known-item', name: 'Known Item', image: '/known.png' }]])
@@ -222,6 +222,7 @@ describe('Processes list route contract', () => {
         });
 
         expect(await screen.findByText('1x Known Item')).toBeTruthy();
-        expect(screen.getByText('2x missing-item')).toBeTruthy();
+        expect(screen.getByText(/^2x\s*$/)).toBeTruthy();
+        expect(screen.queryByText('missing-item')).toBeNull();
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent the UI from briefly showing raw internal item IDs in process preview rows while item metadata is still loading to avoid visual flicker and leaking implementation details. 
- Keep the rest of the process list rendering fast and non-blocking while waiting for metadata to resolve.

### Description
- Change preview line generation in `frontend/src/pages/processes/ProcessListRow.svelte` so `name` and `image` are left empty/null until trusted metadata is available (`hasMetadata` guard). 
- Only render preview `<img>` elements when an image URL is present to avoid showing fallback icons or untrusted data. 
- Update unit tests in `frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts` to assert blank placeholders (count-only) and absence of images while metadata is loading and to verify proper update after metadata arrives. 
- Update route-level tests in `frontend/src/pages/processes/__tests__/Processes.spec.ts` to assert preview names remain blank for missing metadata. 
- Add a Playwright regression test `frontend/e2e/processes-item-metadata-loading.spec.ts` that seeds a custom process with a unique missing item and asserts the raw item id never transiently appears during `/processes` hydration.

### Testing
- Ran unit tests with Vitest: `npx vitest run -c vitest.config.mts frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts frontend/src/pages/processes/__tests__/Processes.spec.ts`, and all tests passed (`2 files, 11 tests` passed).
- Added Playwright e2e test and attempted to run it via `cd frontend && npm run test:e2e -- e2e/processes-item-metadata-loading.spec.ts`; this run failed in this environment due to inability to download Playwright browsers/system dependencies (network restrictions), not due to test assertions. The Playwright spec is included and should pass in CI where Playwright browsers are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4df6d8cc832f93820b39f44b513d)