### PR TITLE
🛠️ fix docs skills index test paths

### DIFF
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'url';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testFilePath = fileURLToPath(import.meta.url);
+const frontendRoot = path.resolve(path.dirname(testFilePath), '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
+const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
 
 describe('docs Skills quest-tree mapping', () => {
     it('maps quest module paths to exactly one tree per quests/json subdirectory', () => {
@@ -34,7 +38,6 @@ describe('docs Skills quest-tree mapping', () => {
             .map((entry) => entry.name)
             .sort((left, right) => left.localeCompare(right));
 
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))


### PR DESCRIPTION
### Motivation
- The docs skills index tests were failing with `ENOENT` because they constructed `frontend/src/...` paths using `process.cwd()`, which becomes `frontend/frontend/...` when the suite runs from the `frontend/` workspace.

### Description
- Resolve the quest and docs roots relative to the test file location using `fileURLToPath(import.meta.url)` instead of `process.cwd()` so paths are correct when tests run from `frontend/`.
- Add `fileURLToPath` import and compute `frontendRoot`, `questsJsonRoot`, and `docsRoot` in `frontend/tests/docsSkillsIndex.test.ts` and remove the `process.cwd()`-based docs root.
- File changed: `frontend/tests/docsSkillsIndex.test.ts`.
- Diff (unified):

```diff
diff --git a/frontend/tests/docsSkillsIndex.test.ts b/frontend/tests/docsSkillsIndex.test.ts
index aebb261..c6ae926 100644
--- a/frontend/tests/docsSkillsIndex.test.ts
+++ b/frontend/tests/docsSkillsIndex.test.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'url';
 import { getQuestTreesFromModulePaths, mergeSkillLinks } from '../src/utils/docsSkillsIndex.js';
 
-const questsJsonRoot = path.join(process.cwd(), 'frontend/src/pages/quests/json');
+const testFilePath = fileURLToPath(import.meta.url);
+const frontendRoot = path.resolve(path.dirname(testFilePath), '..');
+const questsJsonRoot = path.join(frontendRoot, 'src/pages/quests/json');
+const docsRoot = path.join(frontendRoot, 'src/pages/docs/md');
@@
-        const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
         const docsSlugs = fs
             .readdirSync(docsRoot, { withFileTypes: true })
             .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
``` 

### Testing
- Ran `cd frontend && npm test -- tests/docsSkillsIndex.test.ts` and the targeted test file passed.
- Command output excerpt:

```text
✓ tests/docsSkillsIndex.test.ts (3 tests) 21ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```
- No other files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4ab2e34832f9390fc1a78e62502)