### PR TITLE
Route completed custom quests into Completed Quests and remove in-tile "Completed" label

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -106,8 +106,7 @@ describe('Quests Component', () => {
         const completedStatusSlot = completedQuestTile?.querySelector(
             "[data-testid='quest-status-slot']"
         );
-        expect(completedStatusSlot).not.toBeNull();
-        expect(completedStatusSlot?.textContent?.trim()).toBe('Completed');
+        expect(completedStatusSlot).toBeNull();
     });
 
     it('keeps locked and unknown quests out of the main built-in grid', () => {
@@ -240,6 +239,52 @@ describe('Quests Component', () => {
 
             const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
             expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('shows completed custom quests in Completed Quests and not in Custom Quests', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => ({
+                ...quest,
+                status: quest.id === 'custom/done' ? 'completed' : 'available',
+            }))
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            {
+                id: 'custom/done',
+                title: 'Done Custom Quest',
+                route: '/quests/custom/done',
+                custom: true,
+            },
+            {
+                id: 'custom/ready',
+                title: 'Ready Custom Quest',
+                route: '/quests/custom/ready',
+                custom: true,
+            },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const customSection = host.querySelector("[data-testid='custom-quests-section']");
+            expect(customSection).not.toBeNull();
+            expect(customSection?.textContent).toContain('Ready Custom Quest');
+            expect(customSection?.textContent).not.toContain('Done Custom Quest');
+
+            expect(host.textContent).toContain('Completed Quests');
+            const completedCustomQuestTile = host.querySelector(
+                "a[data-questid='custom/done'] [data-testid='quest-tile']"
+            );
+            expect(completedCustomQuestTile).not.toBeNull();
+            expect(
+                completedCustomQuestTile?.querySelector("[data-testid='quest-status-slot']")
+            ).toBeNull();
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md
+++ b/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md
@@ -1,0 +1,25 @@
+---
+title: 'Custom quest completion list regression (2026-04-16)'
+slug: '2026-04-16-custom-quest-completion-list-regression'
+summary: 'Completed custom quests stayed in Custom Quests and showed a redundant Completed label instead of appearing with the shared Completed Quests list.'
+---
+
+# Custom quest completion list regression (2026-04-16)
+
+- **Summary**: Completing a custom quest left its tile in **Custom Quests** with a visible "Completed"
+  status label.
+- **Impact**: Players saw inconsistent completion behavior between built-in and custom quests, and
+  completed custom quests were not grouped with other completed quests.
+- **Root cause**:
+    - The quests page filtered custom quests into a single visible list that included both
+      `available` and `completed` states.
+    - The quest tile component rendered a "Completed" status label for completed quests.
+- **Resolution**:
+    - Updated custom quest list handling so only `available` custom quests stay in **Custom Quests**.
+    - Merged completed custom quests into the shared **Completed Quests** list rendering path.
+    - Removed the visual "Completed" status label from quest tiles.
+    - Added regression test coverage to ensure completed custom quests render with completed quests.
+- **Prevention**:
+    - Keep custom and built-in quest completion presentation on a shared rendering path whenever
+      possible.
+    - Add explicit tests for custom quest state transitions between actionable and completed sections.

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -6,9 +6,7 @@
     let imageLoaded = false;
 
     $: statusLabel =
-        status === 'completed'
-            ? 'Completed'
-            : status === 'available'
+        status === 'available' || status === 'completed'
               ? ''
               : status === 'locked'
                 ? 'Locked'

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -40,7 +40,9 @@
     let activeBuiltInQuests = [];
     let customQuestRecords = [];
     let customClassified = [];
-    let visibleCustomQuests = [];
+    let availableCustomQuests = [];
+    let completedCustomQuests = [];
+    let completedQuests = [];
     let customMergeComplete = false;
     let showQuestGraphVisualizer = false;
     let unsubscribeState;
@@ -104,9 +106,8 @@
     const classifyCustomQuests = (snapshot) => {
         const normalizedCustomQuests = normalizeQuestList(customQuestRecords);
         customClassified = classifyQuestList({ quests: normalizedCustomQuests, snapshot });
-        visibleCustomQuests = customClassified.filter(
-            (quest) => quest.status === 'available' || quest.status === 'completed'
-        );
+        availableCustomQuests = customClassified.filter((quest) => quest.status === 'available');
+        completedCustomQuests = customClassified.filter((quest) => quest.status === 'completed');
     };
 
     // Define buttons for easy expansion
@@ -119,6 +120,7 @@
     $: if (builtInQuests.length > 0) {
         applyBuiltInClassification({ authoritative: false, completedQuestIds: [] });
     }
+    $: completedQuests = [...completedBuiltInQuests, ...completedCustomQuests];
 
     onMount(async () => {
         markPerf('quests:list-hydration-start');
@@ -224,7 +226,7 @@
         aria-hidden="true"
         data-testid="custom-quests-merge-status"
         data-merge-complete={customMergeComplete ? 'true' : 'false'}
-        data-custom-count={String(visibleCustomQuests.length)}
+        data-custom-count={String(availableCustomQuests.length)}
     ></div>
 
     {#if showQuestGraphVisualizer}
@@ -233,11 +235,11 @@
         </div>
     {/if}
 
-    {#if customMergeComplete && visibleCustomQuests.length > 0}
+    {#if customMergeComplete && availableCustomQuests.length > 0}
         <section class="custom-section" data-testid="custom-quests-section">
             <h2>Custom Quests</h2>
             <div class="quests-grid">
-                {#each visibleCustomQuests as quest}
+                {#each availableCustomQuests as quest}
                     <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                         <Quest {quest} status={quest.status} />
                     </a>
@@ -246,9 +248,9 @@
         </section>
     {/if}
 
-    {#if completedBuiltInQuests.length > 0}
+    {#if completedQuests.length > 0}
         <h2>Completed Quests</h2>
-        {#each completedBuiltInQuests as quest}
+        {#each completedQuests as quest}
             <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                 <Quest {quest} compact={true} status={quest.status} />
             </a>


### PR DESCRIPTION
### Motivation
- Fix a regression where completed custom quests remained in the "Custom Quests" section with a visible "Completed" label instead of appearing with built-in completed quests.
- Ensure visual parity between built-in and custom quest completion presentation and preserve screen-reader status semantics.

### Description
- Split custom quest classification into `available` and `completed` buckets and merge completed custom quests into the shared completed list by updating `frontend/src/pages/quests/svelte/Quests.svelte`.
- Stop rendering a visible in-card "Completed" label by changing the `statusLabel` logic while preserving the assistive `assistiveStatusLabel` in `frontend/src/pages/quests/svelte/Quest.svelte`.
- Update unit tests in `frontend/__tests__/Quests.test.js` to assert completed custom quests appear in the `Completed Quests` list, are excluded from `Custom Quests`, and do not render a visible status slot.
- Add an outage log documenting the regression and remediation at `frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md`.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npx vitest run frontend/__tests__/Quests.test.js --config vitest.config.mts` and the test file passed (`7 tests` passed).
- Ran `npm run link-check` and all local markdown links resolved successfully.
- Executed `npm run test:ci`; build and verification stages completed but the broader PR test harness run did not produce a final consolidated completion line within the captured environment output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08adb3610832f8ccb801cb03629d2)