### PR TITLE
🐛 Fix flaky Quests test by waiting for custom section to render

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -230,6 +230,9 @@ describe('Quests Component', () => {
             mountedComponent = mount(Quests, { target: host, props: { quests } });
             await vi.runAllTimersAsync();
             await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+            await vi.waitFor(() =>
+                expect(host.querySelector("[data-testid='custom-quests-section']")).not.toBeNull()
+            );
 
             const customSection = host.querySelector("[data-testid='custom-quests-section']");
             expect(customSection).not.toBeNull();

--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -274,6 +274,9 @@ describe('Quests Component', () => {
             mountedComponent = mount(Quests, { target: host, props: { quests } });
             await vi.runAllTimersAsync();
             await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
+            await vi.waitFor(() =>
+                expect(host.querySelector("[data-testid='custom-quests-section']")).not.toBeNull()
+            );
 
             const customSection = host.querySelector("[data-testid='custom-quests-section']");
             expect(customSection?.textContent).toContain('Available Custom Quest');


### PR DESCRIPTION
### Motivation
- Stabilize an intermittent test failure where the `custom-quests-section` could be asserted before the async custom-quest merge/render completed, causing the test to see a missing section.

### Description
- Added an explicit async assertion to wait for the custom section to appear in `frontend/__tests__/Quests.test.js` so the test only inspects content after the DOM has rendered.
- Re-ran frontend-specific Prettier formatting (using `frontend/.prettierrc`) for the three files flagged by the formatting gate: `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, and `frontend/src/utils/legacySaveParsing.js` (formatting only; no semantic changes).

### Testing
- Ran formatter write with `cd frontend && npx prettier --config .prettierrc --write __tests__/migrations.test.js __tests__/offlineWorkerRegistration.test.js src/utils/legacySaveParsing.js` and the files were already compliant.
- Verified formatting gate with `npm run format:check` (frontend Prettier config) which succeeded.
- Ran the targeted tests with `npx vitest run frontend/__tests__/Quests.test.js scripts/tests/prettierFormatting.test.ts` and both tests passed.
- Ran repository checks `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48e2d8300832fbea12171a0c57bb5)