### PR TITLE
fix(auth-e2e): add CORS & mock for gists to stabilize token-save E2E

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -4,8 +4,27 @@ import { flushGameStateWrites, registerClientStateHooks, waitForHydration } from
 registerClientStateHooks(test);
 
 test('Authentication flow saves and clears token', async ({ page }) => {
+    const corsHeaders = {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, POST, OPTIONS',
+        'access-control-allow-headers': '*',
+    };
+
     await page.route('**/gists?per_page=1', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+        route.fulfill({
+            status: 200,
+            headers: corsHeaders,
+            contentType: 'application/json',
+            body: '[]',
+        })
+    );
+    await page.route('**/gists?per_page=30', (route) =>
+        route.fulfill({
+            status: 200,
+            headers: corsHeaders,
+            contentType: 'application/json',
+            body: '[]',
+        })
     );
 
     const token = 'ghp_' + 'a'.repeat(36);


### PR DESCRIPTION
### Motivation
- The authentication E2E intermittently failed because the test only mocked `gists?per_page=1` (without CORS) and the app issues additional gist requests during save/refresh, so the in-browser validation path could fail and the success message (`data-testid="sync-success"`) never appeared.

### Description
- Add CORS headers to the mocked `gists?per_page=1` response and add a matching stub for `gists?per_page=30` in `frontend/e2e/authentication-flow.spec.ts` so the token validation and backup refresh are fully mocked and deterministic.

### Testing
- Attempted to run the targeted Playwright test with `cd frontend && npx playwright test authentication-flow.spec.ts --workers=1 --reporter=dot`, but browser/system dependency downloads failed in this environment (`ENETUNREACH`) so the Playwright run could not complete; the test is expected to pass once Playwright browsers are available.
- Verified repository checks locally in this environment: `npm run lint` passed, `npm run type-check` passed, and `npm run build` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b7daee4832f82e81a52ca36fe04)