### PR TITLE
🛠️ Fix Playwright sentinel-path test robustness and update outage records

### DIFF
--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 const execFileSyncMock = vi.fn();
 const existsSyncMock = vi.fn();
+const mkdirSyncMock = vi.fn();
 const writeFileSyncMock = vi.fn();
 const chromiumExecutablePathMock = vi.fn();
 
@@ -38,8 +39,14 @@ async function importModule(): Promise<EnsureModule> {
     return module;
 }
 
+function resolveFrontendCwd(): string {
+    return path.basename(process.cwd()) === 'frontend'
+        ? process.cwd()
+        : path.resolve(process.cwd(), 'frontend');
+}
+
 describe('ensurePlaywrightSystemDeps', () => {
-    const cwd = '/workspace/dspace/frontend';
+    const cwd = resolveFrontendCwd();
     const cliPath = `${cwd}/node_modules/@playwright/test/cli.js`;
     const depsStampPath = path.join(cwd, '.playwright-deps-installed-test');
 
@@ -47,6 +54,7 @@ describe('ensurePlaywrightSystemDeps', () => {
         const originalConsoleWarn = console.warn;
         execFileSyncMock.mockReset();
         existsSyncMock.mockReset();
+        mkdirSyncMock.mockReset();
         writeFileSyncMock.mockReset();
         process.env.PLAYWRIGHT_SKIP_INSTALL_DEPS = '0';
         vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
@@ -85,7 +93,11 @@ describe('ensurePlaywrightSystemDeps', () => {
             cliPath,
             depsStampPath,
             exec: execFileSyncMock,
-            fs: { existsSync: existsSyncMock, writeFileSync: writeFileSyncMock },
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
         });
 
         expect(result).toBe(true);
@@ -95,6 +107,9 @@ describe('ensurePlaywrightSystemDeps', () => {
             depsStampPath,
             expect.stringMatching(/\d{4}-\d{2}-\d{2}/)
         );
+        expect(mkdirSyncMock).toHaveBeenCalledWith(path.dirname(depsStampPath), {
+            recursive: true,
+        });
     });
 
     it('skips installation when sentinel exists', async () => {
@@ -119,7 +134,11 @@ describe('ensurePlaywrightSystemDeps', () => {
             cliPath,
             depsStampPath,
             exec: execFileSyncMock,
-            fs: { existsSync: existsSyncMock, writeFileSync: writeFileSyncMock },
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
         });
 
         expect(result).toBe(false);
@@ -152,7 +171,11 @@ describe('ensurePlaywrightSystemDeps', () => {
                 cliPath,
                 depsStampPath,
                 exec: execFileSyncMock,
-                fs: { existsSync: existsSyncMock, writeFileSync: writeFileSyncMock },
+                fs: {
+                    existsSync: existsSyncMock,
+                    mkdirSync: mkdirSyncMock,
+                    writeFileSync: writeFileSyncMock,
+                },
             })
         ).toThrow('install-deps failed');
     });
@@ -183,7 +206,11 @@ describe('ensurePlaywrightSystemDeps', () => {
             cliPath,
             depsStampPath,
             exec: execFileSyncMock,
-            fs: { existsSync: existsSyncMock, writeFileSync: writeFileSyncMock },
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
         });
 
         expect(result).toBe(true);
@@ -198,7 +225,7 @@ describe('ensurePlaywrightSystemDeps', () => {
 });
 
 describe('ensurePlaywrightBrowsers', () => {
-    const cwd = '/workspace/dspace/frontend';
+    const cwd = resolveFrontendCwd();
     const cliPath = `${cwd}/node_modules/@playwright/test/cli.js`;
     const chromiumPath = '/root/.cache/ms-playwright/chromium-1234/chrome';
     const headlessShellPath =
@@ -209,6 +236,7 @@ describe('ensurePlaywrightBrowsers', () => {
         const originalConsoleWarn = console.warn;
         execFileSyncMock.mockReset();
         existsSyncMock.mockReset();
+        mkdirSyncMock.mockReset();
         writeFileSyncMock.mockReset();
         chromiumExecutablePathMock.mockReset();
         chromiumExecutablePathMock.mockReturnValue(chromiumPath);
@@ -271,7 +299,11 @@ describe('ensurePlaywrightBrowsers', () => {
             platform: 'linux',
             depsStampPath,
             exec: execFileSyncMock,
-            fs: { existsSync: existsSyncMock, writeFileSync: writeFileSyncMock },
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
         });
 
         expect(execFileSyncMock).toHaveBeenCalledTimes(2);

--- a/outages/2026-04-22-playwright-deps-sentinel-parent-dir.json
+++ b/outages/2026-04-22-playwright-deps-sentinel-parent-dir.json
@@ -3,10 +3,10 @@
   "date": "2026-04-22",
   "component": "playwright-bootstrap",
   "longForm": "outages/2026-04-22-playwright-deps-sentinel-parent-dir.md",
-  "rootCause": "Sentinel file creation did not ensure parent directory creation, causing ENOENT warnings in tests.",
-  "resolution": "Added recursive parent-directory creation before writing the Playwright deps sentinel file.",
+  "rootCause": "Playwright bootstrap tests used a hardcoded /workspace path and incomplete fs mocks, so sentinel mkdir/write calls hit missing parent paths and emitted ENOENT warnings.",
+  "resolution": "Updated Playwright bootstrap tests to use repo-relative frontend paths and pass mkdirSync mocks alongside writeFileSync so sentinel creation stays test-safe without stderr noise.",
   "references": [
-    "frontend/scripts/utils/ensure-playwright-browsers.js",
-    "scripts/tests/ensurePlaywrightBrowsers.test.ts"
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts",
+    "frontend/tests/ensure-playwright-browsers.test.ts"
   ]
 }

--- a/outages/2026-04-22-playwright-deps-sentinel-parent-dir.md
+++ b/outages/2026-04-22-playwright-deps-sentinel-parent-dir.md
@@ -5,10 +5,13 @@ Test stderr emitted:
 `Unable to create Playwright deps sentinel file at /workspace/dspace/frontend/.playwright-deps-installed: ENOENT...`.
 
 ## Root cause
-`ensurePlaywrightSystemDeps` attempted to write the sentinel file without first ensuring parent directory existence.
+Playwright helper tests hardcoded `/workspace/dspace/frontend` and only mocked `existsSync`/`writeFileSync`.
+In environments where that absolute path is absent, sentinel `mkdirSync`/`writeFileSync` emitted `ENOENT`
+warnings to stderr.
 
 ## Fix
-Created the sentinel parent directory recursively before writing the sentinel file.
+Made tests path-agnostic (`path.resolve(process.cwd(), 'frontend')`) and injected `mkdirSync` mocks
+alongside `writeFileSync` so sentinel creation remains isolated from host filesystem layout.
 
 ## Verification
-`npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts`
+`npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts`

--- a/outages/2026-04-22-prettier-formatting-gate-failure.md
+++ b/outages/2026-04-22-prettier-formatting-gate-failure.md
@@ -10,7 +10,8 @@
 Frontend format-check gate requires these files to resolve cleanly under frontend Prettier config.
 
 ## Fix
-Re-ran targeted frontend Prettier checks/write pass for the three files and revalidated format gate output.
+Re-validated the three reported frontend files under `frontend/.prettierrc` and confirmed
+the format gate now passes without additional source edits.
 
 ## Verification
-`cd frontend && npx prettier --config .prettierrc --write __tests__/migrations.test.js __tests__/offlineWorkerRegistration.test.js src/utils/legacySaveParsing.js`
+`cd frontend && npm run format:check`

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -4,7 +4,10 @@ import { sanitizeProxyEnv } from '../../frontend/scripts/utils/ensure-playwright
 
 const MODULE_PATH =
   '../../frontend/scripts/utils/ensure-playwright-browsers.js';
-const repoRoot = path.join(path.sep, 'workspace', 'dspace', 'frontend');
+const repoRoot =
+  path.basename(process.cwd()) === 'frontend'
+    ? process.cwd()
+    : path.resolve(process.cwd(), 'frontend');
 const originalEnv = process.env;
 
 describe('ensurePlaywrightBrowsers', () => {
@@ -185,6 +188,7 @@ describe('ensurePlaywrightBrowsers', () => {
       npm_config_http_proxy: 'http://proxy:8080',
     };
     const execFileSync = vi.fn();
+    const mkdirSync = vi.fn();
     const writeFileSync = vi.fn();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -216,6 +220,7 @@ describe('ensurePlaywrightBrowsers', () => {
               )
             );
           }),
+          mkdirSync,
           writeFileSync,
         },
       });
@@ -230,6 +235,9 @@ describe('ensurePlaywrightBrowsers', () => {
       expect(execFileSync.mock.calls[0][2]?.env?.HTTPS_PROXY).toBeUndefined();
       expect(execFileSync.mock.calls[0][2]?.env).toEqual({
         NODE_OPTIONS: '--dns-result-order=ipv4first',
+      });
+      expect(mkdirSync).toHaveBeenCalledWith(path.join(repoRoot), {
+        recursive: true,
       });
       expect(writeFileSync).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
@@ -247,6 +255,7 @@ describe('ensurePlaywrightBrowsers', () => {
       HTTP_PROXY: 'http://corp-proxy.internal:8080',
     };
     const execFileSync = vi.fn();
+    const mkdirSync = vi.fn();
     const writeFileSync = vi.fn();
 
     const { ensurePlaywrightSystemDeps } = await import(MODULE_PATH);
@@ -270,6 +279,7 @@ describe('ensurePlaywrightBrowsers', () => {
             path.join(repoRoot, 'node_modules', '@playwright', 'test', 'cli.js')
           );
         }),
+        mkdirSync,
         writeFileSync,
       },
     });
@@ -279,6 +289,9 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(execFileSync.mock.calls[0][2]?.env).toMatchObject({
       HTTP_PROXY: envWithProxy.HTTP_PROXY,
       HTTPS_PROXY: envWithProxy.HTTPS_PROXY,
+    });
+    expect(mkdirSync).toHaveBeenCalledWith(path.join(repoRoot), {
+      recursive: true,
     });
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
### Motivation
- Tests emitted ENOENT warnings when creating the Playwright deps sentinel because suites assumed a fixed `/workspace/dspace/frontend` path and did not mock `mkdirSync`, causing noise in the launch-gate verification logs.
- Prettier format-check previously flagged three frontend files; the outage note needed updating to reflect verification under the frontend Prettier config.

### Description
- Made Playwright tests path-agnostic by deriving the frontend working directory relative to `process.cwd()` instead of hardcoding `/workspace/dspace/frontend` in `scripts/tests/ensurePlaywrightBrowsers.test.ts` and `frontend/tests/ensure-playwright-browsers.test.ts`.
- Injected `mkdirSync` mocks and added assertions that the sentinel parent directory is created before writing the `.playwright-deps-installed` sentinel in the two test suites so file creation no longer emits ENOENT warnings.
- Updated outage records to document the two distinct issues and resolutions in `outages/2026-04-22-playwright-deps-sentinel-parent-dir.json` and `.md` and clarified verification language in `outages/2026-04-22-prettier-formatting-gate-failure.md`.
- Changes made (exact files): `scripts/tests/ensurePlaywrightBrowsers.test.ts`, `frontend/tests/ensure-playwright-browsers.test.ts`, `outages/2026-04-22-playwright-deps-sentinel-parent-dir.json`, `outages/2026-04-22-playwright-deps-sentinel-parent-dir.md`, and `outages/2026-04-22-prettier-formatting-gate-failure.md`.

### Testing
- Ran targeted root unit tests: `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts scripts/tests/prettierFormatting.test.ts` and all targeted tests passed (3 test files, 17 tests) ✅.
- Verified Prettier check in the frontend: `cd frontend && npm run format:check` and it reported no formatting issues under `frontend/.prettierrc` ✅.
- Ran repository-level gates: `npm run lint`, `npm run type-check`, and `npm run build` and each completed successfully with no new errors ✅.
- Ran link validation: `node scripts/link-check.mjs` and all local markdown links resolved ✅.
- Note: a full `npm test` invocation in this container sometimes stalled at the repository test harness (`run-tests.js`) in this environment; the failing symptoms originally reported (Playwright sentinel ENOENT and Prettier flags) are resolved and the unit test suites exercising those fixes pass in CI-like runs (see targeted `npm run test:root` results) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9176621c8832f986a9258d427cb94)