### PR TITLE
Skip local Astro build setup for remote Playwright perf runs

### DIFF
--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -25,8 +25,35 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
+const shouldSkipLocalAstroBuildSetup = () => {
+    const remoteSmokeMode =
+        process.env.REMOTE_SMOKE === '1' || Boolean((process.env.QUESTS_PERF_BASE_URL || '').trim());
+    const remoteMigrationMode = process.env.REMOTE_MIGRATION === '1';
+    const remoteCompletionistAwardIIIMode = process.env.REMOTE_COMPLETIONIST_AWARD_III === '1';
+    const remoteRunMode = remoteSmokeMode || remoteMigrationMode || remoteCompletionistAwardIIIMode;
+
+    if (!remoteRunMode) {
+        return false;
+    }
+
+    const useWebServerForRemoteSmoke = process.env.REMOTE_SMOKE_USE_WEBSERVER === '1';
+    const useWebServerForRemoteMigration = process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1';
+    const useWebServerForRemoteCompletionistAwardIII =
+        process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1';
+    const shouldUseWebServer =
+        useWebServerForRemoteSmoke ||
+        useWebServerForRemoteMigration ||
+        useWebServerForRemoteCompletionistAwardIII;
+
+    return !shouldUseWebServer;
+};
+
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
-ensureAstroBuild();
+if (shouldSkipLocalAstroBuildSetup()) {
+    console.log('Remote Playwright mode detected; skipping local Astro build setup.');
+} else {
+    ensureAstroBuild();
+}
 
 const readExistingBuildMetaSha = async () => {
     const buildMetaPath = path.join(rootDir, 'src', 'generated', 'build_meta.json');


### PR DESCRIPTION
### Motivation
- Remote Playwright perf runs (when `QUESTS_PERF_BASE_URL` / remote flags are used) were triggering an unnecessary local `astro build` inside `setup-test-env.js`, flooding logs with Astro "Unsupported file type …" warnings.  
- The intent is to avoid that rebuild in remote mode while preserving existing local-preview and explicit override behavior.

### Description
- Added a small helper `shouldSkipLocalAstroBuildSetup()` to `frontend/scripts/setup-test-env.js` that returns true when Playwright remote modes are active and the corresponding `*_USE_WEBSERVER` override is not set.  
- The helper mirrors the remote-mode semantics used in `frontend/playwright.config.ts` (`REMOTE_SMOKE`, `REMOTE_MIGRATION`, `REMOTE_COMPLETIONIST_AWARD_III` and the `*_USE_WEBSERVER` flags) and also treats `QUESTS_PERF_BASE_URL` as remote-smoke intent so perf scripts behave correctly at setup time.  
- When skipping, the script emits the single-line message `Remote Playwright mode detected; skipping local Astro build setup.` and leaves all existing directory/bootstrap/test-artifact setup unchanged.

### Testing
- Ran `npm --prefix frontend run test -- --runInBand`, which executed `setup-test-env` successfully but the Vitest invocation failed in this environment because Vitest reported an unknown `--runInBand` option.  
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests`, and `setup-test-env` printed `Remote Playwright mode detected; skipping local Astro build setup.`; the subsequent Playwright run failed due to environment network/browser-install limitations, but the local Astro rebuild and its unsupported-file warning flood were not present.  
- Ran `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu`, and `setup-test-env` printed the same skip message; the perf run failed later for the same network/browser-install issues, and again the local Astro rebuild warnings were absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2a768218832fbaf6c35f27159837)