### PR TITLE
Settings: responsive grid layout and unified card styling

### DIFF
--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -42,17 +42,20 @@ test.describe('Settings route', () => {
             const uniqueCardRows = new Set(cards.map(toRoundedTop));
             const settingsRect = settingsContent.getBoundingClientRect();
             const legacyRect = legacyUpgrade.getBoundingClientRect();
-            const gridColumns = getComputedStyle(settingsContent)
-                .gridTemplateColumns.split(' ')
-                .filter(Boolean);
+            const settingsStyles = getComputedStyle(settingsContent);
+            const gridColumns = settingsStyles.gridTemplateColumns.split(' ').filter(Boolean);
+            const settingsContentLeft =
+                settingsRect.left + parseFloat(settingsStyles.paddingLeft || '0');
+            const settingsContentRight =
+                settingsRect.right - parseFloat(settingsStyles.paddingRight || '0');
 
             return {
                 rowCount: uniqueCardRows.size,
                 cardCount: cards.length,
                 gridColumnCount: gridColumns.length,
                 legacyGridColumn: getComputedStyle(legacyUpgrade).gridColumn,
-                settingsWidth: settingsRect.width,
-                legacyWidth: legacyRect.width,
+                legacyLeftGap: Math.abs(legacyRect.left - settingsContentLeft),
+                legacyRightGap: Math.abs(settingsContentRight - legacyRect.right),
             };
         });
 
