### PR TITLE
docs: add v3.0.1-rc.2 release metadata to v3.0.1 QA checklist

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.1`.
+> current candidate under validation: `v3.0.1-rc.2`.
 
 Related docs:
 
@@ -17,7 +17,17 @@ Related docs:
 
 ---
 
-## 0) Patch scope summary (required read before testing)
+## 0) Release metadata
+
+> Historical tags are tracked canonically in [docs/releases.md](../releases.md).
+> This section is a release-specific snapshot for v3.0.1 QA context.
+
+| Tag name | Commit SHA | Notes |
+| --- | --- | --- |
+| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that supersedes rc.1 for final validation/signoff. |
+| [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline. |
+
+## 1) Patch scope summary (required read before testing)
 
 `v3.0.1` patch themes to validate end-to-end:
 
@@ -32,7 +42,7 @@ Related docs:
 
 ---
 
-### 0.1 Commit-range audit (required before checklist execution)
+### 1.1 Commit-range audit (required before checklist execution)
 
 Derive this checklist from the audited patch delta first, then execute QA against that scoped delta.
 Run these exact commands and attach output to release evidence:
@@ -53,10 +63,10 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 
 ---
 
-## 1) Release metadata + signoff
+## 2) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.1`
+- [ ] Candidate tag under test: `v3.0.1-rc.2`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`
@@ -67,7 +77,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 
 ---
 
-## 2) Automated checks (required launch gates)
+## 3) Automated checks (required launch gates)
 
 Run from repo root unless noted:
 
@@ -109,7 +119,7 @@ npm run qa:remote-smoke -- --baseURL=https://staging.democratized.space --chat-m
 
 ---
 
-## 3) Staging deploy + health validation (required)
+## 4) Staging deploy + health validation (required)
 
 Deploy the immutable candidate to `https://staging.democratized.space`.
 
