### PR TITLE
🧪 Fix quest-process-option test quest JSON root resolution

### DIFF
--- a/frontend/tests/quest-process-option.test.ts
+++ b/frontend/tests/quest-process-option.test.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const QUEST_JSON_ROOT = path.resolve(TEST_DIR, '..', 'src', 'pages', 'quests', 'json');
 
 function getQuestFiles(): string[] {
     const questFiles: string[] = [];


### PR DESCRIPTION
### Motivation
- The test constructed `QUEST_JSON_ROOT` using `process.cwd()` which created `frontend/frontend/...` when the suite is run from the `frontend/` workspace, causing ENOENT failures.

### Description
- Resolve the quest JSON root relative to the test file using `import.meta.url` and `fileURLToPath` so the path is correct regardless of current working directory.
- File changed: `frontend/tests/quest-process-option.test.ts`.
- Key code change (diff):
```diff
--- a/frontend/tests/quest-process-option.test.ts
+++ b/frontend/tests/quest-process-option.test.ts
@@
-import path from 'node:path';
-
-import { describe, expect, it } from 'vitest';
-
-const QUEST_JSON_ROOT = path.join(process.cwd(), 'frontend', 'src', 'pages', 'quests', 'json');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const QUEST_JSON_ROOT = path.resolve(TEST_DIR, '..', 'src', 'pages', 'quests', 'json');
```

### Testing
- Ran `cd frontend && npm test -- tests/quest-process-option.test.ts` and the test file passed.
- Exact successful output excerpt:
```
✓ tests/quest-process-option.test.ts (1 test) 42ms

Test Files  1 passed (1)
Tests       1 passed (1)
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eea1f8c0832fad9c4fc1ed505ca2)