### PR TITLE
Prevent quest unavailable gate flicker before game state readiness

### DIFF
--- a/frontend/src/pages/quests/svelte/QuestChat.svelte
+++ b/frontend/src/pages/quests/svelte/QuestChat.svelte
@@ -3,7 +3,12 @@
     import { writable } from 'svelte/store';
     import QuestChatOption from './QuestChatOption.svelte';
     import { getUnmetQuestRequirements, questFinished } from '../../../utils/gameState.js';
-    import { state, syncGameStateFromLocalIfStale } from '../../../utils/gameState/common.js';
+    import {
+        state,
+        syncGameStateFromLocalIfStale,
+        ready,
+        isGameStateReady,
+    } from '../../../utils/gameState/common.js';
     import { isBrowser } from '../../../utils/ssr.js';
     import { getItemMap } from '../../../utils/itemResolver.js';
     import { formatDialogue } from '../../../utils/formatDialogue.ts';
@@ -16,6 +21,7 @@
     const clientSideRendered = writable(false);
     const finished = writable(false);
     const available = writable(null);
+    const gameStateReady = writable(false);
 
     let unmetRequirements = [];
 
@@ -71,6 +77,10 @@
         '/assets/pfp/7ecc9e2a-dd79-4bf8-87b5-57f090dd8c14.jpg';
 
     onMount(() => {
+        void ready.finally(() => {
+            gameStateReady.set(true);
+        });
+
         refreshIntervalId = setInterval(() => {
             syncGameStateFromLocalIfStale();
         }, 3000);
@@ -103,13 +113,18 @@
 
     $: {
         if ($state && quest) {
-            unmetRequirements = getUnmetQuestRequirements(quest);
-            available.set(!questFinished(quest.id) && unmetRequirements.length === 0);
-            if ($state.quests[quest.id]) {
-                pointer = $state.quests[quest.id].stepId;
-                currentDialogue = dialogueMap?.get(pointer);
+            if (!$gameStateReady && !isGameStateReady()) {
+                available.set(null);
+                finished.set(false);
+            } else {
+                unmetRequirements = getUnmetQuestRequirements(quest);
+                available.set(!questFinished(quest.id) && unmetRequirements.length === 0);
+                if ($state.quests[quest.id]) {
+                    pointer = $state.quests[quest.id].stepId;
+                    currentDialogue = dialogueMap?.get(pointer);
+                }
+                finished.set(questFinished(quest.id));
             }
-            finished.set(questFinished(quest.id));
         }
     }
 
@@ -144,6 +159,12 @@
                 <h4>Quest not available yet</h4>
                 <p>Complete these quests first:</p>
                 <QuestLinkChips questIds={unmetRequirements} />
+            </div>
+        </div>
+    {:else if $available === null}
+        <div class="chat" data-testid="chat-panel">
+            <div class="chat-body">
+                <div class="temp-container"></div>
             </div>
         </div>
     {:else}

--- a/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
+++ b/frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts
@@ -13,7 +13,13 @@ type Store<T> = {
     update: (updater: (value: T) => T) => void;
 };
 
-const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoisted(() => {
+const {
+    mockState,
+    canStartQuestMock,
+    getUnmetQuestRequirementsMock,
+    isGameStateReadyMock,
+    readyRef,
+} = vi.hoisted(() => {
     let value: QuestState = { quests: {}, inventory: {} };
     const subscribers = new Set<(current: QuestState) => void>();
     const subscribe = (run: (current: QuestState) => void) => {
@@ -33,6 +39,8 @@ const { mockState, canStartQuestMock, getUnmetQuestRequirementsMock } = vi.hoist
         mockState: { subscribe, set, update } as Store<QuestState>,
         canStartQuestMock: vi.fn(() => true),
         getUnmetQuestRequirementsMock: vi.fn(() => [] as string[]),
+        isGameStateReadyMock: vi.fn(() => true),
+        readyRef: { value: Promise.resolve() as Promise<unknown> },
     };
 });
 
@@ -42,8 +50,10 @@ vi.mock('../../../../utils/gameState/common.js', async (importOriginal) => {
         ...actual,
         state: mockState,
         syncGameStateFromLocalIfStale: vi.fn(),
-        isGameStateReady: vi.fn(() => true),
-        ready: Promise.resolve(),
+        isGameStateReady: () => isGameStateReadyMock(),
+        get ready() {
+            return readyRef.value;
+        },
     };
 });
 
@@ -63,8 +73,55 @@ vi.mock('../../../../utils/itemResolver.js', () => ({
 
 describe('QuestChat', () => {
     beforeEach(() => {
+        mockState.set({ quests: {}, inventory: {} });
         canStartQuestMock.mockReturnValue(true);
         getUnmetQuestRequirementsMock.mockReturnValue([]);
+        isGameStateReadyMock.mockReturnValue(true);
+        readyRef.value = Promise.resolve();
+    });
+
+    it('shows blank chat container until game state readiness is confirmed', async () => {
+        let resolveReady: (() => void) | undefined;
+        readyRef.value = new Promise<void>((resolve) => {
+            resolveReady = resolve;
+        });
+        isGameStateReadyMock.mockReturnValue(false);
+        getUnmetQuestRequirementsMock.mockReturnValue(['welcome/howtodoquests']);
+
+        const quest = {
+            id: 'hydroponics/bucket_10',
+            title: "Bucket, we'll do it live!",
+            description: 'Locked quest',
+            image: '/quest.png',
+            npc: '/npc.png',
+            start: 'start',
+            requiresQuests: ['welcome/howtodoquests'],
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'You should not see this if the quest is locked.',
+                    options: [{ id: 'finish', text: 'Finish', type: 'finish' }],
+                },
+            ],
+            rewards: [{ id: 'item-1', count: 1 }],
+        };
+
+        const { container, queryByTestId } = render(QuestChat, {
+            props: { quest },
+        });
+
+        await waitFor(() => {
+            expect(container.querySelector('.temp-container')).not.toBeNull();
+        });
+
+        expect(queryByTestId('quest-unavailable')).toBeNull();
+
+        isGameStateReadyMock.mockReturnValue(true);
+        resolveReady?.();
+
+        await waitFor(() => {
+            expect(queryByTestId('quest-unavailable')).not.toBeNull();
+        });
     });
 
     it('renders newline and inline code formatting while escaping raw HTML', async () => {


### PR DESCRIPTION
### Motivation
- The quest page briefly shows the "Quest not available yet" gate on refresh because availability is evaluated before the persisted `gameState` readiness is confirmed.  
- That flash is jarring for users and should be replaced with a neutral loading placeholder until readiness is known.  
- The intent is to only show the unavailable messaging after `gameState` has been loaded and confirmed ready.

### Description
- Gate availability checks on game state readiness by importing `ready` and `isGameStateReady` from `frontend/src/utils/gameState/common.js` and adding a `gameStateReady` writable store.  
- Keep `available` as `null` while readiness is pending and render a blank placeholder (`.temp-container`) when `available === null` instead of the unavailable gate.  
- Update the reactive availability block in `frontend/src/pages/quests/svelte/QuestChat.svelte` to defer `getUnmetQuestRequirements` / `questFinished` evaluation until readiness is confirmed.  
- Add a regression test in `frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` that simulates a pending `ready` promise, asserts the blank container is shown during pending readiness, and verifies the unavailable gate appears only after readiness resolves.

### Testing
- Ran the focused spec tests with `npx vitest run -c vitest.config.mts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts`, and the test file passed (4 tests passed).  
- The modified component was formatted with `prettier` as part of the change (no formatting regressions reported by the local run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df00788544832f93977a0450d048b0)