@@ -135,21 +145,21 @@ Evidence captured in Codex session (2026-04-11 UTC):
 
 - `curl -fsS https://staging.democratized.space/config.json` returned JSON with
   `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
-  `"featureFlags":[]` (captured for runtime-config visibility; expected v3.0.1-rc.1-specific
+  `"featureFlags":[]` (captured for runtime-config visibility; expected v3.0.1-rc.2-specific
   config parity still pending).
 - `curl -fsS https://staging.democratized.space/healthz` returned JSON with
   `"status":"ready"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match `v3.0.1-rc.1`; keep the expected-version checkbox open until the RC artifact is
+  not match `v3.0.1-rc.2`; keep the expected-version checkbox open until the RC artifact is
   deployed (or documented as commit-equivalent).
 
 ---
 
-## 4) `/quests` validation (required)
+## 5) `/quests` validation (required)
 
-### 4.1 Performance gate (baseline vs optimized)
+### 5.1 Performance gate (baseline vs optimized)
 
 Run a strict two-candidate comparison on staging:
 
@@ -183,13 +193,13 @@ Required marks/measures:
 - [x] Go/no-go decision is based on comparable cold-run data
   - Evidence: [comparison summary + raw perf logs](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234251554), [DevTools traces](https://github.com/democratizedspace/dspace/pull/4337#issuecomment-4234258451)
 
-### 4.2 Built-in quest correctness
+### 5.2 Built-in quest correctness
 
 - [x] `/quests` shows only actionable built-in quests in the primary grid (no locked built-ins in the active grid)
 - [x] Completed built-ins remain in the completed section
 - [x] No incorrect optimistic `Start`/`Continue` affordance appears before authoritative reconciliation
 
-### 4.3 Custom quest regressions and coexistence (critical)
+### 5.3 Custom quest regressions and coexistence (critical)
 
 - [x] Custom quests still load from local custom content storage
 - [x] Custom quest section appears only after merge completion, without displacing built-in cards
@@ -200,16 +210,16 @@ Required marks/measures:
 
 ---
 
-## 5) `/processes` validation (required)
+## 6) `/processes` validation (required)
 
-### 5.1 Summary-first list behavior
+### 6.1 Summary-first list behavior
 
 - [ ] `/processes` renders summary rows (title, duration, requires/consumes/creates counts)
 - [x] List route keeps detail controls out of rows (`Start`, `Pause`, `Resume`, `Collect`,
       `Buy required items` are not shown in list rows)
 - [x] Built-in processes appear immediately on list load
 
-### 5.2 Custom process merge and coexistence (critical)
+### 6.2 Custom process merge and coexistence (critical)
 
 - [ ] Custom processes merge after list load and are labeled/identifiable as custom
 - [ ] Custom content must continue to function correctly alongside built-in content
@@ -217,7 +227,7 @@ Required marks/measures:
 - [ ] `View details` links resolve correctly for both built-in and custom processes
 - [ ] Mixed-state scenario: with active built-in process progress present, load/import custom processes and confirm list rows + detail routing work for both sets in the same session
 
-### 5.3 Detail-route behavior unchanged
+### 6.3 Detail-route behavior unchanged
 
 - [x] `/processes/:processId` still provides full interactive process runtime controls
       (legacy alias `/process/:slug`, if still supported, also resolves correctly)
@@ -226,7 +236,7 @@ Required marks/measures:
 
 ---
 
-## 6) `/docs` validation (required)
+## 7) `/docs` validation (required)
 
 - [x] Default browse view loads and is useful without full body text in initial payload
 - [x] `has:` operator searches (for example `has:link`, `has:image`) still work without corpus fetch
@@ -243,7 +253,7 @@ Suggested manual checks:
 
 ---
 
-## 7) `/chat` regression checks (required due to docs/RAG dependency)
+## 8) `/chat` regression checks (required due to docs/RAG dependency)
 
 Goal: confirm docs-backed retrieval still produces grounded responses after `/docs` deferred-corpus changes.
 
@@ -265,7 +275,7 @@ Record brief transcript snippets and whether responses appear grounded vs generi
 
 ---
 
-## 8) Production promotion gate
+## 9) Production promotion gate
 
 - [ ] Promote only the exact immutable artifact validated in staging
 - [ ] Confirm rollback tag/command before deploy
@@ -302,9 +312,9 @@ Evidence captured in Codex session (2026-04-11 UTC):
 
 ---
 
-## 9) Rollback + closeout
+## 10) Rollback + closeout
 
-### 9.1 Rollback (if any required gate fails)
+### 10.1 Rollback (if any required gate fails)
 
 - [ ] Roll back immediately to previous known-good immutable tag
 - [ ] Re-run prod health checks
@@ -320,7 +330,7 @@ cd ~/sugarkube
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=<rollback-immutable-tag>
 ```
 
-### 9.2 Release closeout
+### 10.2 Release closeout
 
 - [ ] Final release git tag created and pushed (`v3.0.1`)
 - [ ] `v3.0.1` patch-note addendum published in changelog
@@ -330,7 +340,7 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
 ---
 
-## 10) Optional supplementary evidence (recommended, not blocking)
+## 11) Optional supplementary evidence (recommended, not blocking)
 
 - Lighthouse run for `/quests`, `/processes`, and `/docs` as trend-only evidence (not release gate)
 - Short screen recordings showing:

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -19,8 +19,8 @@ Related docs:
 
 ## 0) Release metadata
 
