### PR TITLE
🧹 fix: remove unused Process CSS selectors

### DIFF
--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -890,19 +890,6 @@
         color: #1f2937;
     }
 
-    .deposit-input-label {
-        color: #ffffff;
-        font-size: 0.9rem;
-    }
-
-    .deposit-input {
-        border: 1px solid rgba(255, 255, 255, 0.35);
-        border-radius: 8px;
-        background: rgba(17, 24, 39, 0.45);
-        color: #ffffff;
-        padding: 8px 10px;
-    }
-
     .process-error {
         padding: 1rem;
         border-radius: 12px;


### PR DESCRIPTION
### Motivation
- Svelte reported unused CSS selector warnings for `.deposit-input-label` and `.deposit-input` because those classes were only present in the style block and not used in the component, so the dead rules should be removed to silence test output without affecting UI behavior.

### Description
- Removed the two dead CSS blocks for `.deposit-input-label` and `.deposit-input` from `frontend/src/components/svelte/Process.svelte` and made no other code changes.

### Testing
- Ran `npm run test:root -- frontend/src/components/__tests__/Process.spec.ts` which passed: `24 passed` and the unused-selector warnings did not appear.
- Ran `npm run build` which completed successfully and the unused-selector warnings did not appear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae1fa4dbc832f9b5aaacf57ae8d65)