### PR TITLE
🛠️ Fix root prettier resolution and spawn mock typing regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "minisearch": "^7.2.0",
+    "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^2.10.1",
     "prism-svelte": "^0.5.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.1
       prettier-plugin-svelte:
         specifier: ^2.10.1
         version: 2.10.1(prettier@3.8.1)(svelte@5.46.0)

--- a/tests/runRemoteCompletionistAwardIIIResolver.test.ts
+++ b/tests/runRemoteCompletionistAwardIIIResolver.test.ts
@@ -7,6 +7,20 @@ import {
   resolvePlaywrightCli,
 } from '../scripts/run-remote-completionist-award-iii.mjs';
 
+type ChildProcessLike = {
+  on: (event: string, handler: (...args: unknown[]) => void) => ChildProcessLike;
+};
+
+type SpawnFn = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    stdio: 'inherit';
+    env: NodeJS.ProcessEnv;
+  }
+) => ChildProcessLike;
+
 describe('resolvePlaywrightCli', () => {
   it('looks up the Playwright CLI package via require.resolve search paths', () => {
     const calls = [];
@@ -83,7 +97,7 @@ describe('Node version preflight', () => {
   });
 
   it('fails before attempting Playwright launch on unsupported Node', () => {
-    const spawnFn = vi.fn();
+    const spawnFn = vi.fn<SpawnFn>();
     const resolvePlaywrightCliFn = vi.fn();
     const errorLog = vi.fn();
     const exitFn = vi.fn();
@@ -108,13 +122,13 @@ describe('Node version preflight', () => {
   it('uses the current Node runtime to launch Playwright', () => {
     const events = new Map<string, (...args: unknown[]) => void>();
     const printChecklistSummaryFn = vi.fn();
-    const child = {
+    const child: ChildProcessLike = {
       on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
         events.set(event, handler);
         return child;
       }),
     };
-    const spawnFn = vi.fn(() => child);
+    const spawnFn = vi.fn<SpawnFn>(() => child);
     const exitFn = vi.fn();
 
     main({


### PR DESCRIPTION
### Motivation
- Resolve two launch-gate regressions flagged by automated QA: root-side scripts could not resolve `prettier` and a Vitest mock in the remote completionist resolver test had too-narrow typing causing `npm run type-check` to fail.

### Description
- Add `prettier` to root `devDependencies` in `package.json` using the repo-aligned version to ensure root scripts that import `prettier` resolve reliably and keep `prettier-plugin-svelte` in place.
- Update `pnpm-lock.yaml` minimally to reflect the new root `prettier` entry so installs remain reproducible.
- Tighten the test typing in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` by adding `ChildProcessLike` and `SpawnFn` types and using `vi.fn<SpawnFn>()` for the mock `spawnFn` to preserve the existing runtime assertions (including the `process.execPath` check) while satisfying TypeScript.
- Scope of changes limited to `package.json`, `pnpm-lock.yaml`, and the single test file with no product/runtime behavior changes.

### Testing
- Ran `pnpm install` successfully and lockfile was updated to include the root `prettier` entry.
- Ran `npm run type-check` and it completed without type errors.
- Ran `npm run build` and the build completed with no `ERR_MODULE_NOT_FOUND` for `prettier` during docs/RAG and build steps.
- Ran `npm test` which executed pretest steps, root/unit suites, quest validation, hardening, docs-RAG validation, lint and format checks successfully; the grouped Playwright E2E harness began in this environment and did not progress to completion here (environment-limited), and no code changes were made that affect E2E behavior.
- Ran `node scripts/link-check.mjs` and all local markdown links resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f9e03d44832faad135bd865d187e)