### PR TITLE
✅ fix: stabilize flaky custom quests visibility assertion

### DIFF
--- a/frontend/__tests__/Quests.test.js
+++ b/frontend/__tests__/Quests.test.js
@@ -231,14 +231,18 @@ describe('Quests Component', () => {
             await vi.runAllTimersAsync();
             await vi.waitFor(() => expect(listCustomQuests).toHaveBeenCalled());
 
-            const customSection = host.querySelector("[data-testid='custom-quests-section']");
-            expect(customSection).not.toBeNull();
-            expect(customSection?.textContent).toContain('Ready Custom Quest');
-            expect(customSection?.textContent).not.toContain('Locked Custom Quest');
-            expect(customSection?.textContent).not.toContain('Locked');
+            await vi.waitFor(() => {
+                const customSection = host.querySelector("[data-testid='custom-quests-section']");
+                expect(customSection).not.toBeNull();
+                expect(customSection?.textContent).toContain('Ready Custom Quest');
+                expect(customSection?.textContent).not.toContain('Locked Custom Quest');
+                expect(customSection?.textContent).not.toContain('Locked');
 
-            const mergeStatus = host.querySelector("[data-testid='custom-quests-merge-status']");
-            expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+                const mergeStatus = host.querySelector(
+                    "[data-testid='custom-quests-merge-status']"
+                );
+                expect(mergeStatus?.getAttribute('data-custom-count')).toBe('1');
+            });
         } finally {
             vi.useRealTimers();
         }


### PR DESCRIPTION
### Motivation
- A test intermittently failed because the `Quests` test asserted custom-quest DOM content before the component's async custom-quest merge/render had settled.

### Description
- Update the test to wait for render completion by wrapping the custom-section assertions in `vi.waitFor(...)` in `frontend/__tests__/Quests.test.js`, preserving the existing user-visible contract and making no runtime code changes.

### Testing
- Formatted the requested frontend files with the frontend Prettier config via `cd frontend && npx prettier --config .prettierrc --write __tests__/migrations.test.js __tests__/offlineWorkerRegistration.test.js src/utils/legacySaveParsing.js` and confirmed `npm run format:check` passed.
- Ran `npx vitest run frontend/__tests__/Quests.test.js --config vitest.config.mts` and `npx vitest run scripts/tests/prettierFormatting.test.ts --config vitest.config.mts`, and both tests succeeded.
- Executed `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48e2d8300832fbea12171a0c57bb5)