### PR TITLE
fix: dedupe Playwright headless-shell fallback warning

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -18,6 +18,7 @@ const PROXY_ENV_KEYS = [
     'npm_config_https_proxy',
 ];
 const PROXY_PLACEHOLDERS = new Set(['http://proxy:8080', 'https://proxy:8080', 'proxy:8080']);
+const warnedMissingHeadlessShellExecutables = new Set();
 
 function hasPlaceholderProxyEnv(env = process.env) {
     return PROXY_ENV_KEYS.some((key) => {
@@ -144,9 +145,12 @@ export function hasChromiumExecutable(browser) {
 
         const headlessShellPath = resolveHeadlessShellPath(executablePath);
         if (!headlessShellPath || !existsSync(headlessShellPath)) {
-            console.warn(
-                `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
-            );
+            if (!warnedMissingHeadlessShellExecutables.has(executablePath)) {
+                warnedMissingHeadlessShellExecutables.add(executablePath);
+                console.warn(
+                    `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
+                );
+            }
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- Reduce repeated noisy warnings when Playwright's Chromium binary is present but the `chromium-headless-shell` artifact is missing during repeated E2E setup checks.

### Description
- Add a module-level `Set` `warnedMissingHeadlessShellExecutables` and gate the `console.warn` in `frontend/scripts/utils/ensure-playwright-browsers.js` so the missing headless-shell message is emitted at most once per Chromium executable path.

### Testing
- Ran `npm run playwright:install` which completed successfully; ran `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts` and both test files passed; ran `cd frontend && npx playwright test test-coverage.spec.ts --workers=1 --reporter=dot` and the Playwright coverage spec passed with the repeated headless-shell warning removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf6b081e0832fb1db225bf33750cd)