### PR TITLE
De-duplicate Playwright missing headless-shell warning

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -18,6 +18,7 @@ const PROXY_ENV_KEYS = [
     'npm_config_https_proxy',
 ];
 const PROXY_PLACEHOLDERS = new Set(['http://proxy:8080', 'https://proxy:8080', 'proxy:8080']);
+const warnedMissingHeadlessShellPaths = new Set();
 
 function hasPlaceholderProxyEnv(env = process.env) {
     return PROXY_ENV_KEYS.some((key) => {
@@ -144,9 +145,12 @@ export function hasChromiumExecutable(browser) {
 
         const headlessShellPath = resolveHeadlessShellPath(executablePath);
         if (!headlessShellPath || !existsSync(headlessShellPath)) {
-            console.warn(
-                `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
-            );
+            if (!warnedMissingHeadlessShellPaths.has(executablePath)) {
+                warnedMissingHeadlessShellPaths.add(executablePath);
+                console.warn(
+                    `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only.`
+                );
+            }
             return true;
         }
 


### PR DESCRIPTION
### Motivation
- Prevent repeated log spam from `ensure-playwright-browsers` when Playwright's Chromium binary is present but the separate `headless_shell` artifact is missing by emitting the fallback warning at most once per Chromium executable path.

### Description
- Added a `Set` (`warnedMissingHeadlessShellPaths`) and gated the `console.warn` in `hasChromiumExecutable()` so the same warning is only logged once per `executablePath`, preserving the existing fallback behavior.
- File changed: `frontend/scripts/utils/ensure-playwright-browsers.js`.

### Testing
- Ran `npm run playwright:install` which completed and installed Chromium + headless shell successfully.
- Ran `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts` and both test files passed (16 tests total).
- Ran `cd frontend && npx playwright test test-coverage.spec.ts --workers=1 --reporter=dot` and the Playwright run passed (7 tests) with the repeated headless-shell warning no longer appearing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf6b081e0832fb1db225bf33750cd)