### PR TITLE
🛠️ Fix Playwright sentinel ENOENT noise and normalize frontend Prettier drift

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -293,20 +293,35 @@ export function ensurePlaywrightSystemDeps(options = {}) {
         return false;
     }
 
+    const depsDirectory = path.dirname(depsStampPath);
+    let canWriteSentinel = fsExistsSync(depsDirectory);
+
     try {
-        fsMkdirSync(path.dirname(depsStampPath), { recursive: true });
+        if (!canWriteSentinel) {
+            fsMkdirSync(depsDirectory, { recursive: true });
+            canWriteSentinel = true;
+        }
     } catch (error) {
-        console.warn(
-            `Unable to create Playwright deps sentinel directory for ${depsStampPath}: ${error.message}`
-        );
+        if (error?.code !== 'ENOENT') {
+            console.warn(
+                `Unable to create Playwright deps sentinel directory for ${depsStampPath}: ${error.message}`
+            );
+        }
+        canWriteSentinel = false;
+    }
+
+    if (!canWriteSentinel) {
+        return true;
     }
 
     try {
         fsWriteFileSync(depsStampPath, `${new Date().toISOString()}\n`);
     } catch (error) {
-        console.warn(
-            `Unable to create Playwright deps sentinel file at ${depsStampPath}: ${error.message}`
-        );
+        if (error?.code !== 'ENOENT') {
+            console.warn(
+                `Unable to create Playwright deps sentinel file at ${depsStampPath}: ${error.message}`
+            );
+        }
     }
 
     return true;

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -195,6 +195,37 @@ describe('ensurePlaywrightSystemDeps', () => {
         expect(execFileSyncMock.mock.calls[0][2]?.env?.HTTP_PROXY).toBeUndefined();
         expect(execFileSyncMock.mock.calls[0][2]?.env?.HTTPS_PROXY).toBeUndefined();
     });
+
+    it('does not warn when sentinel directory is unavailable with ENOENT', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const missingDirError = Object.assign(new Error('missing'), { code: 'ENOENT' });
+
+        existsSyncMock.mockImplementation((target: string) => target === cliPath);
+
+        const { ensurePlaywrightSystemDeps } = await importModule();
+
+        const result = ensurePlaywrightSystemDeps({
+            cwd,
+            env: { PLAYWRIGHT_SKIP_INSTALL_DEPS: '0' },
+            platform: 'linux',
+            cliPath,
+            depsStampPath,
+            exec: execFileSyncMock,
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: vi.fn(() => {
+                    throw missingDirError;
+                }),
+                writeFileSync: writeFileSyncMock,
+            },
+        });
+
+        expect(result).toBe(true);
+        expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+        expect(writeFileSyncMock).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
 });
 
 describe('ensurePlaywrightBrowsers', () => {

--- a/outages/2026-04-22-frontend-prettier-drift.json
+++ b/outages/2026-04-22-frontend-prettier-drift.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-22-frontend-prettier-drift",
+  "date": "2026-04-22",
+  "component": "frontend:formatting",
+  "rootCause": "Frontend format gate detected style drift in tracked JavaScript test/utility files, causing scripts/tests/prettierFormatting.test.ts to fail the QA launch sequence.",
+  "resolution": "Normalized formatting for the flagged frontend files with the frontend Prettier configuration so npm run format:check and the formatting regression test pass cleanly.",
+  "references": [
+    "frontend/__tests__/migrations.test.js",
+    "frontend/__tests__/offlineWorkerRegistration.test.js",
+    "frontend/src/utils/legacySaveParsing.js",
+    "scripts/tests/prettierFormatting.test.ts"
+  ]
+}

--- a/outages/2026-04-22-playwright-sentinel-enoent.json
+++ b/outages/2026-04-22-playwright-sentinel-enoent.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-04-22-playwright-sentinel-enoent",
+  "date": "2026-04-22",
+  "component": "frontend:scripts-ensure-playwright-browsers",
+  "rootCause": "Playwright dependency bootstrap attempted to create sentinel directories unconditionally and logged ENOENT warnings when test environments used non-existent absolute cwd paths like /workspace/dspace/frontend.",
+  "resolution": "Made sentinel writes conditional on directory availability, suppressed non-actionable ENOENT warnings for sentinel creation/write, and added a regression test to keep install-deps behavior quiet and deterministic in missing-path environments.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "frontend/tests/ensure-playwright-browsers.test.ts",
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Tests and the pre-PR gate were emitting noisy `ENOENT` warnings when the Playwright sentinel parent directory could not be created for absolute test `cwd` paths (for example `/workspace/dspace/frontend`).
- The Prettier formatting gate failed for three frontend files, causing the `prettierFormatting` test to fail and blocking the v3.0.1 QA launch-gate.

### Description
- Made `ensurePlaywrightSystemDeps` robust by checking the sentinel parent directory before creating it, only attempting `mkdir` when necessary, suppressing non-actionable `ENOENT` warnings for sentinel directory/file writes, and skipping sentinel writes when the directory cannot be created; implemented in `frontend/scripts/utils/ensure-playwright-browsers.js`.
- Added a focused regression test that simulates `ENOENT` during sentinel directory creation and asserts `ensurePlaywrightSystemDeps` returns success without emitting warnings in `frontend/tests/ensure-playwright-browsers.test.ts`.
- Normalized Prettier formatting for the flagged frontend files so the formatting gate passes; the files affected were `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, and `frontend/src/utils/legacySaveParsing.js` (formatted using the frontend Prettier config).
- Added two outage records documenting the regressions at `outages/2026-04-22-playwright-sentinel-enoent.json` and `outages/2026-04-22-frontend-prettier-drift.json` following `outages/schema.json`.

### Testing
- Ran the QA launch-gate sequence and related checks: `npm run lint` (passed), `npm run type-check` (passed), `npm run build` (passed), `npm run format:check` (from `frontend/`, passed), and `node scripts/link-check.mjs` (passed).
- Ran the unit/test suites: `npm run test:root` succeeded and the root/unit test suites completed with all tests passing; `scripts/tests/prettierFormatting.test.ts` now passes because Prettier no longer flags files.
- Executed the broader `npm test` run which exercised the repository test harness and root suites; no functional failures were observed in the runs performed (E2E grouped phases are long-running but no regressions were reported during verification).
- Files changed: `frontend/scripts/utils/ensure-playwright-browsers.js`, `frontend/tests/ensure-playwright-browsers.test.ts`, formatted `frontend/__tests__/migrations.test.js`, `frontend/__tests__/offlineWorkerRegistration.test.js`, `frontend/src/utils/legacySaveParsing.js`, and new outages `outages/2026-04-22-playwright-sentinel-enoent.json` and `outages/2026-04-22-frontend-prettier-drift.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9176621c8832f986a9258d427cb94)