### PR TITLE
🩹 Fix Quests custom section test timing and clear formatting gate

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -231,14 +231,18 @@ describe('Quests Component', () => {
             await vi.runAllTimersAsync();
             await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
 
+            await vi.waitFor(() => {
+                const mergeStatus = host.querySelector(
+                    "[data-testid='custom-quests-merge-status']"
+                );
+                expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+            });
+
             const customSection = host.querySelector("[data-testid='custom-quests-section']");
             expect(customSection).not.toBeNull();
             expect(customSection?.textContent).toContain('Ready Custom Quest');
             expect(customSection?.textContent).not.toContain('Locked Custom Quest');
             expect(customSection?.textContent).not.toContain('Locked');
-
-            const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
-            expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
         } finally {
             vi.useRealTimers();
         }


### PR DESCRIPTION
### Motivation
- A timing race caused `frontend/__tests__/Quests.test.js` to assert the custom-quests section before the async custom-merge/classification completed, making the test flaky.
- The Prettier formatting gate reported several frontend files; run the frontend-specific Prettier config to ensure the formatting check is satisfied.

### Description
- Wait for the hidden merge-status marker to reflect `data-custom-count='1'` before asserting the custom section in `frontend/__tests__/Quests.test.js`, stabilizing the test without changing component logic.
- Ran Prettier with the frontend config (`frontend/.prettierrc`) against the specified frontend files (`frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, `frontend/src/utils/legacySaveParsing.js`) to satisfy the formatting gate; those files were already formatted and required no semantic edits.
- No production/component code was modified.

### Testing
- Ran `cd frontend && npx prettier --config .prettierrc --write __tests__/migrations.test.js __tests__/offlineWorkerRegistration.test.js src/utils/legacySaveParsing.js` and the files were unchanged (already formatted).
- Ran `npm run format:check` and the frontend formatting check passed.
- Ran `npm run test:root -- frontend/__tests__/Quests.test.js scripts/tests/prettierFormatting.test.ts` and both targeted tests passed.
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, and each command completed successfully.
- Note: a full `npm test` run using the repository harness was started earlier in the session but the long-running `run-tests.js` process did not complete before manual interruption; the targeted root tests and the Prettier gate that were failing are now green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48e2d8300832fbea12171a0c57bb5)