### PR TITLE
Do not render changelog `Note:` metadata on homepage and changelog page

### DIFF
--- a/frontend/src/components/WhatsNew.astro
+++ b/frontend/src/components/WhatsNew.astro
@@ -1,6 +1,5 @@
 ---
 import Button from './Button.astro';
-import { appendChangelogNotes } from '../utils/changelogNotes';
 import { logServerError } from '../utils/serverLogger';
 
 let changelogs = [];
@@ -11,9 +10,8 @@ let changelogRenderError: Error | undefined;
 const route = Astro.url?.pathname ?? '/';
 const method = Astro.request?.method ?? 'GET';
 
-function prepareHtml(html, slug) {
-    const withNotes = appendChangelogNotes(html, slug);
-    return withNotes + `
+function prepareHtml(html) {
+    return html + `
         <style>
             .latest-update-html img {
                 max-width: 100%;
@@ -32,17 +30,6 @@ function prepareHtml(html, slug) {
                 margin: 0.75rem auto;
             }
 
-            .changelog-note {
-                margin-top: 1.5rem;
-                padding: 1rem;
-                border-left: 4px solid var(--color-highlight, #5b21b6);
-                background: rgba(91, 33, 182, 0.08);
-                border-radius: 12px;
-            }
-
-            .changelog-note p {
-                margin: 0.5rem 0 0;
-            }
         </style>
     `;
 }
@@ -67,7 +54,7 @@ try {
     if (changelogsReversed.length > 0) {
         const [latest] = changelogsReversed;
         latestUpdateTitle = latest?.frontmatter?.title;
-        latestUpdateHtml = prepareHtml(latest?.compiledContent(), latest?.frontmatter?.slug);
+        latestUpdateHtml = prepareHtml(latest?.compiledContent());
     }
 } catch (error) {
     changelogRenderError = error instanceof Error ? error : new Error(String(error));

--- a/frontend/src/pages/changelog.astro
+++ b/frontend/src/pages/changelog.astro
@@ -1,6 +1,5 @@
 ---
 import Page from '../components/Page.astro';
-import { appendChangelogNotes } from '../utils/changelogNotes';
 
 const changelogs = await Astro.glob('./docs/md/changelog/*.md');
 
@@ -8,8 +7,8 @@ const changelogsReversed = changelogs.reverse();
 
 const slugToHeadingId = (slug) => (slug ? String(slug).toLowerCase() : 'changelog');
 
-function prepareHtml(html, slug) {
-    return appendChangelogNotes(html, slug);
+function prepareHtml(html) {
+    return html;
 }
 
 const CHANGELOG_SCROLL_BUFFER_PX = 16;
@@ -34,7 +33,7 @@ const CHANGELOG_SCROLL_BUFFER_PX = 16;
                         </div>
                         <div
                             class="entry-body"
-                            set:html={prepareHtml(doc.compiledContent(), doc.frontmatter.slug)}
+                            set:html={prepareHtml(doc.compiledContent())}
                         ></div>
                     </div>
                 </section>


### PR DESCRIPTION
### Motivation
- `Note:` entries in the changelog are repository/source metadata and must not be displayed to end users on the homepage (`/`) or the changelog page (`/changelog`).

### Description
- Removed use of `appendChangelogNotes` from `frontend/src/components/WhatsNew.astro` and stopped appending note markup to the homepage latest-update HTML.
- Removed use of `appendChangelogNotes` from `frontend/src/pages/changelog.astro` and render `doc.compiledContent()` directly for each changelog entry.
- Dropped the `.changelog-note` stylesheet block from the homepage component and simplified the `prepareHtml` helper signatures to accept only the compiled HTML string.
- Left the `frontend/src/utils/changelogNotes.ts` data/functions intact (notes remain available as programmatic metadata but are no longer injected into rendered HTML).

### Testing
- Ran `npm run lint` in the frontend workspace and lint completed successfully.
- Ran `npm run build` as part of `npm run test:ci` and the Astro build completed successfully (client/server build phases finished).
- Ran `npm run type-check` which failed due to an existing, unrelated TypeScript test typing error in `tests/runRemoteCompletionistAwardIIIResolver.test.ts`, not introduced by this change.
- Started `npm run test:ci` (with `SKIP_E2E=1`) and the pre-test/build steps completed in this environment, but the full test suite execution was not captured to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d126df38832f88085324a760629b)