### PR TITLE
stabilize logout-flow E2E token persistence check

### DIFF
--- a/frontend/e2e/logout-flow.spec.ts
+++ b/frontend/e2e/logout-flow.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, expectLocalStorageCleared, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    expectLocalStorageCleared,
+    flushGameStateWrites,
+    waitForHydration,
+} from './test-helpers';
 
 async function setCloudGistId(page, gistId) {
     await page.evaluate(async (value) => {
@@ -102,6 +107,8 @@ test.describe('Logout flow', () => {
         const tokenField = page.getByLabel(/GitHub Token/i);
         await tokenField.fill(token);
         await page.getByRole('button', { name: /save/i }).click();
+        await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
+        await flushGameStateWrites(page);
 
         await page.reload();
         await waitForHydration(page);


### PR DESCRIPTION
### Motivation
- Fix an intermittent E2E failure where the test reloaded the app immediately after clicking Save and observed an empty token field because async game-state writes had not completed.

### Description
- Modify `frontend/e2e/logout-flow.spec.ts` to wait for the save success indicator (`sync-success`) and call `flushGameStateWrites(page)` (imported from `test-helpers`) before reloading; no application runtime code was changed.

### Testing
- Ran `cd frontend && npm run setup-test-env` (setup completed, but Playwright browser/system dependency installation failed in this environment due to network errors); running the Playwright spec was blocked by missing Chromium binaries here.
- Attempted `cd frontend && npx playwright test logout-flow.spec.ts --workers=1 --reporter=dot` but it could not complete because Playwright could not download browsers (ENETUNREACH); the added waits should address the original test race in a normal CI/dev environment.
- Executed `npm run lint`, `npm run type-check`, and `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabf557a1c832f80d503b15a46bc76)