### PR TITLE
📝 docs: restructure v3.0.1 patch notes for readability

### DIFF
--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,49 +141,12 @@ forward.
 
 ### Patch notes
 
-#### Gameplay / UI
-
-**What you'll notice:** `/quests` and `/processes` are more responsive and consistent on first load, and the preflight-check quest flow no longer dead-ends.
-
 - **`/quests` performance + correctness:** improved list-path time-to-interactive, tightened built-in/custom coexistence behavior, fixed locked-quest status visibility regressions, and removed dead-end gating in preflight-check quest flow.
-  - Cold run benchmark in this patch notes set: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
-  - 4x CPU-throttled benchmark in this patch notes set: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
-- **`/processes` reliability:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`, and hardened buy-required metadata-loading behavior plus regression coverage.
-
-#### Security / Safety
-
-**What you'll notice:** unsafe custom quest-tile links no longer route out unexpectedly; they resolve safely back to in-app quest links.
-
-- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
-
-#### Saves / Migration / Data Integrity
-
-**What you'll notice:** malformed save/mod payloads are handled more defensively, and item/process preview data is normalized more safely.
-
+  - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
+  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
 - **Gameplay/data integrity hardening:** normalized stored item counts, rejected unknown item containers, aligned geothermal reward docs with quest data, and sanitized compact item/process preview image handling.
-- **Migration + remote-smoke harness hardening:** fixed remote legacy migration real-v2 coverage and strengthened remote smoke flow reliability for custom-item mutations and live-chat checks.
-
-#### Docs / Chat
-
-**What you'll notice:** `/docs` browsing stays immediate; first keyword search can trigger full-text corpus fetch before returning results.
-
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
+- **`/processes` reliability:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`, and hardened buy-required metadata-loading behavior plus regression coverage.
 - **`/docs` and chat retrieval:** deferred `/docs` full-text corpus fetch until first keyword search (with immediate browse/`has:` access), plus hardened docs-index/chat smoke assertions.
-
-#### Dev / Release / QA
-
-**What you'll notice:** no player-facing feature change; release validation and rollback guidance are tighter for safer patch promotion.
-
+- **Migration + remote-smoke harness hardening:** fixed remote legacy migration real-v2 coverage and strengthened remote smoke flow reliability for custom-item mutations and live-chat checks.
 - **Release governance/runbook updates:** tightened v3.0.1 QA checklists/evidence gates, added canonical release-history tracking, and clarified rollback/promotion runbook links and compare-based PR references.
-
-#### Stricter behavior changes to be aware of
-
-- Custom quest tile routes are now sanitized and may be rewritten to internal `/quests/{id}` links when input is unsafe.
-- Unknown item containers are now rejected instead of being accepted silently.
-
-#### How to verify (quick checks)
-
-- Open `/quests` on a fresh load and confirm the list appears quickly.
-- On `/quests`, confirm locked quests now display locked status correctly (if you previously saw status mismatches, this is the targeted fix).
-- Open `/processes` and confirm list rows render with summary-first content, while runtime controls still work on `/processes/:processId`.
-- Open `/docs` and confirm browse/`has:` flows are immediate, while the first keyword search may trigger index fetch before returning results.
-- If you rely on custom quest-tile URLs, verify unsafe values (for example protocol-relative forms like `//`) now fall back to internal `/quests/{id}` links.

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -141,12 +141,49 @@ forward.
 
 ### Patch notes
 
+#### Gameplay / UI
+
+**What you'll notice:** `/quests` and `/processes` are more responsive and consistent on first load, and the preflight-check quest flow no longer dead-ends.
+
 - **`/quests` performance + correctness:** improved list-path time-to-interactive, tightened built-in/custom coexistence behavior, fixed locked-quest status visibility regressions, and removed dead-end gating in preflight-check quest flow.
-  - Cold run: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
-  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
-- **Gameplay/data integrity hardening:** normalized stored item counts, rejected unknown item containers, aligned geothermal reward docs with quest data, and sanitized compact item/process preview image handling.
-- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
+  - Cold run benchmark in this patch notes set: list visible 30.3 ms → 0.3 ms (~101x faster); full reconciliation 72.6 ms → 0.7 ms (~104x faster).
+  - 4x CPU-throttled benchmark in this patch notes set: list visible 115.5 ms → 1.9 ms (~61x faster); full reconciliation 262.6 ms → 6.2 ms (~42x faster).
 - **`/processes` reliability:** switched list rows to summary-first rendering while retaining runtime controls on `/processes/:processId`, and hardened buy-required metadata-loading behavior plus regression coverage.
