### PR TITLE
Fix Buy required items behavior on process detail pages

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -13,12 +13,78 @@
     let processData = null;
     let displayProcess = builtInProcess;
     let disableBuy = true;
+    let disableReason = 'No buyable required items remain.';
     let toastVisible = false;
     let toastMessage = '';
 
-    const getUnitPrice = (item) => {
-        const { price } = getPriceStringComponents(item?.price);
-        return Number.isFinite(price) && price > 0 ? price : null;
+    const getUnitPriceAndSymbol = (item) => {
+        const { price, symbol } = getPriceStringComponents(item?.price);
+        if (!Number.isFinite(price) || price <= 0 || !symbol) {
+            return { unitPrice: null, symbol: '' };
+        }
+
+        return { unitPrice: price, symbol };
+    };
+
+    const getCurrencyItemId = (symbol) => {
+        if (!symbol) {
+            return null;
+        }
+
+        const currencyItem = items.find((item) => item.symbol === symbol || item.name === symbol);
+        return currencyItem?.id ?? null;
+    };
+
+    const getBuyPlan = () => {
+        const requireItems = displayProcess?.requireItems ?? [];
+        const missingRequirements = requireItems
+            .map((req) => {
+                const have = getItemCount(req.id);
+                const need = req.count - have;
+                const item = items.find((i) => i.id === req.id);
+                const { unitPrice, symbol } = getUnitPriceAndSymbol(item);
+                const currencyId = getCurrencyItemId(symbol);
+                return {
+                    id: req.id,
+                    need,
+                    unitPrice,
+                    symbol,
+                    currencyId,
+                    totalCost: unitPrice === null ? Infinity : unitPrice * need,
+                };
+            })
+            .filter((req) => req.need > 0 && req.unitPrice !== null && req.currencyId);
+
+        const balancesByCurrency = new Map();
+        missingRequirements.forEach((req) => {
+            if (!balancesByCurrency.has(req.currencyId)) {
+                balancesByCurrency.set(req.currencyId, getItemCount(req.currencyId));
+            }
+        });
+
+        const plannedPurchases = [];
+        missingRequirements
+            .sort((a, b) => a.totalCost - b.totalCost)
+            .forEach((req) => {
+                const availableCurrency = balancesByCurrency.get(req.currencyId) ?? 0;
+                const maxAffordableQty = availableCurrency / req.unitPrice;
+                const quantity = Math.min(req.need, maxAffordableQty);
+                if (quantity <= 0) {
+                    return;
+                }
+
+                const totalCost = quantity * req.unitPrice;
+                balancesByCurrency.set(req.currencyId, availableCurrency - totalCost);
+                plannedPurchases.push({
+                    id: req.id,
+                    quantity,
+                    price: req.unitPrice,
+                    symbol: req.symbol,
+                    currencyId: req.currencyId,
+                });
+            });
+
+        return plannedPurchases;
     };
 
     const canBuyRequired = () => {
@@ -26,55 +92,53 @@
             return false;
         }
 
-        return displayProcess.requireItems.some((req) => {
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
-        });
+        return true;
     };
 
     const updateDisabled = () => {
         if (!displayProcess || !displayProcess.requireItems) {
             disableBuy = true;
+            disableReason = 'This process has no required items.';
             return;
         }
 
-        const hasPurchasableGap = displayProcess.requireItems.some((req) => {
+        const missingRequirements = displayProcess.requireItems.filter((req) => {
             const have = getItemCount(req.id);
-            const need = req.count - have;
-            if (need <= 0) {
-                return false;
-            }
-
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
+            return req.count - have > 0;
         });
 
-        disableBuy = !hasPurchasableGap;
-    };
-
-    const buyItem = (id, qty) => {
-        const item = items.find((i) => i.id === id);
-        if (!item) return;
-
-        const unitPrice = getUnitPrice(item);
-        if (unitPrice === null) {
+        if (missingRequirements.length === 0) {
+            disableBuy = true;
+            disableReason = 'All required items are already available.';
             return;
         }
 
-        buyItems([{ id, quantity: qty, price: unitPrice }]);
+        const hasBuyableMissingRequirements = missingRequirements.some((req) => {
+            const item = items.find((i) => i.id === req.id);
+            const { unitPrice, symbol } = getUnitPriceAndSymbol(item);
+            return unitPrice !== null && getCurrencyItemId(symbol);
+        });
+
+        if (!hasBuyableMissingRequirements) {
+            disableBuy = true;
+            disableReason = 'No remaining required items can be bought.';
+            return;
+        }
+
+        const buyPlan = getBuyPlan();
+        disableBuy = buyPlan.length === 0;
+        disableReason = disableBuy
+            ? 'Not enough currency to buy any remaining required items.'
+            : '';
     };
 
     const buyRequired = () => {
         if (!displayProcess) return;
-        let added = 0;
-        displayProcess.requireItems.forEach((req) => {
-            const have = getItemCount(req.id);
-            const need = req.count - have;
-            if (need > 0) {
-                buyItem(req.id, need);
-                added += need;
-            }
-        });
+        const buyPlan = getBuyPlan();
+        const added = buyPlan.reduce((total, item) => total + item.quantity, 0);
+        if (buyPlan.length > 0) {
+            buyItems(buyPlan);
+        }
         if (added > 0) {
             toastMessage = `\u2713 Added ${added} items to inventory`;
             toastVisible = true;
@@ -111,10 +175,15 @@
             type="button"
             on:click={buyRequired}
             aria-disabled={disableBuy}
+            aria-describedby={disableBuy ? 'buy-required-reason' : undefined}
+            title={disableBuy ? disableReason : ''}
             disabled={disableBuy}
         >
             Buy required items
         </button>
+    {/if}
+    {#if disableBuy}
+        <p id="buy-required-reason" class="sr-only">{disableReason}</p>
     {/if}
     {#if toastVisible}
         <div class="toast" role="status" aria-live="polite">{toastMessage}</div>
@@ -154,5 +223,16 @@
         padding: 10px 20px;
         border-radius: 5px;
         text-align: center;
+    }
+    .sr-only {
+        border: 0;
+        clip: rect(0, 0, 0, 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
     }
 </style>

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -12,7 +12,11 @@ vi.mock('../../../../generated/processes.json', () => ({
         {
             id: 'detail-process',
             title: 'Detail Process',
-            requireItems: [{ id: 'req-item', count: 2 }],
+            requireItems: [
+                { id: 'cheap-item', count: 2 },
+                { id: 'expensive-item', count: 2 },
+                { id: 'non-buyable-item', count: 1 },
+            ],
             consumeItems: [],
             createItems: [],
         },
@@ -22,8 +26,21 @@ vi.mock('../../../../generated/processes.json', () => ({
 vi.mock('../../../inventory/json/items', () => ({
     default: [
         {
-            id: 'req-item',
+            id: 'dusd',
+            name: 'dUSD',
+            symbol: 'dUSD',
+        },
+        {
+            id: 'cheap-item',
             price: '5 dUSD',
+        },
+        {
+            id: 'expensive-item',
+            price: '10 dUSD',
+        },
+        {
+            id: 'non-buyable-item',
+            price: '',
         },
     ],
 }));
@@ -46,13 +63,38 @@ vi.mock('../../../../utils/customcontent.js', async (importOriginal) => {
 });
 
 describe('ProcessView detail controls', () => {
+    let inventory;
+
     beforeEach(() => {
         buyItemsMock.mockReset();
         getItemCountMock.mockReset();
-        getItemCountMock.mockReturnValue(0);
+        inventory = {
+            dusd: 0,
+            'cheap-item': 0,
+            'expensive-item': 0,
+            'non-buyable-item': 1,
+        };
+        getItemCountMock.mockImplementation((id) => inventory[id] ?? 0);
+        buyItemsMock.mockImplementation((purchases) => {
+            purchases.forEach(({ id, quantity, price, currencyId = 'dusd' }) => {
+                inventory[currencyId] -= quantity * price;
+                inventory[id] = (inventory[id] ?? 0) + quantity;
+            });
+        });
     });
 
-    it('keeps Buy required items on detail route and purchases missing requirements', async () => {
+    it('always shows Buy required items and explains insufficient currency when disabled', async () => {
+        render(ProcessView, { props: { slug: 'detail-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).not.toBeNull();
+        expect(
+            await screen.findByText('Not enough currency to buy any remaining required items.')
+        ).toBeTruthy();
+    });
+
+    it('purchases as many missing requirements as possible by increasing price*quantity', async () => {
+        inventory.dusd = 25;
         render(ProcessView, { props: { slug: 'detail-process' } });
 
         const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
@@ -62,14 +104,34 @@ describe('ProcessView detail controls', () => {
         try {
             await fireEvent.click(buyButton);
 
-            expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
+            expect(buyItemsMock).toHaveBeenCalledWith([
+                { id: 'cheap-item', quantity: 2, price: 5, symbol: 'dUSD', currencyId: 'dusd' },
+                {
+                    id: 'expensive-item',
+                    quantity: 1.5,
+                    price: 10,
+                    symbol: 'dUSD',
+                    currencyId: 'dusd',
+                },
+            ]);
             expect((await screen.findByRole('status')).textContent).toContain(
-                'Added 2 items to inventory'
+                'Added 3.5 items to inventory'
             );
 
             vi.runAllTimers();
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('shows disabled reason when all required items are already available', async () => {
+        inventory.dusd = 25;
+        inventory['cheap-item'] = 2;
+        inventory['expensive-item'] = 2;
+        render(ProcessView, { props: { slug: 'detail-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).not.toBeNull();
+        expect(await screen.findByText('All required items are already available.')).toBeTruthy();
     });
 });

--- a/frontend/src/utils/gameState/inventory.js
+++ b/frontend/src/utils/gameState/inventory.js
@@ -119,12 +119,17 @@ export const getSalesTaxPercentage = () => {
     return Math.min(dCarbonCount / 1000, 90);
 };
 
-export const buyItems = (items) => {
+export const buyItems = (transactionItems) => {
     const gameState = loadFreshStateForMutation();
 
-    items.forEach((item) => {
-        const { price, quantity } = item;
-        const currencyId = dUSDId;
+    transactionItems.forEach((item) => {
+        const { price, quantity, currencyId: explicitCurrencyId, symbol } = item;
+        const resolvedCurrencyId =
+            explicitCurrencyId ??
+            items.find(
+                (catalogItem) => catalogItem.symbol === symbol || catalogItem.name === symbol
+            )?.id ??
+            dUSDId;
 
         const parsedPrice = parseFloat(price);
         const parsedQuantity = parseFloat(quantity);
@@ -133,8 +138,12 @@ export const buyItems = (items) => {
         if (!Number.isFinite(parsedPrice) || parsedPrice <= 0) return;
         if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) return;
 
-        if (gameState.inventory[currencyId] && gameState.inventory[currencyId] >= totalPrice) {
-            gameState.inventory[currencyId] -= totalPrice; // Subtracting the currency for buying.
+        if (
+            resolvedCurrencyId !== undefined &&
+            gameState.inventory[resolvedCurrencyId] &&
+            gameState.inventory[resolvedCurrencyId] >= totalPrice
+        ) {
+            gameState.inventory[resolvedCurrencyId] -= totalPrice; // Subtracting the currency for buying.
             gameState.inventory[item.id] = (gameState.inventory[item.id] || 0) + parsedQuantity; // Adding the bought item to inventory.
         }
     });


### PR DESCRIPTION
### Motivation
- The process detail UI hid or incorrectly enabled the "Buy required items" control in cases where partial purchases should be possible or when a non-dUSD currency was involved.
- Users need a consistent affordance that is always visible when requirements exist and provides an accessible reason when disabled.

### Description
- Always render the `Buy required items` button when a process has `requireItems`, and compute `disableBuy` with an explicit `disableReason` shown via `title` and `aria-describedby` (in `frontend/src/pages/process/[slug]/ProcessView.svelte`).
- Add deterministic partial-purchase planning (`getBuyPlan`) that groups by currency, sorts missing requirements by ascending `price * quantity`, and buys as many units as affordable (in `ProcessView.svelte`).
- Extend price handling to return both unit price and symbol (`getUnitPriceAndSymbol`) and resolve the currency item id from the symbol (`getCurrencyItemId`) (in `ProcessView.svelte`).
- Update `buyItems` to accept transaction items with `currencyId`/`symbol` and resolve currency before decrementing the wallet (in `frontend/src/utils/gameState/inventory.js`).
- Expand tests in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` to cover always-visible button + disabled reason, partial buys under limited funds, and the disabled state when all requirements are already met.

### Testing
- Ran the updated ProcessView unit tests with `npx vitest run frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts`, and all tests passed (3 tests).
- Ran formatting with `npx prettier` and project lint with `npm run lint`, and `npm run lint` completed successfully.
- Began the full CI test run with `npm run test:ci`; the build and test harness started and progressed but was interrupted in this environment due to runtime constraints (build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4f186f60832fa1f860de385cbf89)