### PR TITLE
chore: refresh caniuse-lite lock metadata

### DIFF
--- a/outages/2026-04-28-browserslist-caniuse-lite-stale.md
+++ b/outages/2026-04-28-browserslist-caniuse-lite-stale.md
@@ -1,0 +1,20 @@
+# Browserslist caniuse-lite stale warning in launch gate
+
+## Symptom
+The v3.0.1 QA launch-gate build sequence completed successfully, but emitted:
+`Browserslist: browsers data (caniuse-lite) is 10 months old` during `npm run build`.
+
+## Impact
+This did **not** fail tests or block the build, but it added persistent QA noise and made
+launch-gate logs look unhealthy.
+
+## Root cause
+`caniuse-lite` metadata in the committed npm lockfile had become stale relative to the
+current Browserslist database expected by the build toolchain.
+
+## Fix
+Refreshed Browserslist database metadata by updating the lockfile entry for
+`caniuse-lite` to the current release and committed the updated `package-lock.json`.
+
+## Verification
+Confirmed `npm run build` no longer prints the stale Browserslist/caniuse-lite warning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3550,7 +3550,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
+        "caniuse-lite": "^1.0.30001791",
         "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Motivation

- Remove a persistent "Browserslist: browsers data (caniuse-lite) is 10 months old" warning that appears during `npm run build` in the v3.0.1 QA launch-gate run and causes noisy logs. 
- Make a minimal dependency-only change limited to refreshing Browserslist metadata so build behavior and toolchain remain unchanged.

### Description

- Updated `package-lock.json` to refresh the `caniuse-lite` entry to the current release (`1.0.30001791`), including the resolved tarball URL and integrity hash, so Browserslist no longer reports stale data. 
- Added an outage note at `outages/2026-04-28-browserslist-caniuse-lite-stale.md` documenting the symptom, impact, root cause, fix, and verification and explicitly stating this was QA noise (not a test failure).
- Changes are limited to lockfile/dependency metadata and the outage documentation; no functional code or build configuration changes were made. 

### Testing

- Ran `npm run lint` and it completed successfully. 
- Ran `npm run type-check` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm run build` and verified the build completes and the stale Browserslist/caniuse-lite warning is no longer emitted. 
- Ran `node scripts/link-check.mjs` and all local markdown links resolved. 
- `npm test` (full test suite) did not complete within the execution timeout in this environment, so full-suite completion should be verified in CI/locally if required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f053116ae0832f99643f52ae5f27c1)