### PR TITLE
🛠️ fix: avoid $state ambiguity in quest option components

### DIFF
--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -3,14 +3,14 @@
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { get, writable } from 'svelte/store';
     import { finishQuest } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { isValidGitHubToken } from '../../../../utils/githubToken.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let quest, option;
     let githubConnected = false;
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
     let isDisabled = false;
 
@@ -21,15 +21,15 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
             );
         }
     }
 
     $: {
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub ? isValidGitHubToken($gameStateStore?.github?.token) : false;
     }
 
     $: isDisabled = (option.requiresGitHub && !githubConnected) || !$itemRequirementsMet;

--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -10,7 +10,11 @@
     export let quest, option;
     let githubConnected = false;
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
+        areItemRequirementsMet(
+            option.requiresItems,
+            get(gameStateStore)?.inventory,
+            get(gameStateStore)
+        )
     );
     let isDisabled = false;
 
@@ -23,13 +27,19 @@
     $: {
         if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }
 
     $: {
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($gameStateStore?.github?.token) : false;
+        githubConnected = option.requiresGitHub
+            ? isValidGitHubToken($gameStateStore?.github?.token)
+            : false;
     }
 
     $: isDisabled = (option.requiresGitHub && !githubConnected) || !$itemRequirementsMet;

--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -3,13 +3,13 @@
     import Chip from '../../../../components/svelte/Chip.svelte';
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { setCurrentDialogueStep } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
 
     export let option, questId;
 
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
     );
 
     function onClick() {
@@ -19,9 +19,9 @@
     }
 
     $: {
-        if ($state) {
+        if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
             );
         }
     }

--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -9,7 +9,11 @@
     export let option, questId;
 
     const itemRequirementsMet = writable(
-        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
+        areItemRequirementsMet(
+            option.requiresItems,
+            get(gameStateStore)?.inventory,
+            get(gameStateStore)
+        )
     );
 
     function onClick() {
@@ -21,7 +25,11 @@
     $: {
         if ($gameStateStore) {
             itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
+                areItemRequirementsMet(
+                    option.requiresItems,
+                    $gameStateStore.inventory,
+                    $gameStateStore
+                )
             );
         }
     }


### PR DESCRIPTION
### Motivation
- Svelte emitted ambiguity warnings because both `FinishOption.svelte` and `GotoOption.svelte` imported a store named `state` and used the `$state` rune, which collides with a local binding named `state`; renaming the local binding removes the rune ambiguity without changing behavior.

### Description
- Renamed the imported `state` binding to `gameStateStore` in `frontend/src/pages/quests/svelte/option/FinishOption.svelte` and `frontend/src/pages/quests/svelte/option/GotoOption.svelte`, and updated `get(...)` calls and reactive `$...` references to use `$gameStateStore` to preserve existing logic.

### Testing
- Ran `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` which succeeded: both test files passed (2 files, 9 tests) and the `$state` ambiguity warnings for these components no longer appeared.
- Ran `npm run build` which completed successfully (Astro build complete) with no `$state` ambiguity warnings from the modified files.

Verification commands and results:
- `npm run test:root -- frontend/tests/quest-finish-option.test.ts frontend/src/pages/quests/svelte/__tests__/QuestChat.spec.ts` — passed (2 test files, 9 tests).
- `npm run build` — passed (Astro build complete).

Diff:
```diff
diff --git a/frontend/src/pages/quests/svelte/option/FinishOption.svelte b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
--- a/frontend/src/pages/quests/svelte/option/FinishOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/FinishOption.svelte
@@ -3,14 +3,14 @@
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { get, writable } from 'svelte/store';
     import { finishQuest } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { isValidGitHubToken } from '../../../../utils/githubToken.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
@@
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
@@
-        if ($state) {
-            itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
-            );
-        }
+        if ($gameStateStore) {
+            itemRequirementsMet.set(
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
+            );
+        }
@@
-        githubConnected = option.requiresGitHub ? isValidGitHubToken($state?.github?.token) : false;
+        githubConnected = option.requiresGitHub ? isValidGitHubToken($gameStateStore?.github?.token) : false;
diff --git a/frontend/src/pages/quests/svelte/option/GotoOption.svelte b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
--- a/frontend/src/pages/quests/svelte/option/GotoOption.svelte
+++ b/frontend/src/pages/quests/svelte/option/GotoOption.svelte
@@ -3,13 +3,13 @@
     import Chip from '../../../../components/svelte/Chip.svelte';
     import CompactItemList from '../../../../components/svelte/CompactItemList.svelte';
     import { setCurrentDialogueStep } from '../../../../utils/gameState.js';
-    import { state } from '../../../../utils/gameState/common.js';
+    import { state as gameStateStore } from '../../../../utils/gameState/common.js';
     import { areItemRequirementsMet } from './itemRequirements.js';
@@
-        areItemRequirementsMet(option.requiresItems, get(state)?.inventory, get(state))
+        areItemRequirementsMet(option.requiresItems, get(gameStateStore)?.inventory, get(gameStateStore))
@@
-        if ($state) {
-            itemRequirementsMet.set(
-                areItemRequirementsMet(option.requiresItems, $state.inventory, $state)
-            );
-        }
+        if ($gameStateStore) {
+            itemRequirementsMet.set(
+                areItemRequirementsMet(option.requiresItems, $gameStateStore.inventory, $gameStateStore)
+            );
+        }
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae5df8044832fb1fd688c1ef4533b)