### PR TITLE
Filter Astro unsupported-file warning spam in frontend build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
         "dev:safe": "concurrently \"npm run dev\" \"npm run fix-artifacts\"",
         "fix-artifacts": "node scripts/fix-artifact-error.js",
         "start": "astro dev --host 0.0.0.0 --port=$PORT",
-        "build": "astro build",
+        "build": "node scripts/run-astro-build.mjs",
         "preview": "node scripts/ensure-astro-build.mjs && astro preview --host 0.0.0.0 --port=3000",
         "astro": "astro",
         "setup-test-env": "node scripts/setup-test-env.js",

--- a/frontend/scripts/run-astro-build.mjs
+++ b/frontend/scripts/run-astro-build.mjs
@@ -1,15 +1,22 @@
 import { spawn } from 'node:child_process';
-const ignoredLinePatterns = [/Prefix filename with an underscore/];
+
+// Intentionally filter only Astro's unsupported-file warning spam for known support/content files
+// under frontend/src/pages/**, while preserving every other warning and normal build output.
+const ignoredPatterns = [/Prefix filename with an underscore/];
+const unsupportedFileTypeMarker = 'Unsupported file type';
+const underscoreHintMarker = 'Prefix filename with an underscore';
 
 const knownSvelteRouteSupportFiles = new Set([
     '/src/pages/achievements/Achievements.svelte',
     '/src/pages/dchat/TokenBadge.svelte',
     '/src/pages/inventory/Inventory.svelte',
     '/src/pages/inventory/item/ItemPage.svelte',
+    '/src/pages/item/[slug]/ItemProcesses.svelte',
     '/src/pages/leaderboard/Leaderboard.svelte',
     '/src/pages/process/[slug]/ProcessView.svelte',
     '/src/pages/processes/ProcessListRow.svelte',
     '/src/pages/processes/Processes.svelte',
+    '/src/pages/profile/ProfileTitles.svelte',
     '/src/pages/shop/ShoppingForm.svelte',
     '/src/pages/titles/Titles.svelte',
 ]);
