### PR TITLE
Improve v3.0.1 changelog readability with player-facing sections

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,12 +141,72 @@ forward.
 
 ### Patch notes
 
-- **`/quests` performance + correctness:** improved list-path time-to-interactive, tightened built-in/custom coexistence behavior, fixed locked-quest status visibility regressions, and removed dead-end gating in preflight-check quest flow.
-  - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
-  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
-- **Gameplay/data integrity hardening:** normalized stored item counts, rejected unknown item containers, aligned geothermal reward docs with quest data, and sanitized compact item/process preview image handling.
-- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
-- **`/processes` reliability:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`, and hardened buy-required metadata-loading behavior plus regression coverage.
-- **`/docs` and chat retrieval:** deferred `/docs` full-text corpus fetch until first keyword search (with immediate browse/`has:` access), plus hardened docs-index/chat smoke assertions.
-- **Migration + remote-smoke harness hardening:** fixed remote legacy migration real-v2 coverage and strengthened remote smoke flow reliability for custom-item mutations and live-chat checks.
-- **Release governance/runbook updates:** tightened v3.0.1 QA checklists/evidence gates, added canonical release-history tracking, and clarified rollback/promotion runbook links and compare-based PR references.
+#### Gameplay / UI (`/quests`, `/processes`)
+
+**What you'll notice:** `/quests` appears much faster and locked-state behavior is more consistent;
+`/processes` list rows render in a summary-first layout while per-process runtime controls remain on
+`/processes/:processId`.
+
+- **`/quests` performance + correctness:** improved list-path time-to-interactive, tightened
+  built-in/custom coexistence behavior, fixed locked-quest status visibility regressions, and
+  removed dead-end gating in preflight-check quest flow.
+  - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7
+    ms (~104x faster).
+  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation
+    262.6 ms → 6.2 ms (~42x faster).
+- **`/processes` reliability:** switched list rows to summary-first rendering while retaining
+  runtime controls on `/processes/:processId`, and hardened buy-required metadata-loading behavior
+  plus regression coverage.
+
+#### Security / Safety
+
+**What you'll notice:** unsafe custom quest tile URLs no longer stay as-is; they are sanitized to
+safe internal quest links.
+
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal
+  `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and
+  slash-backslash variants like `/\`.
+
+#### Saves / Migration / Data Integrity
+
+**What you'll notice:** inventory/item state handling is stricter and more consistent; malformed
+container shapes no longer pass through silently.
+
+- **Gameplay/data integrity hardening:** normalized stored item counts, rejected unknown item
+  containers, aligned geothermal reward docs with quest data, and sanitized compact item/process
+  preview image handling.
+- **Migration + remote-smoke harness hardening:** fixed remote legacy migration real-v2 coverage
+  and strengthened remote smoke flow reliability for custom-item mutations and live-chat checks.
+
+#### Docs / Chat
+
+**What you'll notice:** `/docs` browse and `has:` flows remain available immediately; first keyword
+search fetches the full-text corpus on demand.
+
+- **`/docs` and chat retrieval:** deferred `/docs` full-text corpus fetch until first keyword
+  search (with immediate browse/`has:` access), plus hardened docs-index/chat smoke assertions.
+
+#### Dev / Release / QA
+
+**What you'll notice:** this is mainly release-process hardening; player-facing behavior is covered
+by stricter regression checks and rollout/runbook hygiene.
+
+- **Release governance/runbook updates:** tightened v3.0.1 QA checklists/evidence gates, added
+  canonical release-history tracking, and clarified rollback/promotion runbook links and
+  compare-based PR references.
+
+#### Stricter behavior to be aware of
+
+- Custom quest tile route values that are unsafe are now sanitized to internal `/quests/{id}` links
+  instead of being used directly.
+- Unknown item containers are rejected rather than tolerated, which can surface malformed save/mod
+  data earlier.
+
+#### How to verify (quick checks)
+
+- Open `/quests` on a fresh load and confirm the list appears quickly, then verify locked quest
+  status displays correctly.
+- Open `/processes` and confirm list rows render with summary-first content while runtime controls
+  still work on `/processes/:processId`.
+- Open `/docs` and verify browse + `has:` usage works immediately; run a first keyword search and
+  confirm full-text search still works after the corpus fetch.


### PR DESCRIPTION
### Motivation

- The original v3.0.1 addendum was accurate but presented as a single flat stream that is hard for players to scan.  
- Restructure notes so players can quickly see what changed, what they'll notice, any stricter behavior, and how to verify without altering release facts or metrics.

### Description

- Rewrote the `June 1, 2026 — DSPACE v3.0.1 (patch addendum)` section in the canonical changelog `frontend/src/pages/docs/md/changelog/20260401.md` into focused sections: `Gameplay / UI`, `Security / Safety`, `Saves / Migration / Data Integrity`, `Docs / Chat`, and `Dev / Release / QA`.  
- Added brief “What you'll notice” summaries under each section to call out player-visible symptoms and tied fixes to routes like `/quests`, `/processes`, and `/docs`.  
- Added an explicit “Stricter behavior to be aware of” subsection that calmly calls out already-documented hardening (for example, sanitized quest tile routes and rejecting unknown item containers).  
- Added a concise “How to verify (quick checks)” subsection with short route-focused verification steps, and preserved all original facts, dates, and benchmark numbers without introducing new claims.

### Testing

- Ran `npm run lint` in the repo and it completed successfully.  
- Ran `npm run test:root -- tests/changelogDocsReleaseChecklist.test.ts` and the test passed.  
- Ran `npm run build` and the site build completed successfully.  
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` as part of staging and found no issues.

Files changed: `frontend/src/pages/docs/md/changelog/20260401.md`.

Notes: intentionally did not add additional benchmark context (hardware/setup/cached vs cold assumptions) beyond the numbers already present in the file to avoid introducing unsupported facts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08f7603c0832f828d47c84de539b2)