### PR TITLE
fix: stabilize Playwright setup and satisfy Prettier formatting gate

### DIFF
--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -276,6 +276,17 @@ if (!fs.existsSync(PLAYWRIGHT_CLI)) {
 
 const PLAYWRIGHT_COMMAND = `node ${JSON.stringify(PLAYWRIGHT_CLI)} test`;
 
+function getPlaywrightEnv(baseEnv = process.env) {
+    const env = { ...baseEnv };
+    const nodeOptions = env.NODE_OPTIONS || '';
+
+    if (!nodeOptions.includes('--dns-result-order')) {
+        env.NODE_OPTIONS = `${nodeOptions} --dns-result-order=ipv4first`.trim();
+    }
+
+    return env;
+}
+
 // Function to run a test group
 function runTestGroup(group) {
     console.log(`${colors.bright}${colors.blue}Running ${group.name}${colors.reset}`);
@@ -307,7 +318,7 @@ function runTestGroup(group) {
         console.log(
             `${colors.cyan}Using ${group.parallel ? group.workers || MAX_WORKERS : 1} worker(s)${colors.reset}`
         );
-        execSync(command, { stdio: 'inherit', cwd: rootDir });
+        execSync(command, { stdio: 'inherit', cwd: rootDir, env: getPlaywrightEnv() });
         console.log(`${colors.green}✓ ${group.name} completed successfully${colors.reset}`);
         return true;
     } catch (error) {

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import os from 'os';
+import { withPlaywrightNetworkEnv } from './utils/ensure-playwright-browsers.js';
 
 // Get the directory name in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -276,17 +277,6 @@ if (!fs.existsSync(PLAYWRIGHT_CLI)) {
 
 const PLAYWRIGHT_COMMAND = `node ${JSON.stringify(PLAYWRIGHT_CLI)} test`;
 
-function getPlaywrightEnv(baseEnv = process.env) {
-    const env = { ...baseEnv };
-    const nodeOptions = env.NODE_OPTIONS || '';
-
-    if (!nodeOptions.includes('--dns-result-order')) {
-        env.NODE_OPTIONS = `${nodeOptions} --dns-result-order=ipv4first`.trim();
-    }
-
-    return env;
-}
-
 // Function to run a test group
 function runTestGroup(group) {
     console.log(`${colors.bright}${colors.blue}Running ${group.name}${colors.reset}`);
@@ -318,7 +308,11 @@ function runTestGroup(group) {
         console.log(
             `${colors.cyan}Using ${group.parallel ? group.workers || MAX_WORKERS : 1} worker(s)${colors.reset}`
         );
-        execSync(command, { stdio: 'inherit', cwd: rootDir, env: getPlaywrightEnv() });
+        execSync(command, {
+            stdio: 'inherit',
+            cwd: rootDir,
+            env: withPlaywrightNetworkEnv(),
+        });
         console.log(`${colors.green}✓ ${group.name} completed successfully${colors.reset}`);
         return true;
     } catch (error) {

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -31,6 +31,17 @@ function hasPlaceholderProxyEnv(env = process.env) {
     });
 }
 
+function withPlaywrightNetworkEnv(env = process.env) {
+    const mergedEnv = { ...env };
+    const existingNodeOptions = mergedEnv.NODE_OPTIONS || '';
+
+    if (!existingNodeOptions.includes('--dns-result-order')) {
+        mergedEnv.NODE_OPTIONS = `${existingNodeOptions} --dns-result-order=ipv4first`.trim();
+    }
+
+    return mergedEnv;
+}
+
 export function sanitizeProxyEnv(env = process.env) {
     const sanitized = { ...env };
 
@@ -168,7 +179,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         fs = { existsSync, writeFileSync },
     } = options;
 
-    const sanitizedEnv = sanitizeProxyEnv(env);
+    const sanitizedEnv = withPlaywrightNetworkEnv(sanitizeProxyEnv(env));
     const browser = providedBrowser ?? (await getChromiumBrowser());
 
     const executableOverride = env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
@@ -253,7 +264,7 @@ export function ensurePlaywrightSystemDeps(options = {}) {
         return false;
     }
 
-    const sanitizedEnv = sanitizeProxyEnv(env);
+    const sanitizedEnv = withPlaywrightNetworkEnv(sanitizeProxyEnv(env));
     const hadPlaceholderProxy = hasPlaceholderProxyEnv(env);
     if (hadPlaceholderProxy) {
         console.warn(

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -31,7 +31,7 @@ function hasPlaceholderProxyEnv(env = process.env) {
     });
 }
 
-function withPlaywrightNetworkEnv(env = process.env) {
+export function withPlaywrightNetworkEnv(env = process.env) {
     const mergedEnv = { ...env };
     const existingNodeOptions = mergedEnv.NODE_OPTIONS || '';
 

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -63,6 +63,15 @@ describe('ensurePlaywrightBrowsers', () => {
       npm_config_https_proxy: 'http://legit-proxy:3128',
     };
     const sanitizedEnv = sanitizeProxyEnv(envWithProxy);
+    const expectedNodeOptions = sanitizedEnv.NODE_OPTIONS?.includes(
+      '--dns-result-order'
+    )
+      ? sanitizedEnv.NODE_OPTIONS
+      : `${sanitizedEnv.NODE_OPTIONS ?? ''} --dns-result-order=ipv4first`.trim();
+    const expectedEnv = {
+      ...sanitizedEnv,
+      NODE_OPTIONS: expectedNodeOptions,
+    };
     const execFileSync = vi.fn((_command, args: string[]) => {
       const action = args[1];
       if (action === 'install-deps') {
@@ -134,7 +143,7 @@ describe('ensurePlaywrightBrowsers', () => {
       expect.objectContaining({
         cwd: repoRoot,
         stdio: 'inherit',
-        env: sanitizedEnv,
+        env: expectedEnv,
       }),
     ]);
     expect(execFileSync.mock.calls[1]).toEqual([
@@ -150,7 +159,7 @@ describe('ensurePlaywrightBrowsers', () => {
       expect.objectContaining({
         cwd: repoRoot,
         stdio: 'inherit',
-        env: sanitizedEnv,
+        env: expectedEnv,
       }),
     ]);
     expect(executablePath).toHaveBeenCalledTimes(2);
@@ -215,9 +224,9 @@ describe('ensurePlaywrightBrowsers', () => {
     });
     expect(execFileSync.mock.calls[0][2]?.env?.HTTP_PROXY).toBeUndefined();
     expect(execFileSync.mock.calls[0][2]?.env?.HTTPS_PROXY).toBeUndefined();
-    expect(Object.keys(execFileSync.mock.calls[0][2]?.env ?? {})).toHaveLength(
-      0
-    );
+    expect(execFileSync.mock.calls[0][2]?.env).toEqual({
+      NODE_OPTIONS: '--dns-result-order=ipv4first',
+    });
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
 

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -57,7 +57,7 @@ describe('ensurePlaywrightBrowsers', () => {
     let chromeExists = false;
     let depsSentinelExists = false;
     const existingHeadless = new Set<string>();
-    const envWithProxy = {
+    const envWithProxy: NodeJS.ProcessEnv = {
       ...process.env,
       HTTPS_PROXY: 'http://legit-proxy:3128',
       npm_config_https_proxy: 'http://legit-proxy:3128',

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -62,15 +62,11 @@ describe('ensurePlaywrightBrowsers', () => {
       HTTPS_PROXY: 'http://legit-proxy:3128',
       npm_config_https_proxy: 'http://legit-proxy:3128',
     };
+    delete envWithProxy.NODE_OPTIONS;
     const sanitizedEnv = sanitizeProxyEnv(envWithProxy);
-    const expectedNodeOptions = sanitizedEnv.NODE_OPTIONS?.includes(
-      '--dns-result-order'
-    )
-      ? sanitizedEnv.NODE_OPTIONS
-      : `${sanitizedEnv.NODE_OPTIONS ?? ''} --dns-result-order=ipv4first`.trim();
     const expectedEnv = {
       ...sanitizedEnv,
-      NODE_OPTIONS: expectedNodeOptions,
+      NODE_OPTIONS: '--dns-result-order=ipv4first',
     };
     const execFileSync = vi.fn((_command, args: string[]) => {
       const action = args[1];


### PR DESCRIPTION
### Motivation
- The repo-root `npm test` was blocked by a Playwright bootstrap/download/deps/network issue after ensuring frontend formatting; formatting check itself reported three files (per original failure) but they were already Prettier-compliant in this checkout.
- Add a minimal, scoped runtime change to make Playwright-driven test phases robust in this environment without changing test semantics or widening scope.

### Description
- Formatted-check command was run using the frontend Prettier config (`frontend/.prettierrc`) against the three reported files and they were already compliant (Prettier reported `unchanged`).
- Added an env helper to inject `--dns-result-order=ipv4first` into `NODE_OPTIONS` for Playwright invocations to avoid IPv6/network reachability issues during browser download and launch.
- Applied the helper in two places: `frontend/scripts/utils/ensure-playwright-browsers.js` and `frontend/scripts/run-test-groups.mjs` and updated the unit test expectations accordingly.
- Files changed: `frontend/scripts/utils/ensure-playwright-browsers.js`, `frontend/scripts/run-test-groups.mjs`, and `scripts/tests/ensurePlaywrightBrowsers.test.ts`.

### Testing
- Ran the requested Prettier write from the frontend directory with `--config frontend/.prettierrc`, and the three target files were reported `unchanged` by Prettier (they were already formatted).
- Verified formatting: `cd frontend && npm run format:check` returned "All matched files use Prettier code style!" and therefore passed.
- Verified test suite: repo-root `npm test` completed successfully (all automated tests passed after the Playwright bootstrap fix).
- Additional blocker and fix: Playwright browser/deps failed to download/launch due to network/host conditions, fixed by injecting `NODE_OPTIONS=--dns-result-order=ipv4first` for Playwright bootstrap and grouped E2E runs, and updated tests to expect the injected env variable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ec1cd1d4832f8ab266bf75846d7b)