### PR TITLE
Gate quest-unavailable UI on game-state readiness to prevent flicker

### DIFF
--- a/frontend/src/pages/quests/svelte/QuestChat.svelte
+++ b/frontend/src/pages/quests/svelte/QuestChat.svelte
@@ -3,7 +3,12 @@
     import { writable } from 'svelte/store';
     import QuestChatOption from './QuestChatOption.svelte';
     import { getUnmetQuestRequirements, questFinished } from '../../../utils/gameState.js';
-    import { state, syncGameStateFromLocalIfStale } from '../../../utils/gameState/common.js';
+    import {
+        isGameStateReady,
+        ready,
+        state,
+        syncGameStateFromLocalIfStale,
+    } from '../../../utils/gameState/common.js';
     import { isBrowser } from '../../../utils/ssr.js';
     import { getItemMap } from '../../../utils/itemResolver.js';
     import { formatDialogue } from '../../../utils/formatDialogue.ts';
@@ -16,6 +21,7 @@
     const clientSideRendered = writable(false);
     const finished = writable(false);
     const available = writable(null);
+    const gameStateLoaded = writable(false);
 
     let unmetRequirements = [];
 
@@ -92,6 +98,14 @@
             currentDialogue = dialogueMap.get(pointer);
         }
 
+        if (isGameStateReady()) {
+            gameStateLoaded.set(true);
+        } else {
+            void ready.finally(() => {
+                gameStateLoaded.set(true);
+            });
+        }
+
         clientSideRendered.set(true);
         void loadRewardItems();
     });
@@ -138,7 +152,7 @@
                 </p>
             </div>
         </div>
-    {:else if $available === false}
+    {:else if $gameStateLoaded && $available === false}
         <div class="chat" data-testid="chat-panel">
             <div class="vertical unavailable-content" data-testid="quest-unavailable">
                 <h4>Quest not available yet</h4>
@@ -149,7 +163,7 @@
     {:else}
         <div class="chat" data-testid="chat-panel">
             <div class="chat-body">
-                {#if $clientSideRendered && quest && dialogueMap}
+                {#if $clientSideRendered && $gameStateLoaded && quest && dialogueMap}
                     <div class="quest-banner">
                         <img class="banner" src={quest.image} alt={quest.title} />
                     </div>
@@ -181,7 +195,7 @@
         <h5>Status:</h5>
         {#if $finished}
             <p class="green">Complete</p>
-        {:else if $available === false}
+        {:else if $gameStateLoaded && $available === false}
             <p>Not available yet</p>
         {:else}
             <p class="orange">In Progress</p>

--- a/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
+++ b/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
@@ -13,7 +13,13 @@ type Store<T> = {
     update: (updater: (value: T) => T) => void;
 };
 
-const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoisted(() => {
+const {
+    mockState,
+    canStartQuestMock,
+    getUnmetQuestRequirementsMock,
+    isGameStateReadyMock,
+    mockReadyPromise,
+} = vi.hoisted(() => {
     let value: QuestState = { quests: {}, inventory: {} };
     const subscribers = new Set<(current: QuestState) => void>();
     const subscribe = (run: (current: QuestState) => void) => {
@@ -33,6 +39,8 @@ const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoist
         mockState: { subscribe, set, update } as Store<QuestState>,
         canStartQuestMock: vi.fn(() => true),
         getUnmetQuestRequirementsMock: vi.fn(() => [] as string[]),
+        isGameStateReadyMock: vi.fn(() => true),
+        mockReadyPromise: new Promise<void>(() => {}),
     };
 });
 
@@ -42,8 +50,8 @@ vi.mock('../../../../utils/gameState/common.js', async (importOriginal) => {
         ...actual,
         state: mockState,
         syncGameStateFromLocalIfStale: vi.fn(),
-        isGameStateReady: vi.fn(() => true),
-        ready: Promise.resolve(),
+        isGameStateReady: (...args: unknown[]) => isGameStateReadyMock(...args),
+        ready: mockReadyPromise,
     };
 });
 
@@ -65,6 +73,7 @@ describe('QuestChat', () => {
     beforeEach(() => {
         canStartQuestMock.mockReturnValue(true);
         getUnmetQuestRequirementsMock.mockReturnValue([]);
+        isGameStateReadyMock.mockReturnValue(true);
     });
 
     it('renders newline and inline code formatting while escaping raw HTML', async () => {
@@ -139,6 +148,38 @@ describe('QuestChat', () => {
             expect(optionsText).toContain('Claim');
             expect(optionsText).toContain('Finish');
         });
+    });
+
+    it('renders a blank container while game state readiness is unresolved', () => {
+        isGameStateReadyMock.mockReturnValue(false);
+        canStartQuestMock.mockReturnValue(false);
+        getUnmetQuestRequirementsMock.mockReturnValue(['welcome/howtodoquests']);
+
+        const quest = {
+            id: 'hydroponics/bucket_10',
+            title: "Bucket, we'll do it live!",
+            description: 'Locked quest',
+            image: '/quest.png',
+            npc: '/npc.png',
+            start: 'start',
+            requiresQuests: ['welcome/howtodoquests'],
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'You should not see this if the quest is locked.',
+                    options: [{ id: 'finish', text: 'Finish', type: 'finish' }],
+                },
+            ],
+            rewards: [{ id: 'item-1', count: 1 }],
+        };
+
+        const { container, queryByText, queryByTestId } = render(QuestChat, {
+            props: { quest },
+        });
+
+        expect(container.querySelector('.temp-container')).not.toBeNull();
+        expect(queryByTestId('quest-unavailable')).toBeNull();
+        expect(queryByText('Quest not available yet')).toBeNull();
     });
 
     it('shows unavailable gate instead of chat when requirements are unmet', async () => {


### PR DESCRIPTION
### Motivation
- Refreshing a quest page briefly showed the "Quest not available yet" gate before persisted progress finished hydrating, causing a jarring UI flash. 
- The unavailable message should only be shown after the authoritative game-state readiness has been confirmed.

### Description
- Import `isGameStateReady` and `ready` from `frontend/src/utils/gameState/common.js` and add a `gameStateLoaded` store to track readiness in `QuestChat.svelte`.
- Delay rendering the unavailable gate and the quest chat body until `$gameStateLoaded` is true, showing a blank `.temp-container` placeholder while readiness is unresolved.
- Gate the side-panel status label so `Not available yet` only appears after game-state readiness is confirmed.
- Add a regression test in `frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` that mocks unresolved readiness and asserts the blank container is shown instead of the unavailable gate.

### Testing
- Ran formatting with `npx prettier --config .prettierrc --write` on the modified files and it completed successfully.
- Ran the updated spec with `npx vitest run frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` and the file's tests passed (`4 tests` all passed).
- Ran lint with `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df00788544832f93977a0450d048b0)