### PR TITLE
Unify /settings layout with responsive grid and full-width panels

### DIFF
--- a/frontend/src/components/svelte/DataReset.svelte
+++ b/frontend/src/components/svelte/DataReset.svelte
@@ -197,7 +197,7 @@
         padding: 1.5rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #2c0c13, #19070c);
         color: #f9fafb;
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);

--- a/frontend/src/components/svelte/LegacySaveUpgrade.svelte
+++ b/frontend/src/components/svelte/LegacySaveUpgrade.svelte
@@ -543,7 +543,7 @@
         padding: 1.5rem;
         display: grid;
         gap: 1rem;
-        max-width: 960px;
+        width: 100%;
         background: linear-gradient(135deg, #0f172a, #0b1222);
         color: #f9fafb;
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.45);

--- a/frontend/src/components/svelte/LogoutPanel.svelte
+++ b/frontend/src/components/svelte/LogoutPanel.svelte
@@ -72,7 +72,7 @@
         border: 2px solid #007006;
         border-radius: 12px;
         padding: 16px;
-        max-width: 480px;
+        width: 100%;
         color: #fff;
         display: flex;
         flex-direction: column;

--- a/frontend/src/components/svelte/QaCheatsToggle.svelte
+++ b/frontend/src/components/svelte/QaCheatsToggle.svelte
@@ -375,7 +375,7 @@
         padding: 1.25rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #0b1f2e, #07131d);
         color: #e0f2ff;
         box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);

--- a/frontend/src/components/svelte/QuestGraphToggle.svelte
+++ b/frontend/src/components/svelte/QuestGraphToggle.svelte
@@ -128,7 +128,7 @@
         padding: 1.25rem;
         display: grid;
         gap: 0.75rem;
-        max-width: 640px;
+        width: 100%;
         background: linear-gradient(135deg, #0b1221, #0d1828);
         color: #e2e8f0;
         box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -40,8 +40,34 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
 <style>
     .settings-content {
         display: grid;
-        justify-content: center;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        grid-auto-flow: dense;
+        align-items: start;
         gap: 1rem;
+        width: min(1500px, 100%);
+        margin: 0 auto;
         padding: 1rem;
+    }
+
+    .settings-content :global(.logout-panel),
+    .settings-content :global(.qa-cheats),
+    .settings-content :global(.panel),
+    .settings-content :global(.legacy-upgrade),
+    .settings-content :global(.data-reset) {
+        width: 100%;
+        max-width: none;
+    }
+
+    .settings-content :global(.qa-tools) {
+        background: linear-gradient(135deg, #111b2f, #0d1426);
+        border-style: solid;
+        border-color: rgba(56, 189, 248, 0.35);
+    }
+
+    @media (min-width: 1100px) {
+        .settings-content :global(.legacy-upgrade),
+        .settings-content :global(.qa-tools) {
+            grid-column: 1 / -1;
+        }
     }
 </style>


### PR DESCRIPTION
### Motivation
- The /settings page used stacked, narrow panels with fixed max-widths which wasted horizontal space on wide and ultrawide screens.
- Make settings visually consistent with other full-width pages (e.g. /quests, /inventory) by letting cards use available real estate and forming a 2D grid.

### Description
- Switch `/settings` to a responsive 2D CSS grid and center content with `grid-template-columns: repeat(auto-fit, minmax(320px, 1fr))` and `grid-auto-flow: dense` in `frontend/src/pages/settings.astro`.
- Add page-level overrides so settings panels expand to their grid tracks by removing per-component `max-width` caps and ensuring `width: 100%` for panels in `settings.astro`.
- Update individual settings components to fill available width by replacing `max-width` with `width: 100%` in `LogoutPanel.svelte`, `QaCheatsToggle.svelte`, `QuestGraphToggle.svelte`, `LegacySaveUpgrade.svelte`, and `DataReset.svelte`.
- Keep larger QA/legacy sections readable by adding a desktop media rule so `.legacy-upgrade` and `.qa-tools` span the full row on wide screens and harmonize the QA tools surface styling.

### Testing
- Ran `npm run lint` and the lint suite completed successfully.
- Ran the full CI test suite with `npm run test:ci` and all automated tests passed.
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` as part of the pre-commit checks and it completed without flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e089847a78832fa61d52e585d44d03)