### PR TITLE
🧹 fix: remove dead deposit CSS selectors in Process.svelte

### DIFF
--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -890,19 +890,6 @@
         color: #1f2937;
     }
 
-    .deposit-input-label {
-        color: #ffffff;
-        font-size: 0.9rem;
-    }
-
-    .deposit-input {
-        border: 1px solid rgba(255, 255, 255, 0.35);
-        border-radius: 8px;
-        background: rgba(17, 24, 39, 0.45);
-        color: #ffffff;
-        padding: 8px 10px;
-    }
-
     .process-error {
         padding: 1rem;
         border-radius: 12px;


### PR DESCRIPTION
### Motivation
- Remove two legacy CSS selectors (`.deposit-input-label` and `.deposit-input`) left in `frontend/src/components/svelte/Process.svelte` that produced Svelte "Unused CSS selector" warnings during root-level tests and build.

### Description
- Deleted the unused `.deposit-input-label` and `.deposit-input` CSS blocks from `frontend/src/components/svelte/Process.svelte` as a minimal, behavior-preserving cleanup.

```diff
diff --git a/frontend/src/components/svelte/Process.svelte b/frontend/src/components/svelte/Process.svelte
index 8300d45..784c828 100644
--- a/frontend/src/components/svelte/Process.svelte
+++ b/frontend/src/components/svelte/Process.svelte
@@ -890,19 +890,6 @@
         color: #1f2937;
     }
 
-    .deposit-input-label {
-        color: #ffffff;
-        font-size: 0.9rem;
-    }
-
-    .deposit-input {
-        border: 1px solid rgba(255, 255, 255, 0.35);
-        border-radius: 8px;
-        background: rgba(17, 24, 39, 0.45);
-        color: #ffffff;
-        padding: 8px 10px;
-    }
-
     .process-error {
         padding: 1rem;
         border-radius: 12px;
``` 

### Testing
- Ran `npm run test:root -- frontend/src/components/__tests__/Process.spec.ts` which passed (`24 tests` all green) and no `.deposit-input-label`/`.deposit-input` unused-selector warnings were reported.
- Ran `npm run build` which completed successfully and the two unused selector warnings no longer appear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae1fa4dbc832f9b5aaacf57ae8d65)