### PR TITLE
Reduce noisy passing-path E2E logs

### DIFF
--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -5,10 +5,10 @@ import { test, expect, Page } from '@playwright/test';
 import {
     clearUserData,
     createTestItems,
+    debugLog,
     fillProcessForm,
     ItemSelectorHelper,
 } from './test-helpers';
-const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
 const inlineItemImageBuffer = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgIBJ3QpJ8gAAAAASUVORK5CYII=',
@@ -738,9 +738,7 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                if (E2E_DEBUG_LOGS) {
-                    console.log(`Selector ${selector} didn't find item, trying another...`);
-                }
+                debugLog(`Selector ${selector} didn't find item, trying another...`);
             }
         }
 
@@ -749,9 +747,7 @@ test.describe('Custom Content Management', () => {
 
         // If we still can't find it, log but continue the test
         if (!itemFound) {
-            if (E2E_DEBUG_LOGS) {
-                console.log('Could not find item in the inventory, but continuing the test');
-            }
+            debugLog('Could not find item in the inventory, but continuing the test');
             // Don't fail here - let the test continue
         }
 
@@ -802,9 +798,7 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                if (E2E_DEBUG_LOGS) {
-                    console.log(`Selector ${selector} didn't find process, trying another...`);
-                }
+                debugLog(`Selector ${selector} didn't find process, trying another...`);
             }
         }
 
@@ -862,13 +856,13 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find quest, trying another...`);
+                debugLog(`Selector ${selector} didn't find quest, trying another...`);
             }
         }
 
         // If we can't find it, log but continue the test
         if (!questFound) {
-            console.log('Could not find quest entry immediately, may be due to delayed indexing');
+            debugLog('Could not find quest entry immediately, may be due to delayed indexing');
         }
 
         // Take the final test screenshot

--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -215,9 +215,9 @@ test.describe('Custom Content Management', () => {
         // Create some items first that we can use in the process
         try {
             const itemIds = await createTestItems(page, 2);
-            console.log(`Created ${itemIds.length} test items for process test`);
+            debugLog(`Created ${itemIds.length} test items for process test`);
         } catch (e) {
-            console.log('Failed to create test items, but continuing with test');
+            debugLog('Failed to create test items, but continuing with test');
         }
 
         // Navigate to the process creation page
@@ -279,7 +279,7 @@ test.describe('Custom Content Management', () => {
             expect(success).toBe(true);
         } else {
             // If we couldn't find a submit button, take a screenshot and mark test as passed if we at least filled some fields
-            console.log('No submit button found - form may have changed');
+            debugLog('No submit button found - form may have changed');
             await page.screenshot({ path: './test-artifacts/process-form-no-submit.png' });
 
             // Consider test successful if we at least filled the name field
@@ -626,7 +626,7 @@ test.describe('Custom Content Management', () => {
             // Wait for navigation
             await page.waitForLoadState('networkidle');
         } catch (e) {
-            console.log('Failed to create initial test item, but continuing with test');
+            debugLog('Failed to create initial test item, but continuing with test');
         }
 
         // Navigate to the inventory page
@@ -669,7 +669,7 @@ test.describe('Custom Content Management', () => {
             // Check that we're on the processes page
             expect(page.url()).toContain('/process');
         } catch (e) {
-            console.log('Processes page may not exist, skipping');
+            debugLog('Processes page may not exist, skipping');
         }
     });
 

--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -8,6 +8,7 @@ import {
     fillProcessForm,
     ItemSelectorHelper,
 } from './test-helpers';
+const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
 const inlineItemImageBuffer = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgIBJ3QpJ8gAAAAASUVORK5CYII=',
@@ -737,7 +738,9 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find item, trying another...`);
+                if (E2E_DEBUG_LOGS) {
+                    console.log(`Selector ${selector} didn't find item, trying another...`);
+                }
             }
         }
 
@@ -746,7 +749,9 @@ test.describe('Custom Content Management', () => {
 
         // If we still can't find it, log but continue the test
         if (!itemFound) {
-            console.log('Could not find item in the inventory, but continuing the test');
+            if (E2E_DEBUG_LOGS) {
+                console.log('Could not find item in the inventory, but continuing the test');
+            }
             // Don't fail here - let the test continue
         }
 
@@ -797,7 +802,9 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find process, trying another...`);
+                if (E2E_DEBUG_LOGS) {
+                    console.log(`Selector ${selector} didn't find process, trying another...`);
+                }
             }
         }
 

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -8,6 +8,7 @@ const PERF_MARKS = [
     'quests:full-state-reconciliation-complete',
     'quests:custom-quests-merge-complete',
 ];
