### PR TITLE
Fix Buy required items for consume-only process requirements

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -62,12 +62,25 @@
         };
     };
 
-    const getPendingBuyRequirements = () => {
-        if (!displayProcess?.requireItems?.length) {
+    const getAutoBuyRequirements = () => {
+        if (!displayProcess) {
             return [];
         }
 
-        return displayProcess.requireItems
+        if (displayProcess.requireItems?.length) {
+            return displayProcess.requireItems;
+        }
+
+        return displayProcess.consumeItems ?? [];
+    };
+
+    const getPendingBuyRequirements = () => {
+        const requirements = getAutoBuyRequirements();
+        if (!requirements.length) {
+            return [];
+        }
+
+        return requirements
             .map((req) => {
                 const have = getItemCount(req.id);
                 const neededQuantity = roundDownQuantity(req.count - have);
@@ -141,11 +154,12 @@
     };
 
     const getDisabledReason = () => {
-        if (!displayProcess || !displayProcess.requireItems) {
+        const requirements = getAutoBuyRequirements();
+        if (!requirements.length) {
             return 'No required items are purchasable.';
         }
 
-        const missingRequirements = displayProcess.requireItems.filter(
+        const missingRequirements = requirements.filter(
             (req) => roundDownQuantity(req.count - getItemCount(req.id)) > 0
         );
         if (missingRequirements.length === 0) {

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -36,6 +36,17 @@ vi.mock('../../../../generated/processes.json', () => ({
             consumeItems: [],
             createItems: [],
         },
+        {
+            id: 'consume-fallback-process',
+            title: 'Consume Fallback Process',
+            requireItems: [],
+            consumeItems: [
+                { id: 'req-item', count: 1 },
+                { id: 'req-item-b', count: 18.48 },
+                { id: 'unpriced-item', count: 10 },
+            ],
+            createItems: [],
+        },
     ],
 }));
 
@@ -64,6 +75,9 @@ vi.mock('../../../inventory/json/items', () => ({
         {
             id: 'dbi-item',
             name: 'dBI',
+        },
+        {
+            id: 'unpriced-item',
         },
     ],
 }));
@@ -219,6 +233,26 @@ describe('ProcessView detail controls', () => {
         expect(buyItemsMock).toHaveBeenCalledWith([
             { id: 'req-item-b', quantity: 1, price: 2, currencyId: 'dusd-item' },
             { id: 'dbi-item-required', quantity: 2, price: 4, currencyId: 'dbi-item' },
+        ]);
+    });
+
+    it('falls back to consumeItems when requireItems is empty', async () => {
+        getItemCountMock.mockImplementation((itemId: string) => {
+            if (itemId === 'dusd-item') {
+                return 100;
+            }
+            return 0;
+        });
+        render(ProcessView, { props: { slug: 'consume-fallback-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.hasAttribute('disabled')).toBe(false);
+
+        await fireEvent.click(buyButton);
+
+        expect(buyItemsMock).toHaveBeenCalledWith([
+            { id: 'req-item', quantity: 1, price: 5, currencyId: 'dusd-item' },
+            { id: 'req-item-b', quantity: 18.48, price: 2, currencyId: 'dusd-item' },
         ]);
     });
 });

--- a/outages/2026-04-15-process-buy-required-items-consume-fallback-regression.md
+++ b/outages/2026-04-15-process-buy-required-items-consume-fallback-regression.md
@@ -1,0 +1,22 @@
+# Buy required items incorrectly disabled for consume-only process requirements
+
+## Summary
+The process detail page for `3dprint-rocket-body-tube` showed the **Buy required items** button as disabled with the message "All required items are already available." even when required consume inputs were missing (for example, `entry-level FDM 3D printer` and `green PLA filament` at zero inventory).
+
+## User-visible impact
+- Players could not use **Buy required items** to purchase missing consumables for affected processes.
+- The disabled reason was misleading because the missing requirements were in `consumeItems`, not `requireItems`.
+
+## Regression window
+- **Introduced:** Before 2026-04-15 (exact introducing commit unknown).
+- **Detected:** 2026-04-15 from staging report on `/processes/3dprint-rocket-body-tube`.
+- **Fixed:** 2026-04-15.
+
+## Root cause
+The auto-buy logic only evaluated `requireItems`. Many built-in processes model start requirements in `consumeItems` (with empty `requireItems`), so missing inputs were ignored and the UI concluded that all required items were available.
+
+## Resolution
+- Updated process detail auto-buy requirement selection to:
+  - use `requireItems` when present,
+  - otherwise fall back to `consumeItems`.
+- Added regression test coverage for consume-only processes to ensure the buy button enables and purchases missing priced consumables while skipping unpriced entries.


### PR DESCRIPTION
### Motivation
- The process detail view showed the Buy required items button as disabled with the reason "All required items are already available" for processes that model start inputs in `consumeItems` (for example `/processes/3dprint-rocket-body-tube`).
- The UI previously only inspected `requireItems`, so consume-only requirement sets were ignored and the button state was computed incorrectly.

### Description
- Added `getAutoBuyRequirements()` in `frontend/src/pages/process/[slug]/ProcessView.svelte` to return `requireItems` when present and fall back to `consumeItems` otherwise. 
- Rewired `getPendingBuyRequirements()` and `getDisabledReason()` to use the unified requirement list when building purchase plans and computing disabled reasons. 
- Added a regression test (`falls back to consumeItems when requireItems is empty`) in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` to assert the buy button enables and purchases missing priced consumables while skipping unpriced items. 
- Logged the incident in a new outage entry `outages/2026-04-15-process-buy-required-items-consume-fallback-regression.md` describing the root cause and resolution. 

### Testing
- Ran `npx vitest run frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` and the suite passed (7 tests, all passed). 
- Ran `npm run lint` (frontend lint step executed) with no blocking errors reported. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to scan staged changes for secrets and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2f6d45f0832f8e0ab91918cd6019)