### PR TITLE
📝 docs: add restrained /quests perf note to v3.0.1 addendum

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,12 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
+
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom
+  coexistence behavior. In validated baseline-vs-rc.1 QA harness runs, cold-run
+  `quests:time-to-list-visible` dropped from `30.3` to `0.3` and
+  `quests:time-to-full-reconciliation` from `72.6` to `0.7`; under 4x CPU throttling,
+  the same timings dropped from `115.5` to `1.9` and `262.6` to `6.2`.
+


### PR DESCRIPTION
### Motivation
- Record a concise, restrained QA-harness summary in the v3.0.1 patch addendum so the changelog captures the validated `/quests` list-path improvement without overstating real-world guarantees.

### Description
- Added a single bullet to the `June 1, 2026 — DSPACE v3.0.1 (patch addendum)` section in `frontend/src/pages/docs/md/changelog/20260401.md` that notes baseline-vs-rc.1 QA harness timings for `quests:time-to-list-visible` and `quests:time-to-full-reconciliation` for normal and 4x CPU-throttled runs, using modest, release-note appropriate wording; no other files were changed.

### Testing
- Ran the repository validation checks used during the update, including the secret scan invoked as `git diff --cached | ./scripts/scan-secrets.py` and verified the edit with `git diff --stat`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8d4dcc64832fb58d4ba6c239c25a)