-> Historical tags are tracked canonically in [docs/releases.md](../releases.md).
-> This section is a release-specific snapshot for v3.0.1 QA context.
+> Broader release history is maintained in [docs/releases.md](../releases.md).
+> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.2`.
 
 | Tag name | Commit SHA | Notes |
 | --- | --- | --- |
@@ -141,7 +141,7 @@ curl -fsS https://staging.democratized.space/livez
 - [ ] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
 - [ ] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
 
-Evidence captured in Codex session (2026-04-11 UTC):
+Evidence captured in Codex session (2026-04-11 UTC, pre-`v3.0.1-rc.2` staging deployment):
 
 - `curl -fsS https://staging.democratized.space/config.json` returned JSON with
   `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
@@ -257,7 +257,7 @@ Suggested manual checks:
 
 Goal: confirm docs-backed retrieval still produces grounded responses after `/docs` deferred-corpus changes.
 
-Prerequisite: execute this section only after Section 6 validates `/docs` browse behavior and first-keyword deferred corpus load from `/docs/full-text-corpus.json`.
+Prerequisite: execute this section only after Section 7 validates `/docs` browse behavior and first-keyword deferred corpus load from `/docs/full-text-corpus.json`.
 
 - [x] Chat UI loads/hydrates normally on `/chat`
 - [x] Launch-check prompts grounded in existing docs still return relevant, non-empty responses
@@ -296,7 +296,7 @@ curl -fsS https://democratized.space/livez
 
 - [ ] `/quests`, `/processes`, `/docs`, and `/chat` pass spot-checks on prod immediately after deploy
 
-Evidence captured in Codex session (2026-04-11 UTC):
+Evidence captured in Codex session (2026-04-11 UTC, pre-`v3.0.1-rc.2` staging deployment):
 
 - `curl -fsS https://democratized.space/healthz` returned JSON with
   `"status":"ready"`, `"version":"v3-3ec45a5"`, `"env":"prod"`.

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -141,19 +141,18 @@ curl -fsS https://staging.democratized.space/livez
 - [ ] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
 - [ ] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
 
-Evidence captured in Codex session (2026-04-11 UTC, pre-`v3.0.1-rc.2` staging deployment):
+Evidence captured in Codex session (2026-04-11 UTC, staging state aligned with `v3.0.1-rc.1`):
 
 - `curl -fsS https://staging.democratized.space/config.json` returned JSON with
   `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
-  `"featureFlags":[]` (captured for runtime-config visibility; expected v3.0.1-rc.2-specific
-  config parity still pending).
+  `"featureFlags":[]` (captured for runtime-config visibility on the rc.1 staging state).
 - `curl -fsS https://staging.democratized.space/healthz` returned JSON with
   `"status":"ready"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match `v3.0.1-rc.2`; keep the expected-version checkbox open until the RC artifact is
-  deployed (or documented as commit-equivalent).
+  not match the current candidate `v3.0.1-rc.2`; keep the expected-version checkbox open until the
+  rc.2 artifact is deployed (or documented as commit-equivalent).
 
 ---
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,6 +18,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.0-rc.3` | Release candidate | [`v3.0.0-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.3) |
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
 | `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
+| `v3.0.1-rc.2` | Release candidate | [`v3.0.1-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) |
 
 ## QA checklists tracked separately (not a tag list)
 


### PR DESCRIPTION
### Motivation

- Make the v3.0.1 release candidates more discoverable by replicating the release-candidate table pattern from `docs/qa/v3.md` into the v3.0.1 QA checklist and surface the new `v3.0.1-rc.2` candidate.

### Description

- Added a new `0) Release metadata` section to `docs/qa/v3.0.1.md` containing a table that lists `v3.0.1-rc.2` and `v3.0.1-rc.1` with release links, commit SHAs, and notes.
- Updated the active candidate references in the checklist from `v3.0.1-rc.1` to `v3.0.1-rc.2` and adjusted related in-text references to the new candidate.
- Renumbered subsequent top-level sections and subsection headers so numbering remains sequential after inserting the new metadata section.

### Testing

- Ran `node scripts/link-check.mjs` and confirmed all local markdown links resolved successfully.
- Ran `git diff --cached | ./scripts/scan-secrets.py` as part of the pre-commit scan and observed no secret findings.
- Verified the presence of remote tags with `git ls-remote --tags https://github.com/democratizedspace/dspace.git 'v3.0.1-rc.*'` to confirm `v3.0.1-rc.2` exists; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddebcd8a58832f9e372c735d4af1bf)