### PR TITLE
🧹 Reduce passing E2E log spam (gate verbose logs behind E2E_VERBOSE_LOGS)

### DIFF
--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -21,6 +21,7 @@ const itemImageFile = {
 const itemImagePath = fileURLToPath(
     new URL('../public/assets/220_ohm_resistor.jpg', import.meta.url)
 );
+const E2E_VERBOSE_LOGS = process.env.E2E_VERBOSE_LOGS === '1';
 
 test.describe('Custom Content Management', () => {
     test.setTimeout(120000); // 2 minutes for end-to-end tests
@@ -737,7 +738,9 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find item, trying another...`);
+                if (E2E_VERBOSE_LOGS) {
+                    console.log(`Selector ${selector} didn't find item, trying another...`);
+                }
             }
         }
 
@@ -746,7 +749,9 @@ test.describe('Custom Content Management', () => {
 
         // If we still can't find it, log but continue the test
         if (!itemFound) {
-            console.log('Could not find item in the inventory, but continuing the test');
+            if (E2E_VERBOSE_LOGS) {
+                console.log('Could not find item in the inventory, but continuing the test');
+            }
             // Don't fail here - let the test continue
         }
 

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -8,6 +8,7 @@ const PERF_MARKS = [
     'quests:full-state-reconciliation-complete',
     'quests:custom-quests-merge-complete',
 ];
+const E2E_VERBOSE_LOGS = process.env.E2E_VERBOSE_LOGS === '1';
 
 test.describe('quests performance marks', () => {
     test.beforeEach(async ({ page }) => {
@@ -60,6 +61,8 @@ test.describe('quests performance marks', () => {
             expect(metrics.markTimes[markName]).not.toBeNull();
         }
 
-        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+        if (E2E_VERBOSE_LOGS) {
+            console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+        }
     });
 });

--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const e2eDir = __dirname;
 const testsDir = path.resolve(__dirname, '../__tests__');
+const E2E_VERBOSE_LOGS = process.env.E2E_VERBOSE_LOGS === '1';
 
 test('verify no e2e test files are orphaned from test:pr workflow', async () => {
     // Read the run-test-groups.mjs file content
@@ -38,16 +39,14 @@ test('verify no e2e test files are orphaned from test:pr workflow', async () => 
     // Find orphaned files (files not referenced in any test group)
     const orphanedFiles = allTestFiles.filter((file) => !referencedFiles.has(file));
 
-    // Log the found files for debugging
-    console.log('All test files:', allTestFiles);
-    console.log('Referenced files:', Array.from(referencedFiles));
-    console.log('Orphaned files:', orphanedFiles);
-
     // Test will fail if there are any orphaned files
     if (orphanedFiles.length > 0) {
         const errorMessage = `Found ${
             orphanedFiles.length
         } orphaned test files not included in test:pr workflow: ${orphanedFiles.join(', ')}`;
+        console.error('All test files:', allTestFiles);
+        console.error('Referenced files:', Array.from(referencedFiles));
+        console.error('Orphaned files:', orphanedFiles);
         console.error(errorMessage);
         test.fail(true, errorMessage);
     }
@@ -186,7 +185,9 @@ test('verify Jest test files are included in Jest configuration', async () => {
         jestConfigCapturesAllFiles = true;
     }
 
-    console.log('All Jest test files:', allJestTestFiles);
+    if (E2E_VERBOSE_LOGS) {
+        console.log('All Jest test files:', allJestTestFiles);
+    }
 
     if (!jestConfigCapturesAllFiles) {
         const errorMessage =
@@ -264,8 +265,6 @@ test('verify playwright web server is properly configured', async ({ page }, tes
 
     // Check that the page loaded successfully
     const pageTitle = await page.title();
-    console.log('Page title:', pageTitle);
-
     // Verify we can interact with the page - using a specific element to avoid strict mode violations
     const mainContent = page.locator('main').first();
     await expect(mainContent).toBeVisible();
@@ -286,8 +285,6 @@ test('verify playwright web server is properly configured', async ({ page }, tes
         expect(url).toContain(configuredBaseURL.replace(/\/$/, ''));
     }
 
-    console.log('Page URL:', url);
-
     // Get the playwright config to confirm the webServer settings
     const configPath = path.resolve(__dirname, '../playwright.config.ts');
 
@@ -302,7 +299,11 @@ test('verify playwright web server is properly configured', async ({ page }, tes
     );
     expect(configContent).toContain('url: baseURL');
 
-    console.log('Playwright webServer is properly configured and running');
+    if (E2E_VERBOSE_LOGS) {
+        console.log('Page title:', pageTitle);
+        console.log('Page URL:', url);
+        console.log('Playwright webServer is properly configured and running');
+    }
 });
 
 test('verify browser has necessary capabilities for tests', async ({ page }) => {
@@ -313,7 +314,6 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
     // Check that JavaScript is enabled (will always pass if we got this far)
     const jsEnabled = await page.evaluate(() => true);
     expect(jsEnabled).toBeTruthy();
-    console.log('JavaScript is enabled');
 
     // Store the results of optional capability checks
     const capabilities = {
@@ -336,13 +336,10 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('localStorage test result:', localStorageAvailable);
         capabilities.localStorage = localStorageAvailable;
 
         if (!localStorageAvailable) {
             console.warn('localStorage is not available. This may affect game save tests.');
-        } else {
-            console.log('localStorage is available and functioning correctly');
         }
     } catch (e) {
         console.warn('Could not test localStorage:', e);
@@ -359,13 +356,10 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Cookies enabled test result:', cookiesEnabled);
         capabilities.cookies = cookiesEnabled;
 
         if (!cookiesEnabled) {
             console.warn('Cookies may be disabled. This could affect login/session tests.');
-        } else {
-            console.log('Cookies are enabled');
         }
     } catch (e) {
         console.warn('Could not test cookies:', e);
@@ -383,26 +377,25 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Fetch test result:', fetchWorks);
         capabilities.fetch = fetchWorks;
 
         if (!fetchWorks) {
             console.warn('Fetch API may not be working. This could affect API tests.');
-        } else {
-            console.log('Browser can make fetch requests');
         }
     } catch (e) {
         console.warn('Could not test fetch capability:', e);
     }
 
-    // Overall browser capability check
-    console.log('Browser capability summary:');
-    console.log('- JavaScript: ✅ (required)');
-    console.log(
-        `- localStorage: ${capabilities.localStorage ? '✅' : '❌'} (optional but recommended)`
-    );
-    console.log(`- Cookies: ${capabilities.cookies ? '✅' : '❌'} (optional but recommended)`);
-    console.log(`- Fetch API: ${capabilities.fetch ? '✅' : '❌'} (optional but recommended)`);
+    if (E2E_VERBOSE_LOGS) {
+        // Overall browser capability check
+        console.log('Browser capability summary:');
+        console.log('- JavaScript: ✅ (required)');
+        console.log(
+            `- localStorage: ${capabilities.localStorage ? '✅' : '❌'} (optional but recommended)`
+        );
+        console.log(`- Cookies: ${capabilities.cookies ? '✅' : '❌'} (optional but recommended)`);
+        console.log(`- Fetch API: ${capabilities.fetch ? '✅' : '❌'} (optional but recommended)`);
+    }
 
     // Log a warning if some capabilities are missing
     if (!capabilities.localStorage || !capabilities.cookies || !capabilities.fetch) {

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -14,6 +14,7 @@ const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
 const DEFAULT_MAX_DURATION_MS = 10_000;
+const E2E_VERBOSE_LOGS = process.env.E2E_VERBOSE_LOGS === '1';
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
@@ -73,6 +74,12 @@ async function wait(page: Page, ms: number): Promise<void> {
     }
 
     await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function debugLog(...args: unknown[]): void {
+    if (E2E_VERBOSE_LOGS) {
+        console.log(...args);
+    }
 }
 
 export async function navigateWithRetry(
@@ -597,7 +604,7 @@ export async function createTestItems(page: Page, count = 2): Promise<string[]> 
             }
         } catch (e) {
             // If no success message, we might have been redirected to inventory already
-            console.log('No success message found, checking for redirect');
+            debugLog('No success message found, checking for redirect');
         }
 
         // If we couldn't extract an ID but the item was created, at least return something
@@ -773,17 +780,17 @@ export async function fillProcessForm(
         const nameInput = page.locator('#name, #title').first();
         if ((await nameInput.count()) > 0) {
             await nameInput.fill(title);
-            console.log('Filled process title');
+            debugLog('Filled process title');
         } else {
-            console.log('Could not find name/title input');
+            debugLog('Could not find name/title input');
         }
 
         const durationInput = page.locator('#duration');
         if ((await durationInput.count()) > 0) {
             await durationInput.fill(duration);
-            console.log('Filled duration');
+            debugLog('Filled duration');
         } else {
-            console.log('Could not find duration input');
+            debugLog('Could not find duration input');
         }
 
         // Screenshot after filling basic details
@@ -810,7 +817,7 @@ export async function fillProcessForm(
                 if ((await buttonSelector.count()) > 0) {
                     for (let i = 0; i < count; i++) {
                         await buttonSelector.click();
-                        console.log(`Added ${type} item ${i + 1}`);
+                        debugLog(`Added ${type} item ${i + 1}`);
 
                         // Try to select an item from the dropdown or selector if one appears
                         await expect.poll(async () => await trySelectItem(page)).toBe(true);
@@ -821,7 +828,7 @@ export async function fillProcessForm(
             }
 
             if (!foundButton && count > 0) {
-                console.log(`Could not find button to add ${type} items`);
+                debugLog(`Could not find button to add ${type} items`);
             }
         };
 


### PR DESCRIPTION
### Motivation
- Passing Playwright E2E runs emitted high-volume informational logs that obscured real signal, so reduce noise while keeping failure diagnostics intact.

### Description
- Add an `E2E_VERBOSE_LOGS` gate (`process.env.E2E_VERBOSE_LOGS === '1'`) and a `debugLog()` helper in `frontend/e2e/test-helpers.ts` and use it to replace noisy `console.log` calls emitted during successful flows.
- Move large test-file listing output in the orphaned-files check to the failure branch so file lists are only dumped on test failure in `frontend/e2e/test-coverage.spec.ts`.
- Gate other informational logs (page title/URL, browser capability summary, quests TTI payload, selector/process helper messages) behind `E2E_VERBOSE_LOGS` in `frontend/e2e/test-coverage.spec.ts`, `frontend/e2e/custom-content.spec.ts`, and `frontend/e2e/quests-tti-metrics.spec.ts` while keeping warnings/errors/screenshots/attachments unchanged.
- Files changed: `frontend/e2e/test-coverage.spec.ts`, `frontend/e2e/test-helpers.ts`, `frontend/e2e/custom-content.spec.ts`, `frontend/e2e/quests-tti-metrics.spec.ts`.

### Testing
- Ran secret-scan on the staged diff with `git diff --cached | ./scripts/scan-secrets.py` which produced no findings.
- Attempted the targeted Playwright verification: `cd frontend && npx playwright test test-coverage.spec.ts process-creation.spec.ts custom-content.spec.ts quests-tti-metrics.spec.ts --workers=1 --reporter=dot`; the run could not complete because Playwright attempted to install system/browser dependencies and downloads failed due to network unreachable/`ENETUNREACH` during environment setup, so E2E execution was blocked by infrastructure rather than the code change.
- Behavioural checks performed in-code: file-list dump is only emitted via `console.error` when the orphaned-files test fails and all gated logs are controlled by `E2E_VERBOSE_LOGS`, so passing runs are expected to be substantially quieter; set `E2E_VERBOSE_LOGS=1` to re-enable full verbose output when debugging.

How to verify locally (when network and Playwright browsers are available):
- Install browsers and run the targeted specs with dot reporter: `cd frontend && npx playwright install-deps && npx playwright install && npx playwright test test-coverage.spec.ts process-creation.spec.ts custom-content.spec.ts quests-tti-metrics.spec.ts --workers=1 --reporter=dot`
- To see verbose logs, prefix with `E2E_VERBOSE_LOGS=1`: `E2E_VERBOSE_LOGS=1 npx playwright test ...`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafce0f5d0832f97af259c1832896f)