### PR TITLE
Skip local Astro build setup in remote Playwright perf mode

### DIFF
--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -26,7 +26,35 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
-ensureAstroBuild();
+
+const shouldSkipLocalAstroBuildSetup = () => {
+    const remoteSmokeMode =
+        process.env.REMOTE_SMOKE === '1' || Boolean(process.env.QUESTS_PERF_BASE_URL?.trim());
+    const remoteMigrationMode = process.env.REMOTE_MIGRATION === '1';
+    const remoteCompletionistAwardIIIMode = process.env.REMOTE_COMPLETIONIST_AWARD_III === '1';
+    const remoteRunMode = remoteSmokeMode || remoteMigrationMode || remoteCompletionistAwardIIIMode;
+
+    if (!remoteRunMode) {
+        return false;
+    }
+
+    const useWebServerForRemoteSmoke = process.env.REMOTE_SMOKE_USE_WEBSERVER === '1';
+    const useWebServerForRemoteMigration = process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1';
+    const useWebServerForRemoteCompletionistAwardIII =
+        process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1';
+
+    return (
+        !useWebServerForRemoteSmoke &&
+        !useWebServerForRemoteMigration &&
+        !useWebServerForRemoteCompletionistAwardIII
+    );
+};
+
+if (shouldSkipLocalAstroBuildSetup()) {
+    console.log('Remote Playwright mode detected; skipping local Astro build setup.');
+} else {
+    ensureAstroBuild();
+}
 
 const readExistingBuildMetaSha = async () => {
     const buildMetaPath = path.join(rootDir, 'src', 'generated', 'build_meta.json');


### PR DESCRIPTION
### Motivation
- Remote Playwright perf runs were triggering an unnecessary local Astro build via `setup-test-env.js`, flooding logs with Astro "Unsupported file type" warnings when `QUESTS_PERF_BASE_URL` is used and no local webserver is needed.
- Align `setup-test-env.js` with the remote/webserver semantics already used in `frontend/playwright.config.ts` so remote perf runs remain lightweight and quiet.

### Description
- Add a small helper in `frontend/scripts/setup-test-env.js` that detects remote Playwright modes (`REMOTE_SMOKE`, `REMOTE_MIGRATION`, `REMOTE_COMPLETIONIST_AWARD_III`) and skips `ensureAstroBuild()` unless the corresponding `*_USE_WEBSERVER=1` override is set.
- Treat a non-empty `QUESTS_PERF_BASE_URL` as remote smoke context so `perf:quests`/`perf:quests:slowcpu` can skip local build prep before `run-quests-perf.mjs` sets `REMOTE_SMOKE=1`.
- Leave all directory creation, permissions, placeholder file, and build-meta behavior unchanged, and log a short message when skipping: `Remote Playwright mode detected; skipping local Astro build setup.`

### Testing
- Ran `npm --prefix frontend run test -- --runInBand` which failed because Vitest in this repo does not accept `--runInBand` (error: `CACError: Unknown option --runInBand`).
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests` which printed `Remote Playwright mode detected; skipping local Astro build setup.` and did not run the local Astro rebuild or emit the prior Astro unsupported-file warnings, but the run later failed in this environment due to Playwright browser installation/network errors.
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu` which also printed the skip message and avoided the Astro rebuild warnings, and similarly failed later due to browser dependency/network issues in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2a768218832fbaf6c35f27159837)