### PR TITLE
Fix Buy required items for consume-only process requirements

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -62,12 +62,37 @@
         };
     };
 
-    const getPendingBuyRequirements = () => {
-        if (!displayProcess?.requireItems?.length) {
+    const getRequiredPurchaseItems = () => {
+        if (!displayProcess) {
             return [];
         }
 
-        return displayProcess.requireItems
+        const requiredCounts = new Map();
+        const addCounts = (sourceItems = []) => {
+            sourceItems.forEach((item) => {
+                const id = item?.id;
+                const count = Number(item?.count);
+                if (!id || !Number.isFinite(count) || count <= 0) {
+                    return;
+                }
+
+                requiredCounts.set(id, Math.max(requiredCounts.get(id) ?? 0, count));
+            });
+        };
+
+        addCounts(displayProcess.requireItems);
+        addCounts(displayProcess.consumeItems);
+
+        return Array.from(requiredCounts.entries()).map(([id, count]) => ({ id, count }));
+    };
+
+    const getPendingBuyRequirements = () => {
+        const requiredItems = getRequiredPurchaseItems();
+        if (!requiredItems.length) {
+            return [];
+        }
+
+        return requiredItems
             .map((req) => {
                 const have = getItemCount(req.id);
                 const neededQuantity = roundDownQuantity(req.count - have);
@@ -141,11 +166,12 @@
     };
 
     const getDisabledReason = () => {
-        if (!displayProcess || !displayProcess.requireItems) {
+        const requiredItems = getRequiredPurchaseItems();
+        if (!requiredItems.length) {
             return 'No required items are purchasable.';
         }
 
-        const missingRequirements = displayProcess.requireItems.filter(
+        const missingRequirements = requiredItems.filter(
             (req) => roundDownQuantity(req.count - getItemCount(req.id)) > 0
         );
         if (missingRequirements.length === 0) {

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -36,6 +36,17 @@ vi.mock('../../../../generated/processes.json', () => ({
             consumeItems: [],
             createItems: [],
         },
+        {
+            id: 'consume-only-process',
+            title: 'Consume Only Process',
+            requireItems: [],
+            consumeItems: [
+                { id: 'printer-item', count: 1 },
+                { id: 'green-pla-item', count: 18.48 },
+                { id: 'energy-item', count: 266.67 },
+            ],
+            createItems: [],
+        },
     ],
 }));
 
@@ -64,6 +75,17 @@ vi.mock('../../../inventory/json/items', () => ({
         {
             id: 'dbi-item',
             name: 'dBI',
+        },
+        {
+            id: 'printer-item',
+            price: '100 dUSD',
+        },
+        {
+            id: 'green-pla-item',
+            price: '4 dUSD',
+        },
+        {
+            id: 'energy-item',
         },
     ],
 }));
@@ -219,6 +241,25 @@ describe('ProcessView detail controls', () => {
         expect(buyItemsMock).toHaveBeenCalledWith([
             { id: 'req-item-b', quantity: 1, price: 2, currencyId: 'dusd-item' },
             { id: 'dbi-item-required', quantity: 2, price: 4, currencyId: 'dbi-item' },
+        ]);
+    });
+
+    it('treats consumed items as buyable requirements when requireItems is empty', async () => {
+        getItemCountMock.mockImplementation((itemId: string) => {
+            if (itemId === 'dusd-item') {
+                return 200;
+            }
+            return 0;
+        });
+        render(ProcessView, { props: { slug: 'consume-only-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.hasAttribute('disabled')).toBe(false);
+
+        await fireEvent.click(buyButton);
+        expect(buyItemsMock).toHaveBeenCalledWith([
+            { id: 'green-pla-item', quantity: 18.48, price: 4, currencyId: 'dusd-item' },
+            { id: 'printer-item', quantity: 1, price: 100, currencyId: 'dusd-item' },
         ]);
     });
 });

--- a/outages/2026-04-15-process-buy-required-consume-fallback.json
+++ b/outages/2026-04-15-process-buy-required-consume-fallback.json
@@ -1,0 +1,11 @@
+{
+  "id": "2026-04-15-process-buy-required-consume-fallback",
+  "date": "2026-04-15",
+  "component": "frontend:process-buy-required-items",
+  "rootCause": "The process detail Buy required items logic only evaluated process.requireItems. Processes that gate startability through consumeItems (with empty requireItems) were treated as already satisfied, incorrectly disabling the button with 'All required items are already available.'",
+  "resolution": "Updated ProcessView purchase requirement derivation to include both requireItems and consumeItems (using per-item max quantity), so consume-only process inputs are considered missing when absent. Added unit coverage for consume-only process purchasing behavior.",
+  "references": [
+    "frontend/src/pages/process/[slug]/ProcessView.svelte",
+    "frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- The process detail UI disabled the `Buy required items` button when `requireItems` was empty even if consumables in `consumeItems` were missing, e.g. `/processes/3dprint-rocket-body-tube`.
- The intent is to allow the UI to offer purchases when any inputs needed to start a process are missing, whether listed under `requireItems` or `consumeItems`.

### Description
- Added `getRequiredPurchaseItems()` to `frontend/src/pages/process/[slug]/ProcessView.svelte` to derive per-item required counts from both `requireItems` and `consumeItems` using a per-item max to avoid double-counting. 
- Switched `getPendingBuyRequirements()` and `getDisabledReason()` to use the merged required set so consume-only inputs are considered when deciding button enabled state and purchase plans. 
- Added a regression test `treats consumed items as buyable requirements when requireItems is empty` in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` that asserts the buy flow purchases `1` printer and `18.48` green PLA when funds exist. 
- Logged the regression in `outages/2026-04-15-process-buy-required-consume-fallback.json` and kept existing pricing/currency behavior intact so non-priced inputs (like energy) remain excluded from auto-purchase.

### Testing
- Ran `npm run test:root -- frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` and all tests passed. 
- Ran `npm run lint` and the lint step completed successfully. 
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which produced no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2f6d45f0832f8e0ab91918cd6019)