### PR TITLE
fix: resolve quest JSON path from test location

### DIFF
--- a/frontend/tests/quest-process-option.test.ts
+++ b/frontend/tests/quest-process-option.test.ts
@@ -1,9 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const QUEST_JSON_ROOT = path.resolve(TEST_DIR, '..', 'src', 'pages', 'quests', 'json');
 
 function getQuestFiles(): string[] {
     const questFiles: string[] = [];


### PR DESCRIPTION
### Motivation
- Fix a failing test that built a `frontend/frontend/...` path because it used `process.cwd()` assumptions instead of resolving the quests JSON root relative to the test file location.

### Description
- Update `frontend/tests/quest-process-option.test.ts` to use `fileURLToPath(import.meta.url)` and `path.resolve(TEST_DIR, '..', 'src', 'pages', 'quests', 'json')` so the test discovers quest JSON files correctly when run from the `frontend/` workspace.

### Testing
- Ran `cd frontend && npm test -- tests/quest-process-option.test.ts` and the single test passed, showing `Test Files  1 passed (1)` and `Tests  1 passed (1)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eea1f8c0832fad9c4fc1ed505ca2)