### PR TITLE
stabilize E2E: wait for cloud-sync hydration in auth flow

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -10,7 +10,7 @@ test('Authentication flow saves and clears token', async ({ page }) => {
 
     const token = 'ghp_' + 'a'.repeat(36);
     await page.goto('/cloudsync');
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
 
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
@@ -54,7 +54,7 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     await expect.poll(getStoredToken, { timeout: 30_000 }).toBe(token);
 
     await page.reload();
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
     await expect(tokenInput).toHaveValue(token);
 
     // clear token and verify removal


### PR DESCRIPTION
### Motivation
- The authentication E2E was flaky because the generic `waitForHydration(page)` helper can resolve when any hydrated node appears, allowing the test to interact with the Cloud Sync UI before the Syncer component finished mounting and announcing the success message.

### Description
- Tighten the hydration wait in `frontend/e2e/authentication-flow.spec.ts` by calling `waitForHydration(page, 'data-testid=cloud-sync-form')` on initial load and after reload so the test only proceeds once the Cloud Sync component is fully mounted.

### Testing
- Ran `npm run lint`, `npm run type-check`, and `npm run build` and they all completed successfully; these commands were executed from the repo root.
- Attempted to run the Playwright spec with `cd frontend && npm run setup-test-env && npx playwright test authentication-flow.spec.ts --workers=1 --reporter=dot`, but Playwright browser/deps install failed in this environment with network `ENETUNREACH`, so the E2E run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b7daee4832f82e81a52ca36fe04)