### PR TITLE
fix: restore root prettier resolution and tighten spawn mock typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest": "^29.7.0",
     "jsdom": "^26.1.0",
     "minisearch": "^7.2.0",
+    "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^2.10.1",
     "prism-svelte": "^0.5.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.1
       prettier-plugin-svelte:
         specifier: ^2.10.1
         version: 2.10.1(prettier@3.8.1)(svelte@5.46.0)

--- a/tests/runRemoteCompletionistAwardIIIResolver.test.ts
+++ b/tests/runRemoteCompletionistAwardIIIResolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, type Mock, vi } from 'vitest';
 
 import {
   getUnsupportedNodeVersionMessage,
@@ -58,6 +58,18 @@ describe('resolvePlaywrightCli', () => {
 });
 
 describe('Node version preflight', () => {
+  type SpawnFn = (
+    command: string,
+    args: string[],
+    options: {
+      cwd: string;
+      stdio: 'inherit';
+      env: NodeJS.ProcessEnv;
+    }
+  ) => {
+    on: (event: string, handler: (...args: unknown[]) => void) => unknown;
+  };
+
   it('rejects unsupported versions and reports guidance', () => {
     expect(isSupportedNodeVersion('18.18.0')).toBe(false);
 
@@ -114,7 +126,7 @@ describe('Node version preflight', () => {
         return child;
       }),
     };
-    const spawnFn = vi.fn(() => child);
+    const spawnFn: Mock<SpawnFn> = vi.fn(() => child);
     const exitFn = vi.fn();
 
     main({


### PR DESCRIPTION
### Motivation
- Root-side scripts (for docs RAG / build / pretest flows) import `prettier` but the root `devDependencies` lacked a declared `prettier`, causing `ERR_MODULE_NOT_FOUND` during `npm run build` / `npm test`.
- A TypeScript regression in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` caused `npm run type-check` to fail because the Vitest mock used for `spawnFn` had an underspecified type for its `.mock` calls.
- Make minimal, targeted fixes that preserve behavior and align root prettier with the frontend config.

### Description
- Added `prettier: "^3.4.2"` to root `devDependencies` in `package.json` to ensure root scripts that `import`/`require` `prettier` resolve during build/test flows.
- Introduced an explicit `SpawnFn` function signature and typed the mock as `Mock<SpawnFn>` in `tests/runRemoteCompletionistAwardIIIResolver.test.ts` so `spawnFn.mock.calls[0][0]` type-checks without changing the test assertion or runtime behavior.
- Updated `pnpm-lock.yaml` minimally as part of installing the new root dependency so the lockfile contains the root importer entry for `prettier`.
- Files changed: `package.json`, `pnpm-lock.yaml`, `tests/runRemoteCompletionistAwardIIIResolver.test.ts`.

### Testing
- Ran `pnpm install` — succeeded and updated lockfile to include the root `prettier` entry.
- Ran `npm run type-check` — succeeded (`tsc --noEmit` passed).
- Ran `npm run build` — succeeded; the `ERR_MODULE_NOT_FOUND: prettier` failure is resolved and docs RAG build completed.
- Ran `npm test` — pretest/root/unit/validation/hardening/docs-rag phases ran successfully (root vitest suites and the large test matrix passed); the run then entered long-running grouped E2E stages in this environment and did not emit a final session completion signal, but no regressions from these changes were observed during the automated phases executed.
- Ran `node scripts/link-check.mjs` — succeeded (all local markdown links resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f9e03d44832faad135bd865d187e)