### PR TITLE
Skip local Astro build setup for remote Playwright perf mode

### DIFF
--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -26,7 +26,31 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
-ensureAstroBuild();
+const isRemotePlaywrightMode = () => {
+    const remoteSmokeMode = process.env.REMOTE_SMOKE === '1';
+    const remoteMigrationMode = process.env.REMOTE_MIGRATION === '1';
+    const remoteCompletionistAwardIIIMode = process.env.REMOTE_COMPLETIONIST_AWARD_III === '1';
+    const useWebServerForRemoteSmoke = process.env.REMOTE_SMOKE_USE_WEBSERVER === '1';
+    const useWebServerForRemoteMigration = process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1';
+    const useWebServerForRemoteCompletionistAwardIII =
+        process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1';
+
+    const remoteRunMode =
+        remoteSmokeMode || remoteMigrationMode || remoteCompletionistAwardIIIMode;
+    const shouldUseWebServer =
+        !remoteRunMode ||
+        useWebServerForRemoteSmoke ||
+        useWebServerForRemoteMigration ||
+        useWebServerForRemoteCompletionistAwardIII;
+
+    return remoteRunMode && !shouldUseWebServer;
+};
+
+if (isRemotePlaywrightMode()) {
+    console.log('Remote Playwright mode detected; skipping local Astro build setup.');
+} else {
+    ensureAstroBuild();
+}
 
 const readExistingBuildMetaSha = async () => {
     const buildMetaPath = path.join(rootDir, 'src', 'generated', 'build_meta.json');


### PR DESCRIPTION
### Motivation
- Reduce noisy local Astro build warnings during remote Playwright perf runs by skipping an unnecessary local Astro build setup when targeting a remote `BASE_URL`, while preserving existing local-preview behavior and explicit webserver overrides.

### Description
- Added a small helper and gating logic in `frontend/scripts/setup-test-env.js` that mirrors the remote-mode semantics already used in `frontend/playwright.config.ts` and only calls `ensureAstroBuild()` when a local webServer is actually required.
- The helper recognizes remote modes (`REMOTE_SMOKE`, `REMOTE_MIGRATION`, `REMOTE_COMPLETIONIST_AWARD_III`) and their `*_USE_WEBSERVER` overrides, and emits the log line `Remote Playwright mode detected; skipping local Astro build setup.` when skipping the build, leaving directory/bootstrap/test-artifact setup unchanged.

### Testing
- Ran `npm --prefix frontend run test -- --runInBand` which failed in this environment due to the test runner rejecting `--runInBand` (`CACError: Unknown option --runInBand`).
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests` and observed the setup script print that it skipped the Astro rebuild (no unsupported-file warnings), but the Playwright run later failed due to environment network/browser-install limitations (ENETUNREACH / missing browser binary).
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu` with the same result: setup skipped local build and Playwright failed later because of external network/browser install issues.
- Confirmed the skip message locally with `REMOTE_SMOKE=1 node frontend/scripts/setup-test-env.js` which printed `Remote Playwright mode detected; skipping local Astro build setup.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2a768218832fbaf6c35f27159837)