### PR TITLE
🧹 fix: remove unused Process.svelte deposit selectors

### DIFF
--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -890,19 +890,6 @@
         color: #1f2937;
     }
 
-    .deposit-input-label {
-        color: #ffffff;
-        font-size: 0.9rem;
-    }
-
-    .deposit-input {
-        border: 1px solid rgba(255, 255, 255, 0.35);
-        border-radius: 8px;
-        background: rgba(17, 24, 39, 0.45);
-        color: #ffffff;
-        padding: 8px 10px;
-    }
-
     .process-error {
         padding: 1rem;
         border-radius: 12px;


### PR DESCRIPTION
### Motivation
- Root cause: `Process.svelte` contained two legacy CSS selectors (`.deposit-input-label`, `.deposit-input`) that were not referenced anywhere in the component, producing unused-selector warnings during tests and build.

### Description
- Removed the dead `.deposit-input-label` and `.deposit-input` rules from `frontend/src/components/svelte/Process.svelte` and kept the change scoped to that single file.

```diff
diff --git a/frontend/src/components/svelte/Process.svelte b/frontend/src/components/svelte/Process.svelte
index 8300d45..784c828 100644
--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -890,19 +890,6 @@
         color: #1f2937;
     }
 
-    .deposit-input-label {
-        color: #ffffff;
-        font-size: 0.9rem;
-    }
-
-    .deposit-input {
-        border: 1px solid rgba(255, 255, 255, 0.35);
-        border-radius: 8px;
-        background: rgba(17, 24, 39, 0.45);
-        color: #ffffff;
-        padding: 8px 10px;
-    }
-
     .process-error {
         padding: 1rem;
         border-radius: 12px;
```

### Testing
- Ran `npm run test:root -- frontend/src/components/__tests__/Process.spec.ts` which passed (`24 tests` passed) and the unused-selector warnings did not appear.
- Ran `npm run build` which completed successfully (Astro build finished) and no unused-selector warnings were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae1fa4dbc832f9b5aaacf57ae8d65)