### PR TITLE
Enforce launch-gate CI coverage; fix JSON import and build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             "docs/**/*.md" "frontend/src/pages/docs/**/*.md"
           format: markdown
           output: lychee/out.md
-  root-tests:
+  launch-gates:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,10 +82,15 @@ jobs:
             ${{ runner.os }}-pnpm-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --reporter=append-only
-      - name: Run lint and type checks
-        run: pnpm run check
-      - name: Run root tests
-        run: pnpm run test:root -- --testTimeout=20000
+      - name: Run launch-gate commands
+        env:
+          SKIP_E2E: '1'
+        run: |
+          npm run lint
+          npm run type-check
+          npm run build
+          npm test
+          node scripts/link-check.mjs
 
   frontend-indexeddb-regression-e2e:
     runs-on: ubuntu-latest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
         "dev:safe": "concurrently \"npm run dev\" \"npm run fix-artifacts\"",
         "fix-artifacts": "node scripts/fix-artifact-error.js",
         "start": "astro dev --host 0.0.0.0 --port=$PORT",
-        "build": "astro build",
+        "build": "astro build --silent",
         "preview": "node scripts/ensure-astro-build.mjs && astro preview --host 0.0.0.0 --port=3000",
         "astro": "astro",
         "setup-test-env": "node scripts/setup-test-env.js",

--- a/frontend/src/utils/gameState.js
+++ b/frontend/src/utils/gameState.js
@@ -34,9 +34,7 @@ let processCreateItemsByIdPromise;
 
 const getProcessCreateItemsById = async () => {
     if (!processCreateItemsByIdPromise) {
-        processCreateItemsByIdPromise = import('../generated/processes.json', {
-            assert: { type: 'json' },
-        })
+        processCreateItemsByIdPromise = import('../generated/processes.json')
             .then(
                 ({ default: processCatalog }) =>
                     new Map(

--- a/scripts/check-workflows.mjs
+++ b/scripts/check-workflows.mjs
@@ -4,7 +4,8 @@ import process from 'node:process';
 import { parse } from 'yaml';
 
 const repoRoot = process.cwd();
-const workflowsDir = process.env.WORKFLOWS_DIR || path.join(repoRoot, '.github', 'workflows');
+const workflowsDir =
+  process.env.WORKFLOWS_DIR || path.join(repoRoot, '.github', 'workflows');
 
 const requiredWorkflows = [
   'build.yml',
@@ -16,6 +17,17 @@ const requiredWorkflows = [
 ];
 
 const errors = [];
+
+const launchGateChecks = [
+  { pattern: /npm run lint/, label: 'npm run lint' },
+  { pattern: /npm run type-check/, label: 'npm run type-check' },
+  { pattern: /npm run build/, label: 'npm run build' },
+  { pattern: /npm test/, label: 'npm test' },
+  {
+    pattern: /node scripts\/link-check\.mjs/,
+    label: 'node scripts/link-check.mjs',
+  },
+];
 
 function asArray(value) {
   if (value === undefined || value === null) {
@@ -118,6 +130,22 @@ for (const workflowFile of workflowFiles) {
   }
 }
 
+const ciWorkflowPath = path.join(workflowsDir, 'ci.yml');
+try {
+  const ciWorkflowContents = readFileSync(ciWorkflowPath, 'utf8');
+  for (const launchGateCheck of launchGateChecks) {
+    if (!launchGateCheck.pattern.test(ciWorkflowContents)) {
+      errors.push(
+        `Workflow ci.yml is missing launch-gate command: ${launchGateCheck.label}`
+      );
+    }
+  }
+} catch (error) {
+  errors.push(
+    `Unable to read ci.yml for launch-gate validation: ${error.message}`
+  );
+}
+
 if (errors.length > 0) {
   console.error('Workflow integrity check failed:');
   for (const error of errors) {
@@ -126,4 +154,6 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Workflow integrity check passed for ${workflowFiles.length} workflow file(s).`);
+console.log(
+  `Workflow integrity check passed for ${workflowFiles.length} workflow file(s).`
+);


### PR DESCRIPTION
### Motivation
- Restore and harden the repo launch-gate checklist so the five required root commands (`lint`, `type-check`, `build`, `test`, `link-check`) run reliably from repo root and surface regressions locally and in CI. 
- Make the build deterministic after a clean install by fixing a real runtime/import mismatch that produced a Vite/Astro warning. 
- Prevent future silent CI drift by adding a lightweight guard that verifies the CI workflow contains the documented launch-gate commands.

### Description
- Add a dedicated `launch-gates` job to `.github/workflows/ci.yml` that runs the repo-root launch-gate sequence under `SKIP_E2E=1` (runs `npm run lint`, `npm run type-check`, `npm run build`, `npm test`, `node scripts/link-check.mjs`).
- Tighten `scripts/check-workflows.mjs` to assert that `ci.yml` contains the required launch-gate command strings and fail the sentinel if they are missing.
- Fix inconsistent JSON import attributes by changing the dynamic import in `frontend/src/utils/gameState.js` to use the plain import style (remove `assert: { type: 'json' }`) so all imports of `src/generated/processes.json` are consistent.
- Reduce noisy Astro build output in CI by making the frontend build script use `astro build --silent` in `frontend/package.json` to keep CI logs focused and actionable.
- Files changed: `.github/workflows/ci.yml`, `scripts/check-workflows.mjs`, `frontend/src/utils/gameState.js`, `frontend/package.json`.

### Testing
- `npm install` — succeeded (clean install completed). 
- `npm run lint` — succeeded (frontend lint + a11y checks pass). 
- `npm run type-check` — succeeded (`tsc --noEmit` passed).
- `npm run build` — succeeded and the inconsistent JSON import warning is resolved (no mixed-attribute import error observed).
- `SKIP_E2E=1 npm test` — succeeded (root/unit + scripts suites exercised under launch-gate mode).
- `node scripts/link-check.mjs` — succeeded (all local markdown links resolved).
- Focused verification: `npm --prefix frontend run test -- frontend/__tests__/Quests.test.js` passed, and `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts scripts/tests/prettierFormatting.test.ts` passed.
- Workflow guard: `node scripts/check-workflows.mjs` passed locally and will fail CI if the launch-gates strings are removed from `ci.yml`.

If anything else is desired (change scopes, further CI tuning, or reverting the `--silent` choice), I can follow up with a narrow PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32cc51c7c832fa4736627113fffe6)