### PR TITLE
Reduce expected test stderr noise in QuestForm and legacy save suites

### DIFF
--- a/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
+++ b/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
@@ -128,6 +128,7 @@ describe('LegacySaveUpgrade', () => {
 
     test('shows v2 parse warnings when localStorage contains invalid JSON', async () => {
         localStorage.setItem('gameState', '{bad json');
+        const parseWarningSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         const { findByText } = render(LegacySaveUpgrade, {
             legacyV1Items: [],
@@ -136,6 +137,11 @@ describe('LegacySaveUpgrade', () => {
         });
 
         await findByText(/Legacy v2 data could not be parsed/i);
+        expect(parseWarningSpy).toHaveBeenCalledWith(
+            'Error reading from localStorage:',
+            expect.any(String)
+        );
+        parseWarningSpy.mockRestore();
     });
 
     test('shows conflict warning and QA clear button for v2 + v3 saves', async () => {

--- a/frontend/src/components/__tests__/QuestForm.spec.ts
+++ b/frontend/src/components/__tests__/QuestForm.spec.ts
@@ -25,9 +25,18 @@ vi.mock('../../utils/questPersistence.js', async () => {
 
 let listSpy: ReturnType<typeof vi.spyOn> | null = null;
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
+let consoleNoiseSpy: ReturnType<typeof vi.spyOn> | null = null;
 
 beforeEach(async () => {
     vi.mocked(syncExistingQuestsToIndexedDB).mockResolvedValue([]);
+    const originalConsoleError = console.error.bind(console);
+    consoleNoiseSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+        if (String(args[0]).includes('Custom content validation failed; continuing with DB.')) {
+            return;
+        }
+
+        originalConsoleError(...args);
+    });
 
     const quests = await db.list(ENTITY_TYPES.QUEST);
     await Promise.all(quests.map((quest) => db.quests.delete(quest.id)));
@@ -42,6 +51,8 @@ afterEach(() => {
     listSpy = null;
     consoleErrorSpy?.mockRestore();
     consoleErrorSpy = null;
+    consoleNoiseSpy?.mockRestore();
+    consoleNoiseSpy = null;
 });
 
 const clearQuests = async () => {
@@ -1040,6 +1051,7 @@ test('clears rewards after creating a quest', async () => {
 
 test('dispatches an error when quest creation fails', async () => {
     const addSpy = vi.spyOn(db.quests, 'add').mockRejectedValueOnce(new Error('Boom'));
+    const saveErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { getByLabelText } = render(QuestForm);
 
     await fireEvent.input(getByLabelText(/Title/i), {
@@ -1055,8 +1067,10 @@ test('dispatches an error when quest creation fails', async () => {
 
     await waitFor(() => {
         expect(addSpy).toHaveBeenCalledTimes(1);
+        expect(saveErrorSpy).toHaveBeenCalledWith('Error saving quest:', expect.any(Error));
     });
 
+    saveErrorSpy.mockRestore();
     addSpy.mockRestore();
 });
 

--- a/frontend/src/components/__tests__/QuestFormImageUpload.spec.ts
+++ b/frontend/src/components/__tests__/QuestFormImageUpload.spec.ts
@@ -62,6 +62,7 @@ function setupDom(): HTMLElement {
 describe('QuestForm image uploads', () => {
     let container: HTMLElement;
     const sampleDataUrl = 'data:image/png;base64,FALLBACKDATA';
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
 
     beforeEach(() => {
         container = setupDom();
@@ -72,6 +73,11 @@ describe('QuestForm image uploads', () => {
         questsUpdateMock.mockResolvedValue(undefined);
         listMock.mockReset();
         listMock.mockResolvedValue([]);
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((message) => {
+            if (String(message).includes('Error preparing quest image:')) {
+                return;
+            }
+        });
         const globalWithMocks = globalThis as typeof globalThis & {
             fetch?: typeof fetch;
             File?: typeof File;
@@ -128,6 +134,8 @@ describe('QuestForm image uploads', () => {
         delete globalWithMocks.fetch;
         delete globalWithMocks.File;
         delete globalWithMocks.FileReader;
+        consoleErrorSpy?.mockRestore();
+        consoleErrorSpy = null;
     });
 
     it('stores quest images locally without calling a remote upload endpoint', async () => {

--- a/frontend/src/utils/gameState/common.js
+++ b/frontend/src/utils/gameState/common.js
@@ -64,10 +64,15 @@ function warnFallback() {
     const message =
         'IndexedDB is unavailable; falling back to localStorage. Storage may be limited.';
     if (isBrowser && typeof window.alert === 'function') {
-        window.alert(message);
-    } else {
-        console.warn(message);
+        try {
+            window.alert(message);
+            return;
+        } catch {
+            // jsdom throws for alert; fall through to console warning.
+        }
     }
+
+    console.warn(message);
 }
 
 function openDB() {

--- a/frontend/tests/legacyV2SeedSkip.test.ts
+++ b/frontend/tests/legacyV2SeedSkip.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { LEGACY_V2_SEED_SKIP_KEY } from '../src/utils/legacySaveParsing.js';
 
 const originalIndexedDB = globalThis.indexedDB;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn> | null = null;
 
 const legacyState = {
     versionNumberString: '2.1',
@@ -34,12 +35,21 @@ const waitForAssertion = async (assertion: () => void, timeoutMs = 2000) => {
 beforeEach(() => {
     vi.resetModules();
     localStorage.clear();
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation((message) => {
+        if (String(message).includes('IndexedDB is unavailable; falling back to localStorage')) {
+            return;
+        }
+    });
     // @ts-expect-error: deliberately remove IndexedDB for deterministic localStorage behavior
     delete globalThis.indexedDB;
 });
 
 afterEach(() => {
     globalThis.indexedDB = originalIndexedDB;
+    vi.restoreAllMocks();
+    consoleWarnSpy?.mockRestore();
+    consoleWarnSpy = null;
 });
 
 test('auto-migration skips when QA seed flag is present', async () => {


### PR DESCRIPTION
### Motivation
- Reduce high-volume, low-value stderr noise produced during `npm test` to keep launch-gate output readable while keeping risk low. 
- Fix low-risk runtime behavior that caused noisy jsdom stack traces (fallback IndexedDB alert path) without changing product behavior.

### Description
- Suppress repeated expected custom-content validation logs in `frontend/src/components/__tests__/QuestForm.spec.ts` by spying `console.error` and filtering the known validation message. (file changed: `frontend/src/components/__tests__/QuestForm.spec.ts`).
- In the quest-create-failure test, mock `console.error` and assert the expected `Error saving quest:` call to preserve test intent while removing stack noise. (file changed: `frontend/src/components/__tests__/QuestForm.spec.ts`).
- Silence expected image-processing error logs in image-fallback tests by spying `console.error` in `frontend/src/components/__tests__/QuestFormImageUpload.spec.ts`. (file changed: `frontend/src/components/__tests__/QuestFormImageUpload.spec.ts`).
- Assert and silence invalid legacy-JSON parse logging in `frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts`. (file changed: `frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts`).
- Harden the IndexedDB fallback path in `warnFallback()` so `window.alert` calls are `try/catch`-guarded and fall back to `console.warn` to avoid jsdom "Not implemented: window.alert" traces. (file changed: `frontend/src/utils/gameState/common.js`).
- Silence the intentional fallback warning for the legacy seed suite by mocking `window.alert` and filtering the specific `console.warn` in `frontend/tests/legacyV2SeedSkip.test.ts`. (file changed: `frontend/tests/legacyV2SeedSkip.test.ts`).
- Intentionally did not change `frontend/src/pages/**` layout or move large numbers of files; the Astro unsupported-file build warnings remain and were left for a separate, lower-risk follow-up. (no page path moves in this PR).

### Testing
- Ran `pnpm install` successfully with dependency warnings only. 
- Ran `npm run build` and verified the build completes successfully, noting that Astro unsupported-file warnings are still present. 
- Ran targeted unit suites with `npm run test:root -- frontend/src/components/__tests__/QuestForm.spec.ts frontend/src/components/__tests__/QuestFormImageUpload.spec.ts frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts frontend/tests/legacyV2SeedSkip.test.ts` and observed the suites pass. 
- Exercised `npm test` orchestration; because `run-tests.js` is a long-running integrator, the verification focused on the targeted root suites above and confirmed the noisy buckets were materially reduced while tests still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e676854d1c832fbba7107d5bb2ba10)