### PR TITLE
🛠️ fix: resolve quest-process-option path from test file

### DIFF
--- a/frontend/tests/quest-process-option.test.ts
+++ b/frontend/tests/quest-process-option.test.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const QUEST_JSON_ROOT = path.resolve(TESTS_DIR, '..', 'src', 'pages', 'quests', 'json');
 
 function getQuestFiles(): string[] {
     const questFiles: string[] = [];


### PR DESCRIPTION
### Motivation
- The test previously used `process.cwd()` to build the quest JSON root which produced a `frontend/frontend/...` path when the suite runs from the `frontend/` workspace, causing an `ENOENT` while scanning quest JSON files.

### Description
- Update `frontend/tests/quest-process-option.test.ts` to compute `TESTS_DIR` from `fileURLToPath(import.meta.url)` and build `QUEST_JSON_ROOT` with `path.resolve(TESTS_DIR, '..', 'src', 'pages', 'quests', 'json')` so the JSON root is resolved relative to the test file instead of `process.cwd()`.

### Testing
- Ran `cd frontend && npm test -- tests/quest-process-option.test.ts` and the single test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eea1f8c0832fad9c4fc1ed505ca2)