### PR TITLE
🧹 fix: reduce launch-gate build/test noise

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -481,7 +481,7 @@ Local-mode validation status (March 20, 2026):
 - [x] Before launch, confirm there is at least one way to detect migration failures quickly (e.g.,
       QA console error review, or a logged event if available).
       ([<backups.md:Storage locations and QA reset notes (inline warnings + console)>](../../frontend/src/pages/docs/md/backups.md#storage-locations-and-qa-reset-notes),
-      [<LegacySaveUpgrade.spec.ts:shows v2 parse warnings when localStorage contains invalid JSON>](../../frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts#L129-L139))
+      [<LegacySaveUpgrade.spec.ts:shows v2 parse warnings when localStorage contains invalid JSON>](../../frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts#L141-L151))
 
 ### 3.3 External links (open + correct destination)
 

--- a/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
+++ b/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
@@ -21,7 +21,21 @@ import { readLegacyV2LocalStorage } from '../../utils/legacySaveParsing.js';
 const EARLY_ADOPTER_ID = items.find((item) => item.name === 'Early Adopter Token')?.id;
 
 describe('LegacySaveUpgrade', () => {
+    let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+
     beforeEach(async () => {
+        const originalConsoleError = console.error;
+        consoleErrorMock = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            const [first] = args;
+            if (
+                typeof first === 'string' &&
+                first.startsWith('Error reading from localStorage:')
+            ) {
+                return;
+            }
+            originalConsoleError(...args);
+        });
+
         document.cookie = '';
         localStorage.clear();
         document.documentElement.dataset.cheatsAvailable = 'false';
@@ -32,6 +46,7 @@ describe('LegacySaveUpgrade', () => {
 
     afterEach(async () => {
         await closeGameStateDatabaseForTesting();
+        consoleErrorMock.mockRestore();
         document.cookie = '';
         localStorage.clear();
         document.documentElement.dataset.cheatsAvailable = 'false';

--- a/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
+++ b/frontend/src/components/__tests__/LegacySaveUpgrade.spec.ts
@@ -27,10 +27,7 @@ describe('LegacySaveUpgrade', () => {
         const originalConsoleError = console.error;
         consoleErrorMock = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
             const [first] = args;
-            if (
-                typeof first === 'string' &&
-                first.startsWith('Error reading from localStorage:')
-            ) {
+            if (typeof first === 'string' && first.startsWith('Error reading from localStorage:')) {
                 return;
             }
             originalConsoleError(...args);

--- a/frontend/src/components/__tests__/QuestForm.spec.ts
+++ b/frontend/src/components/__tests__/QuestForm.spec.ts
@@ -25,8 +25,26 @@ vi.mock('../../utils/questPersistence.js', async () => {
 
 let listSpy: ReturnType<typeof vi.spyOn> | null = null;
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
+const originalConsoleError = console.error;
 
 beforeEach(async () => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+        const firstArg = typeof args[0] === 'string' ? args[0] : '';
+        const expectedNoisePrefixes = [
+            'Error loading quest:',
+            'Error loading quests:',
+            'Error synchronizing existing quests:',
+            'Error saving quest:',
+            'Error loading items:',
+            'Error loading processes:',
+            'Custom content validation failed; continuing with DB.',
+        ];
+        if (expectedNoisePrefixes.some((prefix) => firstArg.startsWith(prefix))) {
+            return;
+        }
+        originalConsoleError(...args);
+    });
+
     vi.mocked(syncExistingQuestsToIndexedDB).mockResolvedValue([]);
 
     const quests = await db.list(ENTITY_TYPES.QUEST);
@@ -564,7 +582,6 @@ test('includes custom processes in the process picker list', async () => {
 });
 
 test('handles item and process list failures gracefully', async () => {
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     listSpy = vi.spyOn(db, 'list').mockImplementation(async (entityType) => {
         if (entityType === ENTITY_TYPES.ITEM) {
             throw new Error('Items unavailable');

--- a/frontend/src/components/__tests__/QuestFormImageUpload.spec.ts
+++ b/frontend/src/components/__tests__/QuestFormImageUpload.spec.ts
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 import { render, fireEvent, waitFor, act } from '@testing-library/svelte';
 import QuestForm from '../svelte/QuestForm.svelte';
 import { downsampleAndCompressToJpeg } from '../../utils/imageDownsample.js';
+const originalConsoleError = console.error;
 
 const { questsAddMock, questsUpdateMock, questsGetMock, listMock } = vi.hoisted(() => ({
     questsAddMock: vi.fn(),
@@ -61,9 +62,20 @@ function setupDom(): HTMLElement {
 
 describe('QuestForm image uploads', () => {
     let container: HTMLElement;
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
     const sampleDataUrl = 'data:image/png;base64,FALLBACKDATA';
 
     beforeEach(() => {
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+            const firstArg = typeof args[0] === 'string' ? args[0] : '';
+            if (
+                firstArg.startsWith('Error preparing quest image:') ||
+                firstArg.startsWith('Error creating quest image preview:')
+            ) {
+                return;
+            }
+            originalConsoleError(...args);
+        });
         container = setupDom();
         questsAddMock.mockReset();
         questsUpdateMock.mockReset();
@@ -119,6 +131,8 @@ describe('QuestForm image uploads', () => {
     });
 
     afterEach(() => {
+        consoleErrorSpy?.mockRestore();
+        consoleErrorSpy = null;
         container.innerHTML = '';
         const globalWithMocks = globalThis as typeof globalThis & {
             fetch?: typeof fetch;

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -365,9 +365,7 @@
         const resolvedDocsRagSourceRef = docsMeta?.sourceRef ?? 'unknown';
         const resolvedDocsRagGeneratedAt = docsMeta?.generatedAt ?? 'unknown';
         const resolvedDocsRagHost =
-            typeof window !== 'undefined' && window.location
-                ? window.location.host
-                : 'unknown';
+            typeof window !== 'undefined' && window.location ? window.location.host : 'unknown';
         const resolvedHostEnvName = deriveEnvNameFromHostname(resolvedDocsRagHost);
         const allowDocsFallback = resolvedHostEnvName === 'dev';
         const appShaInfo = allowDocsFallback

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -41,6 +41,7 @@
         getDocsRagMismatchWarning,
     } from '../../../utils/docsRag.js';
     import { copyToClipboard } from '../../../utils/copyToClipboard.js';
+    import { isBrowser } from '../../../utils/ssr.js';
     import Message from './Message.svelte';
     import Spinner from '../../../components/svelte/Spinner.svelte';
 
@@ -76,6 +77,7 @@
     let debugOverride = false;
     let currentSettings = { showChatDebugPayload: false };
     let lastShowChatDebugPayload;
+    let componentDestroyed = false;
     let playerStateSummary = {
         included: false,
         questsFinishedCount: 0,
@@ -413,6 +415,10 @@
         docsRagEnvWarning = buildDocsEnvMismatchWarning(docsRagHost, docsRagEnvName);
         appGitSha = resolvedAppShaInfo.sha;
         playerStateSummary = getPlayerStateSummary(currentState);
+        if (componentDestroyed || !isBrowser) {
+            return;
+        }
+
         syncSaveSnapshotHintDismissed();
         saveSnapshotHintFocusListener = () => syncSaveSnapshotHintDismissed();
         window.addEventListener('focus', saveSnapshotHintFocusListener);
@@ -437,11 +443,12 @@
     });
 
     onDestroy(() => {
+        componentDestroyed = true;
         settingsUnsubscribe?.();
-        if (saveSnapshotHintFocusListener) {
+        if (isBrowser && saveSnapshotHintFocusListener) {
             window.removeEventListener('focus', saveSnapshotHintFocusListener);
         }
-        if (promptDebugLinkListener) {
+        if (isBrowser && promptDebugLinkListener) {
             window.removeEventListener('hashchange', promptDebugLinkListener);
             window.removeEventListener('popstate', promptDebugLinkListener);
         }

--- a/frontend/src/pages/chat/svelte/OpenAIChat.svelte
+++ b/frontend/src/pages/chat/svelte/OpenAIChat.svelte
@@ -267,7 +267,11 @@
             return null;
         }
         try {
-            const response = await fetch('/build-meta.json', { cache: 'no-store' });
+            const buildMetaUrl =
+                typeof window !== 'undefined' && window.location
+                    ? new URL('/build-meta.json', window.location.href).toString()
+                    : 'http://localhost/build-meta.json';
+            const response = await fetch(buildMetaUrl, { cache: 'no-store' });
             if (!response.ok) {
                 return null;
             }
@@ -360,7 +364,10 @@
         const resolvedDocsRagEnvName = docsMeta?.envName ?? 'unknown';
         const resolvedDocsRagSourceRef = docsMeta?.sourceRef ?? 'unknown';
         const resolvedDocsRagGeneratedAt = docsMeta?.generatedAt ?? 'unknown';
-        const resolvedDocsRagHost = window?.location?.host || 'unknown';
+        const resolvedDocsRagHost =
+            typeof window !== 'undefined' && window.location
+                ? window.location.host
+                : 'unknown';
         const resolvedHostEnvName = deriveEnvNameFromHostname(resolvedDocsRagHost);
         const allowDocsFallback = resolvedHostEnvName === 'dev';
         const appShaInfo = allowDocsFallback

--- a/frontend/tests/cloudSyncCustomContent.test.ts
+++ b/frontend/tests/cloudSyncCustomContent.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
     exportGameStateString,
     importGameStateString,
@@ -92,9 +92,40 @@ const overwriteCustomContent = async () => {
 };
 
 describe('cloud sync custom content', () => {
+    let consoleWarnMock: ReturnType<typeof vi.spyOn>;
+    let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+
     beforeEach(async () => {
+        const originalConsoleWarn = console.warn;
+        const originalConsoleError = console.error;
+        consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+            const [first] = args;
+            if (
+                typeof first === 'string' &&
+                first.startsWith('Custom content validation failed; continuing with DB.')
+            ) {
+                return;
+            }
+            originalConsoleWarn(...args);
+        });
+        consoleErrorMock = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            const [first] = args;
+            if (
+                typeof first === 'string' &&
+                first.startsWith('Custom content validation failed; continuing with DB.')
+            ) {
+                return;
+            }
+            originalConsoleError(...args);
+        });
+
         await resetGameState();
         await deleteCustomContentDatabase();
+    });
+
+    afterEach(() => {
+        consoleWarnMock.mockRestore();
+        consoleErrorMock.mockRestore();
     });
 
     test('uploads custom content in gist payload', async () => {

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -44,10 +44,23 @@ describe('ensurePlaywrightSystemDeps', () => {
     const depsStampPath = path.join(cwd, '.playwright-deps-installed-test');
 
     beforeEach(() => {
+        const originalConsoleWarn = console.warn;
         execFileSyncMock.mockReset();
         existsSyncMock.mockReset();
         writeFileSyncMock.mockReset();
         process.env.PLAYWRIGHT_SKIP_INSTALL_DEPS = '0';
+        vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+            const [first] = args;
+            if (
+                typeof first === 'string' &&
+                first.startsWith(
+                    'Proxy environment variables point to the placeholder proxy:8080 host.'
+                )
+            ) {
+                return;
+            }
+            originalConsoleWarn(...args);
+        });
     });
 
     it('invokes install-deps on linux when sentinel is missing', async () => {
@@ -193,6 +206,7 @@ describe('ensurePlaywrightBrowsers', () => {
     const depsStampPath = path.join(cwd, '.playwright-deps-installed-test');
 
     beforeEach(() => {
+        const originalConsoleWarn = console.warn;
         execFileSyncMock.mockReset();
         existsSyncMock.mockReset();
         writeFileSyncMock.mockReset();
@@ -200,6 +214,19 @@ describe('ensurePlaywrightBrowsers', () => {
         chromiumExecutablePathMock.mockReturnValue(chromiumPath);
         process.env.PLAYWRIGHT_SKIP_INSTALL_DEPS = '0';
         delete process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD;
+        vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+            const [first] = args;
+            if (
+                typeof first === 'string' &&
+                (first.startsWith('Playwright chromium executable is still missing after installation.') ||
+                    first.startsWith(
+                        'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing.'
+                    ))
+            ) {
+                return;
+            }
+            originalConsoleWarn(...args);
+        });
     });
 
     it('installs system deps before browsers when chromium is missing', async () => {
@@ -279,6 +306,7 @@ describe('ensurePlaywrightBrowsers', () => {
 });
 
 afterAll(() => {
+    vi.restoreAllMocks();
     if (originalSkipInstallDeps === undefined) {
         delete process.env.PLAYWRIGHT_SKIP_INSTALL_DEPS;
     } else {

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -218,7 +218,9 @@ describe('ensurePlaywrightBrowsers', () => {
             const [first] = args;
             if (
                 typeof first === 'string' &&
-                (first.startsWith('Playwright chromium executable is still missing after installation.') ||
+                (first.startsWith(
+                    'Playwright chromium executable is still missing after installation.'
+                ) ||
                     first.startsWith(
                         'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing.'
                     ))

--- a/frontend/tests/legacyV2SeedSkip.test.ts
+++ b/frontend/tests/legacyV2SeedSkip.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { LEGACY_V2_SEED_SKIP_KEY } from '../src/utils/legacySaveParsing.js';
 
 const originalIndexedDB = globalThis.indexedDB;
+const originalConsoleError = console.error;
 
 const legacyState = {
     versionNumberString: '2.1',
@@ -34,12 +35,24 @@ const waitForAssertion = async (assertion: () => void, timeoutMs = 2000) => {
 beforeEach(() => {
     vi.resetModules();
     localStorage.clear();
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+        const [first] = args;
+        if (typeof first === 'string' && first.startsWith('IndexedDB read failed:')) {
+            return;
+        }
+        if (first instanceof Error && first.message.includes('Not implemented: window.alert')) {
+            return;
+        }
+        originalConsoleError(...args);
+    });
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
     // @ts-expect-error: deliberately remove IndexedDB for deterministic localStorage behavior
     delete globalThis.indexedDB;
 });
 
 afterEach(() => {
     globalThis.indexedDB = originalIndexedDB;
+    vi.restoreAllMocks();
 });
 
 test('auto-migration skips when QA seed flag is present', async () => {

--- a/scripts/build-with-sha.mjs
+++ b/scripts/build-with-sha.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import {
     assertBuildMetaComplete,
     readBuildMeta,
@@ -6,39 +6,76 @@ import {
     writeBuildMeta,
 } from './write-build-meta.mjs';
 
-const stripNoisyAstroWarnings = (text) => {
-    if (!text) {
-        return '';
+const ignoredPatterns = [/Unsupported file type .*Prefix filename with an underscore/];
+
+const shouldKeepLine = (line) => !ignoredPatterns.some((pattern) => pattern.test(line));
+
+const createFilteredWriter = (stream, filterOutput) => {
+    if (!filterOutput) {
+        return (chunk) => {
+            stream.write(chunk);
+        };
     }
-    const ignoredPatterns = [
-        /Unsupported file type .*Prefix filename with an underscore/,
-    ];
-    return text
-        .split('\n')
-        .filter((line) => !ignoredPatterns.some((pattern) => pattern.test(line)))
-        .join('\n');
+
+    let buffered = '';
+    return (chunk, flush = false) => {
+        buffered += chunk;
+        const parts = buffered.split('\n');
+        buffered = parts.pop() ?? '';
+
+        for (const line of parts) {
+            if (shouldKeepLine(line)) {
+                stream.write(`${line}\n`);
+            }
+        }
+
+        if (flush && buffered && shouldKeepLine(buffered)) {
+            stream.write(buffered);
+            buffered = '';
+        }
+    };
 };
 
-const run = (command, args, options = {}) => {
-    const { filterOutput = false, ...spawnOptions } = options;
-    const result = spawnSync(command, args, {
-        stdio: filterOutput ? 'pipe' : 'inherit',
+const run = async (command, args, options = {}) => {
+    const { filterOutput = false, stdio: _stdio, ...spawnOptions } = options;
+    const child = spawn(command, args, {
+        stdio: 'pipe',
         env: process.env,
         ...spawnOptions,
     });
 
-    if (filterOutput) {
-        process.stdout.write(stripNoisyAstroWarnings(result.stdout?.toString()));
-        process.stderr.write(stripNoisyAstroWarnings(result.stderr?.toString()));
-    }
+    const writeStdout = createFilteredWriter(process.stdout, filterOutput);
+    const writeStderr = createFilteredWriter(process.stderr, filterOutput);
 
-    if (result.error) {
-        console.error(`Failed to run ${command}:`, result.error);
-    }
+    child.stdout.on('data', (chunk) => {
+        writeStdout(chunk.toString());
+    });
 
-    if (result.status !== 0) {
-        process.exit(result.status ?? 1);
-    }
+    child.stderr.on('data', (chunk) => {
+        writeStderr(chunk.toString());
+    });
+
+    return await new Promise((resolve, reject) => {
+        child.on('error', (error) => {
+            reject(error);
+        });
+
+        child.on('close', (code, signal) => {
+            writeStdout('', true);
+            writeStderr('', true);
+
+            if (signal) {
+                reject(new Error(`${command} exited due to signal ${signal}`));
+                return;
+            }
+
+            if (code !== 0) {
+                process.exit(code ?? 1);
+            }
+
+            resolve();
+        });
+    });
 };
 
 const { gitSha, source } = resolveBuildMeta();
@@ -55,5 +92,10 @@ try {
     process.exit(1);
 }
 
-run('npm', ['run', 'build:docs-rag']);
-run('npm', ['--prefix', 'frontend', 'run', 'build'], { filterOutput: true });
+try {
+    await run('npm', ['run', 'build:docs-rag']);
+    await run('npm', ['--prefix', 'frontend', 'run', 'build'], { filterOutput: true });
+} catch (error) {
+    console.error('Failed to run build commands:', error);
+    process.exit(1);
+}

--- a/scripts/build-with-sha.mjs
+++ b/scripts/build-with-sha.mjs
@@ -6,12 +6,31 @@ import {
     writeBuildMeta,
 } from './write-build-meta.mjs';
 
+const stripNoisyAstroWarnings = (text) => {
+    if (!text) {
+        return '';
+    }
+    const ignoredPatterns = [
+        /Unsupported file type .*Prefix filename with an underscore/,
+    ];
+    return text
+        .split('\n')
+        .filter((line) => !ignoredPatterns.some((pattern) => pattern.test(line)))
+        .join('\n');
+};
+
 const run = (command, args, options = {}) => {
+    const { filterOutput = false, ...spawnOptions } = options;
     const result = spawnSync(command, args, {
-        stdio: 'inherit',
+        stdio: filterOutput ? 'pipe' : 'inherit',
         env: process.env,
-        ...options,
+        ...spawnOptions,
     });
+
+    if (filterOutput) {
+        process.stdout.write(stripNoisyAstroWarnings(result.stdout?.toString()));
+        process.stderr.write(stripNoisyAstroWarnings(result.stderr?.toString()));
+    }
 
     if (result.error) {
         console.error(`Failed to run ${command}:`, result.error);
@@ -37,4 +56,4 @@ try {
 }
 
 run('npm', ['run', 'build:docs-rag']);
-run('npm', ['--prefix', 'frontend', 'run', 'build']);
+run('npm', ['--prefix', 'frontend', 'run', 'build'], { filterOutput: true });

--- a/tests/outagesConventions.test.ts
+++ b/tests/outagesConventions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import path from 'path';
 import Ajv from 'ajv';
@@ -52,8 +52,27 @@ function loadJsonFile(filePath: string) {
 }
 
 describe('outages', () => {
+  let consoleWarnMock: ReturnType<typeof vi.spyOn>;
   const repoRoot = process.cwd();
   const outagesDir = path.join(repoRoot, 'outages');
+
+  beforeEach(() => {
+    const originalConsoleWarn = console.warn;
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      const [first] = args;
+      if (
+        typeof first === 'string' &&
+        first.startsWith('Warning: Failed to fetch current UTC time from time API;')
+      ) {
+        return;
+      }
+      originalConsoleWarn(...args);
+    });
+  });
+
+  afterEach(() => {
+    consoleWarnMock.mockRestore();
+  });
 
   it('dates are not in the future and filenames align', async () => {
     const today = await resolveCurrentUtcDate();


### PR DESCRIPTION
### Motivation
- Reduce non-actionable noise from the repo-root launch-gate runs by eliminating repeated Astro "Unsupported file type ... Prefix filename with an underscore" warnings and silencing high-volume expected stderr logs during unit tests.
- Prefer low-risk changes that keep runtime behavior unchanged and avoid large file moves/renames under `frontend/src/pages/**`.

### Description
- Filter the specific Astro unsupported-file warning lines in the repo-root build wrapper by adding an output filter to `scripts/build-with-sha.mjs` so `npm run build` no longer prints the repeated warnings while preserving all other build output.
- Harden runtime build-metadata URL resolution in `frontend/src/pages/chat/svelte/OpenAIChat.svelte` by resolving an absolute `build-meta.json` URL for non-browser/jsdom contexts and guarding `window` reads to avoid URL parse errors in tests.
- Quiet expected error-path console noise at the test boundary by adding targeted `console.error` spies in `frontend/src/components/__tests__/QuestForm.spec.ts` and `frontend/src/components/__tests__/QuestFormImageUpload.spec.ts` that suppress well-known/intentional messages while forwarding unexpected errors.

### Testing
- Ran `pnpm install`; install completed successfully in this environment.
- Ran `npm run build`; build completed and the previous Astro "Unsupported file type" warnings were removed from the displayed output (filtered by the wrapper).
- Ran targeted unit tests with `npm run test:root -- frontend/src/components/__tests__/QuestForm.spec.ts frontend/src/components/__tests__/QuestFormImageUpload.spec.ts frontend/tests/openAIChatErrorMessages.test.ts`; these tests passed with the noisy, expected stderr lines suppressed and no regressions observed.
- Invoked full `npm test` during verification to exercise the PR test harness and observed normal test execution; environment runtime limits prevented a long-running full-suite snapshot here, but root/unit tests were exercised and showed no regressions in the areas changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e676854d1c832fbba7107d5bb2ba10)