### PR TITLE
🐛 Fix completed custom quest placement in /quests

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -73,7 +73,7 @@ describe('Quests Component', () => {
         vi.clearAllMocks();
     });
 
-    it('renders only available quests in the main built-in grid', () => {
+    it('renders only available quests in the main built-in grid', async () => {
         classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
             classifiedQuests.map((quest, index) => {
                 const statuses = ['available', 'locked', 'completed', 'unknown'];
@@ -88,7 +88,7 @@ describe('Quests Component', () => {
         expect(builtInGrid.textContent).not.toContain('Test Quest 2');
         expect(builtInGrid.textContent).not.toContain('Test Quest 3');
 
-        expect(host.textContent).toContain('Completed Quests');
+        await vi.waitFor(() => expect(host.textContent).toContain('Completed Quests'));
         expect(host.textContent).toContain('Test Quest 3');
         const availableQuestTile = host.querySelector(
             "a[data-questid='welcome/test1'] [data-testid='quest-tile']"
@@ -240,6 +240,55 @@ describe('Quests Component', () => {
 
             const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
             expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('moves completed custom quests into the Completed Quests list', async () => {
+        vi.useFakeTimers();
+        classifyQuestList.mockImplementation(({ quests: classifiedQuests = [] }) =>
+            classifiedQuests.map((quest) => {
+                if (quest.id === 'custom/completed') {
+                    return { ...quest, status: 'completed' };
+                }
+                return { ...quest, status: 'available' };
+            })
+        );
+        listCustomQuests.mockResolvedValueOnce([
+            {
+                id: 'custom/completed',
+                title: 'Completed Custom Quest',
+                route: '/quests/custom/completed',
+                custom: true,
+            },
+            {
+                id: 'custom/open',
+                title: 'Open Custom Quest',
+                route: '/quests/custom/open',
+                custom: true,
+            },
+        ]);
+
+        try {
+            mountedComponent = mount(Quests, { target: host, props: { quests } });
+            await vi.runAllTimersAsync();
+            await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+
+            const customSection = host.querySelector("[data-testid='custom-quests-section']");
+            expect(customSection).not.toBeNull();
+            expect(customSection?.textContent).toContain('Open Custom Quest');
+            expect(customSection?.textContent).not.toContain('Completed Custom Quest');
+            expect(customSection?.textContent).not.toContain('Completed');
+
+            expect(host.textContent).toContain('Completed Quests');
+            const completedQuestLink = host.querySelector("a[data-questid='custom/completed']");
+            expect(completedQuestLink).not.toBeNull();
+            const completedQuestTile = completedQuestLink?.querySelector("[data-testid='quest-tile']");
+            const completedStatusSlot = completedQuestTile?.querySelector(
+                "[data-testid='quest-status-slot']"
+            );
+            expect(completedStatusSlot?.textContent?.trim()).toBe('Completed');
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completed-list-regression.md
+++ b/frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completed-list-regression.md
@@ -1,0 +1,20 @@
+---
+title: 'Custom quest completed-list regression (2026-04-16)'
+slug: '2026-04-16-custom-quest-completed-list-regression'
+summary: 'Completed custom quests were kept in the Custom Quests section with an inline Completed label instead of being listed under Completed Quests.'
+---
+
+# Custom quest completed-list regression (2026-04-16)
+
+- **Summary**: Custom quests that reached completion remained in the Custom Quests section and showed an inline `Completed` label.
+- **Impact**: Completed custom quests were not grouped with the rest of completed quests, causing inconsistent UI behavior and duplicate completion signaling.
+- **Root cause**:
+    - The custom quest filter treated both `available` and `completed` quests as visible in the Custom Quests section.
+    - Only built-in quests were eligible for the Completed Quests list.
+- **Resolution**:
+    - Updated quest list classification so the Custom Quests section only shows available custom quests.
+    - Added completed custom quests to the shared Completed Quests list alongside built-in quests.
+    - Added regression coverage to ensure completed custom quests no longer render in Custom Quests and appear under Completed Quests instead.
+- **Prevention**:
+    - Keep custom and built-in quest status handling aligned in list rendering logic.
+    - Maintain regression tests for mixed built-in/custom completion states.

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -37,6 +37,8 @@
     let builtInQuests = [];
     let builtInClassified = [];
     let completedBuiltInQuests = [];
+    let completedCustomQuests = [];
+    let completedQuests = [];
     let activeBuiltInQuests = [];
     let customQuestRecords = [];
     let customClassified = [];
@@ -104,10 +106,11 @@
     const classifyCustomQuests = (snapshot) => {
         const normalizedCustomQuests = normalizeQuestList(customQuestRecords);
         customClassified = classifyQuestList({ quests: normalizedCustomQuests, snapshot });
-        visibleCustomQuests = customClassified.filter(
-            (quest) => quest.status === 'available' || quest.status === 'completed'
-        );
+        visibleCustomQuests = customClassified.filter((quest) => quest.status === 'available');
+        completedCustomQuests = customClassified.filter((quest) => quest.status === 'completed');
     };
+
+    $: completedQuests = [...completedBuiltInQuests, ...completedCustomQuests];
 
     // Define buttons for easy expansion
     const actionButtons = [
@@ -246,9 +249,9 @@
         </section>
     {/if}
 
-    {#if completedBuiltInQuests.length > 0}
+    {#if completedQuests.length > 0}
         <h2>Completed Quests</h2>
-        {#each completedBuiltInQuests as quest}
+        {#each completedQuests as quest}
             <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
                 <Quest {quest} compact={true} status={quest.status} />
             </a>


### PR DESCRIPTION
### Motivation
- Custom quests that reached completion were kept in the "Custom Quests" section with an inline `Completed` label instead of being listed with other completed quests, causing inconsistent UX and duplicate completion signaling. 
- The UI should treat built-in and custom completed quests the same and not display a separate inline completed label in the custom list. 
- A short outage log is required to record the regression and the fix. 

### Description
- Updated `frontend/src/pages/quests/svelte/Quests.svelte` to keep the Custom Quests section limited to available custom quests, collect completed custom quests separately, and render a combined `Completed Quests` list (`completedQuests = [...completedBuiltInQuests, ...completedCustomQuests]`).
- Changed custom classification to set `visibleCustomQuests` to only `available` quests and populated `completedCustomQuests` from classified custom quests. 
- Added a regression test in `frontend/__tests__/Quests.test.js` to verify completed custom quests are removed from the Custom Quests grid and appear under the Completed Quests list, and adjusted an existing test to await the Completed section render. 
- Added outage documentation `frontend/src/pages/docs/md/outages/2026-04-16-custom-quest-completed-list-regression.md` describing the issue, impact, root cause, resolution, and prevention notes. 

### Testing
- Ran `npm run test:root -- frontend/__tests__/Quests.test.js` which passed (all tests in the file: 7/7). 
- Ran `npm run lint` in the repo which completed successfully. 
- Ran the staged diff through the repository secret scanner (`./scripts/scan-secrets.py`) with no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08adb3610832f8ccb801cb03629d2)