### PR TITLE
🛠️ Fix root prettier resolution and spawnFn mock typing regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "minisearch": "^7.2.0",
+    "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^2.10.1",
     "prism-svelte": "^0.5.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.1
       prettier-plugin-svelte:
         specifier: ^2.10.1
         version: 2.10.1(prettier@3.8.1)(svelte@5.46.0)

--- a/tests/runRemoteCompletionistAwardIIIResolver.test.ts
+++ b/tests/runRemoteCompletionistAwardIIIResolver.test.ts
@@ -114,7 +114,17 @@ describe('Node version preflight', () => {
         return child;
       }),
     };
-    const spawnFn = vi.fn(() => child);
+    const spawnFn = vi.fn<
+      (
+        command: string,
+        args: string[],
+        options: {
+          cwd: string;
+          stdio: 'inherit';
+          env: NodeJS.ProcessEnv;
+        }
+      ) => typeof child
+    >(() => child);
     const exitFn = vi.fn();
 
     main({


### PR DESCRIPTION
### Motivation
- Root-side scripts that import `prettier` were failing during `npm run build`/`npm test` because `prettier` was not declared at the repo root. 
- The Vitest mock for `spawnFn` inferred an empty-tuple call shape which made `spawnFn.mock.calls[0][0]` fail TypeScript checks.
- Make targeted fixes that preserve runtime behavior and repository conventions for v3.0.1.

### Description
- Add `prettier` to root `devDependencies` in `package.json` to allow root scripts (for example `scripts/build-docs-rag-index.mjs`) to import `prettier` without module resolution errors, and update `pnpm-lock.yaml` accordingly; files changed: `package.json`, `pnpm-lock.yaml`.
- Give the `spawnFn` mock an explicit function signature in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` so `spawnFn.mock.calls[0][0]` type-checks while preserving the test's semantics; file changed: `tests/runRemoteCompletionistAwardIIIResolver.test.ts`.
- No product behavior changes were made and no unrelated refactors were performed.

### Testing
- Ran `pnpm install` and the install completed successfully with the new root `prettier` added to lockfile.
- Ran `npm run type-check` and TypeScript checks passed after tightening the `spawnFn` mock typing.
- Ran `npm run build` and the root build completed successfully and no longer failed with `ERR_MODULE_NOT_FOUND` for `prettier`.
- Started `npm test`; it reached the root unit test runner prompt (`Running root unit tests...`) in this environment but did not produce further test-run output before the session timed out, and no new `prettier` resolution error occurred during pretest.
- Ran `node scripts/link-check.mjs` and it reported `All local markdown links resolved.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f9e03d44832faad135bd865d187e)