### PR TITLE
fix: stabilize custom quests test & apply frontend Prettier to flagged files

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -231,8 +231,10 @@ describe('Quests Component', () => {
             await vi.runAllTimersAsync();
             await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
 
+            await vi.waitFor(() =>
+                expect(host.querySelector("[data-testid='custom-quests-section']")).not.toBeNull()
+            );
             const customSection = host.querySelector("[data-testid='custom-quests-section']");
-            expect(customSection).not.toBeNull();
             expect(customSection?.textContent).toContain('Ready Custom Quest');
             expect(customSection?.textContent).not.toContain('Locked Custom Quest');
             expect(customSection?.textContent).not.toContain('Locked');


### PR DESCRIPTION
### Motivation
- A timing race in the `Quests` test caused the Custom Quests section to sometimes be queried before Svelte flushed the DOM, producing a spurious failure; the intent is to preserve the asserted user-visible contract (show Ready custom quests, hide Locked ones) without changing implementation.

### Description
- Wait for the custom section DOM node before asserting its contents in the `hides locked custom quests until prerequisites are complete` test by adding a `vi.waitFor(...)` around the query. (file changed: `frontend/__tests__/Quests.test.js`)
- Run frontend Prettier using the frontend config (`frontend/.prettierrc`) on the three files flagged by the formatting gate; no semantic edits were made and the files were already formatted. (files touched for formatting: `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, `frontend/src/utils/legacySaveParsing.js`)

### Testing
- Ran `cd frontend && npx prettier --config .prettierrc --write __tests__/migrations.test.js __tests__/offlineWorkerRegistration.test.js src/utils/legacySaveParsing.js` and Prettier reported the files unchanged (success).
- Ran `cd .. && npm run format:check` and it reported `All matched files use Prettier code style!` (success).
- Ran `npx vitest run frontend/__tests__/Quests.test.js scripts/tests/prettierFormatting.test.ts` and both tests passed (the Quests tests and the Prettier formatting test succeeded).
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` and each step completed successfully; the change is strictly test-side and did not alter runtime behavior.

Files changed:
- `frontend/__tests__/Quests.test.js` (test assertion stabilized)

Notes:
- This is a minimal, test-side fix to eliminate timing flakiness; no quest rendering logic was modified.
- Frontend formatting used the `frontend/.prettierrc` config per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48e2d8300832fbea12171a0c57bb5)