### PR TITLE
chore(frontend): filter Astro unsupported-file warning spam during build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
         "dev:safe": "concurrently \"npm run dev\" \"npm run fix-artifacts\"",
         "fix-artifacts": "node scripts/fix-artifact-error.js",
         "start": "astro dev --host 0.0.0.0 --port=$PORT",
-        "build": "astro build",
+        "build": "node scripts/run-astro-build.mjs",
         "preview": "node scripts/ensure-astro-build.mjs && astro preview --host 0.0.0.0 --port=3000",
         "astro": "astro",
         "setup-test-env": "node scripts/setup-test-env.js",

--- a/frontend/scripts/run-astro-build.mjs
+++ b/frontend/scripts/run-astro-build.mjs
@@ -1,0 +1,69 @@
+import { spawn } from 'node:child_process';
+
+const ignoredPatterns = [/Unsupported file type .*Prefix filename with an underscore/];
+
+const shouldKeepLine = (line) => !ignoredPatterns.some((pattern) => pattern.test(line));
+
+const createFilteredWriter = (stream) => {
+    let buffered = '';
+
+    return (chunk, flush = false) => {
+        buffered += chunk;
+        const parts = buffered.split('\n');
+        buffered = parts.pop() ?? '';
+
+        for (const line of parts) {
+            if (shouldKeepLine(line)) {
+                stream.write(`${line}\n`);
+            }
+        }
+
+        if (flush && buffered) {
+            if (shouldKeepLine(buffered)) {
+                stream.write(buffered);
+            }
+            buffered = '';
+        }
+    };
+};
+
+const runAstroBuild = async () => {
+    const child = spawn('astro', ['build'], {
+        stdio: 'pipe',
+        env: process.env,
+        shell: true,
+    });
+
+    const writeStdout = createFilteredWriter(process.stdout);
+    const writeStderr = createFilteredWriter(process.stderr);
+
+    child.stdout.on('data', (chunk) => {
+        writeStdout(chunk.toString());
+    });
+
+    child.stderr.on('data', (chunk) => {
+        writeStderr(chunk.toString());
+    });
+
+    await new Promise((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', (code, signal) => {
+            writeStdout('', true);
+            writeStderr('', true);
+
+            if (signal) {
+                reject(new Error(`astro build exited due to signal ${signal}`));
+                return;
+            }
+
+            if (code !== 0) {
+                process.exit(code ?? 1);
+                return;
+            }
+
+            resolve();
+        });
+    });
+};
+
+await runAstroBuild();


### PR DESCRIPTION
### Motivation
- Astro emits an "Unsupported file type ... Prefix filename with an underscore" warning for many intentional support/content files kept under `frontend/src/pages/**`, producing large noisy logs during builds.
- Suppress only that specific warning pattern so developers and CI see meaningful build output without changing route or content layout.

### Description
- Change the frontend `build` script in `frontend/package.json` to run a small wrapper (`node scripts/run-astro-build.mjs`) instead of calling `astro build` directly.
- Add `frontend/scripts/run-astro-build.mjs`, a minimal runner that spawns `astro build`, streams stdout/stderr, and filters lines that match the known unsupported-file warning pattern while preserving all other output and exit behavior.
- The change is scoped to log filtering only and does not rename or move any files under `frontend/src/pages`.

### Testing
- Ran `npm run build` (repo root); build completed successfully and the unsupported-file warning spam was not present (success).
- Ran `npm test -- --help`; the test command printed npm run help as expected (success).
- Ran `npm --prefix frontend run build`; frontend build completed successfully and previously noisy unsupported-file warnings were absent (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecc610dc832fb883d6ac8e3852d0)