### PR TITLE
Fix docsMarkdownSafety test docs root resolution

### DIFF
--- a/frontend/tests/docsMarkdownSafety.test.ts
+++ b/frontend/tests/docsMarkdownSafety.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(testDir, '../src/pages/docs/md');
 
 function collectMarkdownFiles(dir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
### Motivation
- The docs markdown safety test failed with `ENOENT` because it built `frontend/frontend/...` by joining `process.cwd()` with `frontend/...` when the suite is executed from the `frontend/` workspace, so the test should resolve the docs root from the test file location instead.

### Description
- Change `frontend/tests/docsMarkdownSafety.test.ts` to compute `docsRoot` from the test file directory using `fileURLToPath(import.meta.url)` and `path.resolve(testDir, '../src/pages/docs/md')` instead of using `process.cwd()`.

### Testing
- Ran `cd frontend && npm test -- tests/docsMarkdownSafety.test.ts` and the single test passed (`1 file, 1 test`), confirming the `ENOENT` and `frontend/frontend/...` path issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea728daa60832f904f85dfcfc9bbc9)