### PR TITLE
🛠️ fix: restore root prettier resolution and tighten spawn mock typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "minisearch": "^7.2.0",
+    "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^2.10.1",
     "prism-svelte": "^0.5.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.1
       prettier-plugin-svelte:
         specifier: ^2.10.1
         version: 2.10.1(prettier@3.8.1)(svelte@5.46.0)

--- a/tests/runRemoteCompletionistAwardIIIResolver.test.ts
+++ b/tests/runRemoteCompletionistAwardIIIResolver.test.ts
@@ -7,6 +7,18 @@ import {
   resolvePlaywrightCli,
 } from '../scripts/run-remote-completionist-award-iii.mjs';
 
+type SpawnFn = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    cwd: string;
+    stdio: 'inherit';
+    env: NodeJS.ProcessEnv;
+  }
+) => {
+  on: (event: string, handler: (...args: unknown[]) => void) => unknown;
+};
+
 describe('resolvePlaywrightCli', () => {
   it('looks up the Playwright CLI package via require.resolve search paths', () => {
     const calls = [];
@@ -114,7 +126,7 @@ describe('Node version preflight', () => {
         return child;
       }),
     };
-    const spawnFn = vi.fn(() => child);
+    const spawnFn = vi.fn<SpawnFn>(() => child);
     const exitFn = vi.fn();
 
     main({


### PR DESCRIPTION
### Motivation
- Root-side scripts import `prettier` (e.g. `scripts/build-docs-rag-index.mjs`) and CI/local `npm run build`/`npm test` were failing because `prettier` was not declared at the repo root.  
- `npm run type-check` failed due to TypeScript inferring an overly-narrow type for the Vitest `spawnFn` mock, causing the `spawnFn.mock.calls[0][0]` assertion to be rejected by the checker.

### Description
- Added `prettier` to root `devDependencies` at `^3.4.2` so root scripts that `import prettier` resolve correctly without changing frontend formatting conventions.  
- Updated `pnpm-lock.yaml` minimally to reflect the new root dependency.  
- Introduced an explicit `SpawnFn` type in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` and applied `vi.fn<SpawnFn>(...)` to the mocked `spawnFn` so the existing runtime assertion (`process.execPath`) type-checks cleanly.  
- Files changed: `package.json`, `pnpm-lock.yaml`, and `tests/runRemoteCompletionistAwardIIIResolver.test.ts` (no behavioral changes to runtime logic or test semantics).

### Testing
- Ran `pnpm install` and it completed successfully with the lockfile updated for the new root dependency.  
- Ran `npm run type-check` and `tsc --noEmit` completed with no errors.  
- Ran `npm run build` and the docs RAG generation and `astro build` steps completed successfully (no `ERR_MODULE_NOT_FOUND` for `prettier`).  
- Ran `npm test` and the pretest/root unit/validation stages completed successfully; the longer grouped Playwright E2E grouping was observed to be executing and the run was intentionally terminated after confirming the pretest/build `prettier` regression was resolved.  
- Ran `node scripts/link-check.mjs` and link checking passed with all local markdown links resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f9e03d44832faad135bd865d187e)