### PR TITLE
docs: expand v3.0.1 changelog addendum and add v3.0.1-rc.3 metadata

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.2`.
+> current candidate under validation: `v3.0.1-rc.3`.
 
 Related docs:
 
@@ -20,11 +20,12 @@ Related docs:
 ## 0) Release metadata
 
 > Broader release history is maintained in [docs/releases.md](../releases.md).
-> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.2`.
+> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.3`.
 
 | Tag name | Commit SHA | Notes |
 | --- | --- | --- |
-| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that supersedes rc.1 for final validation/signoff. |
+| [v3.0.1-rc.3](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) | `899fcb93f705d0fe4051d7ecb74ee242cb8ab59c` | Patch candidate that supersedes rc.2 for final validation/signoff. |
+| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Prior patch candidate retained for audit traceability. |
 | [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline. |
 
 ## 1) Patch scope summary (required read before testing)
@@ -66,7 +67,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ## 2) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.2`
+- [ ] Candidate tag under test: `v3.0.1-rc.3`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,6 +19,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
 | `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 | `v3.0.1-rc.2` | Release candidate | [`v3.0.1-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) |
+| `v3.0.1-rc.3` | Release candidate | [`v3.0.1-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) |
 
 ## QA checklists tracked separately (not a tag list)
 

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,10 +141,15 @@ forward.
 
 ### Patch notes
 
-- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA:
+- **`/quests` performance and correctness:** improved list-path time-to-interactive, delayed custom merge until built-ins are stable, and tightened built-in/custom coexistence behavior. Measured list-path timings improved substantially in QA:
   - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
   - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
-- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
-- **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
-- **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
-- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.
+- **`/quests` UX polish:** removed stale `Start` card-label copy, improved card alignment/status readability, and fixed locked custom-quest visibility so unavailable quests no longer appear actionable.
+- **`/quests` security hardening:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
+- **`/processes` list/detail split:** switched `/processes` rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
+- **`/processes` interaction fixes:** restored lightweight preview context, hid preview IDs until metadata is available, and stabilized `Buy required items` behavior under delayed metadata and non-`dUSD` currencies.
+- **`/docs` performance:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
+- **Gameplay/data fixes:** removed a preflight quest dead-end gate, corrected geothermal/wind reward documentation alignment, and normalized stored item-count/container handling to prevent edge-case progression and inventory inconsistencies.
+- **Security + supply-chain hardening:** sanitized process and compact-item fallback image sources, rejected unknown item containers, pinned privileged CI emulation actions, and updated the `glob` vulnerability override.
+- **Release tooling + QA resilience:** hardened remote smoke/migration harness behavior, reduced remote Playwright setup overhead in perf mode, and expanded targeted regression coverage for quests, processes, docs search, docs-backed chat, and release-checklist compliance.
+- **Release governance docs:** added canonical release-history tracking and refreshed runbooks/checklists so `v3.0.1` promotion evidence remains explicit across staging and production.


### PR DESCRIPTION
### Motivation

- Capture the full audited delta between `v3.0.0` (`3ec45a5...`) and current `HEAD` in the v3 changelog so the June 1, 2026 patch addendum documents all user-visible patch themes. 
- Surface the active release-candidate (`v3.0.1-rc.3`) across release/QA docs so QA and historical records include the new candidate metadata.

### Description

- Expanded the `June 1, 2026 — DSPACE v3.0.1 (patch addendum)` text in `frontend/src/pages/docs/md/changelog/20260401.md` to enumerate the full patch themes (quests perf/correctness and UX, quest route security, processes list/detail and interaction fixes, docs lazy corpus load, gameplay/data fixes, supply-chain/security hardening, QA/tooling resilience, and release-governance updates). 
- Updated `docs/qa/v3.0.1.md` to set `v3.0.1-rc.3` as the current candidate and to include `v3.0.1-rc.2`/`v3.0.1-rc.1` rows for audit traceability, and to reflect the candidate change in the signoff checklist. 
- Added `v3.0.1-rc.3` to the canonical tag table in `docs/releases.md` and adjusted escaping for slash-backslash examples in the changelog to preserve literal characters.

### Testing

- Ran `node scripts/link-check.mjs` and received "All local markdown links resolved." which passed. 
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` on the staged changes and observed no flagged secrets. 
- Verified the edited files are internally consistent with the release/QA checklist references and tag table by inspecting the updated markdown outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deffd1aac4832f8ec1813d86c780cc)