### PR TITLE
Sync quests-tti-baseline perf harness with rc.1 harness-only changes

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,10 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensurePlaywrightBrowsers } from './scripts/utils/ensure-playwright-browsers.js';
+import {
+    getActiveRemotePlaywrightModes,
+    shouldUsePlaywrightWebServer,
+} from './scripts/utils/playwright-remote-mode.js';
 
 if (process.env.CI) {
     await import('fake-indexeddb/auto');
@@ -208,19 +212,13 @@ function resolveProjects(): PlaywrightProjectConfig[] {
 
 const projects = resolveProjects();
 
-const remoteSmokeMode = process.env.REMOTE_SMOKE === '1';
-const remoteMigrationMode = process.env.REMOTE_MIGRATION === '1';
-const remoteCompletionistAwardIIIMode = process.env.REMOTE_COMPLETIONIST_AWARD_III === '1';
-const useWebServerForRemoteSmoke = process.env.REMOTE_SMOKE_USE_WEBSERVER === '1';
-const useWebServerForRemoteMigration = process.env.REMOTE_MIGRATION_USE_WEBSERVER === '1';
-const useWebServerForRemoteCompletionistAwardIII =
-    process.env.REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER === '1';
-const remoteRunMode = remoteSmokeMode || remoteMigrationMode || remoteCompletionistAwardIIIMode;
-const shouldUseWebServer =
-    !remoteRunMode ||
-    useWebServerForRemoteSmoke ||
-    useWebServerForRemoteMigration ||
-    useWebServerForRemoteCompletionistAwardIII;
+const activeRemoteModes = getActiveRemotePlaywrightModes();
+const remoteSmokeMode = activeRemoteModes.some(({ name }) => name === 'remoteSmoke');
+const remoteMigrationMode = activeRemoteModes.some(({ name }) => name === 'remoteMigration');
+const remoteCompletionistAwardIIIMode = activeRemoteModes.some(
+    ({ name }) => name === 'remoteCompletionistAwardIII'
+);
+const shouldUseWebServer = shouldUsePlaywrightWebServer();
 
 if (shouldUseWebServer) {
     ensureAstroBuildArtifacts();

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -9,10 +9,7 @@ if (requestedBaseUrl) {
     baseEnv.REMOTE_SMOKE = '1';
 }
 
-const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
-if (cpuSlowdown) {
-    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
-}
+// QUESTS_TTI_CPU_SLOWDOWN is forwarded automatically via baseEnv = { ...process.env }.
 
 const result = spawnSync(
     'playwright',

--- a/frontend/scripts/run-quests-perf.mjs
+++ b/frontend/scripts/run-quests-perf.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 const baseEnv = { ...process.env };
 const requestedBaseUrl = (baseEnv.QUESTS_PERF_BASE_URL || '').trim();
@@ -10,13 +9,16 @@ if (requestedBaseUrl) {
     baseEnv.REMOTE_SMOKE = '1';
 }
 
-const frontendRoot = fileURLToPath(new URL('..', import.meta.url));
+const cpuSlowdown = (baseEnv.QUESTS_TTI_CPU_SLOWDOWN || '').trim();
+if (cpuSlowdown) {
+    baseEnv.QUESTS_TTI_CPU_SLOWDOWN = cpuSlowdown;
+}
 
 const result = spawnSync(
     'playwright',
     ['test', 'e2e/quests-tti-metrics.spec.ts', '--project=chromium'],
     {
-        cwd: frontendRoot,
+        cwd: new URL('..', import.meta.url),
         stdio: 'inherit',
         env: baseEnv,
         shell: true,

--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -11,6 +11,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fsPromises from 'fs/promises';
 import { resolveBuildMeta, writeBuildMeta } from '../../scripts/write-build-meta.mjs';
+import { isRemotePlaywrightModeWithoutWebServerOverride } from './utils/playwright-remote-mode.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,7 +27,11 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
-ensureAstroBuild();
+if (isRemotePlaywrightModeWithoutWebServerOverride({ includeQuestsPerfBaseUrlSignal: true })) {
+    console.log('Remote Playwright mode detected; skipping local Astro build setup.');
+} else {
+    ensureAstroBuild();
+}
 
 const readExistingBuildMetaSha = async () => {
     const buildMetaPath = path.join(rootDir, 'src', 'generated', 'build_meta.json');

--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -28,6 +28,7 @@ if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');
 if (isRemotePlaywrightModeWithoutWebServerOverride({ includeQuestsPerfBaseUrlSignal: true })) {
+    // Keep this message stable for remote perf verification commands in PR evidence.
     console.log('Remote Playwright mode detected; skipping local Astro build setup.');
 } else {
     ensureAstroBuild();

--- a/frontend/scripts/utils/playwright-remote-mode.js
+++ b/frontend/scripts/utils/playwright-remote-mode.js
@@ -1,0 +1,45 @@
+const isEnabled = (value) => value === '1';
+
+const hasQuestsPerfBaseUrl = () => Boolean(process.env.QUESTS_PERF_BASE_URL?.trim());
+
+export const REMOTE_PLAYWRIGHT_MODE_CONFIGS = Object.freeze([
+    {
+        name: 'remoteSmoke',
+        isEnabled: ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+            isEnabled(process.env.REMOTE_SMOKE) ||
+            // run-quests-perf.mjs sets REMOTE_SMOKE after setup-test-env.js runs,
+            // so setup-test-env opts into this earlier QUESTS_PERF_BASE_URL signal.
+            (includeQuestsPerfBaseUrlSignal && hasQuestsPerfBaseUrl()),
+        useWebServerEnv: 'REMOTE_SMOKE_USE_WEBSERVER',
+    },
+    {
+        name: 'remoteMigration',
+        isEnabled: () => isEnabled(process.env.REMOTE_MIGRATION),
+        useWebServerEnv: 'REMOTE_MIGRATION_USE_WEBSERVER',
+    },
+    {
+        name: 'remoteCompletionistAwardIII',
+        isEnabled: () => isEnabled(process.env.REMOTE_COMPLETIONIST_AWARD_III),
+        useWebServerEnv: 'REMOTE_COMPLETIONIST_AWARD_III_USE_WEBSERVER',
+    },
+]);
+
+export const getActiveRemotePlaywrightModes = ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+    REMOTE_PLAYWRIGHT_MODE_CONFIGS.filter(({ isEnabled }) =>
+        isEnabled({ includeQuestsPerfBaseUrlSignal })
+    );
+
+export const isRemotePlaywrightModeWithoutWebServerOverride = ({
+    includeQuestsPerfBaseUrlSignal = false,
+} = {}) => {
+    const activeRemoteModes = getActiveRemotePlaywrightModes({ includeQuestsPerfBaseUrlSignal });
+
+    if (activeRemoteModes.length === 0) {
+        return false;
+    }
+
+    return activeRemoteModes.every(({ useWebServerEnv }) => process.env[useWebServerEnv] !== '1');
+};
+
+export const shouldUsePlaywrightWebServer = ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
+    !isRemotePlaywrightModeWithoutWebServerOverride({ includeQuestsPerfBaseUrlSignal });


### PR DESCRIPTION
### Motivation
- Bring the baseline perf measurement harness on `quests-tti-baseline` into parity with the `v3.0.1-rc.1` harness behavior so baseline and optimized candidates can be measured with byte-for-byte identical harness code. 
- Make this change restricted to harness-only plumbing and ensure no `/quests` runtime/product behavior is modified.

### Description
- Add a shared remote-mode helper at `frontend/scripts/utils/playwright-remote-mode.js` that centralizes detection for `REMOTE_SMOKE`, `REMOTE_MIGRATION`, and `REMOTE_COMPLETIONIST_AWARD_III` and handles the early `QUESTS_PERF_BASE_URL` signal. 
- Update `frontend/playwright.config.ts` to import and use `getActiveRemotePlaywrightModes` and `shouldUsePlaywrightWebServer` so Playwright web-server/build behavior follows the same centralized remote-mode logic. 
- Update `frontend/scripts/setup-test-env.js` to consult the shared helper and skip the local Astro build when remote perf mode is active, printing `Remote Playwright mode detected; skipping local Astro build setup.` in that case. 
- Tweak `frontend/scripts/run-quests-perf.mjs` to pass through `QUESTS_TTI_CPU_SLOWDOWN` when provided and to use a `URL('..', import.meta.url)` working-directory resolution consistent with rc.1 while keeping the same target test `e2e/quests-tti-metrics.spec.ts` unchanged.

### Testing
- Ran `git diff --stat` and observed the small, harness-only diff: `frontend/playwright.config.ts | 24 ++++++-------, frontend/scripts/run-quests-perf.mjs | 8 +++--, frontend/scripts/setup-test-env.js | 7 +++-, frontend/scripts/utils/playwright-remote-mode.js | 45 ++++++++++++++++++++++++` (total: 4 files changed, 67 insertions(+), 17 deletions(-)).
- Ran `npm --prefix frontend run perf:quests` (exit: `1`) and the run failed in this container due to Playwright browser dependency downloads failing with `ENETUNREACH` and then Chromium launch failing with `Executable doesn't exist .../chromium_headless_shell-1181/.../headless_shell` (environment network limitations, not a harness regression). 
- Ran `npm --prefix frontend run perf:quests:slowcpu` (exit: `1`) and observed the same network/browser-download failure mode as above (environment limitation). 
- Verified harness behavior for remote perf signaling by running `QUESTS_PERF_BASE_URL=http://127.0.0.1:4173 node frontend/scripts/setup-test-env.js` which printed `Remote Playwright mode detected; skipping local Astro build setup.` confirming the skip-local-build path is wired correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc76937560832fa7bfd8393c13b7d9)