### PR TITLE
🐛 Fix logout-flow E2E race: wait for token save and flush writes before reload

### DIFF
--- a/frontend/e2e/logout-flow.spec.ts
+++ b/frontend/e2e/logout-flow.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, expectLocalStorageCleared, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    expectLocalStorageCleared,
+    flushGameStateWrites,
+    waitForHydration,
+} from './test-helpers';
 
 async function setCloudGistId(page, gistId) {
     await page.evaluate(async (value) => {
@@ -102,6 +107,8 @@ test.describe('Logout flow', () => {
         const tokenField = page.getByLabel(/GitHub Token/i);
         await tokenField.fill(token);
         await page.getByRole('button', { name: /save/i }).click();
+        await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+        await flushGameStateWrites(page);
 
         await page.reload();
         await waitForHydration(page);


### PR DESCRIPTION
### Motivation
- The logout-flow E2E was flaky because the test reloaded the page immediately after clicking Save while token validation and async game-state writes were still in-flight, which occasionally left the token input empty after reload.

### Description
- Modify `frontend/e2e/logout-flow.spec.ts` to import `flushGameStateWrites` and to wait for the save success (`getByTestId('sync-success')`) then call `flushGameStateWrites(page)` before `page.reload()`, ensuring the persisted token is available after a reload; no app code changed, only the test was updated.

### Testing
- Attempted `cd frontend && npm run setup-test-env && npx playwright test logout-flow.spec.ts --workers=1 --reporter=dot`, but E2E execution was blocked in this environment because Playwright browsers/deps could not be downloaded (network/apt failures), so the spec could not be run here.
- Ran `cd frontend && npm run lint` which succeeded.
- Ran `cd frontend && npm run build` which succeeded.
- Noted `cd frontend && npm run type-check` is not defined in `frontend/package.json` (attempt returned missing script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabf557a1c832f80d503b15a46bc76)