### PR TITLE
📝 docs: add v3.0.1-rc.3 metadata and complete changelog addendum

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.2`.
+> current candidate under validation: `v3.0.1-rc.3`.
 
 Related docs:
 
@@ -20,10 +20,11 @@ Related docs:
 ## 0) Release metadata
 
 > Broader release history is maintained in [docs/releases.md](../releases.md).
-> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.2`.
+> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.3`.
 
 | Tag name | Commit SHA | Notes |
 | --- | --- | --- |
+| [v3.0.1-rc.3](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) | `899fcb93f705d0fe4051d7ecb74ee242cb8ab59c` | Release candidate that supersedes rc.2 for final validation/signoff. |
 | [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that supersedes rc.1 for final validation/signoff. |
 | [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline. |
 
@@ -66,7 +67,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ## 2) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.2`
+- [ ] Candidate tag under test: `v3.0.1-rc.3`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,6 +19,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
 | `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 | `v3.0.1-rc.2` | Release candidate | [`v3.0.1-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) |
+| `v3.0.1-rc.3` | Release candidate | [`v3.0.1-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) |
 
 ## QA checklists tracked separately (not a tag list)
 

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -138,13 +138,19 @@ forward.
 ## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
 
 `v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening.
+This addendum now reflects the complete delta between `v3.0.0`
+(`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and `v3.0.1-rc.3`.
 
 ### Patch notes
 
 - **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA:
   - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
   - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
+- **`/quests` UX correctness:** built-in quest cards now show only actionable built-ins in the active grid, avoid premature `Start` labeling before authoritative state reconciliation, and preserve stable built-in/custom section behavior under delayed merges.
 - **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
 - **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
+- **`/processes` UX refinements:** restored lightweight item preview context in list cards, hid unstable preview IDs while metadata is loading, and stabilized `Buy required items` button states (including non-`dUSD` currencies and low-balance fallback messaging).
 - **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
-- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.
+- **Security hardening:** sanitized compact item fallback images and process preview image sources, rejected unknown item containers during item ingest, and tightened dependency/workflow guardrails (including pinned `glob` override and privileged CI action constraints).
+- **Data and gameplay correctness:** normalized stored item counts to prevent duplicate lookup drift, aligned quest/process reward expectations in launch-critical paths, and fixed unavailable-quest status labeling surfaced in QuestChat.
+- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, docs-backed chat checks, remote-smoke reliability, and migration harness stability to reduce staging/prod false negatives during promotion.


### PR DESCRIPTION
### Motivation
- Ensure the v3.0.1 changelog addendum documents the complete audited delta from `v3.0.0` through the latest RC and record the new `v3.0.1-rc.3` tag in the QA and canonical releases docs.

### Description
- Updated `frontend/src/pages/docs/md/changelog/20260401.md` to state the addendum covers `v3.0.0`..`v3.0.1-rc.3` and expanded the patch-note themes, added `v3.0.1-rc.3` metadata and candidate references to `docs/qa/v3.0.1.md`, and appended `v3.0.1-rc.3` to `docs/releases.md`.

### Testing
- Ran `npm run lint` which passed, and ran the staged-diff secrets scan via `./scripts/scan-secrets.py` which produced no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deffd1aac4832f8ec1813d86c780cc)