### PR TITLE
docs/qa: check off /quests v3.0.1 performance gate with baseline vs optimized evidence

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -174,9 +174,9 @@ Required marks/measures:
 - `quests:time-to-snapshot-classification`
 - `quests:time-to-full-reconciliation`
 
-- [ ] Same seeded account, route, browser profile, and CPU settings across both candidates
-- [ ] Raw harness output + at least one DevTools trace per candidate attached to release evidence
-- [ ] Go/no-go decision is based on comparable cold-run data
+- [x] Same seeded account, route, browser profile, and CPU settings across both candidates
+- [x] Raw harness output + at least one DevTools trace per candidate attached to release evidence
+- [x] Go/no-go decision is based on comparable cold-run data
 
 ### 4.2 Built-in quest correctness
 


### PR DESCRIPTION
## Summary

This PR checks off the three `docs/qa/v3.0.1.md` §4.1 performance-gate checkboxes for the `/quests` baseline-vs-optimized comparison and links them to attached release evidence.

Specifically, this updates the checklist to reflect that:

- the same seeded account / route / browser profile / CPU settings were used across both candidates
- raw harness output and at least one DevTools trace per candidate were captured and attached to release evidence
- the go/no-go decision is based on comparable cold-run data

## Candidates compared

1. Instrumented baseline candidate branched from `3ec45a5517a35c96767f6b946c01104e6ec88f93`
   - deployed artifact: `v3.0.0-perf-baseline.2-fd4c863`
   - baseline harness-sync commit: `fd4c86300eab93434dbd1aef1b8413ecc40aedef`

2. Optimized `v3.0.1-rc.1` candidate
   - release tag: `v3.0.1-rc.1`
   - deployed immutable artifact: `main-4cd6007`
   - commit SHA: `4cd600734718dedf4225f67ed1e9f4d6f412e2fd`

## Test methodology

All measurements were captured on the same Mac Mini M4 using the same local harness path and the same staging host:

- `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests`
- `QUESTS_PERF_BASE_URL=https://staging.democratized.space npm --prefix frontend run perf:quests:slowcpu`

Environment consistency notes:

- same machine
- same staging URL
- same Playwright Chromium executable
- same 1-worker execution
- same remote-mode skip-local-build behavior
- same normal and 4x CPU-throttled command pair

The baseline and optimized candidates were both measured after the baseline harness was brought into parity with the rc.1 harness, so the compared runs use byte-for-byte identical harness code on the allowed harness surface.

## Result

`v3.0.1-rc.1` materially outperformed the instrumented baseline.

Key comparable measures:

### Normal run

- baseline `quests:time-to-list-visible`: `30.3`
- rc.1 `quests:time-to-list-visible`: `0.3`

- baseline `quests:time-to-full-reconciliation`: `72.6`
- rc.1 `quests:time-to-full-reconciliation`: `0.7`

### Slow CPU run

- baseline `quests:time-to-list-visible`: `115.5`
- rc.1 `quests:time-to-list-visible`: `1.9`

- baseline `quests:time-to-full-reconciliation`: `262.6`
- rc.1 `quests:time-to-full-reconciliation`: `6.2`

Interpretation:

- `/quests` list-path performance improved substantially versus the v3.0.0 baseline
- the improvement remains clear under 4x CPU throttling
- this supports a go decision for the `/quests` performance gate in `v3.0.1`

## Evidence attached to PR

Attached to a PR comment / release-evidence comment:

- raw perf log: optimized candidate
- raw perf log: baseline candidate
- DevTools trace: optimized candidate
- DevTools trace: baseline candidate

## Notes

- Baseline intentionally does not emit `quests:custom-quests-merge-complete`; that field remains `null` on baseline and is not used as the primary comparison point.
- This PR is evidence/checklist-only and does not change runtime behavior.