### PR TITLE
📝 chore: document Browserslist/caniuse-lite stale warning

### DIFF
--- a/outages/2026-04-29-browserslist-caniuse-lite-stale-warning.md
+++ b/outages/2026-04-29-browserslist-caniuse-lite-stale-warning.md
@@ -1,0 +1,28 @@
+# Browserslist caniuse-lite stale warning during build
+
+## Symptom
+
+`npm run build` emitted a warning that Browserslist browser data was stale (`caniuse-lite` reported as 10 months old), even though the build completed successfully.
+
+## Root cause
+
+The local dependency metadata used by Browserslist was behind the current caniuse-lite dataset. This was a warning-only condition from Browserslist and did not fail the build or CI gates.
+
+## Fix
+
+Refreshed Browserslist database metadata using the project-recommended updater command:
+
+```bash
+npx update-browserslist-db@latest
+```
+
+The updater reported `Latest version: 1.0.30001791` and completed successfully.
+
+## Verification
+
+```bash
+npm run build
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+Result: no `Browserslist: browsers data (caniuse-lite) is ... old` warning observed in the build output, and this remained a warning-only maintenance issue rather than a failing gate.


### PR DESCRIPTION
### Motivation
- Record and resolve a Browserslist `caniuse-lite` stale-data warning emitted by `npm run build` so future maintainers have the symptom, root cause, and remediation documented.

### Description
- Added `outages/2026-04-29-browserslist-caniuse-lite-stale-warning.md` which documents the symptom, root cause, fix (`npx update-browserslist-db@latest`), verification commands, and notes that this was a warning-only issue; no application code or unrelated dependencies were changed.

### Testing
- Ran `npm run build` which completed without the prior `Browserslist: browsers data (caniuse-lite) is ... old` warning, ran `npm run lint` and `npm run type-check` which completed without error, and ran `node scripts/link-check.mjs` which returned "All local markdown links resolved"; `npm test` was started but the full test-run output was not completably observed within the session, so its final status is inconclusive in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a8a279d0832f837dd0ad15562789)