-- **`/docs` and chat retrieval:** deferred `/docs` full-text corpus fetch until first keyword search (with immediate browse/`has:` access), plus hardened docs-index/chat smoke assertions.
+
+#### Security / Safety
+
+**What you'll notice:** unsafe custom quest-tile links no longer route out unexpectedly; they resolve safely back to in-app quest links.
+
+- **`/quests` security:** sanitized custom quest tile routes to fall back to internal `/quests/{id}` links when values are unsafe, including protocol-relative prefixes like `//` and slash-backslash variants like `/\`.
+
+#### Saves / Migration / Data Integrity
+
+**What you'll notice:** malformed save/mod payloads are handled more defensively, and item/process preview data is normalized more safely.
+
+- **Gameplay/data integrity hardening:** normalized stored item counts, rejected unknown item containers, aligned geothermal reward docs with quest data, and sanitized compact item/process preview image handling.
 - **Migration + remote-smoke harness hardening:** fixed remote legacy migration real-v2 coverage and strengthened remote smoke flow reliability for custom-item mutations and live-chat checks.
+
+#### Docs / Chat
+
+**What you'll notice:** `/docs` browsing stays immediate; first keyword search can trigger full-text corpus fetch before returning results.
+
+- **`/docs` and chat retrieval:** deferred `/docs` full-text corpus fetch until first keyword search (with immediate browse/`has:` access), plus hardened docs-index/chat smoke assertions.
+
+#### Dev / Release / QA
+
+**What you'll notice:** no player-facing feature change; release validation and rollback guidance are tighter for safer patch promotion.
+
 - **Release governance/runbook updates:** tightened v3.0.1 QA checklists/evidence gates, added canonical release-history tracking, and clarified rollback/promotion runbook links and compare-based PR references.
+
+#### Stricter behavior changes to be aware of
+
+- Custom quest tile routes are now sanitized and may be rewritten to internal `/quests/{id}` links when input is unsafe.
+- Unknown item containers are now rejected instead of being accepted silently.
+
+#### How to verify (quick checks)
+
+- Open `/quests` on a fresh load and confirm the list appears quickly.
+- On `/quests`, confirm locked quests now display locked status correctly (if you previously saw status mismatches, this is the targeted fix).
+- Open `/processes` and confirm list rows render with summary-first content, while runtime controls still work on `/processes/:processId`.
+- Open `/docs` and confirm browse/`has:` flows are immediate, while the first keyword search may trigger index fetch before returning results.
+- If you rely on custom quest-tile URLs, verify unsafe values (for example protocol-relative forms like `//`) now fall back to internal `/quests/{id}` links.

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -5,23 +5,34 @@
 
     let imageLoaded = false;
 
-    $: statusLabel =
-        status === 'completed'
-            ? 'Completed'
-            : status === 'available'
-              ? ''
-              : status === 'locked'
-                ? 'Locked'
-                : 'Checking';
+    const getStatusLabel = (currentStatus) => {
+        switch (currentStatus) {
+            case 'completed':
+                return 'Completed';
+            case 'available':
+                return '';
+            case 'locked':
+                return 'Locked';
+            default:
+                return 'Checking';
+        }
+    };
 
