### PR TITLE
📝 docs: add v3.0.1 release candidate metadata table

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.1`.
+> current candidate under validation: `v3.0.1-rc.2`.
 
 Related docs:
 
@@ -17,7 +17,24 @@ Related docs:
 
 ---
 
-## 0) Patch scope summary (required read before testing)
+## 0) Release metadata
+
+> Historical tags are tracked canonically in [docs/releases.md](../releases.md).
+> This section remains a release-specific snapshot for v3.0.1 QA context.
+
+| Tag name                                                                            | Commit SHA                                 | Notes                                                                |
+| ----------------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Latest release candidate under validation for the v3.0.1 patch train |
+| [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate                                     |
+
+- [ ] RC commit SHA: `a7d99da9bbf9085aa33fd9f99da83b04f812c261`
+- [ ] RC tag/version string: `v3.0.1-rc.2`
+- [ ] Staging URL verified: `https://staging.democratized.space`
+- [ ] Prod URL verified: `https://democratized.space`
+
+---
+
+### 0.1 Patch scope summary (required read before testing)
 
 `v3.0.1` patch themes to validate end-to-end:
 
@@ -32,7 +49,7 @@ Related docs:
 
 ---
 
-### 0.1 Commit-range audit (required before checklist execution)
+### 0.2 Commit-range audit (required before checklist execution)
 
 Derive this checklist from the audited patch delta first, then execute QA against that scoped delta.
 Run these exact commands and attach output to release evidence:
@@ -56,7 +73,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ## 1) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.1`
+- [ ] Candidate tag under test: `v3.0.1-rc.2`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`
@@ -135,14 +152,14 @@ Evidence captured in Codex session (2026-04-11 UTC):
 
 - `curl -fsS https://staging.democratized.space/config.json` returned JSON with
   `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
-  `"featureFlags":[]` (captured for runtime-config visibility; expected v3.0.1-rc.1-specific
+  `"featureFlags":[]` (captured for runtime-config visibility; expected v3.0.1-rc.2-specific
   config parity still pending).
 - `curl -fsS https://staging.democratized.space/healthz` returned JSON with
   `"status":"ready"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match `v3.0.1-rc.1`; keep the expected-version checkbox open until the RC artifact is
+  not match `v3.0.1-rc.2`; keep the expected-version checkbox open until the RC artifact is
   deployed (or documented as commit-equivalent).
 
 ---


### PR DESCRIPTION
### Motivation
- Make v3.0.1 release candidates discoverable directly from the patch QA doc by mirroring the RC table pattern used in `docs/qa/v3.md`.
- Promote the currently validated candidate to `v3.0.1-rc.2` for consistency across the v3.0.1 checklist and staging evidence.

### Description
- Added a new `0) Release metadata` section to `docs/qa/v3.0.1.md` containing a table documenting `v3.0.1-rc.2` (SHA `a7d99da9bbf9085aa33fd9f99da83b04f812c261`) and `v3.0.1-rc.1` (SHA `4cd6007347...`).
- Updated in-file references from `v3.0.1-rc.1` to `v3.0.1-rc.2` (intro, signoff metadata, and staging evidence notes) and renumbered the existing patch-scope subsections to `0.1`/`0.2` under the new metadata section.
- Applied Prettier formatting to `docs/qa/v3.0.1.md` to satisfy repo style rules.

### Testing
- Ran `npx prettier --check docs/qa/v3.0.1.md` which initially reported style warnings, then ran `npx prettier --write docs/qa/v3.0.1.md` and re-ran `npx prettier --check` which passed.
- Ran `git diff --cached | ./scripts/scan-secrets.py` after staging the change and the scan returned no issues.
- No code or unit tests were modified as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddebcd8a58832f9e372c735d4af1bf)