### PR TITLE
Settings: responsive 12-column grid and consistent panel sizing

### DIFF
--- a/frontend/src/components/svelte/DataReset.svelte
+++ b/frontend/src/components/svelte/DataReset.svelte
@@ -197,7 +197,7 @@
         padding: 1.5rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #2c0c13, #19070c);
         color: #f9fafb;
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);

--- a/frontend/src/components/svelte/LegacySaveUpgrade.svelte
+++ b/frontend/src/components/svelte/LegacySaveUpgrade.svelte
@@ -543,7 +543,7 @@
         padding: 1.5rem;
         display: grid;
         gap: 1rem;
-        max-width: 960px;
+        width: 100%;
         background: linear-gradient(135deg, #0f172a, #0b1222);
         color: #f9fafb;
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);

--- a/frontend/src/components/svelte/LogoutPanel.svelte
+++ b/frontend/src/components/svelte/LogoutPanel.svelte
@@ -68,15 +68,15 @@
 
 <style>
     .logout-panel {
-        background: #2c5837;
-        border: 2px solid #007006;
+        background: linear-gradient(135deg, #133727, #0f291d);
+        border: 1px solid #1c7f49;
         border-radius: 12px;
-        padding: 16px;
-        max-width: 480px;
-        color: #fff;
+        padding: 1.25rem;
+        color: #e6f8ec;
         display: flex;
         flex-direction: column;
         gap: 12px;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
     }
 
     h3 {
@@ -90,7 +90,7 @@
 
     button {
         align-self: flex-start;
-        background: #007006;
+        background: #0f8f42;
         border: none;
         border-radius: 8px;
         color: #fff;
@@ -114,6 +114,6 @@
 
     .state {
         font-style: italic;
-        color: #d1f7d1;
+        color: #c9f0d5;
     }
 </style>

--- a/frontend/src/components/svelte/QaCheatsToggle.svelte
+++ b/frontend/src/components/svelte/QaCheatsToggle.svelte
@@ -375,7 +375,7 @@
         padding: 1.25rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #0b1f2e, #07131d);
         color: #e0f2ff;
         box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);

--- a/frontend/src/components/svelte/QuestGraphToggle.svelte
+++ b/frontend/src/components/svelte/QuestGraphToggle.svelte
@@ -128,7 +128,7 @@
         padding: 1.25rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #0b1221, #0d1828);
         color: #e2e8f0;
         box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -16,32 +16,64 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
 
 <Page title="Settings" message="Manage your DSPACE session" columns="1">
     <div class="settings-content">
-        <LogoutPanel client:idle />
+        <div class="settings-card">
+            <LogoutPanel client:idle />
+        </div>
         {
             cheatsAvailable ? (
-                <QaCheatsToggle
-                    cheatsAvailable={cheatsAvailable}
-                    stagingEnvironment={stagingEnvironment}
-                    client:idle
-                />
+                <div class="settings-card settings-card--wide">
+                    <QaCheatsToggle
+                        cheatsAvailable={cheatsAvailable}
+                        stagingEnvironment={stagingEnvironment}
+                        client:idle
+                    />
+                </div>
             ) : null
         }
-        <QuestGraphToggle client:idle />
-        <LegacySaveUpgrade
-            legacyV1Items={legacyV1Items}
-            legacyCookieKeys={legacyCookieKeys}
-            cheatsAvailable={cheatsAvailable}
-            client:idle
-        />
-        <DataReset client:idle />
+        <div class="settings-card">
+            <QuestGraphToggle client:idle />
+        </div>
+        <div class="settings-card settings-card--wide">
+            <LegacySaveUpgrade
+                legacyV1Items={legacyV1Items}
+                legacyCookieKeys={legacyCookieKeys}
+                cheatsAvailable={cheatsAvailable}
+                client:idle
+            />
+        </div>
+        <div class="settings-card">
+            <DataReset client:idle />
+        </div>
     </div>
 </Page>
 
 <style>
     .settings-content {
         display: grid;
-        justify-content: center;
-        gap: 1rem;
-        padding: 1rem;
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        gap: 1.25rem;
+        width: min(1600px, 100%);
+        margin: 0 auto;
+        padding: 1.25rem 1rem 2rem;
+    }
+
+    .settings-card {
+        grid-column: span 6;
+        min-width: 0;
+    }
+
+    .settings-card--wide {
+        grid-column: 1 / -1;
+    }
+
+    .settings-card > :global(*) {
+        width: 100%;
+        height: 100%;
+    }
+
+    @media (max-width: 1024px) {
+        .settings-card {
+            grid-column: span 12;
+        }
     }
 </style>


### PR DESCRIPTION
### Motivation
- Make the `/settings` page use available horizontal real estate on wide screens (including ultrawide) instead of stacking narrow columns. 
- Provide a consistent visual theme and sizing for individual settings panels so they align with other full-width pages like `/quests` and `/inventory`.

### Description
- Convert `frontend/src/pages/settings.astro` to a responsive 12-column grid and wrap each settings widget in `.settings-card` (half-width on desktop, full-width on smaller viewports) and add `.settings-card--wide` for full-span sections. 
- Force children to fill their grid cell via `.settings-card > :global(*) { width: 100%; height: 100%; }` so components align and size consistently. 
- Remove restrictive `max-width` rules from `QaCheatsToggle.svelte`, `QuestGraphToggle.svelte`, `LegacySaveUpgrade.svelte`, and `DataReset.svelte` so panels can expand to the grid (`width: 100%`). 
- Refresh `LogoutPanel.svelte` styling (gradient, border, padding, button color, shadow, and state color) to match the settings card theme.

### Testing
- Ran `npm run lint` and the lint step completed successfully. 
- Ran the build as part of `npm run test:ci` and the Astro client/server build completed, but the full `npm run test:ci` (Vitest) run did not finish in this environment before the session timed out. 
- Ran the pre-commit secrets scan via `git diff --cached | ./scripts/scan-secrets.py` which produced no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e089847a78832fa61d52e585d44d03)