### PR TITLE
✅ fix: align Playwright bootstrap test with platform-specific deps install behavior

### DIFF
--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -99,22 +99,12 @@ describe('ensurePlaywrightBrowsers', () => {
 
     await ensurePlaywrightBrowsers({ cwd: repoRoot, browser, env: envWithProxy });
 
-    expect(execFileSync).toHaveBeenCalledTimes(2);
-    expect(execFileSync.mock.calls[0]).toEqual([
-      process.execPath,
-      expect.arrayContaining([
-        expect.stringContaining(
-          path.join('node_modules', '@playwright', 'test', 'cli.js')
-        ),
-        'install-deps',
-      ]),
-      expect.objectContaining({
-        cwd: repoRoot,
-        stdio: 'inherit',
-        env: sanitizedEnv,
-      }),
-    ]);
-    expect(execFileSync.mock.calls[1]).toEqual([
+    const expectedCalls = process.platform === 'linux' ? 2 : 1;
+    expect(execFileSync).toHaveBeenCalledTimes(expectedCalls);
+
+    const installCall =
+      process.platform === 'linux' ? execFileSync.mock.calls[1] : execFileSync.mock.calls[0];
+    expect(installCall).toEqual([
       process.execPath,
       expect.arrayContaining([
         expect.stringContaining(
@@ -130,6 +120,23 @@ describe('ensurePlaywrightBrowsers', () => {
         env: sanitizedEnv,
       }),
     ]);
+
+    if (process.platform === 'linux') {
+      expect(execFileSync.mock.calls[0]).toEqual([
+        process.execPath,
+        expect.arrayContaining([
+          expect.stringContaining(
+            path.join('node_modules', '@playwright', 'test', 'cli.js')
+          ),
+          'install-deps',
+        ]),
+        expect.objectContaining({
+          cwd: repoRoot,
+          stdio: 'inherit',
+          env: sanitizedEnv,
+        }),
+      ]);
+    }
     expect(executablePath).toHaveBeenCalledTimes(2);
     expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
     expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);


### PR DESCRIPTION
### Motivation
- Two CI gates were failing: the Playwright bootstrap test asserted two `execFileSync` calls unconditionally, and the Prettier formatting gate flagged three frontend files; the goal was to make the smallest change to unblock those gates.
- `ensurePlaywrightBrowsers` intentionally runs `install-deps` only on Linux, so the previous unconditional two-call expectation in the test had drifted from implementation.

### Description
- Updated the missing-chromium test in `scripts/tests/ensurePlaywrightBrowsers.test.ts` to expect `install-deps` only when `process.platform === 'linux'`, while still asserting the browser `install` call, sanitized env usage, and headless-shell path handling.
- Ran Prettier on the three files reported by the formatting gate: `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, and `frontend/src/utils/legacySaveParsing.js`; they were already compliant so no content changes were required.
- Files changed: `scripts/tests/ensurePlaywrightBrowsers.test.ts`.
- Resolution for the Playwright mismatch: the test was adjusted (test-side win) because the runtime helper correctly only runs system-deps installation on Linux and other coverage already verifies deps-install behavior.

### Testing
- Ran `npm run format:check` and it succeeded (`All matched files use Prettier code style!`).
- Ran targeted unit suites with `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts scripts/tests/prettierFormatting.test.ts` and both tests passed.
- Ran full test orchestration `npm test` as part of verification and the suite completed with the previously failing suites now passing per the run logs.
- Ran `npm run lint` which passed, `npm run type-check` which passed, `npm run build` which completed successfully, and `node scripts/link-check.mjs` which reported all local markdown links resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41cc721f8832f8ce11bb953683263)