### PR TITLE
🐛 fix: prevent /processes preview IDs from flashing before metadata resolves

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -17,16 +17,19 @@
 
     const toPreviewLine = (entry, metadataMap, pendingIds) => {
         const entryId = normalizeProcessId(entry?.id);
-        const metadata = metadataMap?.get(entryId);
-        const metadataPending = !metadata && pendingIds instanceof Set && pendingIds.has(entryId);
+        const hasResolvedMetadata = metadataMap instanceof Map && metadataMap.has(entryId);
+        const metadata = hasResolvedMetadata ? metadataMap.get(entryId) : null;
+        const metadataPending =
+            !hasResolvedMetadata && pendingIds instanceof Set && pendingIds.has(entryId);
         const count = Number(entry?.count);
         const countLabel = Number.isFinite(count) ? count : 0;
+        const metadataUnresolved = !hasResolvedMetadata || metadataPending;
 
         return {
             id: entryId,
             countLabel,
-            name: metadataPending ? '' : metadata?.name || entry?.name || entryId || 'Unknown item',
-            image: metadataPending ? null : metadata?.image || '/favicon.ico',
+            name: metadataUnresolved ? '' : metadata?.name || 'Unknown item',
+            image: metadataUnresolved ? null : metadata?.image || '/favicon.ico',
         };
     };
 

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -63,6 +63,34 @@ describe('ProcessListRow', () => {
         expect(queryByText('2x unknown-item')).toBeNull();
     });
 
+    test('does not render preview item id when metadata is unresolved and pending ids are empty', () => {
+        const process = {
+            id: 'process-with-unresolved-item',
+            title: 'Unresolved metadata',
+            duration: '1s',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 0,
+            consumeItemTotal: 0,
+            createItemTypes: 0,
+            createItemTotal: 0,
+            requirePreviewEntries: [{ id: 'raw-item-id', count: 1 }],
+            consumePreviewEntries: [],
+            createPreviewEntries: [],
+        };
+
+        const { getByText, queryByText } = render(ProcessListRow, {
+            props: {
+                process,
+                itemMetadataMap: new Map(),
+                pendingMetadataIds: new Set(),
+            },
+        });
+
+        expect(getByText('1x')).toBeTruthy();
+        expect(queryByText('1x raw-item-id')).toBeNull();
+    });
+
     test('does not render untrusted preview images when metadata is missing', () => {
         const process = {
             id: 'process-with-untrusted-image',
@@ -81,11 +109,11 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByAltText } = render(ProcessListRow, {
+        const { queryByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByAltText('unknown-item').getAttribute('src')).toBe('/favicon.ico');
+        expect(queryByRole('img')).toBeNull();
     });
 
     test('updates preview lines when metadata map changes after mount', async () => {


### PR DESCRIPTION
### Motivation
- Hard refresh of `/processes` could briefly show raw item IDs in preview rows before item metadata finished resolving due to using `entry?.name || entryId` as a fallback and relying on `pendingMetadataIds` being populated after mount.
- The intent is to keep rows rendering immediately but never surface untrusted raw IDs/images on first paint while metadata is unresolved.

### Description
- Update `ProcessListRow.svelte` to consider metadata resolved only when `itemMetadataMap.has(id)` is true and to treat entries as unresolved until that check passes, avoiding `entry.name`/`entry.id` fallbacks during unresolved state. (`frontend/src/pages/processes/ProcessListRow.svelte`)
- Ensure unresolved preview entries render count-only text and no image, while the resolver-provided fallback (`Unknown item` + `/favicon.ico`) is still used when metadata exists for a missing item. (`ProcessListRow.svelte`)
- Add a unit test that reproduces the first-paint case where `itemMetadataMap` is empty and `pendingMetadataIds` is empty to assert raw IDs are not rendered, and tighten the image-safety test to assert no preview `img` is shown while unresolved. (`frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts`)

### Testing
- Ran unit tests: `npm run test:root -- frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts frontend/src/pages/processes/__tests__/Processes.spec.ts` and both spec files passed (all tests green).
- Attempted Playwright e2e: `npm --prefix frontend run test:e2e -- e2e/processes-metadata-loading.spec.ts` but the environment failed to download/install Playwright browser deps due to network/apt reachability, so the e2e run could not complete (failure unrelated to code changes).
- The change is minimal and focused to prevent first-paint ID/image leakage while preserving immediate row rendering and existing resolver fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2e328bdc832faf2ff0199d15d9fb)