### PR TITLE
Update QA documentation with performance evidence links

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -175,8 +175,13 @@ Required marks/measures:
 - `quests:time-to-full-reconciliation`
 
 - [x] Same seeded account, route, browser profile, and CPU settings across both candidates
+  - Evidence: [raw perf logs](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234251554), [DevTools traces](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234258451)
+
 - [x] Raw harness output + at least one DevTools trace per candidate attached to release evidence
+  - Evidence: [raw perf logs](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234251554), [DevTools traces](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234258451)
+
 - [x] Go/no-go decision is based on comparable cold-run data
+  - Evidence: [comparison summary + raw perf logs](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234251554), [DevTools traces](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234258451)
 
 ### 4.2 Built-in quest correctness
 


### PR DESCRIPTION
This pull request adds explicit evidence links to the QA documentation to support key verification steps in the release process. The main improvement is making it easier to find and review the raw performance logs and DevTools traces associated with the QA checklist items.

Documentation improvements:

* Added direct links to raw performance logs and DevTools traces as evidence for using the same seeded account, route, browser profile, and CPU settings across both candidates in `docs/qa/v3.0.1.md`.
* Included evidence links for attaching raw harness output and DevTools traces per candidate to release evidence.
* Provided evidence links for the go/no-go decision based on comparable cold-run data.Added evidence links for performance logs and traces in the QA documentation.

## Summary
- [ ] Summarize your changes
- [ ] Confirm `npm run check` passes
- [ ] Confirm `SKIP_E2E=1 npm run test:pr` passes (or `npm run test:pr` if Playwright browsers are installed)

## Testing
Provide a brief summary of test results.

