### PR TITLE
🔧 fix: dedupe Playwright headless-shell warning spam

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -7,6 +7,7 @@ const PLAYWRIGHT_RELATIVE_CLI = path.join('node_modules', '@playwright', 'test',
 const INSTALL_ARGS = ['install', 'chromium', 'chromium-headless-shell'];
 const INSTALL_DEPS_ARGS = ['install-deps'];
 const INSTALL_DEPS_SENTINEL = '.playwright-deps-installed';
+const warnedMissingHeadlessShellPaths = new Set();
 const PROXY_ENV_KEYS = [
     'HTTP_PROXY',
     'http_proxy',
@@ -144,9 +145,12 @@ export function hasChromiumExecutable(browser) {
 
         const headlessShellPath = resolveHeadlessShellPath(executablePath);
         if (!headlessShellPath || !existsSync(headlessShellPath)) {
-            console.warn(
-                `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
-            );
+            if (!warnedMissingHeadlessShellPaths.has(executablePath)) {
+                warnedMissingHeadlessShellPaths.add(executablePath);
+                console.warn(
+                    `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
+                );
+            }
             return true;
         }
 

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -276,7 +276,13 @@ describe('ensurePlaywrightBrowsers', () => {
         existsSync: vi.fn((candidate: string) => {
           return (
             candidate ===
-            path.join(frontendRoot, 'node_modules', '@playwright', 'test', 'cli.js')
+            path.join(
+              frontendRoot,
+              'node_modules',
+              '@playwright',
+              'test',
+              'cli.js'
+            )
           );
         }),
         mkdirSync,
@@ -377,6 +383,62 @@ describe('ensurePlaywrightBrowsers', () => {
       expect(executablePath).toHaveBeenCalledTimes(1);
       expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
       expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('headless shell is missing')
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('logs missing headless shell warning at most once per chromium executable', async () => {
+    const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
+    const chromeExecutable = path.join(
+      cacheRoot,
+      'chromium-1181',
+      'chrome-linux',
+      'chrome'
+    );
+    const cliPath = path.join(
+      frontendRoot,
+      'node_modules',
+      '@playwright',
+      'test',
+      'cli.js'
+    );
+    const existsSync = vi.fn(
+      (candidate: string) =>
+        candidate === cliPath || candidate === chromeExecutable
+    );
+    const executablePath = vi.fn(() => chromeExecutable);
+    const browser = { executablePath };
+
+    vi.doMock('node:child_process', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:child_process')>(
+          'node:child_process'
+        );
+      return {
+        ...actual,
+        execFileSync: vi.fn(),
+        default: { ...actual, execFileSync: vi.fn() },
+      };
+    });
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        existsSync,
+        default: { ...actual, existsSync },
+      };
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
+      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
+      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('headless shell is missing')
       );


### PR DESCRIPTION
### Motivation
- Repeated Playwright readiness checks logged the same fallback message for missing `chromium-headless-shell` each time, creating noisy E2E output that made logs hard to scan. 
- The change aims to keep the existing safe fallback (continue with Chromium when headless shell is absent) while eliminating duplicate warnings per Chromium executable path.

### Description
- Add an in-process memo (`warnedMissingHeadlessShellPaths`) so `hasChromiumExecutable()` emits the missing headless-shell warning at most once per Chromium executable path. 
- Preserve existing behavior (do not change install flow or requirement to download `chromium-headless-shell`) and only reduce noisy logging. 
- Add a focused regression test that calls `ensurePlaywrightBrowsers()` twice with the same executable and asserts the warning is emitted only once. 

Fenced diff (key changes):
```diff
diff --git a/frontend/scripts/utils/ensure-playwright-browsers.js b/frontend/scripts/utils/ensure-playwright-browsers.js
@@
-const INSTALL_DEPS_SENTINEL = '.playwright-deps-installed';
+const INSTALL_DEPS_SENTINEL = '.playwright-deps-installed';
+const warnedMissingHeadlessShellPaths = new Set();
@@
-        if (!headlessShellPath || !existsSync(headlessShellPath)) {
-            console.warn(
-                `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
-            );
-            return true;
-        }
+        if (!headlessShellPath || !existsSync(headlessShellPath)) {
+            if (!warnedMissingHeadlessShellPaths.has(executablePath)) {
+                warnedMissingHeadlessShellPaths.add(executablePath);
+                console.warn(
+                    `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
+                );
+            }
+            return true;
+        }
```

Files changed:
- `frontend/scripts/utils/ensure-playwright-browsers.js` (add Set and guard the warning)
- `scripts/tests/ensurePlaywrightBrowsers.test.ts` (add regression test for single-warning behavior)

### Testing
- Ran `npm run playwright:install` which completed successfully and downloaded Chromium + `chromium-headless-shell` and required system deps. 
- Ran `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts` and both test files passed (`2 files, 17 tests` passed). 
- Ran `cd frontend && npx playwright test test-coverage.spec.ts --workers=1 --reporter=dot` and the spec passed (`7 passed`), and the E2E run no longer produced repeated `headless shell is missing` spam (the regression test confirms `console.warn` was called exactly once for the same executable path).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf6b081e0832fb1db225bf33750cd)