@@ -36,7 +43,7 @@ const knownDataFiles = new Set([
 const normalizePath = (value) => value.replaceAll('\\', '/');
 
 const extractUnsupportedFilePath = (line) => {
-    const match = line.match(/Unsupported file type (.+?) found\./);
+    const match = line.match(/Unsupported file type\s+(.+?)(?:\s+found\.)?(?:\s+Prefix filename with an underscore.*)?$/);
     return match?.[1] ? normalizePath(match[1]) : null;
 };
 
@@ -76,11 +83,11 @@ const createFilteredWriter = (stream) => {
         for (const line of parts) {
             const unsupportedPath = extractUnsupportedFilePath(line);
             if (unsupportedPath && isKnownIntentionalUnsupportedFile(unsupportedPath)) {
-                suppressUnderscoreHintLine = true;
+                suppressUnderscoreHintLine = line.includes(unsupportedFileTypeMarker) && !line.includes(underscoreHintMarker);
                 continue;
             }
 
-            if (suppressUnderscoreHintLine && ignoredLinePatterns.some((pattern) => pattern.test(line))) {
+            if (suppressUnderscoreHintLine && ignoredPatterns.some((pattern) => pattern.test(line))) {
                 suppressUnderscoreHintLine = false;
                 continue;
             }
@@ -92,7 +99,7 @@ const createFilteredWriter = (stream) => {
         if (flush && buffered) {
             const unsupportedPath = extractUnsupportedFilePath(buffered);
             if (!(unsupportedPath && isKnownIntentionalUnsupportedFile(unsupportedPath))) {
-                if (!(suppressUnderscoreHintLine && ignoredLinePatterns.some((pattern) => pattern.test(buffered)))) {
+                if (!(suppressUnderscoreHintLine && ignoredPatterns.some((pattern) => pattern.test(buffered)))) {
                     stream.write(buffered);
                 }
             }

--- a/frontend/scripts/run-astro-build.mjs
+++ b/frontend/scripts/run-astro-build.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process';
+
+const ignoredPatterns = [/Unsupported file type .*Prefix filename with an underscore/];
+
+const shouldKeepLine = (line) => !ignoredPatterns.some((pattern) => pattern.test(line));
+
+const createFilteredWriter = (stream) => {
+    let buffered = '';
+
+    return (chunk, flush = false) => {
+        buffered += chunk;
+        const parts = buffered.split('\n');
+        buffered = parts.pop() ?? '';
+
+        for (const line of parts) {
+            if (shouldKeepLine(line)) {
+                stream.write(`${line}\n`);
+            }
+        }
+
+        if (flush && buffered && shouldKeepLine(buffered)) {
+            stream.write(buffered);
+            buffered = '';
+        }
+    };
+};
+
+const child = spawn('astro', ['build'], {
+    env: process.env,
+    stdio: 'pipe',
+    shell: true,
+});
+
+const writeStdout = createFilteredWriter(process.stdout);
+const writeStderr = createFilteredWriter(process.stderr);
+
+child.stdout.on('data', (chunk) => writeStdout(chunk.toString()));
+child.stderr.on('data', (chunk) => writeStderr(chunk.toString()));
+
+child.on('close', (code, signal) => {
+    writeStdout('', true);
+    writeStderr('', true);
+
+    if (signal) {
+        console.error(`astro build exited due to signal ${signal}`);
+        process.exit(1);
+    }
+
+    process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+    console.error('Failed to run astro build:', error);
+    process.exit(1);
+});

--- a/frontend/scripts/run-astro-build.mjs
+++ b/frontend/scripts/run-astro-build.mjs
@@ -1,11 +1,72 @@
 import { spawn } from 'node:child_process';
+const ignoredLinePatterns = [/Prefix filename with an underscore/];
 
-const ignoredPatterns = [/Unsupported file type .*Prefix filename with an underscore/];
+const knownSvelteRouteSupportFiles = new Set([
+    '/src/pages/achievements/Achievements.svelte',
+    '/src/pages/dchat/TokenBadge.svelte',
+    '/src/pages/inventory/Inventory.svelte',
+    '/src/pages/inventory/item/ItemPage.svelte',
+    '/src/pages/leaderboard/Leaderboard.svelte',
+    '/src/pages/process/[slug]/ProcessView.svelte',
+    '/src/pages/processes/ProcessListRow.svelte',
+    '/src/pages/processes/Processes.svelte',
+    '/src/pages/shop/ShoppingForm.svelte',
+    '/src/pages/titles/Titles.svelte',
+]);
 
-const shouldKeepLine = (line) => !ignoredPatterns.some((pattern) => pattern.test(line));
+const knownDataFilePrefixes = [
+    '/src/pages/docs/images/',
+    '/src/pages/docs/json/',
+    '/src/pages/inventory/json/',
+    '/src/pages/inventory/jsonSchemas/',
+    '/src/pages/processes/hardening/',
+    '/src/pages/quests/archive/',
+    '/src/pages/quests/json/',
+    '/src/pages/quests/jsonSchemas/',
+    '/src/pages/quests/templates/',
+    '/src/pages/sharedSchemas/',
+];
+
+const knownDataFiles = new Set([
+    '/src/pages/docs/sections.json',
+    '/src/pages/processes/base.json',
+    '/src/pages/processes/process.schema.json',
+]);
+
+const normalizePath = (value) => value.replaceAll('\\', '/');
+
+const extractUnsupportedFilePath = (line) => {
+    const match = line.match(/Unsupported file type (.+?) found\./);
+    return match?.[1] ? normalizePath(match[1]) : null;
+};
+
+const isKnownIntentionalUnsupportedFile = (filePath) => {
+    const normalizedPath = normalizePath(filePath);
+
+    if (!normalizedPath.includes('/src/pages/')) {
+        return false;
+    }
+
+    if (/\/src\/pages\/.*\/svelte\/.+\.svelte$/.test(normalizedPath)) {
+        return true;
+    }
+
+    if (knownSvelteRouteSupportFiles.has(normalizedPath.slice(normalizedPath.indexOf('/src/pages/')))) {
+        return true;
+    }
+
+    const pagesRelativePath = normalizedPath.slice(normalizedPath.indexOf('/src/pages/'));
+
+    if (knownDataFiles.has(pagesRelativePath)) {
+        return true;
+    }
+
+    return knownDataFilePrefixes.some((prefix) => pagesRelativePath.startsWith(prefix));
+};
 
 const createFilteredWriter = (stream) => {
     let buffered = '';
+    let suppressUnderscoreHintLine = false;
 
     return (chunk, flush = false) => {
         buffered += chunk;
@@ -13,19 +74,35 @@ const createFilteredWriter = (stream) => {
         buffered = parts.pop() ?? '';
 
         for (const line of parts) {
-            if (shouldKeepLine(line)) {
-                stream.write(`${line}\n`);
+            const unsupportedPath = extractUnsupportedFilePath(line);
+            if (unsupportedPath && isKnownIntentionalUnsupportedFile(unsupportedPath)) {
+                suppressUnderscoreHintLine = true;
+                continue;
             }
+
+            if (suppressUnderscoreHintLine && ignoredLinePatterns.some((pattern) => pattern.test(line))) {
+                suppressUnderscoreHintLine = false;
+                continue;
+            }
+
+            suppressUnderscoreHintLine = false;
+            stream.write(`${line}\n`);
         }
 
-        if (flush && buffered && shouldKeepLine(buffered)) {
-            stream.write(buffered);
+        if (flush && buffered) {
+            const unsupportedPath = extractUnsupportedFilePath(buffered);
+            if (!(unsupportedPath && isKnownIntentionalUnsupportedFile(unsupportedPath))) {
+                if (!(suppressUnderscoreHintLine && ignoredLinePatterns.some((pattern) => pattern.test(buffered)))) {
+                    stream.write(buffered);
+                }
+            }
             buffered = '';
+            suppressUnderscoreHintLine = false;
         }
     };
 };
 
-const child = spawn('astro', ['build'], {
+const child = spawn('astro', ['build', ...process.argv.slice(2)], {
     env: process.env,
     stdio: 'pipe',
     shell: true,
@@ -43,7 +120,8 @@ child.on('close', (code, signal) => {
 
     if (signal) {
         console.error(`astro build exited due to signal ${signal}`);
-        process.exit(1);
+        process.kill(process.pid, signal);
+        return;
     }
 
     process.exit(code ?? 1);


### PR DESCRIPTION
### Motivation
- Astro emits repeated “Unsupported file type … Prefix filename with an underscore” warnings because intentional support/content files (e.g. `.svelte`, `.json`, `.txt`) live under `frontend/src/pages`, flooding build/setup logs. 
- The goal is to eliminate the spam with a minimal, low-risk change that preserves routing, docs, quests, and runtime behavior.

### Description
- Replace the frontend `build` script in `frontend/package.json` to run a small wrapper instead of calling `astro build` directly. 
- Add `frontend/scripts/run-astro-build.mjs`, a tiny runner that executes `astro build` and filters only the known unsupported-file warning pattern while leaving all other build output and exit codes unchanged. 
- The change is narrowly scoped to filtering the single warning pattern and does not rename, move, or otherwise modify content under `frontend/src/pages`.

### Testing
- Ran `npm run build` at the repo root and the build completed successfully with the unsupported-file warnings removed. 
- Ran `npm --prefix frontend run build` and the frontend build completed successfully with the warnings filtered. 
- Ran `npm test -- --help` and the command returned expected help output (setup/build hooks executed) without the previous warning spam.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecc610dc832fb883d6ac8e3852d0)