### PR TITLE
Filter Astro unsupported-file warning spam during frontend build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
         "dev:safe": "concurrently \"npm run dev\" \"npm run fix-artifacts\"",
         "fix-artifacts": "node scripts/fix-artifact-error.js",
         "start": "astro dev --host 0.0.0.0 --port=$PORT",
-        "build": "astro build",
+        "build": "node scripts/run-astro-with-filter.mjs build",
         "preview": "node scripts/ensure-astro-build.mjs && astro preview --host 0.0.0.0 --port=3000",
         "astro": "astro",
         "setup-test-env": "node scripts/setup-test-env.js",

--- a/frontend/scripts/run-astro-with-filter.mjs
+++ b/frontend/scripts/run-astro-with-filter.mjs
@@ -1,0 +1,62 @@
+import { spawn } from 'node:child_process';
+
+const astroArgs = process.argv.slice(2);
+
+if (astroArgs.length === 0) {
+    console.error('Usage: node scripts/run-astro-with-filter.mjs <astro-args...>');
+    process.exit(1);
+}
+
+const ignoredPatterns = [/Unsupported file type .*Prefix filename with an underscore/];
+
+const shouldKeepLine = (line) => !ignoredPatterns.some((pattern) => pattern.test(line));
+
+const createFilteredWriter = (stream) => {
+    let buffered = '';
+
+    return (chunk, flush = false) => {
+        buffered += chunk;
+        const parts = buffered.split('\n');
+        buffered = parts.pop() ?? '';
+
+        for (const line of parts) {
+            if (shouldKeepLine(line)) {
+                stream.write(`${line}\n`);
+            }
+        }
+
+        if (flush && buffered && shouldKeepLine(buffered)) {
+            stream.write(buffered);
+            buffered = '';
+        }
+    };
+};
+
+const astro = spawn('astro', astroArgs, {
+    stdio: 'pipe',
+    env: process.env,
+    shell: true,
+});
+
+const writeStdout = createFilteredWriter(process.stdout);
+const writeStderr = createFilteredWriter(process.stderr);
+
+astro.stdout.on('data', (chunk) => {
+    writeStdout(chunk.toString());
+});
+
+astro.stderr.on('data', (chunk) => {
+    writeStderr(chunk.toString());
+});
+
+astro.on('close', (code, signal) => {
+    writeStdout('', true);
+    writeStderr('', true);
+
+    if (signal) {
+        console.error(`astro exited due to signal ${signal}`);
+        process.exit(1);
+    }
+
+    process.exit(code ?? 1);
+});


### PR DESCRIPTION
### Motivation
- Astro emits many `Unsupported file type` warnings for intentional support/content files colocated under `frontend/src/pages`, producing noisy build logs without changing runtime routes. 
- The goal is a minimal-risk fix that preserves routes and content layout while removing the noisy warning spam.

### Description
- Added `frontend/scripts/run-astro-with-filter.mjs` which spawns `astro` and filters lines matching the unsupported-file warning pattern. 
- Updated the frontend `build` script in `frontend/package.json` to run `node scripts/run-astro-with-filter.mjs build` instead of `astro build`. 
- The change only alters build logging; no routes, page files, or runtime behavior were modified.

### Testing
- Ran `npm run build` and observed a successful build with no regression in server/client outputs. 
- Ran `npm test -- --help` and confirmed it exits successfully with no unsupported-file spam. 
- Ran `npm --prefix frontend run build` and verified `unsupported_count: 0` (previously ~561 warnings), and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecc610dc832fb883d6ac8e3852d0)