### PR TITLE
Require Playwright headless shell during browser bootstrap

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -191,7 +191,8 @@ export async function ensurePlaywrightBrowsers(options = {}) {
 
     if (env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
         if (browser) {
-            const { hasChromium, hasHeadlessShell, executablePath } = getChromiumAssetStatus(browser);
+            const { hasChromium, hasHeadlessShell, executablePath } =
+                getChromiumAssetStatus(browser);
             if (!hasChromium) {
                 console.warn(
                     'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
@@ -237,7 +238,9 @@ export async function ensurePlaywrightBrowsers(options = {}) {
 
     const postInstallAssets = getChromiumAssetStatus(browser);
     if (!postInstallAssets.hasChromium || !postInstallAssets.hasHeadlessShell) {
-        const missingAsset = !postInstallAssets.hasChromium ? 'chromium executable' : 'chromium headless shell';
+        const missingAsset = !postInstallAssets.hasChromium
+            ? 'chromium executable'
+            : 'chromium headless shell';
         console.warn(
             `Playwright ${missingAsset} is still missing after installation. Tests may fail if browsers are unavailable.`
         );

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -149,6 +149,11 @@ function getChromiumAssetStatus(browser) {
 }
 
 export function hasChromiumExecutable(browser) {
+    const { hasChromium } = getChromiumAssetStatus(browser);
+    return hasChromium;
+}
+
+export function hasChromiumAssets(browser) {
     const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser);
     return hasChromium && hasHeadlessShell;
 }
@@ -184,7 +189,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         return;
     }
 
-    if (process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
+    if (env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
         if (browser) {
             const { hasChromium, hasHeadlessShell, executablePath } = getChromiumAssetStatus(browser);
             if (!hasChromium) {
@@ -206,8 +211,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         return;
     }
 
-    const chromiumAssets = getChromiumAssetStatus(browser);
-    if (chromiumAssets.hasChromium && chromiumAssets.hasHeadlessShell) {
+    if (hasChromiumAssets(browser)) {
         return;
     }
 

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -132,32 +132,25 @@ export function resolveHeadlessShellPath(executablePath) {
     return '';
 }
 
-export function hasChromiumExecutable(browser) {
+function getChromiumAssetStatus(browser) {
     try {
         const executablePath = browser.executablePath();
-        if (!executablePath) {
-            return false;
-        }
-
-        if (!existsSync(executablePath)) {
-            return false;
+        if (!executablePath || !existsSync(executablePath)) {
+            return { hasChromium: false, hasHeadlessShell: false, executablePath: '' };
         }
 
         const headlessShellPath = resolveHeadlessShellPath(executablePath);
-        if (!headlessShellPath || !existsSync(headlessShellPath)) {
-            if (!warnedMissingHeadlessShellPaths.has(executablePath)) {
-                warnedMissingHeadlessShellPaths.add(executablePath);
-                console.warn(
-                    `Playwright chromium executable found at ${executablePath} but headless shell is missing. Proceeding with chromium binary only. Run "npm run playwright:install" to install it.`
-                );
-            }
-            return true;
-        }
+        const hasHeadlessShell = Boolean(headlessShellPath && existsSync(headlessShellPath));
 
-        return true;
+        return { hasChromium: true, hasHeadlessShell, executablePath };
     } catch (error) {
-        return false;
+        return { hasChromium: false, hasHeadlessShell: false, executablePath: '' };
     }
+}
+
+export function hasChromiumExecutable(browser) {
+    const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser);
+    return hasChromium && hasHeadlessShell;
 }
 
 async function getChromiumBrowser() {
@@ -192,10 +185,18 @@ export async function ensurePlaywrightBrowsers(options = {}) {
     }
 
     if (process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
-        if (browser && !hasChromiumExecutable(browser)) {
-            console.warn(
-                'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
-            );
+        if (browser) {
+            const { hasChromium, hasHeadlessShell, executablePath } = getChromiumAssetStatus(browser);
+            if (!hasChromium) {
+                console.warn(
+                    'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
+                );
+            } else if (!hasHeadlessShell && !warnedMissingHeadlessShellPaths.has(executablePath)) {
+                warnedMissingHeadlessShellPaths.add(executablePath);
+                console.warn(
+                    `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing for ${executablePath}. E2E tests may fail.`
+                );
+            }
         }
         return;
     }
@@ -205,7 +206,8 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         return;
     }
 
-    if (hasChromiumExecutable(browser)) {
+    const chromiumAssets = getChromiumAssetStatus(browser);
+    if (chromiumAssets.hasChromium && chromiumAssets.hasHeadlessShell) {
         return;
     }
 
@@ -229,9 +231,11 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         env: sanitizedEnv,
     });
 
-    if (!hasChromiumExecutable(browser)) {
+    const postInstallAssets = getChromiumAssetStatus(browser);
+    if (!postInstallAssets.hasChromium || !postInstallAssets.hasHeadlessShell) {
+        const missingAsset = !postInstallAssets.hasChromium ? 'chromium executable' : 'chromium headless shell';
         console.warn(
-            'Playwright chromium executable is still missing after installation. Tests may fail if browsers are unavailable.'
+            `Playwright ${missingAsset} is still missing after installation. Tests may fail if browsers are unavailable.`
         );
     }
 }

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -324,6 +324,41 @@ describe('ensurePlaywrightBrowsers', () => {
         expect(writeFileSyncMock).toHaveBeenCalled();
     });
 
+
+    it('uses provided env for skip-download behavior', async () => {
+        const chromiumPath = '/root/.cache/ms-playwright/chromium-1234/chrome';
+        existsSyncMock.mockImplementation((target: string) => target === chromiumPath);
+        chromiumExecutablePathMock.mockReturnValue(chromiumPath);
+
+        const { ensurePlaywrightBrowsers } = await importModule();
+
+        await ensurePlaywrightBrowsers({
+            cwd,
+            env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' },
+            platform: 'linux',
+            exec: execFileSyncMock,
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
+        });
+
+        await ensurePlaywrightBrowsers({
+            cwd,
+            env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' },
+            platform: 'linux',
+            exec: execFileSyncMock,
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
+        });
+
+        expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
     it('respects skip flag for browser download', async () => {
         existsSyncMock.mockReturnValue(false);
         chromiumExecutablePathMock.mockReturnValue(undefined as unknown as string);

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -251,7 +251,13 @@ describe('ensurePlaywrightBrowsers', () => {
                     'Playwright chromium executable is still missing after installation.'
                 ) ||
                     first.startsWith(
+                        'Playwright chromium headless shell is still missing after installation.'
+                    ) ||
+                    first.startsWith(
                         'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing.'
+                    ) ||
+                    first.startsWith(
+                        'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing'
                     ))
             ) {
                 return;

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -324,7 +324,6 @@ describe('ensurePlaywrightBrowsers', () => {
         expect(writeFileSyncMock).toHaveBeenCalled();
     });
 
-
     it('uses provided env for skip-download behavior', async () => {
         const chromiumPath = '/root/.cache/ms-playwright/chromium-1234/chrome';
         existsSyncMock.mockImplementation((target: string) => target === chromiumPath);

--- a/outages/2026-04-28-playwright-headless-shell-bootstrap-warning.json
+++ b/outages/2026-04-28-playwright-headless-shell-bootstrap-warning.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-28-playwright-headless-shell-bootstrap-warning",
+  "date": "2026-04-28",
+  "component": "frontend:playwright-bootstrap",
+  "longForm": "outages/2026-04-28-playwright-headless-shell-bootstrap-warning.md",
+  "rootCause": "The Playwright bootstrap check treated Chromium as fully installed even when chromium-headless-shell was missing, so grouped E2E runs skipped browser installation and emitted repeated launcher warnings in each Playwright invocation.",
+  "resolution": "Updated browser asset validation to require both Chromium and chromium-headless-shell before skipping installation, and kept installation centralized through ensurePlaywrightBrowsers so grouped E2E installs missing assets once up front.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts",
+    "outages/2026-04-28-playwright-headless-shell-bootstrap-warning.md"
+  ]
+}

--- a/outages/2026-04-28-playwright-headless-shell-bootstrap-warning.md
+++ b/outages/2026-04-28-playwright-headless-shell-bootstrap-warning.md
@@ -1,0 +1,30 @@
+# Playwright headless shell bootstrap warning spam in grouped E2E
+
+## Symptom
+Grouped Playwright runs (`npm run test:e2e:groups`) repeatedly logged:
+
+- `headless shell is missing`
+- `Proceeding with chromium binary only`
+
+This message appeared across multiple E2E groups even when Chromium itself existed.
+
+## Impact
+The warning was noisy and obscured QA signal. It also meant local/CI setup could proceed without
+all required Chromium assets, leaving each test process to rediscover the same gap.
+
+## Root cause
+The shared bootstrap helper (`ensurePlaywrightBrowsers`) accepted the install as complete when the
+Chromium executable existed, even if `chromium-headless-shell` was absent. Because of that early
+return, grouped E2E invocations never triggered a corrective Playwright install path.
+
+## Fix
+- Tightened Playwright asset validation to require **both** Chromium and the headless shell.
+- If headless shell is missing, bootstrap now executes the standard Playwright install workflow
+  before test groups run.
+- Added regression coverage to assert missing-headless-shell paths trigger installation instead of
+  warning-only behavior.
+
+## Verification
+- `npm --prefix frontend run playwright:install`
+- `npm --prefix frontend run test:e2e:groups`
+- Grouped E2E logs no longer emit the repeated missing-headless-shell warning pair.

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -302,7 +302,7 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('warns but continues when headless shell is missing', async () => {
+  it('installs missing headless shell when chromium executable already exists', async () => {
     const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
     const chromeExecutable = path.join(
       cacheRoot,
@@ -379,130 +379,19 @@ describe('ensurePlaywrightBrowsers', () => {
 
       await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
 
-      expect(execFileSync).not.toHaveBeenCalled();
-      expect(executablePath).toHaveBeenCalledTimes(1);
+      expect(execFileSync).toHaveBeenCalledTimes(2);
+      expect(execFileSync.mock.calls[0][1]).toEqual([cliPath, 'install-deps']);
+      expect(execFileSync.mock.calls[1][1]).toEqual([
+        cliPath,
+        'install',
+        'chromium',
+        'chromium-headless-shell',
+      ]);
+      expect(executablePath).toHaveBeenCalledTimes(2);
       expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
       expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('headless shell is missing')
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('logs missing headless shell warning only once per process', async () => {
-    const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
-    const chromeExecutable = path.join(
-      cacheRoot,
-      'chromium-1181',
-      'chrome-linux',
-      'chrome'
-    );
-    const cliPath = path.join(
-      frontendRoot,
-      'node_modules',
-      '@playwright',
-      'test',
-      'cli.js'
-    );
-    const existsSync = vi.fn((candidate: string) => {
-      if (candidate === cliPath || candidate === chromeExecutable) {
-        return true;
-      }
-      return false;
-    });
-    const browser = { executablePath: vi.fn(() => chromeExecutable) };
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    vi.doMock('node:fs', async () => {
-      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
-      return {
-        ...actual,
-        existsSync,
-        default: { ...actual, existsSync },
-      };
-    });
-
-    try {
-      const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
-
-      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
-      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
-
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('headless shell is missing')
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('npm run playwright:install')
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('logs missing headless shell warning for each distinct chromium path', async () => {
-    const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
-    const firstChromeExecutable = path.join(
-      cacheRoot,
-      'chromium-1181',
-      'chrome-linux',
-      'chrome'
-    );
-    const secondChromeExecutable = path.join(
-      cacheRoot,
-      'chromium-1200',
-      'chrome-linux',
-      'chrome'
-    );
-    const cliPath = path.join(
-      frontendRoot,
-      'node_modules',
-      '@playwright',
-      'test',
-      'cli.js'
-    );
-    const existsSync = vi.fn((candidate: string) => {
-      if (
-        candidate === cliPath ||
-        candidate === firstChromeExecutable ||
-        candidate === secondChromeExecutable
-      ) {
-        return true;
-      }
-      return false;
-    });
-    const executablePath = vi
-      .fn<() => string>()
-      .mockReturnValueOnce(firstChromeExecutable)
-      .mockReturnValueOnce(secondChromeExecutable);
-    const browser = { executablePath };
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    vi.doMock('node:fs', async () => {
-      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
-      return {
-        ...actual,
-        existsSync,
-        default: { ...actual, existsSync },
-      };
-    });
-
-    try {
-      const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
-
-      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
-      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
-
-      expect(warnSpy).toHaveBeenCalledTimes(2);
-      expect(warnSpy).toHaveBeenNthCalledWith(
-        1,
-        expect.stringContaining(firstChromeExecutable)
-      );
-      expect(warnSpy).toHaveBeenNthCalledWith(
-        2,
-        expect.stringContaining(secondChromeExecutable)
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Proceeding with chromium binary only')
       );
     } finally {
       warnSpy.mockRestore();

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -377,7 +377,12 @@ describe('ensurePlaywrightBrowsers', () => {
     try {
       const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
 
-      await ensurePlaywrightBrowsers({ cwd: frontendRoot, browser });
+      await ensurePlaywrightBrowsers({
+        cwd: frontendRoot,
+        browser,
+        platform: 'linux',
+        env: { ...process.env, PLAYWRIGHT_SKIP_INSTALL_DEPS: '0' },
+      });
 
       expect(execFileSync).toHaveBeenCalledTimes(2);
       expect(execFileSync.mock.calls[0][1]).toEqual([cliPath, 'install-deps']);


### PR DESCRIPTION
### Motivation

- Grouped E2E runs repeatedly logged `headless shell is missing` / `Proceeding with chromium binary only` because the bootstrap helper treated the Chromium executable presence as sufficient and skipped installing `chromium-headless-shell`.
- The goal is to ensure grouped/local/CI E2E setup installs all required Playwright Chromium assets once up-front so individual test groups do not rediscover and re-log the same warning.

### Description

- Tightened Playwright bootstrap validation in `frontend/scripts/utils/ensure-playwright-browsers.js` so it only short-circuits when both the Chromium executable and `chromium-headless-shell` are present, and post-install messaging now identifies which asset is still missing.
- When headless shell is absent the helper now runs the standard install flow (`install-deps` then `install chromium chromium-headless-shell`) instead of silently proceeding with Chromium-only state.
- Updated regression tests to assert the new install behavior in `scripts/tests/ensurePlaywrightBrowsers.test.ts` and adjusted frontend test warning filters in `frontend/tests/ensure-playwright-browsers.test.ts` to account for the new messages.
- Added an outage record (`outages/2026-04-28-playwright-headless-shell-bootstrap-warning.{json,md}`) that documents symptom, impact, root cause, fix, and verification steps.

### Testing

- Ran repository checks: `npm run lint` (frontend lint executed) — completed without blocking errors.
- Ran type and build: `npm run type-check` and `npm run build` — succeeded in this environment.
- Ran link validation: `node scripts/link-check.mjs` — succeeded.
- Unit/regression tests: `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts frontend/tests/ensure-playwright-browsers.test.ts` — both test files passed (all tests green).
- Playwright bootstrap flow verification: `npm --prefix frontend run playwright:install` — successfully installed missing system deps and downloaded `chromium-headless-shell` in this environment.
- Early grouped E2E verification: `npm --prefix frontend run test:e2e:groups` was exercised and early group output no longer emitted the prior repeated `headless shell is missing` / `Proceeding with chromium binary only` warning (full long suite was time-boxed during the run but the regression was observed resolved in initial groups).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e9b52840832f9e757669d0d5bc91)