### PR TITLE
Fix Svelte $state ambiguity warnings in quest option components

### DIFF
--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -3,14 +3,18 @@
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { get, writable } from 'svelte/store';
     import { finishQuest } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { isValidGitHubToken } from '../../../../utils/githubToken.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let quest, option;
     let githubConnected = false;
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(
+            option.requiresItems,
+            get(gameStateStore)?.inventory,
+            get(gameStateStore)
+        )
     );
     let isDisabled = false;
 
@@ -21,15 +25,21 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }
 
     $: {
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub
+            ? isValidGitHubToken($gameStateStore?.github?.token)
+            : false;
     }
 
     $: isDisabled = (option.requiresGitHub && !githubConnected) || !$itemRequirementsMet;

--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -3,13 +3,17 @@
     import Chip from '../../../../components/svelte/Chip.svelte';
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { setCurrentDialogueStep } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let option, questId;
 
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(
+            option.requiresItems,
+            get(gameStateStore)?.inventory,
+            get(gameStateStore)
+        )
     );
 
     function onClick() {
@@ -19,9 +23,13 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }


### PR DESCRIPTION
### Motivation
- Root cause: both option components imported a local binding named `state` and used `$state` in reactive code, which Svelte 5 parses as the `$state` rune and emits ambiguity warnings.
- Change intent: remove the ambiguous local binding name while preserving behavior exactly to silence the warnings during tests and build.

### Description
- Renamed the imported store binding from `state` to `gameStateStore` in `frontend/src/pages/quests/svelte/option/FinishOption.svelte` and `frontend/src/pages/quests/svelte/option/GotoOption.svelte` and updated all `get(...)` and `$...` references accordingly.
- No behavioral logic was changed; the same store is used and reactive updates remain identical.
- Files changed:
  - `frontend/src/pages/quests/svelte/option/FinishOption.svelte`
  - `frontend/src/pages/quests/svelte/option/GotoOption.svelte`
- Diff (focused):
```diff
- import { state } from '../../../../utils/gameState/common.js';
+ import { state as gameStateStore } from '../../../../utils/gameState/common.js';
- areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+ areItemRequirementsMet(
+     option.requiresItems,
+     get(gameStateStore)?.inventory,
+     get(gameStateStore)
+ )
- if ($state) { ... $state.inventory ... }
+ if ($gameStateStore) { ... $gameStateStore.inventory ... }
- isValidGitHubToken($state?.github?.token)
+ isValidGitHubToken($gameStateStore?.github?.token)
```

### Testing
- Ran component/unit checks: `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` and all tests passed (9 tests across 2 files).
- Ran full build: `npm run build` and the Astro build completed successfully.
- Confirmed the specific ambiguity warning is gone by running the tests and searching the output for the warning string; the command used was:
  - `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts 2>&1 | tee /tmp/issue5-test.log && ! rg "It looks like you're using the \\$state rune" /tmp/issue5-test.log` and it returned success (warning not present).
- Status: automated tests passed and build succeeded; the `$state` ambiguity warnings no longer appear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae5df8044832fb1fd688c1ef4533b)