### PR TITLE
🐛 fix: prevent process preview ID flicker on /processes

### DIFF
--- a/frontend/src/pages/processes/ProcessListRow.svelte
+++ b/frontend/src/pages/processes/ProcessListRow.svelte
@@ -1,7 +1,6 @@
 <script>
     export let process;
     export let itemMetadataMap = new Map();
-    export let pendingMetadataIds = new Set();
 
     const normalizeProcessId = (id) => String(id ?? '').trim();
 
@@ -15,44 +14,41 @@
     $: consumeSummary = formatItemSummary(process?.consumeItemTypes, process?.consumeItemTotal);
     $: createSummary = formatItemSummary(process?.createItemTypes, process?.createItemTotal);
 
-    const toPreviewLine = (entry, metadataMap, pendingIds) => {
+    const toPreviewLine = (entry, metadataMap) => {
         const entryId = normalizeProcessId(entry?.id);
-        const metadata = metadataMap?.get(entryId);
-        const metadataPending = !metadata && pendingIds instanceof Set && pendingIds.has(entryId);
+        const metadataResolved = metadataMap instanceof Map && metadataMap.has(entryId);
+        const metadata = metadataResolved ? metadataMap.get(entryId) : null;
         const count = Number(entry?.count);
         const countLabel = Number.isFinite(count) ? count : 0;
 
         return {
             id: entryId,
             countLabel,
-            name: metadataPending ? '' : metadata?.name || entry?.name || entryId || 'Unknown item',
-            image: metadataPending ? null : metadata?.image || '/favicon.ico',
+            name: metadataResolved ? metadata?.name || 'Unknown item' : '',
+            image: metadataResolved ? metadata?.image || '/favicon.ico' : null,
         };
     };
 
-    const getPreviewLines = (entries = [], metadataMap, pendingIds) =>
+    const getPreviewLines = (entries = [], metadataMap) =>
         Array.isArray(entries)
             ? entries
                   .map((entry) => ({ ...entry, id: normalizeProcessId(entry?.id) }))
                   .filter((entry) => entry.id.length > 0)
                   .slice(0, 2)
-                  .map((entry) => toPreviewLine(entry, metadataMap, pendingIds))
+                  .map((entry) => toPreviewLine(entry, metadataMap))
             : [];
 
     $: requirePreviewLines = getPreviewLines(
         process?.requirePreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
+        itemMetadataMap
     );
     $: consumePreviewLines = getPreviewLines(
         process?.consumePreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
+        itemMetadataMap
     );
     $: createPreviewLines = getPreviewLines(
         process?.createPreviewEntries,
-        itemMetadataMap,
-        pendingMetadataIds
+        itemMetadataMap
     );
 </script>
 

--- a/frontend/src/pages/processes/Processes.svelte
+++ b/frontend/src/pages/processes/Processes.svelte
@@ -9,7 +9,6 @@
 
     let customProcesses = [];
     let itemMetadataMap = new Map();
-    let pendingMetadataIds = new Set();
     let metadataRequestId = 0;
     let isMounted = false;
     let previousMetadataIdsKey = '';
@@ -155,7 +154,6 @@
         if (nextMetadataIdsKey !== previousMetadataIdsKey) {
             const requestId = ++metadataRequestId;
             previousMetadataIdsKey = nextMetadataIdsKey;
-            pendingMetadataIds = new Set(uniqueIds);
 
             Promise.resolve()
                 .then(async () => {
@@ -173,13 +171,9 @@
 
                     releaseMapImages(itemMetadataMap);
                     itemMetadataMap = nextMap;
-                    pendingMetadataIds = new Set();
                 })
                 .catch((error) => {
                     console.error('Failed to load process item metadata:', error);
-                    if (requestId === metadataRequestId) {
-                        pendingMetadataIds = new Set();
-                    }
                 });
         }
     }
