### PR TITLE
fix(e2e): stabilize logout-flow token persistence race

### DIFF
--- a/frontend/e2e/logout-flow.spec.ts
+++ b/frontend/e2e/logout-flow.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, expectLocalStorageCleared, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    expectLocalStorageCleared,
+    flushGameStateWrites,
+    waitForHydration,
+} from './test-helpers';
 
 async function setCloudGistId(page, gistId) {
     await page.evaluate(async (value) => {
@@ -102,6 +107,8 @@ test.describe('Logout flow', () => {
         const tokenField = page.getByLabel(/GitHub Token/i);
         await tokenField.fill(token);
         await page.getByRole('button', { name: /save/i }).click();
+        await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+        await flushGameStateWrites(page);
 
         await page.reload();
         await waitForHydration(page);


### PR DESCRIPTION
### Motivation
- The logout-flow E2E intermittently failed because the test reloaded immediately after clicking Save before the async token validation/persist completed, producing a race where the token field was empty on reload.

### Description
- Wait for the cloud-sync success message and call `flushGameStateWrites` before reloading in `frontend/e2e/logout-flow.spec.ts`, and import `flushGameStateWrites` from `test-helpers`; no app code was changed.

### Testing
- Attempted `npx playwright test logout-flow.spec.ts` but E2E could not run here due to Playwright browser installation/network failures (browsers download errored with `ENETUNREACH`), so the E2E could not be executed in this environment; the test now explicitly waits for save + flush to avoid the race.
- Ran `cd frontend && npm run lint` which completed; ran `npm run type-check` at repo root which succeeded; ran `cd frontend && npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabf557a1c832f80d503b15a46bc76)