### PR TITLE
🐛 fix docsSkillsIndex test path resolution

### DIFF
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testDir, '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
 
 describe('docs Skills quest-tree mapping', () => {
     it('maps quest module paths to exactly one tree per quests/json subdirectory', () => {
@@ -34,7 +37,7 @@ describe('docs Skills quest-tree mapping', () => {
             .map((entry) => entry.name)
             .sort((left, right) => left.localeCompare(right));
 
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+        const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))


### PR DESCRIPTION
### Motivation
- The `docsSkillsIndex` test used `process.cwd()` to locate `frontend/src/pages/...`, which resolved to `frontend/frontend/...` when the suite runs from the `frontend/` workspace and caused `ENOENT` failures.

### Description
- Update `frontend/tests/docsSkillsIndex.test.ts` to compute the frontend root from the test file location using `fileURLToPath(import.meta.url)` and derive `questsJsonRoot` and `docsRoot` from that `frontendRoot`, preserving the original assertions and behavior.

### Testing
- Ran `cd frontend && npm test -- tests/docsSkillsIndex.test.ts` and the test file completed successfully: `1 passed, 3 tests`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4ab2e34832f9390fc1a78e62502)