@@ -197,7 +191,7 @@
             <div class="no-processes">No processes found</div>
         {:else}
             {#each allProcesses as process (normalizeProcessId(process.id))}
-                <ProcessListRow {process} {itemMetadataMap} {pendingMetadataIds} />
+                <ProcessListRow {process} {itemMetadataMap} />
             {/each}
         {/if}
     </div>

--- a/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
+++ b/frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts
@@ -35,7 +35,7 @@ describe('ProcessListRow', () => {
         expect(getAllByRole('img')).toHaveLength(3);
     });
 
-    test('leaves preview item name blank while metadata is still loading', () => {
+    test('leaves preview item name blank while metadata is unresolved even without pending ids', () => {
         const process = {
             id: 'process-with-missing-item',
             title: 'Missing item metadata',
@@ -55,7 +55,6 @@ describe('ProcessListRow', () => {
             props: {
                 process,
                 itemMetadataMap: new Map(),
-                pendingMetadataIds: new Set(['unknown-item']),
             },
         });
 
@@ -63,7 +62,7 @@ describe('ProcessListRow', () => {
         expect(queryByText('2x unknown-item')).toBeNull();
     });
 
-    test('does not render untrusted preview images when metadata is missing', () => {
+    test('does not render preview images before metadata resolves', () => {
         const process = {
             id: 'process-with-untrusted-image',
             title: 'Untrusted image',
@@ -81,11 +80,12 @@ describe('ProcessListRow', () => {
             createPreviewEntries: [],
         };
 
-        const { getByAltText } = render(ProcessListRow, {
+        const { container, queryByRole } = render(ProcessListRow, {
             props: { process, itemMetadataMap: new Map() },
         });
 
-        expect(getByAltText('unknown-item').getAttribute('src')).toBe('/favicon.ico');
+        expect(container.querySelector('.item-preview-list img')).toBeNull();
+        expect(queryByRole('img')).toBeNull();
     });
 
     test('updates preview lines when metadata map changes after mount', async () => {
@@ -108,7 +108,6 @@ describe('ProcessListRow', () => {
             props: {
                 process,
                 itemMetadataMap: new Map(),
-                pendingMetadataIds: new Set(['smart-plug']),
             },
         });
 
@@ -121,7 +120,6 @@ describe('ProcessListRow', () => {
             itemMetadataMap: new Map([
                 ['smart-plug', { id: 'smart-plug', name: 'Smart Plug', image: '/smart-plug.png' }],
             ]),
-            pendingMetadataIds: new Set(),
         });
 
         expect(getByText('1x Smart Plug')).toBeTruthy();


### PR DESCRIPTION
### Motivation
- Hard refreshes of `/processes` briefly showed raw item IDs in preview rows before resolver metadata finished loading, causing an undesirable first-paint leakage.
- The previous gating used a `pendingMetadataIds` signal that could be populated after first render, allowing raw IDs to appear before the pending set was established.

### Description
- Change `ProcessListRow.svelte` to only render preview `name` and `image` when the entry ID is present in `itemMetadataMap`, treating unresolved entries as hidden (empty name, no image) until resolver-backed metadata is available.
- Remove the `pendingMetadataIds` prop from the row and stop relying on it; `Processes.svelte` no longer maintains or passes `pendingMetadataIds` to rows and continues to populate `itemMetadataMap` asynchronously.
- Preserve resolver fallback behavior by using resolved metadata values (`Unknown item` and `/favicon.ico`) only when those are returned by the resolver map.
- Update `frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts` to assert that preview names/images are not shown before metadata resolution and to keep the update-after-resolve assertions.

### Testing
- Ran unit tests: `npm run test:root -- frontend/src/pages/processes/__tests__/ProcessListRow.spec.ts frontend/src/pages/processes/__tests__/Processes.spec.ts` and all tests passed (12 tests total) ✅.
- Attempted Playwright E2E: `npm --prefix frontend run test:e2e -- e2e/processes-metadata-loading.spec.ts` but browser/system dependencies could not be downloaded in this environment due to network restrictions, so the Playwright run failed to start (environment/network issue), not a behavior regression ⚠️.
- The change is covered by the updated unit tests which verify no initial raw-ID rendering and correct metadata hydration once `itemMetadataMap` is populated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2e328bdc832faf2ff0199d15d9fb)