### PR TITLE
🩹 fix: resolve docs markdown path from test file

### DIFF
--- a/frontend/tests/docsMarkdownSafety.test.ts
+++ b/frontend/tests/docsMarkdownSafety.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(testsDir, '../src/pages/docs/md');
 
 function collectMarkdownFiles(dir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
### Motivation
- The docs markdown safety test used `process.cwd()` which produced a non-existent `frontend/frontend/...` path when Vitest runs from the `frontend/` workspace, causing an `ENOENT` failure.

### Description
- Update `frontend/tests/docsMarkdownSafety.test.ts` to compute `docsRoot` from the test file location using `fileURLToPath(import.meta.url)` and `path.resolve`, and keep the change limited to that single test file.

### Testing
- Ran `cd frontend && npm test -- tests/docsMarkdownSafety.test.ts` and the test passed:

```
✓ tests/docsMarkdownSafety.test.ts (1 test) 22ms

Test Files  1 passed (1)
     Tests  1 passed (1)
```

Changed files:
- `frontend/tests/docsMarkdownSafety.test.ts`

Diff:
```diff
diff --git a/frontend/tests/docsMarkdownSafety.test.ts b/frontend/tests/docsMarkdownSafety.test.ts
index aec8547..653ef4b 100644
--- a/frontend/tests/docsMarkdownSafety.test.ts
+++ b/frontend/tests/docsMarkdownSafety.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const docsRoot = path.join(process.cwd(), 'frontend/src/pages/docs/md');
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(testsDir, '../src/pages/docs/md');
 
 function collectMarkdownFiles(dir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea728daa60832f904f85dfcfc9bbc9)