### PR TITLE
✅ fix: stabilize auth token save e2e assertion

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -4,7 +4,7 @@ import { flushGameStateWrites, registerClientStateHooks, waitForHydration } from
 registerClientStateHooks(test);
 
 test('Authentication flow saves and clears token', async ({ page }) => {
-    await page.route('**/gists?per_page=1', (route) =>
+    await page.route('**/gists?per_page=*', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
     );
 
@@ -15,7 +15,7 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+    await expect(page.getByText(/Token saved and validated/i).first()).toBeVisible();
 
     const getStoredToken = async () =>
         page.evaluate(async () => {


### PR DESCRIPTION
### Motivation
- The authentication E2E was flaky because the test only mocked `GET /gists?per_page=1` while the save flow also triggers gist listing requests with other `per_page` values and the assertion relied on a fragile `data-testid` node path instead of the visible success message.

### Description
- Broadened the Playwright network stub to `**/gists?per_page=*` in `frontend/e2e/authentication-flow.spec.ts` so validation and backup-list requests are deterministically mocked.
- Replaced the brittle `await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);` with a visibility check of the user-visible success text: `await expect(page.getByText(/Token saved and validated/i).first()).toBeVisible();`.
- Only `frontend/e2e/authentication-flow.spec.ts` was changed to keep the diff minimal and focused.

### Testing
- Attempted to run the Playwright spec with `cd frontend && npx playwright test authentication-flow.spec.ts --workers=1 --reporter=dot`, but Playwright browser install/download failed due to network restrictions (`ENETUNREACH`), so the E2E could not be executed in this environment.
- `npm run lint` completed successfully.
- `npm run type-check` completed successfully.
- `npm run build` completed successfully.

Diff:
```diff
diff --git a/frontend/e2e/authentication-flow.spec.ts b/frontend/e2e/authentication-flow.spec.ts
index 3684d08..110d33b 100644
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -4,7 +4,7 @@ import { flushGameStateWrites, registerClientStateHooks, waitForHydration } from
 registerClientStateHooks(test);
 
 test('Authentication flow saves and clears token', async ({ page }) => {
-    await page.route('**/gists?per_page=1', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
-    );
+    await page.route('**/gists?per_page=*', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    );
@@
-    await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+    await expect(page.getByText(/Token saved and validated/i).first()).toBeVisible();
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b7daee4832f82e81a52ca36fe04)