### PR TITLE
🛠️ fix: suppress expected Playwright SW block warning

### DIFF
--- a/frontend/__tests__/offlineWorkerRegistration.test.js
+++ b/frontend/__tests__/offlineWorkerRegistration.test.js
@@ -217,6 +217,29 @@ describe('registerOfflineWorker', () => {
         });
     });
 
+    it('suppresses expected Playwright service worker block warnings', async () => {
+        fetch.mockImplementation(() => mockFetchResponse({ offlineWorker: {} }));
+        serviceWorker.register.mockRejectedValue(
+            new Error('Service Worker registration blocked by Playwright')
+        );
+
+        const { registerOfflineWorker } = await import(
+            '../public/scripts/offlineWorkerRegistration.js'
+        );
+
+        registerOfflineWorker();
+        await dispatchLoad();
+
+        await vi.waitFor(() => {
+            expect(serviceWorker.register).toHaveBeenCalled();
+        });
+
+        expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+            'Service worker registration failed:',
+            expect.any(Error)
+        );
+    });
+
     it('logs warning when service worker registration fails', async () => {
         fetch.mockImplementation(() => mockFetchResponse({ offlineWorker: {} }));
         serviceWorker.register.mockRejectedValue(new Error('Registration failed'));

--- a/frontend/public/scripts/offlineWorkerRegistration.js
+++ b/frontend/public/scripts/offlineWorkerRegistration.js
@@ -1,4 +1,11 @@
 export function registerOfflineWorker() {
+
+function isExpectedPlaywrightServiceWorkerBlock(error) {
+    const message = typeof error?.message === 'string' ? error.message : String(error ?? '');
+    return message.includes('Service Worker registration blocked by Playwright');
+}
+
+
     if (!('serviceWorker' in navigator)) {
         return;
     }
@@ -228,6 +235,9 @@ export function registerOfflineWorker() {
                 }
             })
             .catch((error) => {
+                if (isExpectedPlaywrightServiceWorkerBlock(error)) {
+                    return;
+                }
                 console.warn('Service worker registration failed:', error);
             });
     });

--- a/outages/2026-04-29-playwright-sw-registration-warning.json
+++ b/outages/2026-04-29-playwright-sw-registration-warning.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-29-playwright-sw-registration-warning",
+  "date": "2026-04-29",
+  "component": "frontend:service-worker-registration",
+  "longForm": "outages/2026-04-29-playwright-sw-registration-warning.md",
+  "rootCause": "The offline worker registration script logs registration failures as console warnings. In Playwright runs that use serviceWorkers: 'block', browser-level service worker registration is intentionally rejected with the message 'Service Worker registration blocked by Playwright', which surfaced as repetitive warning noise across grouped E2E suites.",
+  "resolution": "Added a narrow suppression path in offlineWorkerRegistration so registration rejections matching the exact Playwright blocked message are treated as expected in automation while preserving warning logs for all other service worker registration failures.",
+  "references": [
+    "frontend/public/scripts/offlineWorkerRegistration.js",
+    "frontend/__tests__/offlineWorkerRegistration.test.js",
+    "outages/2026-04-29-playwright-sw-registration-warning.md"
+  ]
+}

--- a/outages/2026-04-29-playwright-sw-registration-warning.md
+++ b/outages/2026-04-29-playwright-sw-registration-warning.md
@@ -1,0 +1,21 @@
+# Playwright service worker registration warning noise
+
+## Impact
+Grouped Playwright runs were green, but emitted repeated warning lines:
+
+- `[console.warning] Service Worker registration blocked by Playwright`
+
+This created QA noise and obscured unexpected warnings.
+
+## Root cause
+The app always attempts offline service worker registration in browser contexts where it is enabled.
+During many E2E projects, Playwright is configured with `serviceWorkers: 'block'`, so registration is intentionally denied.
+The rejection bubbled into generic warning logging (`Service worker registration failed:`), producing expected-but-noisy console warnings.
+
+## Fix
+A targeted guard now detects this exact expected Playwright rejection message and suppresses that one case only.
+All other registration failures continue to log warnings.
+
+## Verification
+- Unit test coverage added for the suppressed Playwright block path.
+- Existing registration failure warning tests remain in place to ensure non-Playwright failures still warn.


### PR DESCRIPTION
### Motivation
- Reduce repetitive, known-benign console warnings emitted during grouped Playwright E2E runs where Playwright intentionally blocks service worker registration, while keeping real registration failures visible.
- Prevent QA noise that obscures other warnings without altering service worker behavior in production or staging.

### Description
- Add a narrow guard `isExpectedPlaywrightServiceWorkerBlock` in `frontend/public/scripts/offlineWorkerRegistration.js` that detects the exact Playwright rejection message and returns early in the registration `catch` handler.
- Preserve the existing `console.warn('Service worker registration failed:', ...)` behavior for all non-Playwright failures.
- Add a unit test in `frontend/__tests__/offlineWorkerRegistration.test.js` that verifies the Playwright-blocked rejection does not emit the generic registration warning while keeping the existing failure test.
- Add an `outages/2026-04-29-playwright-sw-registration-warning.{json,md}` record documenting impact, root cause, resolution, and verification steps.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run type-check` (`tsc --noEmit`) which completed successfully.
- Attempted to run the focused unit test file with `npm test`/`vitest` but the repository’s current Vitest include patterns prevented executing the single test file (no tests were run by that direct invocation); the new test is present and follows existing test conventions for the offline worker registration behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1627a9634832fb9245c3198c7cabe)