### PR TITLE
Fix docsSkillsIndex test path resolution in frontend workspace

### DIFF
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'url';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testsRoot = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testsRoot, '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
 
 describe('docs Skills quest-tree mapping', () => {
     it('maps quest module paths to exactly one tree per quests/json subdirectory', () => {
@@ -34,7 +37,7 @@ describe('docs Skills quest-tree mapping', () => {
             .map((entry) => entry.name)
             .sort((left, right) => left.localeCompare(right));
 
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+        const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))


### PR DESCRIPTION
### Motivation
- Tests were failing because `docsSkillsIndex.test.ts` used `process.cwd()` to build `frontend/src/...` paths which produced `frontend/frontend/...` when the test suite was run from the `frontend/` workspace.

### Description
- Update `frontend/tests/docsSkillsIndex.test.ts` to compute `testsRoot` from `import.meta.url` and derive `frontendRoot` via `path.resolve(testsRoot, '..')` so `questsJsonRoot` and `docsRoot` are resolved relative to the frontend workspace.
- Only the test file `frontend/tests/docsSkillsIndex.test.ts` was modified and no assertions or test logic were changed.

### Testing
- Ran `cd frontend && npm test -- tests/docsSkillsIndex.test.ts` and the file executed successfully with all tests passing.
- Test output showed the single file and three tests passed: `Test Files  1 passed (1)` and `Tests  3 passed (3)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4ab2e34832f9390fc1a78e62502)