@@ -60,9 +63,8 @@ test.describe('Settings route', () => {
         expect(desktopLayout?.gridColumnCount).toBeGreaterThan(1);
         expect(desktopLayout?.rowCount).toBeLessThan(desktopLayout?.cardCount ?? 0);
         expect(desktopLayout?.legacyGridColumn).toContain('1 / -1');
-        expect(desktopLayout?.legacyWidth ?? 0).toBeGreaterThanOrEqual(
-            (desktopLayout?.settingsWidth ?? 0) - 2
-        );
+        expect(desktopLayout?.legacyLeftGap ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(4);
+        expect(desktopLayout?.legacyRightGap ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(4);
 
         await page.setViewportSize({ width: 390, height: 844 });
         await page.reload();

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -18,4 +18,84 @@ test.describe('Settings route', () => {
         await expect(page.getByRole('button', { name: 'Log out' })).toBeVisible();
         await expect(page.getByTestId('logout-state')).toHaveText('No saved credentials detected.');
     });
+
+    test('keeps settings layout contract across desktop and mobile viewports', async ({ page }) => {
+        await page.setViewportSize({ width: 1440, height: 900 });
+        await page.goto('/settings');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const desktopLayout = await page.evaluate(() => {
+            const settingsContent = document.querySelector('.settings-content');
+            const legacyUpgrade = document.querySelector('.legacy-upgrade');
+            const cards = ['.logout-panel', '.panel', '.data-reset']
+                .map((selector) => document.querySelector(selector))
+                .filter((element): element is Element => element !== null);
+
+            if (!settingsContent || !legacyUpgrade || cards.length < 3) {
+                return null;
+            }
+
+            const toRoundedTop = (element: Element): number =>
+                Math.round(element.getBoundingClientRect().top);
+
+            const uniqueCardRows = new Set(cards.map(toRoundedTop));
+            const settingsRect = settingsContent.getBoundingClientRect();
+            const legacyRect = legacyUpgrade.getBoundingClientRect();
+            const gridColumns = getComputedStyle(settingsContent)
+                .gridTemplateColumns.split(' ')
+                .filter(Boolean);
+
+            return {
+                rowCount: uniqueCardRows.size,
+                cardCount: cards.length,
+                gridColumnCount: gridColumns.length,
+                legacyGridColumn: getComputedStyle(legacyUpgrade).gridColumn,
+                settingsWidth: settingsRect.width,
+                legacyWidth: legacyRect.width,
+            };
+        });
+
+        expect(desktopLayout).not.toBeNull();
+        expect(desktopLayout?.gridColumnCount).toBeGreaterThan(1);
+        expect(desktopLayout?.rowCount).toBeLessThan(desktopLayout?.cardCount ?? 0);
+        expect(desktopLayout?.legacyGridColumn).toContain('1 / -1');
+        expect(desktopLayout?.legacyWidth ?? 0).toBeGreaterThanOrEqual(
+            (desktopLayout?.settingsWidth ?? 0) - 2
+        );
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        const mobileLayout = await page.evaluate(() => {
+            const settingsContent = document.querySelector('.settings-content');
+            const cards = ['.logout-panel', '.panel', '.data-reset']
+                .map((selector) => document.querySelector(selector))
+                .filter((element): element is Element => element !== null);
+
+            if (!settingsContent || cards.length < 3) {
+                return null;
+            }
+
+            const uniqueCardRows = new Set(
+                cards.map((element) => Math.round(element.getBoundingClientRect().top))
+            );
+
+            const gridColumns = getComputedStyle(settingsContent)
+                .gridTemplateColumns.split(' ')
+                .filter(Boolean);
+
+            return {
+                rowCount: uniqueCardRows.size,
+                cardCount: cards.length,
+                gridColumnCount: gridColumns.length,
+            };
+        });
+
+        expect(mobileLayout).not.toBeNull();
+        expect(mobileLayout?.gridColumnCount).toBe(1);
+        expect(mobileLayout?.rowCount).toBe(mobileLayout?.cardCount);
+    });
 });

--- a/frontend/src/components/svelte/LogoutPanel.svelte
+++ b/frontend/src/components/svelte/LogoutPanel.svelte
@@ -68,30 +68,32 @@
 
 <style>
     .logout-panel {
-        background: #2c5837;
-        border: 2px solid #007006;
+        border: 1px solid #1f6b3f;
         border-radius: 12px;
-        padding: 16px;
-        max-width: 480px;
-        color: #fff;
+        padding: 1.25rem;
+        color: #f0fdf4;
         display: flex;
         flex-direction: column;
         gap: 12px;
+        background: linear-gradient(135deg, #0e2a1b, #08150f);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
     }
 
     h3 {
         margin: 0;
+        color: #dcfce7;
     }
 
     p {
         margin: 0;
         line-height: 1.5;
+        color: #bbf7d0;
     }
 
     button {
         align-self: flex-start;
-        background: #007006;
-        border: none;
+        background: #15803d;
+        border: 1px solid #22c55e;
         border-radius: 8px;
         color: #fff;
         cursor: pointer;
@@ -105,15 +107,15 @@
     }
 
     .status {
-        color: #90ee90;
+        color: #86efac;
     }
 
     .error {
-        color: #ff9f9f;
+        color: #fecaca;
     }
 
     .state {
         font-style: italic;
-        color: #d1f7d1;
+        color: #dcfce7;
     }
 </style>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -40,8 +40,36 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
 <style>
     .settings-content {
         display: grid;
-        justify-content: center;
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        align-items: start;
         gap: 1rem;
         padding: 1rem;
+        width: min(1600px, 100%);
+        margin: 0 auto;
+    }
+
+    .settings-content > :global(*) {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .settings-content > :global(.qa-tools),
+    .settings-content > :global(.legacy-upgrade) {
+        grid-column: 1 / -1;
+    }
+
+    .settings-content > :global(.logout-panel),
+    .settings-content > :global(.qa-cheats),
+    .settings-content > :global(.panel),
+    .settings-content > :global(.data-reset),
+    .settings-content > :global(.legacy-upgrade) {
+        max-width: none;
+    }
+
+    @media (max-width: 720px) {
+        .settings-content {
+            grid-template-columns: 1fr;
+            padding: 0.75rem;
+        }
     }
 </style>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -53,16 +53,16 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
         min-width: 0;
     }
 
-    .settings-content > :global(.qa-tools),
-    .settings-content > :global(.legacy-upgrade) {
+    .settings-content :global(.qa-tools),
+    .settings-content :global(.legacy-upgrade) {
         grid-column: 1 / -1;
     }
 
-    .settings-content > :global(.logout-panel),
-    .settings-content > :global(.qa-cheats),
-    .settings-content > :global(.panel),
-    .settings-content > :global(.data-reset),
-    .settings-content > :global(.legacy-upgrade) {
+    .settings-content :global(.logout-panel),
+    .settings-content :global(.qa-cheats),
+    .settings-content :global(.panel),
+    .settings-content :global(.data-reset),
+    .settings-content :global(.legacy-upgrade) {
         max-width: none;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce wasted horizontal whitespace on wide displays and align the `/settings` page with other full-width sections like `/quests` and `/inventory`.
- Prevent dense sections (QA tools, legacy save upgrade) from being cramped into narrow columns on large screens by allowing them to span the full row.
- Unify the visual language of settings cards so small and large panels share the same dark card treatment.

### Description
- Converted `frontend/src/pages/settings.astro` to a responsive 2D CSS grid using `grid-template-columns: repeat(auto-fit, minmax(340px, 1fr))`, capped the content width, centered the container, and added a mobile fallback to a single column.
- Added `:global(...)` rules so child panels take full column width, ensured `.qa-tools` and `.legacy-upgrade` span `grid-column: 1 / -1`, and removed per-card `max-width` limits to let cards size to grid cells.
- Restyled `frontend/src/components/svelte/LogoutPanel.svelte` to match the darker card theme (gradient background, adjusted border/shadow/padding, and updated button and text colors).
- This change is layout and styling only and does not alter any settings behavior or JS logic.

### Testing
- Ran `npm run lint` and formatting checks, which passed.
- Ran the full CI-style suite with `npm run test:ci`, which completed successfully with all tests passing.
- Ran the staged-diff secret scan via `./scripts/scan-secrets.py` and it reported no credential-like additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e089847a78832fa61d52e585d44d03)