### PR TITLE
🧹 chore: refresh caniuse-lite lock and document QA Browserslist warning

### DIFF
--- a/outages/2026-04-27-browserslist-caniuse-lite-stale.json
+++ b/outages/2026-04-27-browserslist-caniuse-lite-stale.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-04-27-browserslist-caniuse-lite-stale",
+  "date": "2026-04-27",
+  "component": "build-tooling",
+  "longForm": "outages/2026-04-27-browserslist-caniuse-lite-stale.md",
+  "rootCause": "The npm lockfile still resolved an older caniuse-lite package, so Browserslist browser data age warnings appeared during build.",
+  "resolution": "Updated lockfile metadata to refresh caniuse-lite and remove stale Browserslist warning noise from QA launch-gate logs.",
+  "references": [
+    "package-lock.json",
+    "scripts/run-astro-build.mjs"
+  ]
+}

--- a/outages/2026-04-27-browserslist-caniuse-lite-stale.md
+++ b/outages/2026-04-27-browserslist-caniuse-lite-stale.md
@@ -1,0 +1,18 @@
+# Stale Browserslist/caniuse-lite warning during v3.0.1 launch-gate QA
+
+## Symptom
+`npm run build` completed successfully but emitted noisy warning output:
+`Browserslist: browsers data (caniuse-lite) is 10 months old.`
+
+## Impact
+No functional build or test failure occurred.
+This remained outstanding QA noise in the v3.0.1 launch-gate sequence and obscured signal in otherwise green logs.
+
+## Root cause
+`package-lock.json` still pinned an older `caniuse-lite` release in the npm dependency graph used by the QA build path.
+
+## Fix
+Refresh lockfile metadata for `caniuse-lite` so npm resolves current Browserslist browser data.
+
+## Verification
+- `npm run build` no longer prints the stale Browserslist/caniuse-lite warning line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Motivation
- Remove noisy Browserslist/caniuse-lite staleness warning emitted during `npm run build` in the v3.0.1 QA launch-gate so logs are less noisy. 
- Keep the change minimal and lockfile-only (plus an outage record) to avoid unrelated dependency churn.

### Description
- Update `package-lock.json` to refresh `caniuse-lite` metadata to `1.0.30001791` so Browserslist no longer reports stale browser data during builds. 
- Add a long-form outage entry `outages/2026-04-27-browserslist-caniuse-lite-stale.md` documenting symptom, impact, root cause, fix, and verification. 
- Add the matching outage JSON record `outages/2026-04-27-browserslist-caniuse-lite-stale.json` that references the lockfile and build script. 
- Keep other generated/frontend files out of the commit by restoring them before the final commit; only the lockfile and outage files are persisted.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run type-check` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm run build` and the build completed without emitting the stale Browserslist/caniuse-lite warning. 
- Ran focused test subset with `npm run test:root` and it passed. 
- Ran link validation with `node scripts/link-check.mjs` and it reported all local markdown links resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f053116ae0832f99643f52ae5f27c1)