### PR TITLE
🐛 Fix buy control on process pages: always show button, add disabled reasons and partial purchasing

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -13,6 +13,7 @@
     let processData = null;
     let displayProcess = builtInProcess;
     let disableBuy = true;
+    let disableReason = 'No buyable required items are still needed.';
     let toastVisible = false;
     let toastMessage = '';
 
@@ -21,60 +22,128 @@
         return Number.isFinite(price) && price > 0 ? price : null;
     };
 
-    const canBuyRequired = () => {
-        if (!displayProcess?.requireItems?.length) {
-            return false;
+    const getCurrencyIdForSymbol = (symbol) => {
+        if (!symbol) {
+            return null;
         }
 
-        return displayProcess.requireItems.some((req) => {
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
-        });
+        const currencyItem = items.find((item) => item?.name === symbol || item?.id === symbol);
+        return currencyItem?.id ?? null;
     };
 
-    const updateDisabled = () => {
-        if (!displayProcess || !displayProcess.requireItems) {
-            disableBuy = true;
-            return;
+    const getBuyPlan = () => {
+        if (!displayProcess || !Array.isArray(displayProcess.requireItems)) {
+            return {
+                missingRequiredCount: 0,
+                buyableRequirements: [],
+            };
         }
 
-        const hasPurchasableGap = displayProcess.requireItems.some((req) => {
-            const have = getItemCount(req.id);
-            const need = req.count - have;
-            if (need <= 0) {
-                return false;
-            }
+        let missingRequiredCount = 0;
+        const buyableRequirements = [];
 
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
-        });
-
-        disableBuy = !hasPurchasableGap;
-    };
-
-    const buyItem = (id, qty) => {
-        const item = items.find((i) => i.id === id);
-        if (!item) return;
-
-        const unitPrice = getUnitPrice(item);
-        if (unitPrice === null) {
-            return;
-        }
-
-        buyItems([{ id, quantity: qty, price: unitPrice }]);
-    };
-
-    const buyRequired = () => {
-        if (!displayProcess) return;
-        let added = 0;
         displayProcess.requireItems.forEach((req) => {
             const have = getItemCount(req.id);
             const need = req.count - have;
-            if (need > 0) {
-                buyItem(req.id, need);
-                added += need;
+            if (need <= 0) {
+                return;
+            }
+
+            missingRequiredCount += need;
+
+            const item = items.find((i) => i.id === req.id);
+            const unitPrice = getUnitPrice(item);
+            if (unitPrice === null) {
+                return;
+            }
+
+            const { symbol } = getPriceStringComponents(item?.price);
+            const currencyId = getCurrencyIdForSymbol(symbol);
+            if (!currencyId) {
+                return;
+            }
+
+            const lineTotal = unitPrice * need;
+            buyableRequirements.push({
+                id: req.id,
+                need,
+                price: unitPrice,
+                currencyId,
+                lineTotal,
+            });
+        });
+
+        return { missingRequiredCount, buyableRequirements };
+    };
+
+    const updateDisabled = () => {
+        const { missingRequiredCount, buyableRequirements } = getBuyPlan();
+
+        if (missingRequiredCount === 0) {
+            disableBuy = true;
+            disableReason = 'All required items are already available.';
+            return;
+        }
+
+        if (buyableRequirements.length === 0) {
+            disableBuy = true;
+            disableReason = 'No buyable required items are still needed.';
+            return;
+        }
+
+        const canBuyAnyRequirement = buyableRequirements.some((req) =>
+            getItemCount(req.currencyId) >= req.price
+        );
+
+        if (!canBuyAnyRequirement) {
+            disableBuy = true;
+            disableReason = 'Not enough currency to buy any required items.';
+            return;
+        }
+
+        disableBuy = false;
+        disableReason = '';
+    };
+
+    const buyRequired = () => {
+        if (!displayProcess) {
+            return;
+        }
+
+        const { buyableRequirements } = getBuyPlan();
+        if (buyableRequirements.length === 0) {
+            updateDisabled();
+            return;
+        }
+
+        const sortedByLineTotal = [...buyableRequirements].sort((a, b) => a.lineTotal - b.lineTotal);
+        const remainingByCurrency = new Map();
+        const transactions = [];
+        let added = 0;
+
+        sortedByLineTotal.forEach((req) => {
+            const currentCurrencyBudget =
+                remainingByCurrency.get(req.currencyId) ?? getItemCount(req.currencyId);
+            const maxAffordableQty = Math.floor(currentCurrencyBudget / req.price);
+            const quantityToBuy = Math.min(req.need, Math.max(0, maxAffordableQty));
+
+            if (quantityToBuy > 0) {
+                const spend = quantityToBuy * req.price;
+                remainingByCurrency.set(req.currencyId, currentCurrencyBudget - spend);
+                transactions.push({
+                    id: req.id,
+                    quantity: quantityToBuy,
+                    price: req.price,
+                    currencyId: req.currencyId,
+                });
+                added += quantityToBuy;
             }
         });
+
+        if (transactions.length > 0) {
+            buyItems(transactions);
+        }
+
         if (added > 0) {
             toastMessage = `\u2713 Added ${added} items to inventory`;
             toastVisible = true;
@@ -105,16 +174,20 @@
 
 <div class="process-view">
     <Process inverted={true} processId={slug} {processData} />
-    {#if canBuyRequired()}
+    <span title={disableBuy && disableReason ? disableReason : undefined}>
         <button
             class="primary"
             type="button"
             on:click={buyRequired}
             aria-disabled={disableBuy}
             disabled={disableBuy}
+            aria-describedby={disableBuy ? 'buy-required-reason' : undefined}
         >
             Buy required items
         </button>
+    </span>
+    {#if disableBuy && disableReason}
+        <span id="buy-required-reason" class="sr-only">{disableReason}</span>
     {/if}
     {#if toastVisible}
         <div class="toast" role="status" aria-live="polite">{toastMessage}</div>
@@ -154,5 +227,16 @@
         padding: 10px 20px;
         border-radius: 5px;
         text-align: center;
+    }
+    .sr-only {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
     }
 </style>

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -16,6 +16,16 @@ vi.mock('../../../../generated/processes.json', () => ({
             consumeItems: [],
             createItems: [],
         },
+        {
+            id: 'partial-process',
+            title: 'Partial Process',
+            requireItems: [
+                { id: 'req-item', count: 2 },
+                { id: 'other-req-item', count: 2 },
+            ],
+            consumeItems: [],
+            createItems: [],
+        },
     ],
 }));
 
@@ -24,6 +34,14 @@ vi.mock('../../../inventory/json/items', () => ({
         {
             id: 'req-item',
             price: '5 dUSD',
+        },
+        {
+            id: 'other-req-item',
+            price: '2 dUSD',
+        },
+        {
+            id: 'dUSD',
+            name: 'dUSD',
         },
     ],
 }));
@@ -49,7 +67,7 @@ describe('ProcessView detail controls', () => {
     beforeEach(() => {
         buyItemsMock.mockReset();
         getItemCountMock.mockReset();
-        getItemCountMock.mockReturnValue(0);
+        getItemCountMock.mockImplementation((id: string) => (id === 'dUSD' ? 100 : 0));
     });
 
     it('keeps Buy required items on detail route and purchases missing requirements', async () => {
@@ -62,7 +80,9 @@ describe('ProcessView detail controls', () => {
         try {
             await fireEvent.click(buyButton);
 
-            expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
+            expect(buyItemsMock).toHaveBeenCalledWith([
+                { id: 'req-item', quantity: 2, price: 5, currencyId: 'dUSD' },
+            ]);
             expect((await screen.findByRole('status')).textContent).toContain(
                 'Added 2 items to inventory'
             );
@@ -71,5 +91,42 @@ describe('ProcessView detail controls', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('shows disabled reason when all required items are already available', async () => {
+        getItemCountMock.mockImplementation((id: string) => {
+            if (id === 'req-item') {
+                return 2;
+            }
+            return 0;
+        });
+
+        render(ProcessView, { props: { slug: 'detail-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).toBe('');
+        expect(buyButton.getAttribute('aria-describedby')).toBe('buy-required-reason');
+        expect(screen.getByText('All required items are already available.')).toBeTruthy();
+    });
+
+    it('buys as many required items as possible in ascending price*quantity order', async () => {
+        getItemCountMock.mockImplementation((id: string) => {
+            if (id === 'dUSD') {
+                return 9;
+            }
+            return 0;
+        });
+
+        render(ProcessView, { props: { slug: 'partial-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).toBeNull();
+
+        await fireEvent.click(buyButton);
+
+        expect(buyItemsMock).toHaveBeenCalledWith([
+            { id: 'other-req-item', quantity: 2, price: 2, currencyId: 'dUSD' },
+            { id: 'req-item', quantity: 1, price: 5, currencyId: 'dUSD' },
+        ]);
     });
 });

--- a/frontend/src/utils/gameState/inventory.js
+++ b/frontend/src/utils/gameState/inventory.js
@@ -124,7 +124,11 @@ export const buyItems = (items) => {
 
     items.forEach((item) => {
         const { price, quantity } = item;
-        const currencyId = dUSDId;
+        const currencyId = item.currencyId || dUSDId;
+
+        if (!currencyId) {
+            return;
+        }
 
         const parsedPrice = parseFloat(price);
         const parsedQuantity = parseFloat(quantity);


### PR DESCRIPTION
### Motivation
- Process detail pages hid the “Buy required items” control inconsistently and provided no clear reason when it was disabled.
- The UI must always show the action, provide an accessible explanation when disabled, and still allow partial purchases when funds are limited.

### Description
- Always render the `Buy required items` button on the process detail page and compute a structured buy plan in `frontend/src/pages/process/[slug]/ProcessView.svelte`.
- Add deterministic disabled-state reasoning (`All required items are already available.`, `No buyable required items are still needed.`, `Not enough currency to buy any required items.`) surfaced via `title`, `aria-describedby` and an sr-only element.
- Implement partial purchasing that buys as many missing requirements as possible in ascending `price * quantity` order and aggregate per-currency budgets; pass `currencyId` through each transaction.
- Update `buyItems` in `frontend/src/utils/gameState/inventory.js` to accept an optional `currencyId` (defaults to `dUSD`) so the correct currency is debited, preserving backward compatibility.
- Add/adjust unit tests in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` to cover normal purchase, disabled reason rendering, and partial-purchase ordering/quantities.

### Testing
- Ran the focused unit suite with `npx vitest run frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` and all tests passed (3/3).
- Ran linting via `npm run lint` and it completed successfully.
- Initiated the full `npm run test:ci` build+test pipeline during development; the build and targeted test run completed in this environment but full CI suite should still be verified in upstream CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4f186f60832fa1f860de385cbf89)