### PR TITLE
fix: move completed custom quests into Completed Quests and remove visible "Completed" label

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -284,6 +284,11 @@ describe('Quests Component', () => {
             expect(
                 completedCustomQuestTile?.querySelector("[data-testid='quest-status-slot']")
             ).toBeNull();
+            expect(
+                completedCustomQuestTile
+                    ?.querySelector('.sr-only')
+                    ?.textContent?.includes('Status: Completed')
+            ).toBe(true);
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -106,8 +106,7 @@ describe('Quests Component', () => {
         const completedStatusSlot = completedQuestTile?.querySelector(
             "[data-testid='quest-status-slot']"
         );
-        expect(completedStatusSlot).not.toBeNull();
-        expect(completedStatusSlot?.textContent?.trim()).toBe('Completed');
+        expect(completedStatusSlot).toBeNull();
     });
 
     it('keeps locked and unknown quests out of the main built-in grid', () => {
@@ -240,6 +239,51 @@ describe('Quests Component', () => {
 
             const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
             expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('moves completed custom quests into Completed Quests and removes completed label text', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => ({
+                ...quest,
+                status: quest.id === 'custom/completed' ? 'completed' : 'available',
+            }))
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            {
+                id: 'custom/completed',
+                title: 'Completed Custom Quest',
+                route: '/quests/custom/completed',
+                custom: true,
+            },
+            {
+                id: 'custom/available',
+                title: 'Available Custom Quest',
+                route: '/quests/custom/available',
+                custom: true,
+            },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const customSection = host.querySelector("[data-testid='custom-quests-section']");
+            expect(customSection?.textContent).toContain('Available Custom Quest');
+            expect(customSection?.textContent).not.toContain('Completed Custom Quest');
+
+            expect(host.textContent).toContain('Completed Quests');
+            const completedCustomQuestTile = host.querySelector(
+                "a[data-questid='custom/completed'] [data-testid='quest-tile']"
+            );
+            expect(completedCustomQuestTile).not.toBeNull();
+            expect(
+                completedCustomQuestTile?.querySelector("[data-testid='quest-status-slot']")
+            ).toBeNull();
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-listing-regression.md
+++ b/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-listing-regression.md
@@ -1,0 +1,20 @@
+---
+title: 'Custom quest completion listing regression (2026-04-16)'
+slug: '2026-04-16-custom-quest-completion-listing-regression'
+summary: 'Completed custom quests were shown in Custom Quests with a visible Completed label instead of being listed alongside all completed quests.'
+---
+
+# Custom quest completion listing regression (2026-04-16)
+
+- **Summary**: Completed custom quests remained in the **Custom Quests** section and showed a visible "Completed" label.
+- **Impact**: Players saw inconsistent completion behavior between built-in and custom quests on `/quests`.
+- **Root cause**:
+    - Custom quest filtering included both `available` and `completed` statuses for the Custom Quests section.
+    - The tile component rendered a visible `Completed` status label for completed quests.
+- **Resolution**:
+    - Updated quest list classification usage so custom completed quests render under **Completed Quests**.
+    - Removed the visible `Completed` status label from quest tiles while preserving completion state handling.
+    - Added regression coverage to verify completed custom quests appear in **Completed Quests** and not in **Custom Quests**.
+- **Prevention**:
+    - Keep completed quest presentation unified regardless of quest source (built-in vs custom).
+    - Maintain explicit regression tests for list placement and status label rendering in `/quests`.

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -7,8 +7,8 @@
 
     $: statusLabel =
         status === 'available' || status === 'completed'
-              ? ''
-              : status === 'locked'
+            ? ''
+            : status === 'locked'
                 ? 'Locked'
                 : 'Checking';
 

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -6,9 +6,7 @@
     let imageLoaded = false;
 
     $: statusLabel =
-        status === 'completed'
-            ? 'Completed'
-            : status === 'available'
+        status === 'available' || status === 'completed'
               ? ''
               : status === 'locked'
                 ? 'Locked'

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -41,6 +41,7 @@
     let customQuestRecords = [];
     let customClassified = [];
     let visibleCustomQuests = [];
+    let completedCustomQuests = [];
     let customMergeComplete = false;
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
@@ -104,9 +105,8 @@
     const classifyCustomQuests = (snapshot) => {
         const normalizedCustomQuests = normalizeQuestList(customQuestRecords);
         customClassified = classifyQuestList({ quests: normalizedCustomQuests, snapshot });
-        visibleCustomQuests = customClassified.filter(
-            (quest) => quest.status === 'available' || quest.status === 'completed'
-        );
+        visibleCustomQuests = customClassified.filter((quest) => quest.status === 'available');
+        completedCustomQuests = customClassified.filter((quest) => quest.status === 'completed');
     };
 
     // Define buttons for easy expansion
@@ -246,9 +246,14 @@
         </section>
     {/if}
 
-    {#if completedBuiltInQuests.length > 0}
+    {#if completedBuiltInQuests.length + completedCustomQuests.length > 0}
         <h2>Completed Quests</h2>
         {#each completedBuiltInQuests as quest}
+            <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
+                <Quest {quest} compact={true} status={quest.status} />
+            </a>
+        {/each}
+        {#each completedCustomQuests as quest}
             <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                 <Quest {quest} compact={true} status={quest.status} />
             </a>

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -42,6 +42,7 @@
     let customClassified = [];
     let visibleCustomQuests = [];
     let completedCustomQuests = [];
+    let completedQuests = [];
     let customMergeComplete = false;
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
@@ -119,6 +120,7 @@
     $: if (builtInQuests.length > 0) {
         applyBuiltInClassification({ authoritative: false, completedQuestIds: [] });
     }
+    $: completedQuests = [...completedBuiltInQuests, ...completedCustomQuests];
 
     onMount(async () => {
         markPerf('quests:list-hydration-start');
@@ -246,14 +248,9 @@
         </section>
     {/if}
 
-    {#if completedBuiltInQuests.length + completedCustomQuests.length > 0}
+    {#if completedQuests.length > 0}
         <h2>Completed Quests</h2>
-        {#each completedBuiltInQuests as quest}
-            <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
-                <Quest {quest} compact={true} status={quest.status} />
-            </a>
-        {/each}
-        {#each completedCustomQuests as quest}
+        {#each completedQuests as quest}
             <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                 <Quest {quest} compact={true} status={quest.status} />
             </a>


### PR DESCRIPTION
### Motivation
- Completed custom quests were being shown inside the **Custom Quests** section with a visible "Completed" label instead of being listed alongside built-in completed quests, causing inconsistent UX.

### Description
- Update `frontend/src/pages/quests/svelte/Quests.svelte` to separate `visibleCustomQuests` (only `available`) from `completedCustomQuests` and render completed custom quests in the shared `Completed Quests` list.
- Update `frontend/src/pages/quests/svelte/Quest.svelte` to remove the visible `statusLabel` for `completed` quests while preserving the assistive status text.
- Add a regression test in `frontend/__tests__/Quests.test.js` that asserts completed custom quests are excluded from the Custom Quests section, included in Completed Quests, and do not render visible status text.
- Add an outages entry at `frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-listing-regression.md` documenting the regression, root cause, and fix.

### Testing
- Ran `npx vitest run frontend/__tests__/Quests.test.js` and the test file passed (7 tests passed).
- Ran `npm run lint` from the repo root and the linting step completed successfully.
- Ran the staged-diff secrets scan via `./scripts/scan-secrets.py` on the changes and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08adb3610832f8ccb801cb03629d2)