### PR TITLE
🧹 Reduce E2E passing log noise

### DIFF
--- a/frontend/e2e/custom-content.spec.ts
+++ b/frontend/e2e/custom-content.spec.ts
@@ -22,6 +22,13 @@ const itemImagePath = fileURLToPath(
     new URL('../public/assets/220_ohm_resistor.jpg', import.meta.url)
 );
 
+const isDebugLoggingEnabled = process.env.E2E_DEBUG_LOGS === '1';
+const debugLog = (...args: unknown[]) => {
+    if (isDebugLoggingEnabled) {
+        console.log(...args);
+    }
+};
+
 test.describe('Custom Content Management', () => {
     test.setTimeout(120000); // 2 minutes for end-to-end tests
     test.use({ serviceWorkers: 'block' });
@@ -214,9 +221,9 @@ test.describe('Custom Content Management', () => {
         // Create some items first that we can use in the process
         try {
             const itemIds = await createTestItems(page, 2);
-            console.log(`Created ${itemIds.length} test items for process test`);
+            debugLog(`Created ${itemIds.length} test items for process test`);
         } catch (e) {
-            console.log('Failed to create test items, but continuing with test');
+            debugLog('Failed to create test items, but continuing with test');
         }
 
         // Navigate to the process creation page
@@ -278,7 +285,7 @@ test.describe('Custom Content Management', () => {
             expect(success).toBe(true);
         } else {
             // If we couldn't find a submit button, take a screenshot and mark test as passed if we at least filled some fields
-            console.log('No submit button found - form may have changed');
+            debugLog('No submit button found - form may have changed');
             await page.screenshot({ path: './test-artifacts/process-form-no-submit.png' });
 
             // Consider test successful if we at least filled the name field
@@ -625,7 +632,7 @@ test.describe('Custom Content Management', () => {
             // Wait for navigation
             await page.waitForLoadState('networkidle');
         } catch (e) {
-            console.log('Failed to create initial test item, but continuing with test');
+            debugLog('Failed to create initial test item, but continuing with test');
         }
 
         // Navigate to the inventory page
@@ -668,7 +675,7 @@ test.describe('Custom Content Management', () => {
             // Check that we're on the processes page
             expect(page.url()).toContain('/process');
         } catch (e) {
-            console.log('Processes page may not exist, skipping');
+            debugLog('Processes page may not exist, skipping');
         }
     });
 
@@ -737,7 +744,7 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find item, trying another...`);
+                debugLog(`Selector ${selector} didn't find item, trying another...`);
             }
         }
 
@@ -746,7 +753,7 @@ test.describe('Custom Content Management', () => {
 
         // If we still can't find it, log but continue the test
         if (!itemFound) {
-            console.log('Could not find item in the inventory, but continuing the test');
+            debugLog('Could not find item in the inventory, but continuing the test');
             // Don't fail here - let the test continue
         }
 
@@ -797,7 +804,7 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find process, trying another...`);
+                debugLog(`Selector ${selector} didn't find process, trying another...`);
             }
         }
 
@@ -855,13 +862,13 @@ test.describe('Custom Content Management', () => {
                 }
             } catch (e) {
                 // Continue trying different selectors
-                console.log(`Selector ${selector} didn't find quest, trying another...`);
+                debugLog(`Selector ${selector} didn't find quest, trying another...`);
             }
         }
 
         // If we can't find it, log but continue the test
         if (!questFound) {
-            console.log('Could not find quest entry immediately, may be due to delayed indexing');
+            debugLog('Could not find quest entry immediately, may be due to delayed indexing');
         }
 
         // Take the final test screenshot

--- a/frontend/e2e/quests-tti-metrics.spec.ts
+++ b/frontend/e2e/quests-tti-metrics.spec.ts
@@ -8,6 +8,7 @@ const PERF_MARKS = [
     'quests:full-state-reconciliation-complete',
     'quests:custom-quests-merge-complete',
 ];
+const isDebugLoggingEnabled = process.env.E2E_DEBUG_LOGS === '1';
 
 test.describe('quests performance marks', () => {
     test.beforeEach(async ({ page }) => {
@@ -60,6 +61,8 @@ test.describe('quests performance marks', () => {
             expect(metrics.markTimes[markName]).not.toBeNull();
         }
 
-        console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+        if (isDebugLoggingEnabled) {
+            console.log('[quests-tti-metrics]', JSON.stringify({ cpuSlowdown, ...metrics }, null, 2));
+        }
     });
 });

--- a/frontend/e2e/test-coverage.spec.ts
+++ b/frontend/e2e/test-coverage.spec.ts
@@ -9,6 +9,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const e2eDir = __dirname;
 const testsDir = path.resolve(__dirname, '../__tests__');
+const isDebugLoggingEnabled = process.env.E2E_DEBUG_LOGS === '1';
+const debugLog = (...args: unknown[]) => {
+    if (isDebugLoggingEnabled) {
+        console.log(...args);
+    }
+};
 
 test('verify no e2e test files are orphaned from test:pr workflow', async () => {
     // Read the run-test-groups.mjs file content
@@ -38,16 +44,14 @@ test('verify no e2e test files are orphaned from test:pr workflow', async () => 
     // Find orphaned files (files not referenced in any test group)
     const orphanedFiles = allTestFiles.filter((file) => !referencedFiles.has(file));
 
-    // Log the found files for debugging
-    console.log('All test files:', allTestFiles);
-    console.log('Referenced files:', Array.from(referencedFiles));
-    console.log('Orphaned files:', orphanedFiles);
-
     // Test will fail if there are any orphaned files
     if (orphanedFiles.length > 0) {
         const errorMessage = `Found ${
             orphanedFiles.length
         } orphaned test files not included in test:pr workflow: ${orphanedFiles.join(', ')}`;
+        console.error('All test files:', allTestFiles);
+        console.error('Referenced files:', Array.from(referencedFiles));
+        console.error('Orphaned files:', orphanedFiles);
         console.error(errorMessage);
         test.fail(true, errorMessage);
     }
@@ -186,9 +190,8 @@ test('verify Jest test files are included in Jest configuration', async () => {
         jestConfigCapturesAllFiles = true;
     }
 
-    console.log('All Jest test files:', allJestTestFiles);
-
     if (!jestConfigCapturesAllFiles) {
+        console.error('All Jest test files:', allJestTestFiles);
         const errorMessage =
             'Jest configuration might not capture all test files. ' +
             'Make sure testMatch includes "**/*.test.js" or similar pattern in package.json or jest.config.js.';
@@ -264,7 +267,7 @@ test('verify playwright web server is properly configured', async ({ page }, tes
 
     // Check that the page loaded successfully
     const pageTitle = await page.title();
-    console.log('Page title:', pageTitle);
+    debugLog('Page title:', pageTitle);
 
     // Verify we can interact with the page - using a specific element to avoid strict mode violations
     const mainContent = page.locator('main').first();
@@ -286,7 +289,7 @@ test('verify playwright web server is properly configured', async ({ page }, tes
         expect(url).toContain(configuredBaseURL.replace(/\/$/, ''));
     }
 
-    console.log('Page URL:', url);
+    debugLog('Page URL:', url);
 
     // Get the playwright config to confirm the webServer settings
     const configPath = path.resolve(__dirname, '../playwright.config.ts');
@@ -302,7 +305,7 @@ test('verify playwright web server is properly configured', async ({ page }, tes
     );
     expect(configContent).toContain('url: baseURL');
 
-    console.log('Playwright webServer is properly configured and running');
+    debugLog('Playwright webServer is properly configured and running');
 });
 
 test('verify browser has necessary capabilities for tests', async ({ page }) => {
@@ -313,7 +316,7 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
     // Check that JavaScript is enabled (will always pass if we got this far)
     const jsEnabled = await page.evaluate(() => true);
     expect(jsEnabled).toBeTruthy();
-    console.log('JavaScript is enabled');
+    debugLog('JavaScript is enabled');
 
     // Store the results of optional capability checks
     const capabilities = {
@@ -336,13 +339,13 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('localStorage test result:', localStorageAvailable);
+        debugLog('localStorage test result:', localStorageAvailable);
         capabilities.localStorage = localStorageAvailable;
 
         if (!localStorageAvailable) {
             console.warn('localStorage is not available. This may affect game save tests.');
         } else {
-            console.log('localStorage is available and functioning correctly');
+            debugLog('localStorage is available and functioning correctly');
         }
     } catch (e) {
         console.warn('Could not test localStorage:', e);
@@ -359,13 +362,13 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Cookies enabled test result:', cookiesEnabled);
+        debugLog('Cookies enabled test result:', cookiesEnabled);
         capabilities.cookies = cookiesEnabled;
 
         if (!cookiesEnabled) {
             console.warn('Cookies may be disabled. This could affect login/session tests.');
         } else {
-            console.log('Cookies are enabled');
+            debugLog('Cookies are enabled');
         }
     } catch (e) {
         console.warn('Could not test cookies:', e);
@@ -383,26 +386,26 @@ test('verify browser has necessary capabilities for tests', async ({ page }) => 
             }
         });
 
-        console.log('Fetch test result:', fetchWorks);
+        debugLog('Fetch test result:', fetchWorks);
         capabilities.fetch = fetchWorks;
 
         if (!fetchWorks) {
             console.warn('Fetch API may not be working. This could affect API tests.');
         } else {
-            console.log('Browser can make fetch requests');
+            debugLog('Browser can make fetch requests');
         }
     } catch (e) {
         console.warn('Could not test fetch capability:', e);
     }
 
     // Overall browser capability check
-    console.log('Browser capability summary:');
-    console.log('- JavaScript: ✅ (required)');
-    console.log(
+    debugLog('Browser capability summary:');
+    debugLog('- JavaScript: ✅ (required)');
+    debugLog(
         `- localStorage: ${capabilities.localStorage ? '✅' : '❌'} (optional but recommended)`
     );
-    console.log(`- Cookies: ${capabilities.cookies ? '✅' : '❌'} (optional but recommended)`);
-    console.log(`- Fetch API: ${capabilities.fetch ? '✅' : '❌'} (optional but recommended)`);
+    debugLog(`- Cookies: ${capabilities.cookies ? '✅' : '❌'} (optional but recommended)`);
+    debugLog(`- Fetch API: ${capabilities.fetch ? '✅' : '❌'} (optional but recommended)`);
 
     // Log a warning if some capabilities are missing
     if (!capabilities.localStorage || !capabilities.cookies || !capabilities.fetch) {

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -15,6 +15,13 @@ const DEFAULT_RETRY_DELAY_MS = 300;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
 const DEFAULT_MAX_DURATION_MS = 10_000;
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+
+const isDebugLoggingEnabled = process.env.E2E_DEBUG_LOGS === '1';
+const debugLog = (...args: unknown[]) => {
+    if (isDebugLoggingEnabled) {
+        console.log(...args);
+    }
+};
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
     onsuccess: ((event: Event) => void) | null;
@@ -597,7 +604,7 @@ export async function createTestItems(page: Page, count = 2): Promise<string[]> 
             }
         } catch (e) {
             // If no success message, we might have been redirected to inventory already
-            console.log('No success message found, checking for redirect');
+            debugLog('No success message found, checking for redirect');
         }
 
         // If we couldn't extract an ID but the item was created, at least return something
@@ -631,12 +638,12 @@ export async function findAndClickButton(page: Page, buttonText: string): Promis
     }
 
     // Log what we found
-    console.log(`Found ${await buttonLocator.count()} buttons matching "${buttonText}"`);
+    debugLog(`Found ${await buttonLocator.count()} buttons matching "${buttonText}"`);
 
     // Click if found
     if ((await buttonLocator.count()) > 0) {
         await buttonLocator.click();
-        console.log(`Clicked "${buttonText}" button`);
+        debugLog(`Clicked "${buttonText}" button`);
         return true;
     }
 
@@ -669,7 +676,7 @@ export class ItemSelectorHelper {
 
         // If either is visible, consider it expanded
         if ((await expandedView.count()) > 0 || (await itemsList.count()) > 0) {
-            console.log('Item selector already expanded');
+            debugLog('Item selector already expanded');
             await expect(expansionLocator.first()).toBeVisible();
             return true;
         }
@@ -685,13 +692,13 @@ export class ItemSelectorHelper {
             });
 
             await selectButton.first().click();
-            console.log('Clicked Select Item button');
+            debugLog('Clicked Select Item button');
 
             await expect(expansionLocator.first()).toBeVisible();
             return true;
         }
 
-        console.log('Could not open item selector');
+        debugLog('Could not open item selector');
         return false;
     }
 
@@ -714,12 +721,12 @@ export class ItemSelectorHelper {
         const itemRows = container.locator('.item-option');
         const count = await itemRows.count();
 
-        console.log(`Found ${count} item rows`);
+        debugLog(`Found ${count} item rows`);
 
         if (count > index) {
             // Click the item at specified index
             await itemRows.nth(index).click();
-            console.log(`Clicked item at index ${index}`);
+            debugLog(`Clicked item at index ${index}`);
 
             // Wait for selection to take effect (selector should collapse)
             await expect
@@ -730,7 +737,7 @@ export class ItemSelectorHelper {
             return true;
         }
 
-        console.log(`Could not select item at index ${index}`);
+        debugLog(`Could not select item at index ${index}`);
         return false;
     }
 
@@ -747,11 +754,11 @@ export class ItemSelectorHelper {
 
         if ((await quantityInput.count()) > 0) {
             await quantityInput.fill(quantity.toString());
-            console.log(`Set quantity to ${quantity}`);
+            debugLog(`Set quantity to ${quantity}`);
             return true;
         }
 
-        console.log('Quantity input not found');
+        debugLog('Quantity input not found');
         return false;
     }
 }
@@ -773,17 +780,17 @@ export async function fillProcessForm(
         const nameInput = page.locator('#name, #title').first();
         if ((await nameInput.count()) > 0) {
             await nameInput.fill(title);
-            console.log('Filled process title');
+            debugLog('Filled process title');
         } else {
-            console.log('Could not find name/title input');
+            debugLog('Could not find name/title input');
         }
 
         const durationInput = page.locator('#duration');
         if ((await durationInput.count()) > 0) {
             await durationInput.fill(duration);
-            console.log('Filled duration');
+            debugLog('Filled duration');
         } else {
-            console.log('Could not find duration input');
+            debugLog('Could not find duration input');
         }
 
         // Screenshot after filling basic details
@@ -810,7 +817,7 @@ export async function fillProcessForm(
                 if ((await buttonSelector.count()) > 0) {
                     for (let i = 0; i < count; i++) {
                         await buttonSelector.click();
-                        console.log(`Added ${type} item ${i + 1}`);
+                        debugLog(`Added ${type} item ${i + 1}`);
 
                         // Try to select an item from the dropdown or selector if one appears
                         await expect.poll(async () => await trySelectItem(page)).toBe(true);
@@ -821,7 +828,7 @@ export async function fillProcessForm(
             }
 
             if (!foundButton && count > 0) {
-                console.log(`Could not find button to add ${type} items`);
+                debugLog(`Could not find button to add ${type} items`);
             }
         };
 
@@ -879,7 +886,7 @@ async function trySelectItem(page: Page): Promise<boolean> {
             return true;
         }
     } catch (e) {
-        console.log('Error trying to select item:', e);
+        debugLog('Error trying to select item:', e);
     }
 
     return false;
@@ -1016,7 +1023,7 @@ export async function addTestItems(page: Page): Promise<void> {
 
         // Save back to localStorage
         localStorage.setItem('inventory', JSON.stringify(inventory));
-        console.log('Added test items to inventory');
+        debugLog('Added test items to inventory');
     });
 }
 


### PR DESCRIPTION
### Motivation
- Passing E2E runs produced a lot of low-signal `console.log` output that buries failures and makes triage harder. 
- Keep useful failure diagnostics, screenshots and assertions intact while making successful runs concise.

### Description
- Gate chatty test output behind an opt-in env var `E2E_DEBUG_LOGS=1` by adding a `debugLog` wrapper and using it for previously noisy `console.log` calls. 
- Convert test-coverage inventory/log dumps into failure-only diagnostics (`console.error`) so they only appear when the test actually fails.
- Gate the `[quests-tti-metrics]` dump so metrics only print when `E2E_DEBUG_LOGS=1`.
- Files changed: `frontend/e2e/test-helpers.ts`, `frontend/e2e/test-coverage.spec.ts`, `frontend/e2e/custom-content.spec.ts`, `frontend/e2e/quests-tti-metrics.spec.ts`.

### Testing
- Ran the Playwright command from the issue: `cd frontend && npx playwright test test-coverage.spec.ts process-creation.spec.ts custom-content.spec.ts quests-tti-metrics.spec.ts --workers=1 --reporter=dot`; Playwright attempted to ensure browsers but the environment could not download Chromium (network/ENETUNREACH), so browser install failed and many tests errored at launch; Playwright reported `5 passed` and `12 failed` due to missing browser binaries. 
- Verified changes locally in the repository by reviewing diffs and running the repository secret scan: `git diff --cached | ./scripts/scan-secrets.py` (no findings). 
- Note: the logging behavior can be observed locally by running tests with `E2E_DEBUG_LOGS=1` to re-enable verbose output; in CI (with browsers available) passing runs will now be substantially quieter while failures still emit the same error traces and screenshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafce0f5d0832f97af259c1832896f)