### PR TITLE
Sync quests-tti-baseline perf harness with rc.1 harness-only changes

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,10 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensurePlaywrightBrowsers } from './scripts/utils/ensure-playwright-browsers.js';
+import {
+    getActiveRemotePlaywrightModes,
+    shouldUsePlaywrightWebServer,
+} from './scripts/utils/playwright-remote-mode.js';
 
 if (process.env.CI) {
     await import('fake-indexeddb/auto');
@@ -208,19 +212,13 @@ function resolveProjects(): PlaywrightProjectConfig[] {
 
 const projects = resolveProjects();
 
-const remoteSmokeMode = process.env.REMOTE_SMOKE === '1';
-const remoteMigrationMode = process.env.REMOTE_MIGRATION === '1';
-const remoteCompletionistAwardIIIMode = process.env.REMOTE_COMPLETIONIST_AWARD_III === '1';
-const useWebServerForRemoteSmoke = process.env.REMOTE_SMOKE_USE_WEBSERVER === '1';
-const useWebServerForRemoteMigration = process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1';
-const useWebServerForRemoteCompletionistAwardIII =
-    process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1';
-const remoteRunMode = remoteSmokeMode || remoteMigrationMode || remoteCompletionistAwardIIIMode;
-const shouldUseWebServer =
-    !remoteRunMode ||
-    useWebServerForRemoteSmoke ||
-    useWebServerForRemoteMigration ||
-    useWebServerForRemoteCompletionistAwardIII;
+const activeRemoteModes = getActiveRemotePlaywrightModes();
+const remoteSmokeMode = activeRemoteModes.some(({ name }) => name === 'remoteSmoke');
+const remoteMigrationMode = activeRemoteModes.some(({ name }) => name === 'remoteMigration');
+const remoteCompletionistAwardIIIMode = activeRemoteModes.some(
+    ({ name }) => name === 'remoteCompletionistAwardIII'
+);
+const shouldUseWebServer = shouldUsePlaywrightWebServer();
 
 if (shouldUseWebServer) {
     ensureAstroBuildArtifacts();

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 const baseEnv = { ...process.env };
 const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
@@ -10,13 +9,16 @@ if (requestedBaseUrl) {
     baseEnv.REMOTE_SMOKE = '1';
 }
 
-const frontendRoot = fileURLToPath(new URL('..', import.meta.url));
+const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
+if (cpuSlowdown) {
+    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
+}
 
 const result = spawnSync(
     'playwright',
     ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
     {
-        cwd: frontendRoot,
+        cwd: new URL('..', import.meta.url),
         stdio: 'inherit',
         env: baseEnv,
         shell: true,

--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -12,6 +12,35 @@ import { fileURLToPath } from 'url';
 import fsPromises from 'fs/promises';
 import { resolveBuildMeta, writeBuildMeta } from '../../scripts/write-build-meta.mjs';
 
+const isRemotePlaywrightModeWithoutWebServerOverride = () => {
+    const remoteModeMatrix = [
+        {
+            active:
+                process.env.REMOTE_SMOKE === '1' ||
+                // Keep QUESTS_PERF_BASE_URL as an early remote signal: run-quests-perf.mjs
+                // sets REMOTE_SMOKE later, after this setup script has already run.
+                Boolean(process.env.QUESTS_PERF_BASE_URL?.trim()),
+            useWebServer: process.env.REMOTE_SMOKE_USE_WEBSERVER === '1',
+        },
+        {
+            active: process.env.REMOTE_MIGRATION === '1',
+            useWebServer: process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1',
+        },
+        {
+            active: process.env.REMOTE_COMPLETIONIST_AWARD_III === '1',
+            useWebServer: process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1',
+        },
+    ];
+
+    const activeRemoteModes = remoteModeMatrix.filter(({ active }) => active);
+
+    if (activeRemoteModes.length === 0) {
+        return false;
+    }
+
+    return activeRemoteModes.some(({ useWebServer }) => !useWebServer);
+};
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
@@ -26,7 +55,12 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
-ensureAstroBuild();
+
+if (isRemotePlaywrightModeWithoutWebServerOverride()) {
+    console.log('Remote Playwright mode detected; skipping local Astro build setup.');
+} else {
+    ensureAstroBuild();
+}
 
 const readExistingBuildMetaSha = async () => {
     const buildMetaPath = path.join(rootDir, 'src', 'generated', 'build_meta.json');

--- a/frontend/scripts/utils/playwright-remote-mode.js
+++ b/frontend/scripts/utils/playwright-remote-mode.js
@@ -1,0 +1,45 @@
+const isEnabled = (value) => value === '1';
+
+const hasQuestsPerfBaseUrl = () => Boolean(process.env.QUESTS_PERF_BASE_URL?.trim());
+
+export const REMOTE_PLAYWRIGHT_MODE_CONFIGS = Object.freeze([
+    {
+        name: 'remoteSmoke',
+        isEnabled: ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+            isEnabled(process.env.REMOTE_SMOKE) ||
+            // run-quests-perf.mjs sets REMOTE_SMOKE after setup-test-env.js runs,
+            // so setup-test-env opts into this earlier QUESTS_PERF_BASE_URL signal.
+            (includeQuestsPerfBaseUrlSignal && hasQuestsPerfBaseUrl()),
+        useWebServerEnv: 'REMOTE_SMOKE_USE_WEBSERVER',
+    },
+    {
+        name: 'remoteMigration',
+        isEnabled: () => isEnabled(process.env.REMOTE_MIGRATION),
+        useWebServerEnv: 'REMOTE_MIGRATION_USE_WEBSERVER',
+    },
+    {
+        name: 'remoteCompletionistAwardIII',
+        isEnabled: () => isEnabled(process.env.REMOTE_COMPLETIONIST_AWARD_III),
+        useWebServerEnv: 'REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER',
+    },
+]);
+
+export const getActiveRemotePlaywrightModes = ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+    REMOTE_PLAYWRIGHT_MODE_CONFIGS.filter(({ isEnabled }) =>
+        isEnabled({ includeQuestsPerfBaseUrlSignal })
+    );
+
+export const isRemotePlaywrightModeWithoutWebServerOverride = ({
+    includeQuestsPerfBaseUrlSignal = false,
+} = {}) => {
+    const activeRemoteModes = getActiveRemotePlaywrightModes({ includeQuestsPerfBaseUrlSignal });
+
+    if (activeRemoteModes.length === 0) {
+        return false;
+    }
+
+    return activeRemoteModes.every(({ useWebServerEnv }) => process.env[useWebServerEnv] !== '1');
+};
+
+export const shouldUsePlaywrightWebServer = ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+    !isRemotePlaywrightModeWithoutWebServerOverride({ includeQuestsPerfBaseUrlSignal });


### PR DESCRIPTION
### Motivation
- Bring the baseline measurement harness into parity with the `v3.0.1-rc.1` harness behavior so baseline and optimized candidates are measured with identical harness plumbing.
- Achieve parity only in harness files and preserve existing baseline `/quests` runtime behavior and timing semantics.

### Description
- Add a shared remote-mode helper at `frontend/scripts/utils/playwright-remote-mode.js` to centralize remote-run detection and webserver gating. 
- Wire the helper into `frontend/playwright.config.ts` and switch Playwright remote-mode detection to use the centralized logic. 
- Update `frontend/scripts/setup-test-env.js` to skip local Astro build setup when an early remote perf signal (including `QUESTS_PERF_BASE_URL`) indicates remote Playwright mode. 
- Update `frontend/scripts/run-quests-perf.mjs` to propagate `QUESTS_TTI_CPU_SLOWDOWN` and align invocation/cwd behavior with rc.1. 

### Testing
- Diff summary after changes: `frontend/playwright.config.ts                    | 24 ++++++-------` `frontend/scripts/run-quests-perf.mjs             |  8 +++--` `frontend/scripts/setup-test-env.js               | 36 ++++++++++++++++++-` `frontend/scripts/utils/playwright-remote-mode.js | 45 ++++++++++++++++++++++++` (4 files changed, 96 insertions(+), 17 deletions(-)).
- Ran `npm --prefix frontend run perf:quests` which failed in this environment due to Playwright browser/dependency downloads failing with network errors (`ENETUNREACH`) and a missing Chromium executable. 
- Ran `npm --prefix frontend run perf:quests:slowcpu` which failed for the same reason (`ENETUNREACH` during Playwright install/download).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc76937560832fa7bfd8393c13b7d9)