### PR TITLE
📝 docs(changelog): add measured /quests perf note to v3.0.1 addendum

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,10 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
+
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom
+  coexistence behavior. In validated baseline-vs-patch QA harness runs, cold-run list-visible
+  timing dropped from 30.3 to 0.3 and full reconciliation dropped from 72.6 to 0.7; under 4x CPU
+  throttling, those timings dropped from 115.5 to 1.9 and 262.6 to 6.2.


### PR DESCRIPTION
### Motivation
- Capture a concise, restrained QA-harness summary for the `/quests` list-path improvement in the v3.0.1 patch addendum so the changelog records validated baseline-vs-patch measurements without overselling real-world guarantees.

### Description
- Updated `frontend/src/pages/docs/md/changelog/20260401.md` to add a single bullet under "June 1, 2026 — DSPACE v3.0.1 (patch addendum)" that reports the validated cold-run and 4x CPU-throttled `quests` list-visible and full-reconciliation timings (baseline vs rc.1) while leaving all other content unchanged.

### Testing
- No automated tests were run because this is a docs-only markdown change; the edit was verified via a local file preview and `git diff --stat` showing a single-file, small diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8d4dcc64832fb58d4ba6c239c25a)