### PR TITLE
fix(tests): resolve quest JSON path from test file location

### DIFF
--- a/frontend/tests/quest-process-option.test.ts
+++ b/frontend/tests/quest-process-option.test.ts
@@ -1,9 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const QUEST_JSON_ROOT = path.resolve(__dirname, '../src/pages/quests/json');
 
 function getQuestFiles(): string[] {
     const questFiles: string[] = [];


### PR DESCRIPTION
### Motivation
- A test used `process.cwd()` to build `frontend/src/...` which produced an incorrect `frontend/frontend/...` path when the suite runs from the `frontend/` workspace, causing `ENOENT` in `tests/quest-process-option.test.ts`.

### Description
- Change `QUEST_JSON_ROOT` to resolve from the test file location using `import.meta.url` + `fileURLToPath`, avoiding `process.cwd()` assumptions and making the path stable regardless of working directory; modified `frontend/tests/quest-process-option.test.ts` accordingly.

```diff
*** Begin Patch
*** Update File: frontend/tests/quest-process-option.test.ts
@@
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
@@
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const QUEST_JSON_ROOT = path.resolve(__dirname, '../src/pages/quests/json');
*** End Patch
```

Files changed:
- `frontend/tests/quest-process-option.test.ts`

### Testing
- Ran `cd frontend && npm test -- tests/quest-process-option.test.ts` and the test passed.

```
✓ tests/quest-process-option.test.ts (1 test) 36ms

Test Files  1 passed (1)
     Tests  1 passed (1)
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eea1f8c0832fad9c4fc1ed505ca2)