### PR TITLE
fix: move completed custom quests into Completed Quests

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -244,4 +244,50 @@ describe('Quests Component', () => {
             vi.useRealTimers();
         }
     });
+
+    it('moves completed custom quests into Completed Quests and keeps Custom Quests actionable only', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => {
+                if (quest.id === 'custom/completed') {
+                    return { ...quest, status: 'completed' };
+                }
+
+                return { ...quest, status: 'available' };
+            })
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            {
+                id: 'custom/available',
+                title: 'Available Custom Quest',
+                route: '/quests/custom/available',
+                custom: true,
+            },
+            {
+                id: 'custom/completed',
+                title: 'Completed Custom Quest',
+                route: '/quests/custom/completed',
+                custom: true,
+            },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const customSection = host.querySelector("[data-testid='custom-quests-section']");
+            expect(customSection?.textContent).toContain('Available Custom Quest');
+            expect(customSection?.textContent).not.toContain('Completed Custom Quest');
+
+            expect(host.textContent).toContain('Completed Quests');
+            const completedCustomQuestLink = host.querySelector("a[data-questid='custom/completed']");
+            expect(completedCustomQuestLink).not.toBeNull();
+
+            const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
+            expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md
+++ b/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md
@@ -1,0 +1,25 @@
+---
+title: 'Custom quest completion list regression (2026-04-16)'
+slug: '2026-04-16-custom-quest-completion-list-regression'
+summary: 'Completed custom quests were left in the Custom Quests section with a Completed badge instead of being listed with other completed quests.'
+---
+
+# Custom quest completion list regression (2026-04-16)
+
+- **Summary**: Completed custom quests stayed in the "Custom Quests" section and rendered a
+  visible "Completed" label.
+- **Impact**: Completed custom quests were split away from the canonical "Completed Quests"
+  section, creating inconsistent UX between built-in and custom quests.
+- **Root cause**:
+    - Custom quest filtering allowed both `available` and `completed` statuses in the actionable
+      custom grid.
+    - The completed quest list only rendered built-in completed quests.
+- **Resolution**:
+    - Updated custom quest filtering so the "Custom Quests" section only shows actionable
+      `available` custom quests.
+    - Merged completed custom quests into the same completed quest list used by built-in quests.
+    - Added regression coverage to ensure completed custom quests render under "Completed Quests"
+      and not under "Custom Quests."
+- **Prevention**:
+    - Keep list partitioning explicit by source + status, with regression tests for each
+      visible quest section.

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -37,6 +37,8 @@
     let builtInQuests = [];
     let builtInClassified = [];
     let completedBuiltInQuests = [];
+    let completedCustomQuests = [];
+    let completedQuests = [];
     let activeBuiltInQuests = [];
     let customQuestRecords = [];
     let customClassified = [];
@@ -99,14 +101,15 @@
 
         completedBuiltInQuests = builtInClassified.filter((quest) => quest.status === 'completed');
         activeBuiltInQuests = builtInClassified.filter((quest) => quest.status === 'available');
+        completedQuests = [...completedBuiltInQuests, ...completedCustomQuests];
     };
 
     const classifyCustomQuests = (snapshot) => {
         const normalizedCustomQuests = normalizeQuestList(customQuestRecords);
         customClassified = classifyQuestList({ quests: normalizedCustomQuests, snapshot });
-        visibleCustomQuests = customClassified.filter(
-            (quest) => quest.status === 'available' || quest.status === 'completed'
-        );
+        visibleCustomQuests = customClassified.filter((quest) => quest.status === 'available');
+        completedCustomQuests = customClassified.filter((quest) => quest.status === 'completed');
+        completedQuests = [...completedBuiltInQuests, ...completedCustomQuests];
     };
 
     // Define buttons for easy expansion
@@ -246,9 +249,9 @@
         </section>
     {/if}
 
-    {#if completedBuiltInQuests.length > 0}
+    {#if completedQuests.length > 0}
         <h2>Completed Quests</h2>
-        {#each completedBuiltInQuests as quest}
+        {#each completedQuests as quest}
             <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                 <Quest {quest} compact={true} status={quest.status} />
             </a>


### PR DESCRIPTION
### Motivation
- Completed custom quests were rendered inside the "Custom Quests" section with a visible "Completed" label instead of appearing alongside built-in completed quests, causing inconsistent UX.
- The custom-quest list allowed both `available` and `completed` statuses to be shown in the actionable custom grid, while the completed list only included built-in quests.

### Description
- Updated `frontend/src/pages/quests/svelte/Quests.svelte` to partition custom quests by status so the Custom Quests section only shows actionable `available` custom quests and completed custom quests are merged into the shared completed list.
- Added `completedCustomQuests` and `completedQuests` bookkeeping and adjusted classification logic to combine built-in and completed custom quests for display.
- Added a unit/regression test in `frontend/__tests__/Quests.test.js` that verifies completed custom quests do not appear in the Custom Quests grid and instead appear under `Completed Quests`.
- Added an outage report at `frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completion-list-regression.md` documenting the regression, impact, root cause, and fix.

### Testing
- Ran the component test suite for the modified file with `npm run test:root -- frontend/__tests__/Quests.test.js`, and the test file passed (7 tests passed).
- Ran lint checks with `npm run lint`, and the lint step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08adb3610832f8ccb801cb03629d2)