-    $: assistiveStatusLabel =
-        status === 'available'
-            ? 'Available'
-            : status === 'completed'
-              ? 'Completed'
-              : status === 'locked'
-                ? 'Locked'
-                : statusLabel;
+    const getAssistiveStatusLabel = (currentStatus, currentStatusLabel) => {
+        switch (currentStatus) {
+            case 'available':
+                return 'Available';
+            case 'completed':
+                return 'Completed';
+            case 'locked':
+                return 'Locked';
+            default:
+                return currentStatusLabel;
+        }
+    };
+
+    $: statusLabel = getStatusLabel(status);
+    $: assistiveStatusLabel = getAssistiveStatusLabel(status, statusLabel);
 </script>
 
 <div class="container" class:quest data-testid="quest-tile" data-status={status}>

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -46,7 +46,9 @@
                 <div class="content-text" data-testid="quest-tile-text">
                     <h3>{quest.title}</h3>
                     {#if statusLabel}
-                        <div class="status-slot" data-testid="quest-status-slot">{statusLabel}</div>
+                        <div class="status-slot" data-testid="quest-status-slot">
+                            {statusLabel}
+                        </div>
                     {/if}
                     <span class="sr-only">Status: {assistiveStatusLabel}</span>
                 </div>
@@ -72,7 +74,9 @@
                     <h3>{quest.title}</h3>
                     <p>{quest.description}</p>
                     {#if statusLabel}
-                        <div class="status-slot" data-testid="quest-status-slot">{statusLabel}</div>
+                        <div class="status-slot" data-testid="quest-status-slot">
+                            {statusLabel}
+                        </div>
                     {/if}
                     <span class="sr-only">Status: {assistiveStatusLabel}</span>
                 </div>

--- a/frontend/src/pages/quests/svelte/Quest.svelte
+++ b/frontend/src/pages/quests/svelte/Quest.svelte
@@ -9,8 +9,8 @@
         status === 'available' || status === 'completed'
             ? ''
             : status === 'locked'
-                ? 'Locked'
-                : 'Checking';
+              ? 'Locked'
+              : 'Checking';
 
     $: assistiveStatusLabel =
         status === 'available'

--- a/frontend/src/utils/changelogNotes.ts
+++ b/frontend/src/utils/changelogNotes.ts
@@ -169,9 +169,39 @@ const notesBySlug: Record<string, ChangelogNote[]> = {
         },
         {
             message:
-                'Reader guide for the June 1, 2026 v3.0.1 addendum: validate `/quests`, `/processes`, and `/docs` first, then confirm migration and release-runbook updates in the linked references.',
+                'June 1, 2026 v3.0.1 (reader guide) — Gameplay / UI: `/quests` list-path time-to-interactive and correctness updates landed with locked-quest visibility fixes and preflight-check gating cleanup, and `/processes` now renders summary-first rows while retaining runtime controls on `/processes/:processId`.',
+            href: '/docs/changelog/20260401',
+            linkLabel: 'June 1 patch addendum',
+        },
+        {
+            message:
+                'June 1, 2026 v3.0.1 (reader guide) — Security / Safety + stricter behavior: custom quest tile routes are sanitized to internal `/quests/{id}` fallbacks when values are unsafe, and unknown item containers are rejected.',
+            href: '/docs/changelog/20260401',
+            linkLabel: 'Security and integrity details',
+        },
+        {
+            message:
+                'June 1, 2026 v3.0.1 (reader guide) — Saves / Migration / Data Integrity: stored item counts were normalized and remote migration/smoke coverage was hardened for real-v2 and custom-item mutation flows.',
+            href: '/docs/legacy-save-storage',
+            linkLabel: 'Legacy migration context',
+        },
+        {
+            message:
+                'June 1, 2026 v3.0.1 (reader guide) — Docs / Chat: `/docs` full-text corpus fetch is deferred until first keyword search, while docs-index and chat smoke assertions were hardened.',
+            href: '/docs/changelog/20260401',
+            linkLabel: 'Docs and chat notes',
+        },
+        {
+            message:
+                'June 1, 2026 v3.0.1 (reader guide) — Dev / Release / QA: v3.0.1 checklists and evidence gates were tightened, release-history tracking was added, and rollback/promotion runbook links were clarified.',
             href: '/docs/qa/v3',
             linkLabel: 'v3 QA checklist',
+        },
+        {
+            message:
+                'How to verify (player-visible routes): `/quests` (list + locked quest visibility + safe custom tile links), `/processes` (summary-first rows + runtime controls on detail pages), `/docs` (browse/`has:` first, then keyword search).',
+            href: '/docs/changelog/20260401',
+            linkLabel: 'Player route checks',
         },
     ],
 };

--- a/frontend/src/utils/changelogNotes.ts
+++ b/frontend/src/utils/changelogNotes.ts
@@ -167,6 +167,12 @@ const notesBySlug: Record<string, ChangelogNote[]> = {
             href: '/docs/releases',
             linkLabel: 'Release history',
         },
+        {
+            message:
+                'Reader guide for the June 1, 2026 v3.0.1 addendum: validate `/quests`, `/processes`, and `/docs` first, then confirm migration and release-runbook updates in the linked references.',
+            href: '/docs/qa/v3',
+            linkLabel: 'v3 QA checklist',
+        },
     ],
 };
 


### PR DESCRIPTION
### Motivation

- Make the June 1, 2026 `v3.0.1` patch addendum in the April 1 changelog easier for players to scan while preserving all existing facts and metrics. 
- Surface player-visible outcomes, route-level impact, and quick verification steps so players and QA can validate the patch without reading dense paragraphs. 
- Keep historical changelog conventions and snapshot guard requirements intact and avoid introducing any new factual claims not present in the source.

### Description

- Updated the canonical changelog file `frontend/src/pages/docs/md/changelog/20260401.md` to reorganize the `v3.0.1` addendum into player-focused sections: Gameplay / UI, Security / Safety, Saves / Migration / Data Integrity, Docs / Chat, and Dev / Release / QA. 
- Added a short “What you'll notice” summary for each section and tied fixes to player-visible routes and symptoms (for example `/quests`, `/processes`, and `/docs`). 
- Explicitly called out stricter or potentially breaking behavior changes (sanitized custom quest tile routes and rejection of unknown item containers) while keeping wording factual and grounded in existing notes. 
- Appended a concise “How to verify (quick checks)” checklist for route-level validation and clarified benchmark phrasing rather than inventing additional context.

### Testing

- Ran lint with `npm run lint` and the frontend linter step completed successfully. 
- Built the site with `npm run build` and the build completed successfully. 
- Executed targeted changelog tests with `npx vitest run tests/changelogDocsReleaseChecklist.test.ts tests/changelogHistoryGuard.test.ts` and all tests passed. 
- Ran the internal link checker with `node scripts/link-check.mjs` and all local markdown links resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08f7603c0832f828d47c84de539b2)