### PR TITLE
fix(quests): hide non-startable custom quests and remove 'Locked' tile label

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -200,4 +200,39 @@ describe('Quests Component', () => {
             vi.useRealTimers();
         }
     });
+
+    it('renders only startable custom quests and omits locked cards from the custom section', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => {
+                if (quest.id === 'custom/locked') {
+                    return { ...quest, status: 'locked' };
+                }
+                if (quest.id === 'custom/done') {
+                    return { ...quest, status: 'completed' };
+                }
+                return { ...quest, status: 'available' };
+            })
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            { id: 'custom/locked', title: 'Locked Custom Quest' },
+            { id: 'custom/startable', title: 'Startable Custom Quest' },
+            { id: 'custom/done', title: 'Completed Custom Quest' },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const customSection = host.querySelector("[data-testid='custom-quests-section']");
+            expect(customSection).not.toBeNull();
+            expect(customSection?.textContent).toContain('Startable Custom Quest');
+            expect(customSection?.textContent).not.toContain('Locked Custom Quest');
+            expect(customSection?.textContent).not.toContain('Completed Custom Quest');
+            expect(customSection?.textContent).not.toContain('Locked');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -10,18 +10,14 @@
             ? 'Completed'
             : status === 'available'
               ? ''
-              : status === 'locked'
-                ? 'Locked'
-                : 'Checking';
+              : 'Checking';
 
     $: assistiveStatusLabel =
         status === 'available'
             ? 'Available'
             : status === 'completed'
               ? 'Completed'
-              : status === 'locked'
-                ? 'Locked'
-                : statusLabel;
+              : statusLabel;
 </script>
 
 <div class="container" class:quest data-testid="quest-tile" data-status={status}>

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -40,6 +40,7 @@
     let activeBuiltInQuests = [];
     let customQuestRecords = [];
     let customClassified = [];
+    let activeCustomQuests = [];
     let customMergeComplete = false;
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
@@ -103,6 +104,7 @@
     const classifyCustomQuests = (snapshot) => {
         const normalizedCustomQuests = normalizeQuestList(customQuestRecords);
         customClassified = classifyQuestList({ quests: normalizedCustomQuests, snapshot });
+        activeCustomQuests = customClassified.filter((quest) => quest.status === 'available');
     };
 
     // Define buttons for easy expansion
@@ -220,7 +222,7 @@
         aria-hidden="true"
         data-testid="custom-quests-merge-status"
         data-merge-complete={customMergeComplete ? 'true' : 'false'}
-        data-custom-count={String(customClassified.length)}
+        data-custom-count={String(activeCustomQuests.length)}
     ></div>
 
     {#if showQuestGraphVisualizer}
@@ -229,11 +231,11 @@
         </div>
     {/if}
 
-    {#if customMergeComplete && customClassified.length > 0}
+    {#if customMergeComplete && activeCustomQuests.length > 0}
         <section class="custom-section" data-testid="custom-quests-section">
             <h2>Custom Quests</h2>
             <div class="quests-grid">
-                {#each customClassified as quest}
+                {#each activeCustomQuests as quest}
                     <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                         <Quest {quest} status={quest.status} />
                     </a>


### PR DESCRIPTION
### Motivation
- Custom quests that are not startable were being shown on `/quests` with a visible `Locked` label due to TTI/delayed-merge optimizations, which regressed the expected v3.0.0 behavior where non-startable custom quests are not displayed at all. 
- The intent is to preserve the delayed custom-merge performance improvements from v3.0.1 while restoring correct gating/display behavior for custom quests.

### Description
- Filter custom quest cards to only expose actionable entries by deriving `activeCustomQuests = customClassified.filter(q => q.status === 'available')` in `frontend/src/pages/quests/svelte/Quests.svelte`. 
- Change the custom-merge metadata exposed in the DOM to report only actionable custom count by updating `data-custom-count` to use `activeCustomQuests.length` in `Quests.svelte`. 
- Remove explicit `Locked` string rendering from the quest tile status so tiles no longer display a `Locked` label by deleting the `status === 'locked' ? 'Locked'` branch in `frontend/src/pages/quests/svelte/Quest.svelte`. 
- Add a regression unit test `renders only startable custom quests and omits locked cards from the custom section` in `frontend/__tests__/Quests.test.js` to assert locked/completed custom quests are omitted while startable ones appear.

### Testing
- Ran the focused unit test suite with `npx vitest run -c vitest.config.mts frontend/__tests__/Quests.test.js`, and the file-level run passed: `frontend/__tests__/Quests.test.js (6 tests) — all passed`.
- Executed the repository secret-scan via `git diff --cached | ./scripts/scan-secrets.py` with no findings. 
- The changes keep the existing delayed merge flow intact (`__questsCustomMergeDelayMs` handling) and are covered by the new unit test verifying visible custom tiles are only `available` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd6877df8832f99f46d11e139f40e)