### PR TITLE
Document Browserslist/caniuse-lite build warning (outage entry)

### DIFF
--- a/outages/2026-04-29-browserslist-caniuse-lite-warning.json
+++ b/outages/2026-04-29-browserslist-caniuse-lite-warning.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-29-browserslist-caniuse-lite-warning",
+  "date": "2026-04-29",
+  "component": "frontend/build",
+  "symptom": "`npm run build` intermittently printed `Browserslist: browsers data (caniuse-lite) is 10 months old` while the build still completed successfully.",
+  "rootCause": "The warning is emitted when local Browserslist metadata drifts behind the latest caniuse-lite dataset; this affects warning output but not Astro/Vite build correctness.",
+  "fix": "Ran `npx update-browserslist-db@latest` using the repository's existing lockfile conventions. In this environment, caniuse-lite was already at the latest dataset (`1.0.30001791`), so no dependency or lockfile diff was required.",
+  "verification": [
+    "npm run build",
+    "npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs"
+  ],
+  "impact": "Warning-only; this issue did not fail CI gates or block artifact generation."
+}


### PR DESCRIPTION
### Motivation
- Capture and resolve an intermittent `Browserslist: browsers data (caniuse-lite) is ... old` warning emitted during `npm run build` by updating the Browserslist dataset where appropriate and recording the investigation and fix in the repo outage logs.

### Description
- Added `outages/2026-04-29-browserslist-caniuse-lite-warning.json` documenting the symptom, root cause, applied fix (`npx update-browserslist-db@latest`), verification commands, and that this was warning-only; the update reported `caniuse-lite` already current (v`1.0.30001791`) so no lockfile changes were required.

### Testing
- Ran `npm run build` and observed the build complete without the stale Browserslist warning.
- Ran `npm run lint` and `npm run type-check` which completed successfully.
- Invoked `npm test` (the test harness started but did not fully complete within the interactive execution window so full test-suite completion was not observed in this session).
- Ran `node scripts/link-check.mjs` which reported `All local markdown links resolved.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a8a279d0832f837dd0ad15562789)