### PR TITLE
✅ Fix Playwright bootstrap test expectation drift and run Prettier on reported files

### DIFF
--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -99,22 +99,14 @@ describe('ensurePlaywrightBrowsers', () => {
 
     await ensurePlaywrightBrowsers({ cwd: repoRoot, browser, env: envWithProxy });
 
-    expect(execFileSync).toHaveBeenCalledTimes(2);
-    expect(execFileSync.mock.calls[0]).toEqual([
-      process.execPath,
-      expect.arrayContaining([
-        expect.stringContaining(
-          path.join('node_modules', '@playwright', 'test', 'cli.js')
-        ),
-        'install-deps',
-      ]),
-      expect.objectContaining({
-        cwd: repoRoot,
-        stdio: 'inherit',
-        env: sanitizedEnv,
-      }),
-    ]);
-    expect(execFileSync.mock.calls[1]).toEqual([
+    const installDepsCall = execFileSync.mock.calls.find(([, args]) =>
+      Array.isArray(args) && args[1] === 'install-deps'
+    );
+    const installCall = execFileSync.mock.calls.find(([, args]) =>
+      Array.isArray(args) && args[1] === 'install'
+    );
+
+    expect(installCall).toEqual([
       process.execPath,
       expect.arrayContaining([
         expect.stringContaining(
@@ -130,6 +122,24 @@ describe('ensurePlaywrightBrowsers', () => {
         env: sanitizedEnv,
       }),
     ]);
+    if (process.platform === 'linux') {
+      expect(installDepsCall).toEqual([
+        process.execPath,
+        expect.arrayContaining([
+          expect.stringContaining(
+            path.join('node_modules', '@playwright', 'test', 'cli.js')
+          ),
+          'install-deps',
+        ]),
+        expect.objectContaining({
+          cwd: repoRoot,
+          stdio: 'inherit',
+          env: sanitizedEnv,
+        }),
+      ]);
+    } else {
+      expect(installDepsCall).toBeUndefined();
+    }
     expect(executablePath).toHaveBeenCalledTimes(2);
     expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
     expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);


### PR DESCRIPTION
### Motivation
- The Playwright bootstrap unit test assumed two `execFileSync` calls in non-Windows environments, but the runtime helper (`ensure-playwright-browsers.js`) only runs the `install-deps` step on Linux, causing a cross-platform test drift.
- The formatting gate flagged three frontend files; run Prettier on those files to satisfy the formatting check without making semantic changes.

### Description
- Updated `scripts/tests/ensurePlaywrightBrowsers.test.ts` to locate `install` and `install-deps` calls by action instead of asserting a fixed call count, always asserting the browser `install` call and only asserting `install-deps` when `process.platform === 'linux'` to match current helper behavior.
- Preserved important assertions including sanitized env usage, headless-shell path checks, and `executablePath` call counts.
- Ran Prettier in `frontend/` on the three files reported by the failing test: `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, and `frontend/src/utils/legacySaveParsing.js`, which were already formatted.
- Files changed: `scripts/tests/ensurePlaywrightBrowsers.test.ts` (test update); Prettier was executed on the three frontend files but they remained unchanged.

### Testing
- Ran `npm run format:check` and it reported: "All matched files use Prettier code style!" (passed).
- Ran the focused unit test with `npx vitest run scripts/tests/ensurePlaywrightBrowsers.test.ts` and the test suite passed (test now aligns with implementation).
- Ran `npm test` and the full test suite completed successfully in this environment (root/unit and frontend suites exercised and passed).
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41cc721f8832f8ce11bb953683263)