### PR TITLE
🛒 fix: stabilize "Buy required items" — always show, accessibility, multi-currency partial buys

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -13,68 +13,163 @@
     let processData = null;
     let displayProcess = builtInProcess;
     let disableBuy = true;
+    let disableReason = 'No required items are missing.';
     let toastVisible = false;
     let toastMessage = '';
 
-    const getUnitPrice = (item) => {
-        const { price } = getPriceStringComponents(item?.price);
-        return Number.isFinite(price) && price > 0 ? price : null;
-    };
-
-    const canBuyRequired = () => {
-        if (!displayProcess?.requireItems?.length) {
-            return false;
+    const getPriceInfo = (item) => {
+        const { price, symbol } = getPriceStringComponents(item?.price);
+        if (!Number.isFinite(price) || price <= 0 || !symbol) {
+            return null;
         }
 
-        return displayProcess.requireItems.some((req) => {
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
+        const currency = items.find((entry) => entry.name === symbol);
+        if (!currency?.id) {
+            return null;
+        }
+
+        return {
+            unitPrice: price,
+            currencyId: currency.id,
+            currencySymbol: symbol,
+        };
+    };
+
+    const getRequiredPurchaseCandidates = () => {
+        if (!displayProcess?.requireItems?.length) {
+            return {
+                candidates: [],
+                allSatisfied: true,
+                hasNonBuyableMissingItems: false,
+            };
+        }
+
+        let allSatisfied = true;
+        let hasNonBuyableMissingItems = false;
+        const candidates = displayProcess.requireItems.reduce((result, req) => {
+            const neededCount = Math.max(0, Number(req?.count ?? 0) - getItemCount(req?.id));
+            if (neededCount <= 0) {
+                return result;
+            }
+
+            allSatisfied = false;
+            const item = items.find((entry) => entry.id === req.id);
+            const priceInfo = getPriceInfo(item);
+
+            if (!priceInfo) {
+                hasNonBuyableMissingItems = true;
+                return result;
+            }
+
+            result.push({
+                id: req.id,
+                need: neededCount,
+                unitPrice: priceInfo.unitPrice,
+                currencyId: priceInfo.currencyId,
+                currencySymbol: priceInfo.currencySymbol,
+                totalCost: neededCount * priceInfo.unitPrice,
+            });
+            return result;
+        }, []);
+
+        candidates.sort((a, b) => a.totalCost - b.totalCost || a.id.localeCompare(b.id));
+        return {
+            candidates,
+            allSatisfied,
+            hasNonBuyableMissingItems,
+        };
+    };
+
+    const getBuyPlan = () => {
+        const { candidates, allSatisfied, hasNonBuyableMissingItems } = getRequiredPurchaseCandidates();
+        if (!displayProcess?.requireItems?.length) {
+            return {
+                disabled: true,
+                reason: 'No required items for this process.',
+                purchases: [],
+            };
+        }
+
+        if (allSatisfied) {
+            return {
+                disabled: true,
+                reason: 'All required items are already available.',
+                purchases: [],
+            };
+        }
+
+        if (candidates.length === 0) {
+            const reason = hasNonBuyableMissingItems
+                ? 'No buyable required items are still needed.'
+                : 'No required items are missing.';
+            return {
+                disabled: true,
+                reason,
+                purchases: [],
+            };
+        }
+
+        const balances = new Map();
+        const getBalance = (currencyId) => {
+            if (!balances.has(currencyId)) {
+                balances.set(currencyId, getItemCount(currencyId));
+            }
+            return balances.get(currencyId);
+        };
+
+        const purchases = [];
+        candidates.forEach((candidate) => {
+            const balance = getBalance(candidate.currencyId);
+            const maxAffordable = Math.floor(balance / candidate.unitPrice);
+            const quantity = Math.min(candidate.need, Math.max(0, maxAffordable));
+            if (quantity <= 0) {
+                return;
+            }
+
+            const spent = quantity * candidate.unitPrice;
+            balances.set(candidate.currencyId, balance - spent);
+            purchases.push({
+                id: candidate.id,
+                quantity,
+                price: candidate.unitPrice,
+                currencyId: candidate.currencyId,
+            });
         });
+
+        if (!purchases.length) {
+            const neededSymbols = [...new Set(candidates.map((entry) => entry.currencySymbol))];
+            const symbolText = neededSymbols.join(', ');
+            return {
+                disabled: true,
+                reason: `Not enough ${symbolText} to buy missing required items.`,
+                purchases: [],
+            };
+        }
+
+        return {
+            disabled: false,
+            reason: '',
+            purchases,
+        };
     };
 
     const updateDisabled = () => {
-        if (!displayProcess || !displayProcess.requireItems) {
-            disableBuy = true;
-            return;
-        }
-
-        const hasPurchasableGap = displayProcess.requireItems.some((req) => {
-            const have = getItemCount(req.id);
-            const need = req.count - have;
-            if (need <= 0) {
-                return false;
-            }
-
-            const item = items.find((i) => i.id === req.id);
-            return getUnitPrice(item) !== null;
-        });
-
-        disableBuy = !hasPurchasableGap;
-    };
-
-    const buyItem = (id, qty) => {
-        const item = items.find((i) => i.id === id);
-        if (!item) return;
-
-        const unitPrice = getUnitPrice(item);
-        if (unitPrice === null) {
-            return;
-        }
-
-        buyItems([{ id, quantity: qty, price: unitPrice }]);
+        const { disabled, reason } = getBuyPlan();
+        disableBuy = disabled;
+        disableReason = reason;
     };
 
     const buyRequired = () => {
         if (!displayProcess) return;
-        let added = 0;
-        displayProcess.requireItems.forEach((req) => {
-            const have = getItemCount(req.id);
-            const need = req.count - have;
-            if (need > 0) {
-                buyItem(req.id, need);
-                added += need;
-            }
-        });
+
+        const { purchases } = getBuyPlan();
+        const added = purchases.reduce((total, purchase) => total + purchase.quantity, 0);
+        if (!added) {
+            updateDisabled();
+            return;
+        }
+
+        purchases.forEach((purchase) => buyItems([purchase]));
         if (added > 0) {
             toastMessage = `\u2713 Added ${added} items to inventory`;
             toastVisible = true;
@@ -105,16 +200,20 @@
 
 <div class="process-view">
     <Process inverted={true} processId={slug} {processData} />
-    {#if canBuyRequired()}
+    <span title={disableBuy ? disableReason : ''}>
         <button
             class="primary"
             type="button"
             on:click={buyRequired}
             aria-disabled={disableBuy}
+            aria-describedby={disableBuy ? 'buy-required-disabled-reason' : undefined}
             disabled={disableBuy}
         >
             Buy required items
         </button>
+    </span>
+    {#if disableBuy && disableReason}
+        <p id="buy-required-disabled-reason" class="sr-only">{disableReason}</p>
     {/if}
     {#if toastVisible}
         <div class="toast" role="status" aria-live="polite">{toastMessage}</div>
@@ -154,5 +253,16 @@
         padding: 10px 20px;
         border-radius: 5px;
         text-align: center;
+    }
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
     }
 </style>

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -22,6 +22,10 @@ vi.mock('../../../../generated/processes.json', () => ({
 vi.mock('../../../inventory/json/items', () => ({
     default: [
         {
+            id: 'currency-dusd',
+            name: 'dUSD',
+        },
+        {
             id: 'req-item',
             price: '5 dUSD',
         },
@@ -49,7 +53,7 @@ describe('ProcessView detail controls', () => {
     beforeEach(() => {
         buyItemsMock.mockReset();
         getItemCountMock.mockReset();
-        getItemCountMock.mockReturnValue(0);
+        getItemCountMock.mockImplementation((itemId: string) => (itemId === 'currency-dusd' ? 100 : 0));
     });
 
     it('keeps Buy required items on detail route and purchases missing requirements', async () => {
@@ -62,7 +66,9 @@ describe('ProcessView detail controls', () => {
         try {
             await fireEvent.click(buyButton);
 
-            expect(buyItemsMock).toHaveBeenCalledWith([{ id: 'req-item', quantity: 2, price: 5 }]);
+            expect(buyItemsMock).toHaveBeenCalledWith([
+                { id: 'req-item', quantity: 2, price: 5, currencyId: 'currency-dusd' },
+            ]);
             expect((await screen.findByRole('status')).textContent).toContain(
                 'Added 2 items to inventory'
             );
@@ -71,5 +77,36 @@ describe('ProcessView detail controls', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('always renders Buy required items and explains disabled reason when all requirements are available', async () => {
+        getItemCountMock.mockImplementation((itemId: string) => (itemId === 'req-item' ? 3 : 0));
+        render(ProcessView, { props: { slug: 'detail-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).not.toBeNull();
+        expect(buyButton.getAttribute('aria-describedby')).toBe('buy-required-disabled-reason');
+        expect(screen.getByText('All required items are already available.')).toBeTruthy();
+    });
+
+    it('buys as many items as possible when currency is limited', async () => {
+        getItemCountMock.mockImplementation((itemId: string) => {
+            if (itemId === 'req-item') {
+                return 0;
+            }
+            if (itemId === 'currency-dusd') {
+                return 8;
+            }
+            return 0;
+        });
+
+        render(ProcessView, { props: { slug: 'detail-process' } });
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.getAttribute('disabled')).toBeNull();
+
+        await fireEvent.click(buyButton);
+        expect(buyItemsMock).toHaveBeenCalledWith([
+            { id: 'req-item', quantity: 1, price: 5, currencyId: 'currency-dusd' },
+        ]);
     });
 });

--- a/frontend/src/utils/gameState/inventory.js
+++ b/frontend/src/utils/gameState/inventory.js
@@ -124,7 +124,7 @@ export const buyItems = (items) => {
 
     items.forEach((item) => {
         const { price, quantity } = item;
-        const currencyId = dUSDId;
+        const currencyId = item.currencyId ?? dUSDId;
 
         const parsedPrice = parseFloat(price);
         const parsedQuantity = parseFloat(quantity);
@@ -132,6 +132,7 @@ export const buyItems = (items) => {
 
         if (!Number.isFinite(parsedPrice) || parsedPrice <= 0) return;
         if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) return;
+        if (!currencyId) return;
 
         if (gameState.inventory[currencyId] && gameState.inventory[currencyId] >= totalPrice) {
             gameState.inventory[currencyId] -= totalPrice; // Subtracting the currency for buying.


### PR DESCRIPTION
### Motivation
- The “Buy required items” control was sometimes hidden or behaved inconsistently on process detail pages, and provided no accessible explanation when disabled.
- Process buying needed to support items priced in different currencies and to buy as many missing items as funds allow instead of failing silently.
- Provide deterministic, accessible UI behavior with explicit disabled reasons and correct currency bookkeeping.

### Description
- Always render the `Buy required items` button on process detail pages and compute an explicit disabled reason exposed via `aria-describedby` and a hover `title` for screen-reader accessibility in `frontend/src/pages/process/[slug]/ProcessView.svelte`.
- Add buy-planning helpers (`getPriceInfo`, `getRequiredPurchaseCandidates`, `getBuyPlan`) that detect missing requirements, skip non-buyable items, sort candidates by ascending `price * quantity`, and build a purchases list buying as many items as affordable.
- Make buys multi-currency-aware by resolving currency items from price symbols and passing an optional `currencyId` to `buyItems`; update `frontend/src/utils/gameState/inventory.js` so `buyItems` falls back to `dUSD` but honors `currencyId` when present.
- Update unit tests in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` to cover enabled purchase flow, always-rendered disabled state with explanation, and partial purchases when funds are limited.

### Testing
- Ran the focused component tests with `npx vitest run -c vitest.config.mts frontend/src/pages/process/\[slug\]/__tests__/ProcessView.spec.ts` and all tests passed (3 tests).
- Ran `npm run lint` in the repo and linting completed successfully.
- A full `npm run test:ci` was started in the environment but is a large suite and did not complete within the session window (pre-checks and build steps ran successfully before the long test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4f186f60832fa1f860de385cbf89)