### PR TITLE
✅ fix: stabilize logout-flow credential persistence E2E

### DIFF
--- a/frontend/e2e/logout-flow.spec.ts
+++ b/frontend/e2e/logout-flow.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, expectLocalStorageCleared, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    expectLocalStorageCleared,
+    flushGameStateWrites,
+    waitForHydration,
+} from './test-helpers';
 
 async function setCloudGistId(page, gistId) {
     await page.evaluate(async (value) => {
@@ -102,6 +107,8 @@ test.describe('Logout flow', () => {
         const tokenField = page.getByLabel(/GitHub Token/i);
         await tokenField.fill(token);
         await page.getByRole('button', { name: /save/i }).click();
+        await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+        await flushGameStateWrites(page);
 
         await page.reload();
         await waitForHydration(page);


### PR DESCRIPTION
### Motivation
- Fix an intermittent E2E failure where the saved GitHub token sometimes appeared empty after a reload because the test reloaded before async token validation/persistence finished.

### Description
- Wait for the `sync-success` confirmation and call `flushGameStateWrites` (imported from `frontend/e2e/test-helpers.ts`) before reloading in `frontend/e2e/logout-flow.spec.ts` to ensure the token is persisted and observable after reload.

### Testing
- Ran `cd frontend && npx playwright test logout-flow.spec.ts --workers=1 --reporter=dot` (Playwright run blocked by environment browser/dependency download failure), `cd frontend && npm run lint` (passed), and `cd frontend && npm run build` (passed), and noted `npm run type-check` is not defined in `frontend/package.json` so it could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabf557a1c832f80d503b15a46bc76)