### PR TITLE
🐛 Fix quest refresh flicker before game state readiness

### DIFF
--- a/frontend/src/pages/quests/svelte/QuestChat.svelte
+++ b/frontend/src/pages/quests/svelte/QuestChat.svelte
@@ -3,7 +3,12 @@
     import { writable } from 'svelte/store';
     import QuestChatOption from './QuestChatOption.svelte';
     import { getUnmetQuestRequirements, questFinished } from '../../../utils/gameState.js';
-    import { state, syncGameStateFromLocalIfStale } from '../../../utils/gameState/common.js';
+    import {
+        isGameStateReady,
+        ready,
+        state,
+        syncGameStateFromLocalIfStale,
+    } from '../../../utils/gameState/common.js';
     import { isBrowser } from '../../../utils/ssr.js';
     import { getItemMap } from '../../../utils/itemResolver.js';
     import { formatDialogue } from '../../../utils/formatDialogue.ts';
@@ -26,6 +31,7 @@
     let rewardRequestId = 0;
     let rewardItemsKey = '';
     let isMounted = false;
+    let gameStateLoaded = false;
     let refreshIntervalId;
 
     const releaseRewardImages = (items) => {
@@ -92,6 +98,14 @@
             currentDialogue = dialogueMap.get(pointer);
         }
 
+        gameStateLoaded = isGameStateReady();
+
+        if (!gameStateLoaded) {
+            void ready.finally(() => {
+                gameStateLoaded = true;
+            });
+        }
+
         clientSideRendered.set(true);
         void loadRewardItems();
     });
@@ -138,7 +152,7 @@
                 </p>
             </div>
         </div>
-    {:else if $available === false}
+    {:else if gameStateLoaded && $available === false}
         <div class="chat" data-testid="chat-panel">
             <div class="vertical unavailable-content" data-testid="quest-unavailable">
                 <h4>Quest not available yet</h4>
@@ -149,7 +163,7 @@
     {:else}
         <div class="chat" data-testid="chat-panel">
             <div class="chat-body">
-                {#if $clientSideRendered && quest && dialogueMap}
+                {#if gameStateLoaded && $clientSideRendered && quest && dialogueMap}
                     <div class="quest-banner">
                         <img class="banner" src={quest.image} alt={quest.title} />
                     </div>
@@ -181,8 +195,10 @@
         <h5>Status:</h5>
         {#if $finished}
             <p class="green">Complete</p>
-        {:else if $available === false}
+        {:else if gameStateLoaded && $available === false}
             <p>Not available yet</p>
+        {:else if !gameStateLoaded}
+            <p>Loading…</p>
         {:else}
             <p class="orange">In Progress</p>
         {/if}

--- a/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
+++ b/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
@@ -13,7 +13,13 @@ type Store<T> = {
     update: (updater: (value: T) => T) => void;
 };
 
-const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoisted(() => {
+const {
+    mockState,
+    canStartQuestMock,
+    getUnmetQuestRequirementsMock,
+    isGameStateReadyMock,
+    resolveReadyMock,
+} = vi.hoisted(() => {
     let value: QuestState = { quests: {}, inventory: {} };
     const subscribers = new Set<(current: QuestState) => void>();
     const subscribe = (run: (current: QuestState) => void) => {
@@ -33,17 +39,25 @@ const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoist
         mockState: { subscribe, set, update } as Store<QuestState>,
         canStartQuestMock: vi.fn(() => true),
         getUnmetQuestRequirementsMock: vi.fn(() => [] as string[]),
+        isGameStateReadyMock: vi.fn(() => true),
+        resolveReadyMock: vi.fn(() => {}),
     };
 });
 
 vi.mock('../../../../utils/gameState/common.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../../../utils/gameState/common.js')>();
+    let resolveReady: (() => void) | null = null;
+    const readyPromise = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+    });
+    resolveReadyMock.mockImplementation(() => resolveReady?.());
+
     return {
         ...actual,
         state: mockState,
         syncGameStateFromLocalIfStale: vi.fn(),
-        isGameStateReady: vi.fn(() => true),
-        ready: Promise.resolve(),
+        isGameStateReady: (...args: unknown[]) => isGameStateReadyMock(...args),
+        ready: readyPromise,
     };
 });
 
@@ -65,6 +79,7 @@ describe('QuestChat', () => {
     beforeEach(() => {
         canStartQuestMock.mockReturnValue(true);
         getUnmetQuestRequirementsMock.mockReturnValue([]);
+        isGameStateReadyMock.mockReturnValue(true);
     });
 
     it('renders newline and inline code formatting while escaping raw HTML', async () => {
@@ -184,5 +199,44 @@ describe('QuestChat', () => {
         expect(
             getByRole('link', { name: 'Set up your first 3D printer' }).getAttribute('href')
         ).toBe('/quests/3dprinting/start');
+    });
+
+    it('keeps a blank chat container until game state readiness is confirmed', async () => {
+        isGameStateReadyMock.mockReturnValue(false);
+        canStartQuestMock.mockReturnValue(false);
+        getUnmetQuestRequirementsMock.mockReturnValue(['welcome/howtodoquests']);
+
+        const quest = {
+            id: 'hydroponics/bucket_10',
+            title: "Bucket, we'll do it live!",
+            description: 'Locked quest',
+            image: '/quest.png',
+            npc: '/npc.png',
+            start: 'start',
+            requiresQuests: ['welcome/howtodoquests'],
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'You should not see this if the quest is locked.',
+                    options: [{ id: 'finish', text: 'Finish', type: 'finish' }],
+                },
+            ],
+            rewards: [{ id: 'item-1', count: 1 }],
+        };
+
+        const { container, queryByTestId, getByText } = render(QuestChat, { props: { quest } });
+
+        await waitFor(() => {
+            expect(container.querySelector('.temp-container')).not.toBeNull();
+        });
+        expect(queryByTestId('quest-unavailable')).toBeNull();
+        expect(container.querySelector('.npcDialogue')).toBeNull();
+        expect(getByText('Loading…')).toBeTruthy();
+
+        resolveReadyMock();
+
+        await waitFor(() => {
+            expect(queryByTestId('quest-unavailable')).not.toBeNull();
+        });
     });
 });


### PR DESCRIPTION
### Motivation
- The quest page briefly showed the "Quest not available yet" gate while the persisted `gameState` was still hydrating, producing a jarring flash on refresh.
- The UI should present a neutral placeholder while game-state readiness is unresolved and only show the unavailable message once readiness is confirmed and requirements are unmet.

### Description
- Update `QuestChat.svelte` to import `isGameStateReady` and `ready`, add a `gameStateLoaded` flag, and defer rendering of the unavailable gate and quest content until readiness is resolved.
- Show a blank `.temp-container` and a `Loading…` status while readiness is pending, and only show the unavailable UI when `gameStateLoaded` is true and requirements are unmet.
- Add a regression test in `__tests__/QuestChat.spec.ts` that mocks `isGameStateReady`/`ready`, asserts the blank container is shown initially, resolves readiness, and then asserts the unavailable gate appears.

### Testing
- Ran `npm run test:root -- frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` and the spec file passed (`4 tests` all green).
- Ran the frontend Prettier check with `npx prettier --config frontend/.prettierrc --check ...` which failed in this environment due to a Prettier plugin API mismatch (`printer.embed has too many parameters`), unrelated to the functional change.
- Unit test verified the new loading->unavailable transition behavior and existing formatting/escape tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df00788544832f93977a0450d048b0)