### PR TITLE
fix: resolve docs markdown test path

### DIFF
--- a/frontend/tests/docsMarkdownSafety.test.ts
+++ b/frontend/tests/docsMarkdownSafety.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(testDir, '../src/pages/docs/md');
 
 function collectMarkdownFiles(dir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
### Motivation
- The docs markdown safety test failed with an `ENOENT` because it assumed `process.cwd()` was the repo root and computed `frontend/frontend/...` when the suite is run from the `frontend/` workspace.

### Description
- Compute `docsRoot` relative to the test file by deriving `testDir` from `import.meta.url` (using `fileURLToPath`) and resolving `../src/pages/docs/md` instead of using `process.cwd()`.

### Testing
- Ran `cd frontend && npm test -- tests/docsMarkdownSafety.test.ts` and the single test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea728daa60832f904f85dfcfc9bbc9)