### PR TITLE
docs: refine /quests performance note in v3.0.1 changelog addendum

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -132,3 +132,18 @@ achievements and actual space development.
 
 v3 is the biggest DSPACE update yet, and it lays the groundwork for faster content releases moving
 forward.
+
+
+---
+
+## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
+
+`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening.
+
+### Patch notes
+
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; in validated baseline-vs-`v3.0.1-rc.1` QA harness runs, cold-run `quests:time-to-list-visible` dropped from `30.3` to `0.3` and `quests:time-to-full-reconciliation` dropped from `72.6` to `0.7`, while 4x CPU-throttled runs dropped from `115.5` to `1.9` and `262.6` to `6.2`.
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
+- **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
+- **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
+- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.


### PR DESCRIPTION
### Motivation
- Make the v3.0.1 patch addendum explicitly record validated QA-harness timing deltas for the `/quests` list-path so the changelog reflects measured improvements without overselling real-world guarantees.

### Description
- Edited `frontend/src/pages/docs/md/changelog/20260401.md` to update the existing **`/quests`** patch bullet with concise, restrained QA harness numbers (cold-run and 4x CPU-throttled `time-to-list-visible` and `time-to-full-reconciliation`) and kept the change localized to the v3.0.1 addendum.

### Testing
- This is a docs-only change; ran the repository secret scan on the staged diff with `git diff --cached | ./scripts/scan-secrets.py` which passed, and verified the patch with `git diff --stat` (one file changed, 15 insertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8d4dcc64832fb58d4ba6c239c25a)