### PR TITLE
📝 docs: expand v3.0.1 changelog addendum and add v3.0.1-rc.3 metadata

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.2`.
+> current candidate under validation: `v3.0.1-rc.3`.
 
 Related docs:
 
@@ -20,12 +20,13 @@ Related docs:
 ## 0) Release metadata
 
 > Broader release history is maintained in [docs/releases.md](../releases.md).
-> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.2`.
+> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.3`.
 
-| Tag name | Commit SHA | Notes |
-| --- | --- | --- |
-| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that supersedes rc.1 for final validation/signoff. |
-| [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline. |
+| Tag name                                                                            | Commit SHA                                 | Notes                                                                   |
+| ----------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
+| [v3.0.1-rc.3](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) | `899fcb93f705d0fe4051d7ecb74ee242cb8ab59c` | Patch candidate that supersedes rc.2 for final validation/signoff.      |
+| [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that superseded rc.1 and is retained for audit history. |
+| [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline.                              |
 
 ## 1) Patch scope summary (required read before testing)
 
@@ -66,7 +67,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..main
 ## 2) Release metadata + signoff
 
 - [ ] Target version: `v3.0.1`
-- [ ] Candidate tag under test: `v3.0.1-rc.2`
+- [ ] Candidate tag under test: `v3.0.1-rc.3`
 - [ ] Commit SHA: `________________`
 - [ ] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` (or equivalent release branch head)
 - [ ] QA owner + timestamp: `________________`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,16 +9,17 @@ This is the canonical list of all historical DSPACE release tags.
 
 ## Tagged releases
 
-| Tag | Channel | GitHub release page |
-| --- | --- | --- |
-| `v1.0.0` | Stable release | [`v1.0.0`](https://github.com/democratizedspace/dspace/releases/tag/v1.0.0) |
-| `v2.1.0` | Stable release | [`v2.1.0`](https://github.com/democratizedspace/dspace/releases/tag/v2.1.0) |
+| Tag           | Channel           | GitHub release page                                                                   |
+| ------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| `v1.0.0`      | Stable release    | [`v1.0.0`](https://github.com/democratizedspace/dspace/releases/tag/v1.0.0)           |
+| `v2.1.0`      | Stable release    | [`v2.1.0`](https://github.com/democratizedspace/dspace/releases/tag/v2.1.0)           |
 | `v3.0.0-rc.1` | Release candidate | [`v3.0.0-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.1) |
 | `v3.0.0-rc.2` | Release candidate | [`v3.0.0-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.2) |
 | `v3.0.0-rc.3` | Release candidate | [`v3.0.0-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.3) |
 | `v3.0.0-rc.4` | Release candidate | [`v3.0.0-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.0-rc.4) |
 | `v3.0.1-rc.1` | Release candidate | [`v3.0.1-rc.1`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) |
 | `v3.0.1-rc.2` | Release candidate | [`v3.0.1-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) |
+| `v3.0.1-rc.3` | Release candidate | [`v3.0.1-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) |
 
 ## QA checklists tracked separately (not a tag list)
 

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -139,12 +139,16 @@ forward.
 
 `v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening.
 
-### Patch notes
+### Patch notes (audited from `v3.0.0` `3ec45a5517a35c96767f6b946c01104e6ec88f93` to `HEAD` / `v3.0.1-rc.3`)
 
-- **`/quests`:** improved list-path time-to-interactive and tightened built-in/custom coexistence behavior; measured list-path timings improved substantially in QA:
+- **`/quests` performance and UX:** improved list-path time-to-interactive, removed misleading `Start` status labeling, and tightened available-vs-locked rendering behavior so the main grid is immediately actionable.
   - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
   - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
-- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\\`.
-- **`/processes`:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`.
-- **`/docs`:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
-- **Release safety:** expanded targeted regression coverage for quests, processes, docs search, and docs-backed chat checks.
+- **`/quests` custom-content coexistence:** hardened delayed custom-quest merge timing and regressions so built-in and custom quests render together reliably without displacement, duplicate collisions, or stale status affordances.
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
+- **`/processes` list/detail split:** switched `/processes` rows to summary-first rendering and preserved all lifecycle controls (`Start`, `Pause`, `Resume`, `Collect`, `Buy required items`) on `/processes/:processId`.
+- **`/processes` reliability/security fixes:** stabilized metadata-loading states and buy-required behavior, hid transient preview IDs while metadata is unresolved, and sanitized process preview image sources.
+- **`/docs` search performance:** deferred full-text corpus fetch until first keyword search; browse and `has:` flows remain available immediately.
+- **Quest/data correctness:** fixed geothermal reward documentation drift and removed a dead-end wind-evidence gate in preflight progression.
+- **Platform hardening:** blocked unknown item-container identifiers, normalized stored item-count handling, aligned/pinned vulnerable dependencies (`glob`), and tightened container/workflow safeguards used in CI release validation.
+- **Release safety and verification:** expanded targeted regression and E2E coverage for quests, processes, docs search, docs-backed chat, migration, and remote-smoke launch confidence checks.


### PR DESCRIPTION
### Motivation
- Ensure the June 1, 2026 v3.0.1 changelog addendum documents the full audited delta from `v3.0.0` (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) through current `HEAD` / `v3.0.1-rc.3` so release notes reflect the true patch scope. 
- Keep release tracking and QA guidance consistent by adding the new release candidate `v3.0.1-rc.3` to QA metadata and the canonical release history.

### Description
- Expanded `frontend/src/pages/docs/md/changelog/20260401.md` patch addendum to reference the audited commit range and to enumerate the patch deltas (quests, processes, docs search, platform hardening, and release-safety verification). 
- Updated `docs/qa/v3.0.1.md` to mark `v3.0.1-rc.3` as the current candidate and added the rc.3 tag row and SHA (`899fcb93f705d0fe4051d7ecb74ee242cb8ab59c`) in the release metadata table. 
- Added `v3.0.1-rc.3` to `docs/releases.md` canonical tag table so historical release records include the new RC. 
- Applied Prettier formatting to the modified docs and ensured generated artifacts were not committed.

### Testing
- Ran `npm run lint` and it passed. 
- Ran `npm run test:ci` (build + unit suite) and all automated tests passed. 
- Verified formatting with `npx prettier --check` and fixed files with `npx prettier --write` so checks now pass. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to ensure no credential-like strings were added and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deffd1aac4832f8ec1813d86c780cc)