### PR TITLE
🔧 chore: refresh caniuse-lite to stop Browserslist stale-data warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,13 +100,15 @@
   "overrides": {
     "esbuild": "0.25.8",
     "@esbuild/linux-x64": "0.25.8",
-    "glob": "13.0.6"
+    "glob": "13.0.6",
+    "caniuse-lite": "1.0.30001790"
   },
   "pnpm": {
     "overrides": {
       "esbuild": "0.25.8",
       "@esbuild/linux-x64": "0.25.8",
-      "glob": "13.0.6"
+      "glob": "13.0.6",
+      "caniuse-lite": "1.0.30001790"
     }
   },
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: 0.25.8
   '@esbuild/linux-x64': 0.25.8
   glob: 13.0.6
+  caniuse-lite: 1.0.30001790
 
 importers:
 
@@ -2377,8 +2378,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001727:
-    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
   canvas@3.1.2:
     resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
@@ -7894,7 +7895,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001727
+      caniuse-lite: 1.0.30001790
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -8045,7 +8046,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001727
+      caniuse-lite: 1.0.30001790
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -8097,11 +8098,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001727
+      caniuse-lite: 1.0.30001790
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001727: {}
+  caniuse-lite@1.0.30001790: {}
 
   canvas@3.1.2:
     dependencies:


### PR DESCRIPTION
### Motivation
- The root build emits: `Browserslist: browsers data (caniuse-lite) is 10 months old`; this change updates the resolved caniuse-lite dataset so the warning is removed without broad dependency upgrades.

### Description
- Pin `caniuse-lite` to `1.0.30001790` in root `overrides` and `pnpm.overrides` and regenerate `pnpm-lock.yaml`, keeping churn minimal and only changing dependency resolution.
- Exact files changed: `package.json` and `pnpm-lock.yaml`.

### Testing
- Ran `pnpm install --frozen-lockfile` which succeeded and reported the lockfile is up to date.
- Ran `npm run build` and confirmed the previous Browserslist stale `caniuse-lite` warning no longer appears in the build output.
- Ran `npm test -- --help` which completed and printed the npm run-script help, confirming test command invocation works as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac3f424d8832f9f1fc9440397cab0)