### PR TITLE
Require Playwright Chromium headless_shell in bootstrap (install when missing)

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -151,7 +151,7 @@ export function hasChromiumExecutable(browser) {
                     `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only. Run "npm run playwright:install" to install it.`
                 );
             }
-            return true;
+            return false;
         }
 
         return true;

--- a/outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.json
+++ b/outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-28-playwright-chromium-headless-shell-bootstrap",
+  "date": "2026-04-28",
+  "component": "qa:e2e-playwright",
+  "longForm": "outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.md",
+  "rootCause": "The Playwright browser bootstrap treated a missing chromium headless shell as acceptable and returned success as long as the Chromium executable existed.",
+  "resolution": "Updated browser presence checks to require both Chromium and headless_shell before skipping install, which triggers a one-time install path in setup and removes repeated warning spam during grouped runs.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts",
+    "frontend/playwright.config.ts"
+  ]
+}

--- a/outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.md
+++ b/outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.md
@@ -1,0 +1,31 @@
+# Playwright Chromium headless shell bootstrap warning
+
+## Warning
+Grouped E2E output repeatedly logged:
+
+- `headless shell is missing`
+- `Proceeding with chromium binary only`
+
+## Impact
+- QA runs were noisy and harder to triage because each group re-printed the same warning.
+- Setup implied Playwright was healthy even when required Chromium assets were incomplete.
+
+## Root cause
+`ensurePlaywrightBrowsers` used `hasChromiumExecutable` as the readiness gate. That helper returned `true`
+even when the Chromium `headless_shell` binary was missing, so install was skipped and warnings repeated
+for each grouped Playwright invocation.
+
+## Fix
+- Changed the readiness check so missing `headless_shell` returns `false`.
+- Kept the missing-headless warning, but now it is emitted before triggering install.
+- Added/updated tests to verify that when headless shell is missing, browser install runs and grouped
+  reruns do not keep reinstalling once assets are present.
+
+## Verification
+- `npm --prefix frontend run playwright:install`
+- `npm --prefix frontend run test:e2e:groups`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `npm test`
+- `node scripts/link-check.mjs`

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -302,7 +302,7 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('warns but continues when headless shell is missing', async () => {
+  it('installs browsers when headless shell is missing', async () => {
     const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
     const chromeExecutable = path.join(
       cacheRoot,
@@ -346,7 +346,11 @@ describe('ensurePlaywrightBrowsers', () => {
       }
       return false;
     });
-    const execFileSync = vi.fn();
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
+      if (args[1] === 'install') {
+        headlessInstalled = true;
+      }
+    });
     const writeFileSync = vi.fn(() => {
       depsSentinelExists = true;
     });
@@ -379,8 +383,14 @@ describe('ensurePlaywrightBrowsers', () => {
 
       await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
 
-      expect(execFileSync).not.toHaveBeenCalled();
-      expect(executablePath).toHaveBeenCalledTimes(1);
+      expect(execFileSync).toHaveBeenCalledTimes(2);
+      expect(execFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [cliPath, 'install', 'chromium', 'chromium-headless-shell'],
+        expect.objectContaining({ cwd: frontendRoot, stdio: 'inherit' })
+      );
+      expect(executablePath).toHaveBeenCalledTimes(2);
       expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
       expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
       expect(warnSpy).toHaveBeenCalledWith(
@@ -406,14 +416,41 @@ describe('ensurePlaywrightBrowsers', () => {
       'test',
       'cli.js'
     );
+    let headlessInstalled = false;
+    const headlessPath = path.join(
+      cacheRoot,
+      'chromium-headless-shell-1181',
+      'chrome-linux',
+      'headless_shell'
+    );
     const existsSync = vi.fn((candidate: string) => {
       if (candidate === cliPath || candidate === chromeExecutable) {
         return true;
+      }
+      if (candidate === headlessPath) {
+        return headlessInstalled;
       }
       return false;
     });
     const browser = { executablePath: vi.fn(() => chromeExecutable) };
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
+      if (args[1] === 'install') {
+        headlessInstalled = true;
+      }
+    });
+
+    vi.doMock('node:child_process', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:child_process')>(
+          'node:child_process'
+        );
+      return {
+        ...actual,
+        execFileSync,
+        default: { ...actual, execFileSync },
+      };
+    });
 
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -434,9 +471,7 @@ describe('ensurePlaywrightBrowsers', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('headless shell is missing')
       );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('npm run playwright:install')
-      );
+      expect(execFileSync).toHaveBeenCalledTimes(2);
     } finally {
       warnSpy.mockRestore();
     }
@@ -479,6 +514,19 @@ describe('ensurePlaywrightBrowsers', () => {
       .mockReturnValueOnce(secondChromeExecutable);
     const browser = { executablePath };
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const execFileSync = vi.fn();
+
+    vi.doMock('node:child_process', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:child_process')>(
+          'node:child_process'
+        );
+      return {
+        ...actual,
+        execFileSync,
+        default: { ...actual, execFileSync },
+      };
+    });
 
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -495,7 +543,7 @@ describe('ensurePlaywrightBrowsers', () => {
       await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
       await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
 
-      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledTimes(4);
       expect(warnSpy).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining(firstChromeExecutable)
@@ -504,6 +552,7 @@ describe('ensurePlaywrightBrowsers', () => {
         2,
         expect.stringContaining(secondChromeExecutable)
       );
+      expect(execFileSync).toHaveBeenCalledTimes(4);
     } finally {
       warnSpy.mockRestore();
     }


### PR DESCRIPTION
### Motivation

- Stop repeated Playwright warnings that `headless_shell` is missing by making the bootstrap detect the incomplete browser install and trigger the one-time install step. 
- Ensure grouped E2E runs are not noisy and that setup reliably installs all required Chromium assets across platforms and CI. 

### Description

- Change `hasChromiumExecutable` to treat a missing Chromium `headless_shell` as not present so the bootstrap path will install browsers instead of continuing with a partial binary (`frontend/scripts/utils/ensure-playwright-browsers.js`).
- Update unit tests to expect and simulate the install behavior when the headless shell is absent and to assert warning/installation call patterns (`scripts/tests/ensurePlaywrightBrowsers.test.ts`).
- Add an outage record documenting the warning, impact, root cause, fix and verification steps (`outages/2026-04-28-playwright-chromium-headless-shell-bootstrap.json` and `.md`).
- Keep the existing warning message but use it as a precursor to triggering `playwright install` from the centralized bootstrap path used by `frontend/playwright.config.ts` and grouped E2E runs. 

### Testing

- Ran `npm run lint` which completed successfully. 
- Ran `npm run type-check` which completed successfully. 
- Ran `npm run build` which completed successfully. 
- Ran the updated unit tests with `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts` and all tests passed. 
- Executed `npm --prefix frontend run playwright:install` which installed Chromium and the headless shell successfully. 
- Executed `npm --prefix frontend run test:e2e:groups` in this environment and observed multiple groups complete without the repeated `headless shell is missing` warning in the observed output. 
- Ran `node scripts/link-check.mjs` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e9b52840832f9e757669d0d5bc91)