### PR TITLE
🩹 fix: stop rendering changelog note metadata

### DIFF
--- a/frontend/src/components/WhatsNew.astro
+++ b/frontend/src/components/WhatsNew.astro
@@ -32,17 +32,6 @@ function prepareHtml(html, slug) {
                 margin: 0.75rem auto;
             }
 
-            .changelog-note {
-                margin-top: 1.5rem;
-                padding: 1rem;
-                border-left: 4px solid var(--color-highlight, #5b21b6);
-                background: rgba(91, 33, 182, 0.08);
-                border-radius: 12px;
-            }
-
-            .changelog-note p {
-                margin: 0.5rem 0 0;
-            }
         </style>
     `;
 }

--- a/frontend/src/pages/changelog.astro
+++ b/frontend/src/pages/changelog.astro
@@ -167,18 +167,6 @@ const CHANGELOG_SCROLL_BUFFER_PX = 16;
         word-break: break-word;
     }
 
-    .changelog-note {
-        margin-top: 1.5rem;
-        padding: 1rem;
-        border-left: 4px solid var(--color-highlight, #5b21b6);
-        background: rgba(91, 33, 182, 0.08);
-        border-radius: 12px;
-    }
-
-    .changelog-note p {
-        margin: 0.5rem 0 0;
-    }
-
     .visually-hidden {
         position: absolute;
         width: 1px;

--- a/frontend/src/utils/changelogNotes.ts
+++ b/frontend/src/utils/changelogNotes.ts
@@ -238,8 +238,14 @@ export function renderChangelogNotes(slug: string | undefined): string {
     return `<aside class="changelog-note" aria-label="Historical note"><strong>Note:</strong>${body}</aside>`;
 }
 
-export function appendChangelogNotes(html: string, slug: string | undefined): string {
-    void slug;
+/**
+ * Intentionally returns the compiled changelog HTML unchanged.
+ *
+ * `notesBySlug` is source metadata and must stay available via
+ * `renderChangelogNotes`/`getChangelogNotes` for programmatic consumers,
+ * but it should not be injected into user-facing HTML.
+ */
+export function appendChangelogNotes(html: string, _slug: string | undefined): string {
     return html;
 }
 

--- a/frontend/src/utils/changelogNotes.ts
+++ b/frontend/src/utils/changelogNotes.ts
@@ -239,7 +239,8 @@ export function renderChangelogNotes(slug: string | undefined): string {
 }
 
 export function appendChangelogNotes(html: string, slug: string | undefined): string {
-    return html + renderChangelogNotes(slug);
+    void slug;
+    return html;
 }
 
 export function getChangelogNotes(slug: string | undefined): ChangelogNote[] {


### PR DESCRIPTION
### Motivation
- The `Note:` blocks in `notesBySlug` are source metadata and should not be appended into rendered changelog HTML on the homepage (`/`) or the changelog page (`/changelog`).

### Description
- Disable HTML injection by making `appendChangelogNotes` a no-op (keep `notesBySlug`, `renderChangelogNotes`, and `getChangelogNotes` intact) in `frontend/src/utils/changelogNotes.ts` so metadata remains available programmatically but is not rendered to users.

### Testing
- Ran formatting and lint checks with `npm run lint` which passed, and ran the full CI test suite via `npm run test:ci` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d126df38832f88085324a760629b)