### PR TITLE
✨ feat: redesign /settings with responsive 2D grid layout

### DIFF
--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -15,33 +15,71 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
 ---
 
 <Page title="Settings" message="Manage your DSPACE session" columns="1">
-    <div class="settings-content">
-        <LogoutPanel client:idle />
+    <section class="settings-content" aria-label="Settings controls">
+        <div class="settings-item">
+            <LogoutPanel client:idle />
+        </div>
+        <div class="settings-item">
+            <QuestGraphToggle client:idle />
+        </div>
         {
             cheatsAvailable ? (
-                <QaCheatsToggle
-                    cheatsAvailable={cheatsAvailable}
-                    stagingEnvironment={stagingEnvironment}
-                    client:idle
-                />
+                <div class="settings-item settings-item--wide">
+                    <QaCheatsToggle
+                        cheatsAvailable={cheatsAvailable}
+                        stagingEnvironment={stagingEnvironment}
+                        client:idle
+                    />
+                </div>
             ) : null
         }
-        <QuestGraphToggle client:idle />
-        <LegacySaveUpgrade
-            legacyV1Items={legacyV1Items}
-            legacyCookieKeys={legacyCookieKeys}
-            cheatsAvailable={cheatsAvailable}
-            client:idle
-        />
-        <DataReset client:idle />
-    </div>
+        <div class="settings-item settings-item--wide">
+            <LegacySaveUpgrade
+                legacyV1Items={legacyV1Items}
+                legacyCookieKeys={legacyCookieKeys}
+                cheatsAvailable={cheatsAvailable}
+                client:idle
+            />
+        </div>
+        <div class="settings-item">
+            <DataReset client:idle />
+        </div>
+    </section>
 </Page>
 
 <style>
     .settings-content {
         display: grid;
-        justify-content: center;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
         gap: 1rem;
+        width: min(100%, 1800px);
+        margin: 0 auto;
         padding: 1rem;
+        align-items: start;
+    }
+
+    .settings-item {
+        min-width: 0;
+    }
+
+    .settings-item--wide {
+        grid-column: 1 / -1;
+    }
+
+    .settings-item :global(.logout-panel),
+    .settings-item :global(.panel),
+    .settings-item :global(.qa-cheats),
+    .settings-item :global(.legacy-upgrade),
+    .settings-item :global(.data-reset) {
+        max-width: none;
+        width: 100%;
+        height: 100%;
+    }
+
+    @media (max-width: 720px) {
+        .settings-content {
+            grid-template-columns: 1fr;
+            padding: 0.75rem;
+        }
     }
 </style>


### PR DESCRIPTION
### Motivation
- Make the `/settings` page visually consistent with wide-layout pages like `/quests`, `/inventory`, and `/docs` by using a multi-column layout. 
- Use horizontal real estate on monitors and ultrawide displays more efficiently so small settings cards can tile instead of being stretched in a single row.
- Keep mobile ergonomics intact by falling back to a single-column layout on small screens.

### Description
- Refactored `frontend/src/pages/settings.astro` to wrap each settings module in a `settings-item` container and replaced the single stacked layout with a CSS grid container. 
- Added a `settings-item--wide` variant and applied it to the QA cheats and Legacy Save Upgrade sections so larger tools span the full row while compact cards tile side-by-side. 
- Introduced responsive grid styling: `grid-template-columns: repeat(auto-fit, minmax(320px, 1fr))`, a page width cap `width: min(100%, 1800px)`, and center alignment so content uses available monitor/ultrawide space. 
- Added global overrides for the existing panel/card classes via `:global(...)` so those components can expand to fill grid columns, and added a media query fallback (`@media (max-width: 720px)`) for single-column mobile layout.

### Testing
- Ran `npm run lint` and the lint step passed. 
- Ran the full automated suite via `npm run test:ci` and all tests completed successfully.
- `prettier`/format checks executed as part of the CI test flow and passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e089847a78832fa61d52e585d44d03)