### PR TITLE
🛠️ fix: resolve Svelte $state ambiguity in quest option components

### DIFF
--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -3,14 +3,14 @@
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { get, writable } from 'svelte/store';
     import { finishQuest } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { isValidGitHubToken } from '../../../../utils/githubToken.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let quest, option;
     let githubConnected = false;
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
     let isDisabled = false;
 
@@ -21,15 +21,17 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
             );
         }
     }
 
     $: {
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub
+            ? isValidGitHubToken($gameStateStore?.github?.token)
+            : false;
     }
 
     $: isDisabled = (option.requiresGitHub && !githubConnected) || !$itemRequirementsMet;

--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -3,13 +3,13 @@
     import Chip from '../../../../components/svelte/Chip.svelte';
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { setCurrentDialogueStep } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let option, questId;
 
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
 
     function onClick() {
@@ -19,9 +19,9 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
             );
         }
     }


### PR DESCRIPTION
### Motivation
- Remove Svelte warnings about the `$state` rune being ambiguous due to a local `state` binding in quest option components without changing runtime behavior.

### Description
- Renamed the imported store `state` to `gameStateStore` and updated all `get(...)` and reactive `$...` usages to `gameStateStore` in `FinishOption.svelte` and `GotoOption.svelte` to eliminate the `$state` rune ambiguity.

### Testing
- Ran `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` and all tests passed (2 files, 9 tests).
- Ran `npm run build` and the Astro build completed successfully.
- Verified test output contains no `$state` ambiguity warnings for `FinishOption.svelte` or `GotoOption.svelte`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae5df8044832fb1fd688c1ef4533b)