### PR TITLE
🛠️ fix: resolve Svelte $state rune ambiguity in quest options

### DIFF
--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -3,14 +3,14 @@
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { get, writable } from 'svelte/store';
     import { finishQuest } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { isValidGitHubToken } from '../../../../utils/githubToken.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let quest, option;
     let githubConnected = false;
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
     let isDisabled = false;
 
@@ -21,15 +21,21 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }
 
     $: {
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub
+            ? isValidGitHubToken($gameStateStore?.github?.token)
+            : false;
     }
 
     $: isDisabled = (option.requiresGitHub && !githubConnected) || !$itemRequirementsMet;

--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -3,13 +3,13 @@
     import Chip from '../../../../components/svelte/Chip.svelte';
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { setCurrentDialogueStep } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let option, questId;
 
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
 
     function onClick() {
@@ -19,9 +19,13 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }


### PR DESCRIPTION
### Motivation
- Svelte emitted `$state` rune ambiguity warnings because both `FinishOption.svelte` and `GotoOption.svelte` imported the store as `state`, colliding with the `$state` rune name.
- The change aims to eliminate the warnings without changing runtime behavior.

### Description
- Renamed the imported store binding from `state` to `gameStateStore` in the two affected components and updated all `get(...)` and `$...` usages accordingly.
- Files changed: `frontend/src/pages/quests/svelte/option/FinishOption.svelte` and `frontend/src/pages/quests/svelte/option/GotoOption.svelte`.
- Change is minimal and purely a local identifier rename to avoid the Svelte rune/name collision.

```diff
*** Begin Patch
*** Update File: frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
@@
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
@@
-        if ($state) {
-            itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
-            );
-        }
+        if ($gameStateStore) {
+            itemRequirementsMet.set(
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
+            );
+        }
@@
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub
+            ? isValidGitHubToken($gameStateStore?.github?.token)
+            : false;
*** End Patch

*** Begin Patch
*** Update File: frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
@@
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
@@
-        if ($state) {
-            itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
-            );
-        }
+        if ($gameStateStore) {
+            itemRequirementsMet.set(
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
+            );
+        }
*** End Patch
```

### Testing
- Ran unit tests for the affected specs with `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` and all tests passed: "2 files, 9 tests".
- Ran the production build with `npm run build` and it completed successfully (Astro build finished, server and client artifacts produced).
- Verified absence of the targeted warnings by running the tests and grepping the log for the `$state` ambiguity string; the grep reported no matches: `No targeted $state ambiguity warnings found in /tmp/issue5-test.log`.
- All automated checks above succeeded and behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae5df8044832fb1fd688c1ef4533b)