+const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
 test.describe('quests performance marks', () => {
     test.beforeEach(async ({ page }) => {
@@ -60,6 +61,11 @@ test.describe('quests performance marks', () => {
             expect(metrics.markTimes[markName]).not.toBeNull();
         }
 
-        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+        if (E2E_DEBUG_LOGS) {
+            console.log(
+                '[quests-tti-metrics]',
+                JSON.stringify({ cpuSlowdown, ...metrics }, null, 2)
+            );
+        }
     });
 });

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -8,7 +8,6 @@ const PERF_MARKS = [
     'quests:full-state-reconciliation-complete',
     'quests:custom-quests-merge-complete',
 ];
-const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
 test.describe('quests performance marks', () => {
     test.beforeEach(async ({ page }) => {
@@ -61,11 +60,6 @@ test.describe('quests performance marks', () => {
             expect(metrics.markTimes[markName]).not.toBeNull();
         }
 
-        if (E2E_DEBUG_LOGS) {
-            console.log(
-                '[quests-tti-metrics]',
-                JSON.stringify({ cpuSlowdown, ...metrics }, null, 2)
-            );
-        }
+        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
     });
 });

--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -38,11 +38,6 @@ test('verify no e2e test files are orphaned from test:pr workflow', async () => 
     // Find orphaned files (files not referenced in any test group)
     const orphanedFiles = allTestFiles.filter((file) => !referencedFiles.has(file));
 
-    // Log the found files for debugging
-    console.log('All test files:', allTestFiles);
-    console.log('Referenced files:', Array.from(referencedFiles));
-    console.log('Orphaned files:', orphanedFiles);
-
     // Test will fail if there are any orphaned files
     if (orphanedFiles.length > 0) {
         const errorMessage = `Found ${
@@ -186,8 +181,6 @@ test('verify Jest test files are included in Jest configuration', async () => {
         jestConfigCapturesAllFiles = true;
     }
 
-    console.log('All Jest test files:', allJestTestFiles);
-
     if (!jestConfigCapturesAllFiles) {
         const errorMessage =
             'Jest configuration might not capture all test files. ' +
@@ -262,9 +255,8 @@ test('verify playwright web server is properly configured', async ({ page }, tes
     // Take a screenshot to see what loaded
     await page.screenshot({ path: './test-artifacts/webserver-test.png' });
 
-    // Check that the page loaded successfully
     const pageTitle = await page.title();
-    console.log('Page title:', pageTitle);
+    expect(pageTitle.length).toBeGreaterThan(0);
 
     // Verify we can interact with the page - using a specific element to avoid strict mode violations
     const mainContent = page.locator('main').first();
@@ -286,8 +278,6 @@ test('verify playwright web server is properly configured', async ({ page }, tes
         expect(url).toContain(configuredBaseURL.replace(/\/$/, ''));
     }
 
-    console.log('Page URL:', url);
-
     // Get the playwright config to confirm the webServer settings
     const configPath = path.resolve(__dirname, '../playwright.config.ts');
 
@@ -301,8 +291,6 @@ test('verify playwright web server is properly configured', async ({ page }, tes
         /command:\s*`[^`]*?(?:npx\s+)?astro preview --host 0\.0\.0\.0 --port \$\{port}/
     );
     expect(configContent).toContain('url: baseURL');
-
-    console.log('Playwright webServer is properly configured and running');
 });
 
 test('verify browser has necessary capabilities for tests', async ({ page }) => {
@@ -313,7 +301,6 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
     // Check that JavaScript is enabled (will always pass if we got this far)
     const jsEnabled = await page.evaluate(() => true);
     expect(jsEnabled).toBeTruthy();
-    console.log('JavaScript is enabled');
 
     // Store the results of optional capability checks
     const capabilities = {
@@ -336,13 +323,10 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('localStorage test result:', localStorageAvailable);
         capabilities.localStorage = localStorageAvailable;
 
         if (!localStorageAvailable) {
             console.warn('localStorage is not available. This may affect game save tests.');
-        } else {
-            console.log('localStorage is available and functioning correctly');
         }
     } catch (e) {
         console.warn('Could not test localStorage:', e);
@@ -359,13 +343,10 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Cookies enabled test result:', cookiesEnabled);
         capabilities.cookies = cookiesEnabled;
 
         if (!cookiesEnabled) {
             console.warn('Cookies may be disabled. This could affect login/session tests.');
-        } else {
-            console.log('Cookies are enabled');
         }
     } catch (e) {
         console.warn('Could not test cookies:', e);
@@ -383,26 +364,14 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Fetch test result:', fetchWorks);
         capabilities.fetch = fetchWorks;
 
         if (!fetchWorks) {
             console.warn('Fetch API may not be working. This could affect API tests.');
-        } else {
-            console.log('Browser can make fetch requests');
         }
     } catch (e) {
         console.warn('Could not test fetch capability:', e);
     }
-
-    // Overall browser capability check
-    console.log('Browser capability summary:');
-    console.log('- JavaScript: ✅ (required)');
-    console.log(
-        `- localStorage: ${capabilities.localStorage ? '✅' : '❌'} (optional but recommended)`
-    );
-    console.log(`- Cookies: ${capabilities.cookies ? '✅' : '❌'} (optional but recommended)`);
-    console.log(`- Fetch API: ${capabilities.fetch ? '✅' : '❌'} (optional but recommended)`);
 
     // Log a warning if some capabilities are missing
     if (!capabilities.localStorage || !capabilities.cookies || !capabilities.fetch) {

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -5,7 +5,7 @@ import { ITEM_SELECTOR_OPTION_LOCATORS } from './utils/itemSelectors';
 export type { Page };
 const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
-function debugLog(...args: unknown[]): void {
+export function debugLog(...args: unknown[]): void {
     if (E2E_DEBUG_LOGS) {
         console.log(...args);
     }
@@ -886,7 +886,7 @@ async function trySelectItem(page: Page): Promise<boolean> {
             return true;
         }
     } catch (e) {
-        console.log('Error trying to select item:', e);
+        debugLog('Error trying to select item:', e);
     }
 
     return false;

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -1023,7 +1023,6 @@ export async function addTestItems(page: Page): Promise<void> {
 
         // Save back to localStorage
         localStorage.setItem('inventory', JSON.stringify(inventory));
-        console.log('Added test items to inventory');
     });
 }
 

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -3,6 +3,13 @@ import type { Locator, Page } from '@playwright/test';
 import { ITEM_SELECTOR_OPTION_LOCATORS } from './utils/itemSelectors';
 
 export type { Page };
+const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
+
+function debugLog(...args: unknown[]): void {
+    if (E2E_DEBUG_LOGS) {
+        console.log(...args);
+    }
+}
 
 const CONNECTION_REFUSED_PATTERNS = [
     'ECONNREFUSED',
@@ -597,7 +604,7 @@ export async function createTestItems(page: Page, count = 2): Promise<string[]> 
             }
         } catch (e) {
             // If no success message, we might have been redirected to inventory already
-            console.log('No success message found, checking for redirect');
+            debugLog('No success message found, checking for redirect');
         }
 
         // If we couldn't extract an ID but the item was created, at least return something
@@ -631,12 +638,12 @@ export async function findAndClickButton(page: Page, buttonText: string): Promis
     }
 
     // Log what we found
-    console.log(`Found ${await buttonLocator.count()} buttons matching "${buttonText}"`);
+    debugLog(`Found ${await buttonLocator.count()} buttons matching "${buttonText}"`);
 
     // Click if found
     if ((await buttonLocator.count()) > 0) {
         await buttonLocator.click();
-        console.log(`Clicked "${buttonText}" button`);
+        debugLog(`Clicked "${buttonText}" button`);
         return true;
     }
 
@@ -669,7 +676,7 @@ export class ItemSelectorHelper {
 
         // If either is visible, consider it expanded
         if ((await expandedView.count()) > 0 || (await itemsList.count()) > 0) {
-            console.log('Item selector already expanded');
+            debugLog('Item selector already expanded');
             await expect(expansionLocator.first()).toBeVisible();
             return true;
         }
@@ -685,13 +692,13 @@ export class ItemSelectorHelper {
             });
 
             await selectButton.first().click();
-            console.log('Clicked Select Item button');
+            debugLog('Clicked Select Item button');
 
             await expect(expansionLocator.first()).toBeVisible();
             return true;
         }
 
-        console.log('Could not open item selector');
+        debugLog('Could not open item selector');
         return false;
     }
 
@@ -714,12 +721,12 @@ export class ItemSelectorHelper {
         const itemRows = container.locator('.item-option');
         const count = await itemRows.count();
 
-        console.log(`Found ${count} item rows`);
+        debugLog(`Found ${count} item rows`);
 
         if (count > index) {
             // Click the item at specified index
             await itemRows.nth(index).click();
-            console.log(`Clicked item at index ${index}`);
+            debugLog(`Clicked item at index ${index}`);
 
             // Wait for selection to take effect (selector should collapse)
             await expect
@@ -730,7 +737,7 @@ export class ItemSelectorHelper {
             return true;
         }
 
-        console.log(`Could not select item at index ${index}`);
+        debugLog(`Could not select item at index ${index}`);
         return false;
     }
 
@@ -747,11 +754,11 @@ export class ItemSelectorHelper {
 
         if ((await quantityInput.count()) > 0) {
             await quantityInput.fill(quantity.toString());
-            console.log(`Set quantity to ${quantity}`);
+            debugLog(`Set quantity to ${quantity}`);
             return true;
         }
 
-        console.log('Quantity input not found');
+        debugLog('Quantity input not found');
         return false;
     }
 }
@@ -773,17 +780,17 @@ export async function fillProcessForm(
         const nameInput = page.locator('#name, #title').first();
         if ((await nameInput.count()) > 0) {
             await nameInput.fill(title);
-            console.log('Filled process title');
+            debugLog('Filled process title');
         } else {
-            console.log('Could not find name/title input');
+            debugLog('Could not find name/title input');
         }
 
         const durationInput = page.locator('#duration');
         if ((await durationInput.count()) > 0) {
             await durationInput.fill(duration);
-            console.log('Filled duration');
+            debugLog('Filled duration');
         } else {
-            console.log('Could not find duration input');
+            debugLog('Could not find duration input');
         }
 
         // Screenshot after filling basic details
@@ -810,7 +817,7 @@ export async function fillProcessForm(
                 if ((await buttonSelector.count()) > 0) {
                     for (let i = 0; i < count; i++) {
                         await buttonSelector.click();
-                        console.log(`Added ${type} item ${i + 1}`);
+                        debugLog(`Added ${type} item ${i + 1}`);
 
                         // Try to select an item from the dropdown or selector if one appears
                         await expect.poll(async () => await trySelectItem(page)).toBe(true);
@@ -821,7 +828,7 @@ export async function fillProcessForm(
             }
 
             if (!foundButton && count > 0) {
-                console.log(`Could not find button to add ${type} items`);
+                debugLog(`Could not find button to add ${type} items`);
             }
         };
 


### PR DESCRIPTION
### Motivation
- Passing E2E runs produced high-volume console output that obscured real failures and made CI logs noisy.
- Keep rich diagnostics available for failures while making successful runs concise by removing unconditional success-path logs and gating verbose traces.

### Description
- Remove unconditional `console.log` statements from `frontend/e2e/test-coverage.spec.ts` and replace visible-but-unnecessary prints with assertions where appropriate (for example, use `expect(pageTitle.length).toBeGreaterThan(0)` instead of logging the page title).
- Add an environment-gated debug helper `E2E_DEBUG_LOGS` / `debugLog(...)` in `frontend/e2e/test-helpers.ts` and route high-volume helper logs through it so verbose traces are enabled only when `E2E_DEBUG_LOGS=1`.
- Gate noisy selector-retry chatter in `frontend/e2e/custom-content.spec.ts` and the TTI metrics dump in `frontend/e2e/quests-tti-metrics.spec.ts` behind `E2E_DEBUG_LOGS` so diagnostics remain available on demand.
- Keep all failure-path warnings, assertions, attachments (screenshots), and test semantics unchanged.

### Testing
- Ran formatting: `cd frontend && npx prettier --write e2e/test-coverage.spec.ts e2e/test-helpers.ts e2e/custom-content.spec.ts e2e/quests-tti-metrics.spec.ts` and it completed successfully.
- Verified removing/gating of noise via a source search: `cd frontend && rg -n "All test files:|Referenced files:|Orphaned files:|All Jest test files:|Page title:|Page URL:|JavaScript is enabled|localStorage test result|Cookies enabled test result|Fetch test result|Browser capability summary:" e2e` which confirmed the unconditional logs were removed (only a commented line match remained).
- Attempted the required Playwright run: `cd frontend && npx playwright test test-coverage.spec.ts process-creation.spec.ts custom-content.spec.ts quests-tti-metrics.spec.ts --workers=1 --reporter=dot`; this run was blocked by the environment failing to download Playwright browsers/system deps (network/ENETUNREACH) resulting in Playwright browser installation errors and multiple test failures due to missing browser executable, with partial execution showing `5 passed` and the rest failing because browsers could not be installed; this is an environment limitation unrelated to the code changes.
- Summary: formatting and local static verifications passed, grep confirms noisy logs removed, and runtime E2E verification is expected to be quiet on passing runs; full Playwright execution with browsers will verify quieter output in CI where browser install is available.

Files changed: `frontend/e2e/test-coverage.spec.ts`, `frontend/e2e/test-helpers.ts`, `frontend/e2e/custom-content.spec.ts`, `frontend/e2e/quests-tti-metrics.spec.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafce0f5d0832f97af259c1832896f)