### PR TITLE
🐛 fix: resolve docsSkillsIndex paths from test location

### DIFF
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testDir, '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
+const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
 
 describe('docs Skills quest-tree mapping', () => {
     it('maps quest module paths to exactly one tree per quests/json subdirectory', () => {
@@ -34,7 +38,6 @@ describe('docs Skills quest-tree mapping', () => {
             .map((entry) => entry.name)
             .sort((left, right) => left.localeCompare(right));
 
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))


### PR DESCRIPTION
### Motivation
- The test constructed repo-relative paths using `process.cwd()` which produced `frontend/frontend/...` when the suite runs from the `frontend` workspace and led to ENOENT failures for quests/docs directories.

### Description
- Modified `frontend/tests/docsSkillsIndex.test.ts` to derive `frontendRoot` from the test file location using `import.meta.url` and to compute `questsJsonRoot` and `docsRoot` relative to that location.
- Preserved all existing assertions and test intent while removing the `process.cwd()` assumption.
- Files changed: `frontend/tests/docsSkillsIndex.test.ts`.
- Diff:
```diff
diff --git a/frontend/tests/docsSkillsIndex.test.ts b/frontend/tests/docsSkillsIndex.test.ts
index aebb261..0d975ca 100644
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testDir, '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
+const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
 
 describe('docs Skills quest-tree mapping', () => {
     it('maps quest module paths to exactly one tree per quests/json subdirectory', () => {
@@ -34,7 +38,6 @@ describe('docs Skills quest-tree mapping', () => {
             .map((entry) => entry.name)
             .sort((left, right) => left.localeCompare(right));
 
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
``` 

### Testing
- Ran `cd frontend && npm test -- tests/docsSkillsIndex.test.ts`.
- Test output (excerpt) shows the file and all tests passed:
```text
 RUN  v3.2.4 /workspace/dspace/frontend
 ✓ tests/docsSkillsIndex.test.ts (3 tests) 16ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4ab2e34832f9390fc1a78e62502)