### PR TITLE
docs: add v3.0.1-rc.2 release metadata to v3.0.1 QA checklist

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.1`.
+> current candidate under validation: `v3.0.1-rc.2`.
 
 Related docs:
 
@@ -17,7 +17,29 @@ Related docs:
 
 ---
 
-## 0) Patch scope summary (required read before testing)
+## 0) Release metadata
+
+> Historical tags are tracked canonically in [docs/releases.md](../releases.md).
+> This section remains a release-specific snapshot for v3.0.1 QA context.
+
+| Tag name | Commit SHA | Notes |
+| --- | --- | --- |
+| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch-line follow-up candidate for v3.0.1 launch readiness and final QA sign-off. |
+| [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate used for baseline patch-delta validation. |
+
+- [ ] Target version: `v3.0.1`
+- [ ] Candidate tag under test: `v3.0.1-rc.2`
+- [ ] Commit SHA: `________________`
+- [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
+- [ ] QA owner + timestamp: `________________`
+- [ ] Staging sign-off owner + timestamp: `________________`
+- [ ] Production deploy owner + timestamp: `________________`
+- [ ] Previous known-good rollback tag: `________________`
+- [ ] Release notes include only user-visible patch deltas
+
+---
+
+## 1) Patch scope summary (required read before testing)
 
 `v3.0.1` patch themes to validate end-to-end:
 
@@ -32,7 +54,7 @@ Related docs:
 
 ---
 
-### 0.1 Commit-range audit (required before checklist execution)
+### 1.1 Commit-range audit (required before checklist execution)
 
 Derive this checklist from the audited patch delta first, then execute QA against that scoped delta.
 Run these exact commands and attach output to release evidence:
@@ -50,20 +72,6 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ```
 
 - [ ] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
-
----
-
-## 1) Release metadata + signoff
-
-- [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.1`
-- [ ] Commit SHA: `________________`
-- [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
-- [ ] QA owner + timestamp: `________________`
-- [ ] Staging sign-off owner + timestamp: `________________`
-- [ ] Production deploy owner + timestamp: `________________`
-- [ ] Previous known-good rollback tag: `________________`
-- [ ] Release notes include only user-visible patch deltas
 
 ---
 
@@ -142,7 +150,7 @@ Evidence captured in Codex session (2026-04-11 UTC):
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match `v3.0.1-rc.1`; keep the expected-version checkbox open until the RC artifact is
+  not match `v3.0.1-rc.2`; keep the expected-version checkbox open until the RC artifact is
   deployed (or documented as commit-equivalent).
 
 ---


### PR DESCRIPTION
### Motivation
- Make the v3.0.1 release candidates more discoverable by mirroring the `v3` QA checklist release-metadata section in `docs/qa/v3.0.1.md`.
- Surface the new candidate `v3.0.1-rc.2` alongside the prior `v3.0.1-rc.1` so QA and launch owners can easily reference tags and SHAs.
- Keep the v3.0.1 checklist structure consistent with other QA docs to reduce confusion during final validation.

### Description
- Inserted a new `0) Release metadata` section at the top of `docs/qa/v3.0.1.md` including a table with `v3.0.1-rc.2` and `v3.0.1-rc.1` tag links and commit SHAs.
- Updated the active candidate references in the header from `v3.0.1-rc.1` to `v3.0.1-rc.2` and renumbered the original patch-scope subsection to preserve flow.
- Adjusted the commit-range audit subheading numbering to align with the new metadata section without changing the existing checklist content.

### Testing
- Ran `node scripts/link-check.mjs` to validate local markdown links, and it completed with all local links resolved.
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py`, and no secrets were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddebcd8a58832f9e372c735d4af1bf)