### PR TITLE
🐛 Fix /processes preview ID flicker before metadata resolves

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,7 +1,6 @@
 <script>
     export let process;
     export let itemMetadataMap = new Map();
-    export let pendingMetadataIds = new Set();
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
@@ -15,45 +14,33 @@
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
 
-    const toPreviewLine = (entry, metadataMap, pendingIds) => {
+    const toPreviewLine = (entry, metadataMap) => {
         const entryId = normalizeProcessId(entry?.id);
-        const metadata = metadataMap?.get(entryId);
-        const metadataPending = !metadata && pendingIds instanceof Set && pendingIds.has(entryId);
+        const hasResolvedMetadata = metadataMap instanceof Map && metadataMap.has(entryId);
+        const metadata = hasResolvedMetadata ? metadataMap.get(entryId) : null;
         const count = Number(entry?.count);
         const countLabel = Number.isFinite(count) ? count : 0;
 
         return {
             id: entryId,
             countLabel,
-            name: metadataPending ? '' : metadata?.name || entry?.name || entryId || 'Unknown item',
-            image: metadataPending ? null : metadata?.image || '/favicon.ico',
+            name: hasResolvedMetadata ? metadata?.name || 'Unknown item' : '',
+            image: hasResolvedMetadata ? metadata?.image || '/favicon.ico' : null,
         };
     };
 
-    const getPreviewLines = (entries = [], metadataMap, pendingIds) =>
+    const getPreviewLines = (entries = [], metadataMap) =>
         Array.isArray(entries)
             ? entries
                   .map((entry) => ({ ...entry, id: normalizeProcessId(entry?.id) }))
                   .filter((entry) => entry.id.length > 0)
                   .slice(0, 2)
-                  .map((entry) => toPreviewLine(entry, metadataMap, pendingIds))
+                  .map((entry) => toPreviewLine(entry, metadataMap))
             : [];
 
-    $: requirePreviewLines = getPreviewLines(
-        process?.requirePreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
-    );
-    $: consumePreviewLines = getPreviewLines(
-        process?.consumePreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
-    );
-    $: createPreviewLines = getPreviewLines(
-        process?.createPreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
-    );
+    $: requirePreviewLines = getPreviewLines(process?.requirePreviewEntries, itemMetadataMap);
+    $: consumePreviewLines = getPreviewLines(process?.consumePreviewEntries, itemMetadataMap);
+    $: createPreviewLines = getPreviewLines(process?.createPreviewEntries, itemMetadataMap);
 </script>
 
 <article class="process-row" data-process-id={processId}>

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -197,7 +197,7 @@
             <div class="no-processes">No processes found</div>
         {:else}
             {#each allProcesses as process (normalizeProcessId(process.id))}
-                <ProcessListRow {process} {itemMetadataMap} {pendingMetadataIds} />
+                <ProcessListRow {process} {itemMetadataMap} />
             {/each}
         {/if}
     </div>

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -55,7 +55,6 @@ describe('ProcessListRow', () => {
             props: {
                 process,
                 itemMetadataMap: new Map(),
-                pendingMetadataIds: new Set(['unknown-item']),
             },
         });
 
@@ -81,11 +80,38 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByAltText } = render(ProcessListRow, {
+        const { queryByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByAltText('unknown-item').getAttribute('src')).toBe('/favicon.ico');
+        expect(queryByRole('img')).toBeNull();
+    });
+
+    test('never renders raw entry ids before metadata resolves when no pending ids are supplied', () => {
+        const process = {
+            id: 'process-with-unresolved-item',
+            title: 'Unresolved metadata',
+            duration: '1s',
+            requireItemTypes: 1,
+            requireItemTotal: 1,
+            consumeItemTypes: 0,
+            consumeItemTotal: 0,
+            createItemTypes: 0,
+            createItemTotal: 0,
+            requirePreviewEntries: [{ id: 'entry-id-123', count: 1 }],
+            consumePreviewEntries: [],
+            createPreviewEntries: [],
+        };
+
+        const { getByText, queryByText } = render(ProcessListRow, {
+            props: {
+                process,
+                itemMetadataMap: new Map(),
+            },
+        });
+
+        expect(getByText('1x')).toBeTruthy();
+        expect(queryByText('1x entry-id-123')).toBeNull();
     });
 
     test('updates preview lines when metadata map changes after mount', async () => {
@@ -108,7 +134,6 @@ describe('ProcessListRow', () => {
             props: {
                 process,
                 itemMetadataMap: new Map(),
-                pendingMetadataIds: new Set(['smart-plug']),
             },
         });
 
@@ -121,7 +146,6 @@ describe('ProcessListRow', () => {
             itemMetadataMap: new Map([
                 ['smart-plug', { id: 'smart-plug', name: 'Smart Plug', image: '/smart-plug.png' }],
             ]),
-            pendingMetadataIds: new Set(),
         });
 
         expect(getByText('1x Smart Plug')).toBeTruthy();

--- a/frontend/src/pages/processes/__tests__/Processes.spec.ts
+++ b/frontend/src/pages/processes/__tests__/Processes.spec.ts
@@ -232,7 +232,7 @@ describe('Processes list route contract', () => {
         expect(screen.queryByText('2x missing-item')).toBeNull();
     });
 
-    it('renders list details immediately while waiting for preview metadata to resolve', async () => {
+    it('does not leak raw preview ids on first render while metadata is unresolved', async () => {
         customListMock.mockResolvedValue([]);
         let resolveMetadata:
             | ((value: Map<string, { id: string; name: string; image: string }>) => void)
@@ -277,6 +277,7 @@ describe('Processes list route contract', () => {
         ).toBeGreaterThan(0);
         expect(screen.queryByText('1x pending-item')).toBeNull();
         expect(screen.queryByText('1x Pending Item')).toBeNull();
+        expect(screen.queryByRole('img')).toBeNull();
 
         resolveMetadata?.(
             new Map([
@@ -289,5 +290,8 @@ describe('Processes list route contract', () => {
 
         expect(await screen.findByText('1x Pending Item')).toBeTruthy();
         expect(screen.queryByText('1x pending-item')).toBeNull();
+        expect(screen.getByRole('img', { name: 'Pending Item' }).getAttribute('src')).toBe(
+            '/pending.png'
+        );
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent raw item IDs from briefly appearing in process preview rows on first paint when metadata is still loading.
- Ensure rows render immediately (title, duration, summaries, details link) while withholding preview name/image until trustworthy metadata is present.

### Description
- Change `ProcessListRow` to only show preview `name`/`image` when metadata for the entry exists in `itemMetadataMap`, and render count-only (no id or image) while unresolved by returning `name: ''` and `image: null` from `toPreviewLine`.
- Stop relying on `pendingMetadataIds` inside the row and remove the `pendingMetadataIds` prop wiring from `Processes.svelte` to keep the public component API minimal.
- Preserve resolver-provided missing-item fallback by using resolved metadata `name || 'Unknown item'` and `image || '/favicon.ico'` when the resolver has returned an explicit entry.
- Add/adjust unit tests in `ProcessListRow.spec.ts` and route tests in `Processes.spec.ts` to assert no ID leakage on first render, no untrusted images before resolution, and correct upgrade to resolved metadata once available.

### Testing
- Ran unit tests with `npm run test:root -- frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts frontend/src/pages/processes/__tests__/Processes.spec.ts` and all tests passed (13/13) ✅.
- Attempted Playwright regression `npm --prefix frontend run test:e2e -- e2e/processes-metadata-loading.spec.ts` but the run failed to install Playwright browsers due to network/apt reachability in this environment, not due to assertion failures (e2e blocked by system dependency download) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2e328bdc832faf2ff0199d15d9fb)