### PR TITLE
Fix docsMarkdownSafety test docs root path resolution

### DIFF
--- a/frontend/tests/docsMarkdownSafety.test.ts
+++ b/frontend/tests/docsMarkdownSafety.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(currentDir, '../src/pages/docs/md');
 
 function collectMarkdownFiles(dir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
### Motivation
- The test `docsMarkdownSafety.test.ts` assumed a repo-root `process.cwd()` causing a resolved path of `frontend/frontend/...` when run from the `frontend/` workspace and producing ENOENT failures. 

### Description
- Change `frontend/tests/docsMarkdownSafety.test.ts` to resolve the docs markdown root relative to the test file using `fileURLToPath(import.meta.url)` and `path.resolve`, avoiding reliance on `process.cwd()`.
- The change is minimal and localized to the single test file and preserves the original test logic and intent.

### Testing
- Ran `cd frontend && npm test -- tests/docsMarkdownSafety.test.ts` and the test passed with: `1 passed (1)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea728daa60832f904f85dfcfc9bbc9)