### PR TITLE
Fix Buy required items for consume-only process inputs

### DIFF
--- a/frontend/src/pages/process/[slug]/ProcessView.svelte
+++ b/frontend/src/pages/process/[slug]/ProcessView.svelte
@@ -62,12 +62,25 @@
         };
     };
 
-    const getPendingBuyRequirements = () => {
-        if (!displayProcess?.requireItems?.length) {
+    const getBuyableRequirements = () => {
+        if (!displayProcess) {
             return [];
         }
 
-        return displayProcess.requireItems
+        if (displayProcess.requireItems?.length) {
+            return displayProcess.requireItems;
+        }
+
+        return displayProcess.consumeItems ?? [];
+    };
+
+    const getPendingBuyRequirements = () => {
+        const requirements = getBuyableRequirements();
+        if (!requirements.length) {
+            return [];
+        }
+
+        return requirements
             .map((req) => {
                 const have = getItemCount(req.id);
                 const neededQuantity = roundDownQuantity(req.count - have);
@@ -141,11 +154,12 @@
     };
 
     const getDisabledReason = () => {
-        if (!displayProcess || !displayProcess.requireItems) {
+        const requirements = getBuyableRequirements();
+        if (!requirements.length) {
             return 'No required items are purchasable.';
         }
 
-        const missingRequirements = displayProcess.requireItems.filter(
+        const missingRequirements = requirements.filter(
             (req) => roundDownQuantity(req.count - getItemCount(req.id)) > 0
         );
         if (missingRequirements.length === 0) {

--- a/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
+++ b/frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts
@@ -36,6 +36,17 @@ vi.mock('../../../../generated/processes.json', () => ({
             consumeItems: [],
             createItems: [],
         },
+        {
+            id: 'consume-fallback-process',
+            title: 'Consume Fallback Process',
+            requireItems: [],
+            consumeItems: [
+                { id: 'printer-item', count: 1 },
+                { id: 'green-pla-item', count: 18.48 },
+                { id: 'dwatt-item', count: 266.67 },
+            ],
+            createItems: [{ id: 'printer-item', count: 1 }],
+        },
     ],
 }));
 
@@ -64,6 +75,17 @@ vi.mock('../../../inventory/json/items', () => ({
         {
             id: 'dbi-item',
             name: 'dBI',
+        },
+        {
+            id: 'printer-item',
+            price: '300 dUSD',
+        },
+        {
+            id: 'green-pla-item',
+            price: '2 dUSD',
+        },
+        {
+            id: 'dwatt-item',
         },
     ],
 }));
@@ -220,5 +242,37 @@ describe('ProcessView detail controls', () => {
             { id: 'req-item-b', quantity: 1, price: 2, currencyId: 'dusd-item' },
             { id: 'dbi-item-required', quantity: 2, price: 4, currencyId: 'dbi-item' },
         ]);
+    });
+
+    it('falls back to consumeItems when requireItems is empty and disables after buying missing items', async () => {
+        const inventory: Record<string, number> = {
+            'dusd-item': 400,
+            'dwatt-item': 9000,
+            'printer-item': 0,
+            'green-pla-item': 0,
+        };
+        getItemCountMock.mockImplementation((itemId: string) => inventory[itemId] ?? 0);
+        buyItemsMock.mockImplementation((purchases: Array<{ id: string; quantity: number }>) => {
+            purchases.forEach(({ id, quantity }) => {
+                inventory[id] = (inventory[id] ?? 0) + quantity;
+            });
+        });
+        render(ProcessView, { props: { slug: 'consume-fallback-process' } });
+
+        const buyButton = await screen.findByRole('button', { name: 'Buy required items' });
+        expect(buyButton.hasAttribute('disabled')).toBe(false);
+
+        await fireEvent.click(buyButton);
+
+        expect(buyItemsMock).toHaveBeenCalledWith([
+            { id: 'green-pla-item', quantity: 18.48, price: 2, currencyId: 'dusd-item' },
+            { id: 'printer-item', quantity: 1, price: 300, currencyId: 'dusd-item' },
+        ]);
+
+        expect(buyButton.hasAttribute('disabled')).toBe(true);
+        const reasonElement = document.getElementById(
+            'buy-required-disabled-reason-consume-fallback-process'
+        );
+        expect(reasonElement?.textContent).toBe('All required items are already available.');
     });
 });

--- a/outages/2026-04-15-process-buy-required-consume-fallback.json
+++ b/outages/2026-04-15-process-buy-required-consume-fallback.json
@@ -1,0 +1,11 @@
+{
+  "id": "2026-04-15-process-buy-required-consume-fallback",
+  "date": "2026-04-15",
+  "component": "frontend:process-detail-buy-required",
+  "rootCause": "The process detail Buy required items control only inspected process.requireItems. Several production processes define required inputs exclusively in consumeItems, so the button incorrectly reported \"All required items are already available.\" even when consumables were missing.",
+  "resolution": "Updated ProcessView to fall back to consumeItems when requireItems is empty, preserving existing requireItems behavior. Added a regression test covering a process that consumes a durable tool and feedstock, verifies the purchase plan (1 printer + 18.48 green PLA filament), and verifies the control disables after the missing inputs are purchased.",
+  "references": [
+    "frontend/src/pages/process/[slug]/ProcessView.svelte",
+    "frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- The process detail UI reported "All required items are already available." for processes that list inputs in `consumeItems` but have an empty `requireItems` array, preventing the user from buying needed consumables (e.g. the 3D print rocket body tube case).
- The desired behavior is to enable the Buy button when consumables or durable tools are missing and to disable it after purchasing the missing inputs.

### Description
- Add `getBuyableRequirements()` to prefer `requireItems` but fall back to `consumeItems` when `requireItems` is empty, and wire it into `getPendingBuyRequirements()` and `getDisabledReason()` in `frontend/src/pages/process/[slug]/ProcessView.svelte`.
- Keep existing purchase planning and currency logic but derive requirements from the new helper so consume-only processes are handled correctly.
- Add a regression test in `frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts` that verifies buying `1 x entry-level FDM 3D printer` and `18.48 x green PLA filament` and that the control disables afterwards.
- Log the incident in a new outages entry `outages/2026-04-15-process-buy-required-consume-fallback.json` describing root cause and resolution.

### Testing
- Ran the targeted unit spec with `npx vitest run -c vitest.config.mts "frontend/src/pages/process/[slug]/__tests__/ProcessView.spec.ts"`, and the spec passed (7 tests).
- Ran a local secret scan with `git diff --cached | ./scripts/scan-secrets.py`, and it reported clean results.
- A full `npm --prefix frontend test` run in this environment produced unrelated failures in other tests (path/fixture issues) that are not caused by this change, so the focused spec was used to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2f6d45f0832f8e0ab91918cd6019)