### PR TITLE
chore(docs): add QA performance metrics to `/quests` changelog entry

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,7 +141,9 @@ forward.
 
 ### Patch notes
 
-- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA, with cold-run list-visible/full-reconciliation dropping from 30.3/72.6 to 0.3/0.7 (~101x/~104x faster) and 4x CPU-throttled runs dropping from 115.5/262.6 to 1.9/6.2 (~61x/~42x faster).
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA:
+  - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
+  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
 - **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
 - **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
 - **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,7 +141,7 @@ forward.
 
 ### Patch notes
 
-- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior.
+- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA, with cold-run list-visible/full-reconciliation dropping from 30.3/72.6 to 0.3/0.7 (~101x/~104x faster) and 4x CPU-throttled runs dropping from 115.5/262.6 to 1.9/6.2 (~61x/~42x faster).
 - **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
 - **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
 - **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.


### PR DESCRIPTION
### Motivation

- Clarify and quantify the `/quests` list-path performance improvements observed in QA by adding concrete timing and speedup numbers to the changelog.

### Description

- Update `frontend/src/pages/docs/md/changelog/20260401.md` to augment the `/quests` patch note with measured cold-run and 4x CPU-throttled timing values and approximate speedups, replacing the shorter summary with explicit timings and multipliers.

### Testing

- Documentation-only change; automated CI checks for linting and docs build were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8e68703c832fb2ac12ee439b24e1)