### PR TITLE
Fix Playwright bootstrap test platform drift

### DIFF
--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -97,7 +97,12 @@ describe('ensurePlaywrightBrowsers', () => {
     });
     const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
 
-    await ensurePlaywrightBrowsers({ cwd: repoRoot, browser, env: envWithProxy });
+    await ensurePlaywrightBrowsers({
+      cwd: repoRoot,
+      browser,
+      env: envWithProxy,
+      platform: 'linux',
+    });
 
     expect(execFileSync).toHaveBeenCalledTimes(2);
     expect(execFileSync.mock.calls[0]).toEqual([


### PR DESCRIPTION
### Motivation
- The Playwright bootstrap test assumed Linux-only `install-deps` behavior but used the host `process.platform`, causing a host-dependent failure; the test should assert the Linux path explicitly to avoid drift.

### Description
- Update `scripts/tests/ensurePlaywrightBrowsers.test.ts` to call `ensurePlaywrightBrowsers(..., platform: 'linux')` for the scenario that expects both `install-deps` and browser install invocations, and run Prettier on the three files reported by the formatting test (no formatting changes were necessary).

### Testing
- Ran the focused tests with `npx vitest run scripts/tests/ensurePlaywrightBrowsers.test.ts scripts/tests/prettierFormatting.test.ts --config vitest.config.mts` and they passed. 
- Ran `npm run format:check`, `npm run lint`, `npm run type-check`, `npm run build` (with expected Astro warnings), and `node scripts/link-check.mjs`, and they all succeeded. 
- The full `npm test` invocation in this container did not complete (hung at `Running root unit tests...`) while the targeted verifications above show the original failures are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41cc721f8832f8ce11bb953683263)