### PR TITLE
Remove changelog 'Note:' metadata from homepage and changelog rendering

### DIFF
--- a/frontend/src/components/WhatsNew.astro
+++ b/frontend/src/components/WhatsNew.astro
@@ -1,6 +1,5 @@
 ---
 import Button from './Button.astro';
-import { appendChangelogNotes } from '../utils/changelogNotes';
 import { logServerError } from '../utils/serverLogger';
 
 let changelogs = [];
@@ -11,9 +10,8 @@ let changelogRenderError: Error | undefined;
 const route = Astro.url?.pathname ?? '/';
 const method = Astro.request?.method ?? 'GET';
 
-function prepareHtml(html, slug) {
-    const withNotes = appendChangelogNotes(html, slug);
-    return withNotes + `
+function prepareHtml(html) {
+    return html + `
         <style>
             .latest-update-html img {
                 max-width: 100%;
@@ -30,18 +28,6 @@ function prepareHtml(html, slug) {
                 max-width: min(100%, 512px);
                 display: block;
                 margin: 0.75rem auto;
-            }
-
-            .changelog-note {
-                margin-top: 1.5rem;
-                padding: 1rem;
-                border-left: 4px solid var(--color-highlight, #5b21b6);
-                background: rgba(91, 33, 182, 0.08);
-                border-radius: 12px;
-            }
-
-            .changelog-note p {
-                margin: 0.5rem 0 0;
             }
         </style>
     `;
@@ -67,7 +53,7 @@ try {
     if (changelogsReversed.length > 0) {
         const [latest] = changelogsReversed;
         latestUpdateTitle = latest?.frontmatter?.title;
-        latestUpdateHtml = prepareHtml(latest?.compiledContent(), latest?.frontmatter?.slug);
+        latestUpdateHtml = prepareHtml(latest?.compiledContent());
     }
 } catch (error) {
     changelogRenderError = error instanceof Error ? error : new Error(String(error));

--- a/frontend/src/pages/changelog.astro
+++ b/frontend/src/pages/changelog.astro
@@ -1,6 +1,5 @@
 ---
 import Page from '../components/Page.astro';
-import { appendChangelogNotes } from '../utils/changelogNotes';
 
 const changelogs = await Astro.glob('./docs/md/changelog/*.md');
 
@@ -8,8 +7,8 @@ const changelogsReversed = changelogs.reverse();
 
 const slugToHeadingId = (slug) => (slug ? String(slug).toLowerCase() : 'changelog');
 
-function prepareHtml(html, slug) {
-    return appendChangelogNotes(html, slug);
+function prepareHtml(html) {
+    return html;
 }
 
 const CHANGELOG_SCROLL_BUFFER_PX = 16;
@@ -34,7 +33,7 @@ const CHANGELOG_SCROLL_BUFFER_PX = 16;
                         </div>
                         <div
                             class="entry-body"
-                            set:html={prepareHtml(doc.compiledContent(), doc.frontmatter.slug)}
+                            set:html={prepareHtml(doc.compiledContent())}
                         ></div>
                     </div>
                 </section>
@@ -165,18 +164,6 @@ const CHANGELOG_SCROLL_BUFFER_PX = 16;
     .entry-body :global(code) {
         overflow-wrap: anywhere;
         word-break: break-word;
-    }
-
-    .changelog-note {
-        margin-top: 1.5rem;
-        padding: 1rem;
-        border-left: 4px solid var(--color-highlight, #5b21b6);
-        background: rgba(91, 33, 182, 0.08);
-        border-radius: 12px;
-    }
-
-    .changelog-note p {
-        margin: 0.5rem 0 0;
     }
 
     .visually-hidden {


### PR DESCRIPTION
### Motivation
- Prevent `Note:` historical/metadata blocks from appearing in user-facing pages because these are source metadata and should not render on the homepage (`/`) or the changelog page (`/changelog`).

### Description
- Stop appending changelog metadata by removing `appendChangelogNotes` usage and its import from `frontend/src/components/WhatsNew.astro` and by simplifying `prepareHtml` in `frontend/src/pages/changelog.astro` so compiled markdown is rendered directly.
- Remove the now-unused `.changelog-note` presentation CSS from the homepage and changelog rendering contexts and update `prepareHtml` signatures and `set:html` calls to only use the compiled content.
- Leave `frontend/src/utils/changelogNotes.ts` intact so the underlying note data and helper APIs remain available for maintainers if needed.

### Testing
- Ran `npm run lint` which completed successfully.
- Initiated `npm run test:ci` (which performs a build then runs the test suite); the build step completed but the full test run did not finish in this environment before timing out.
- Ran `git diff --cached | ./scripts/scan-secrets.py` which reported no secrets found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d126df38832f88085324a760629b)