### PR TITLE
🩹 fix: stop rendering changelog Note metadata

### DIFF
--- a/frontend/src/utils/changelogNotes.ts
+++ b/frontend/src/utils/changelogNotes.ts
@@ -206,40 +206,12 @@ const notesBySlug: Record<string, ChangelogNote[]> = {
     ],
 };
 
-function escapeHtml(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+export function renderChangelogNotes(_slug: string | undefined): string {
+    return '';
 }
 
-export function renderChangelogNotes(slug: string | undefined): string {
-    if (!slug) {
-        return '';
-    }
-
-    const notes = notesBySlug[slug];
-
-    if (!notes || notes.length === 0) {
-        return '';
-    }
-
-    const body = notes
-        .map((note) => {
-            const safeMessage = escapeHtml(note.message);
-            const safeHref = escapeHtml(note.href);
-            const safeLabel = escapeHtml(note.linkLabel);
-            return `<p>${safeMessage} <a href="${safeHref}">${safeLabel}</a>.</p>`;
-        })
-        .join('');
-
-    return `<aside class="changelog-note" aria-label="Historical note"><strong>Note:</strong>${body}</aside>`;
-}
-
-export function appendChangelogNotes(html: string, slug: string | undefined): string {
-    return html + renderChangelogNotes(slug);
+export function appendChangelogNotes(html: string, _slug: string | undefined): string {
+    return html;
 }
 
 export function getChangelogNotes(slug: string | undefined): ChangelogNote[] {


### PR DESCRIPTION
### Motivation
- The `Note:` blocks in changelog markdown are source-only metadata and should not be injected into user-facing HTML such as the homepage or the `/changelog` listing. 
- Injecting those notes made the site render metadata as content and increased the attack surface for accidental HTML injection. 
- Keep the metadata available in the codebase for internal tooling while removing it from rendered output.

### Description
- Made `renderChangelogNotes` a no-op that returns an empty string so notes are not rendered into HTML. 
- Made `appendChangelogNotes` a pass-through that returns the original HTML unchanged, preventing note asides from being appended. 
- Removed the prior HTML-escaping and note-to-HTML mapping while leaving `notesBySlug` and `getChangelogNotes` intact so metadata remains accessible programmatically. 
- Changes applied to `frontend/src/utils/changelogNotes.ts` only.

### Testing
- Ran `npm run lint` and the linter completed successfully. 
- Ran `npm run type-check` and TypeScript reported a pre-existing failure (`tests/runRemoteCompletionistAwardIIIResolver.test.ts:132`) unrelated to this change. 
- Started `npm run test:ci` (which runs the build and full test suite); the build portion completed and tests were started but the full test run did not finish within this session, and no new change-specific failures were observed before the run was terminated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d126df38832f88085324a760629b)