### PR TITLE
🛠️ Relax Playwright headless-shell requirement to stop noisy warnings

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -207,7 +207,11 @@ export async function ensurePlaywrightBrowsers(options = {}) {
                 console.warn(
                     'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
                 );
-            } else if (requireHeadlessShell && !hasHeadlessShell && !warnedMissingHeadlessShellPaths.has(executablePath)) {
+            } else if (
+                requireHeadlessShell &&
+                !hasHeadlessShell &&
+                !warnedMissingHeadlessShellPaths.has(executablePath)
+            ) {
                 warnedMissingHeadlessShellPaths.add(executablePath);
                 console.warn(
                     `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing for ${executablePath}. E2E tests may fail.`
@@ -247,7 +251,10 @@ export async function ensurePlaywrightBrowsers(options = {}) {
     });
 
     const postInstallAssets = getChromiumAssetStatus(browser);
-    if (!postInstallAssets.hasChromium || (requireHeadlessShell && !postInstallAssets.hasHeadlessShell)) {
+    if (
+        !postInstallAssets.hasChromium ||
+        (requireHeadlessShell && !postInstallAssets.hasHeadlessShell)
+    ) {
         const missingAsset = !postInstallAssets.hasChromium
             ? 'chromium executable'
             : 'chromium headless shell';

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -132,11 +132,16 @@ export function resolveHeadlessShellPath(executablePath) {
     return '';
 }
 
-function getChromiumAssetStatus(browser) {
+function getChromiumAssetStatus(browser, options = {}) {
+    const { includeHeadlessShell = true } = options;
     try {
         const executablePath = browser.executablePath();
         if (!executablePath || !existsSync(executablePath)) {
             return { hasChromium: false, hasHeadlessShell: false, executablePath: '' };
+        }
+
+        if (!includeHeadlessShell) {
+            return { hasChromium: true, hasHeadlessShell: false, executablePath };
         }
 
         const headlessShellPath = resolveHeadlessShellPath(executablePath);
@@ -155,7 +160,9 @@ export function hasChromiumExecutable(browser) {
 
 export function hasChromiumAssets(browser, options = {}) {
     const { requireHeadlessShell = false } = options;
-    const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser);
+    const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser, {
+        includeHeadlessShell: requireHeadlessShell,
+    });
     return requireHeadlessShell ? hasChromium && hasHeadlessShell : hasChromium;
 }
 

--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -153,9 +153,10 @@ export function hasChromiumExecutable(browser) {
     return hasChromium;
 }
 
-export function hasChromiumAssets(browser) {
+export function hasChromiumAssets(browser, options = {}) {
+    const { requireHeadlessShell = false } = options;
     const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser);
-    return hasChromium && hasHeadlessShell;
+    return requireHeadlessShell ? hasChromium && hasHeadlessShell : hasChromium;
 }
 
 async function getChromiumBrowser() {
@@ -189,6 +190,8 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         return;
     }
 
+    const requireHeadlessShell = env.PLAYWRIGHT_REQUIRE_HEADLESS_SHELL === '1';
+
     if (env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
         if (browser) {
             const { hasChromium, hasHeadlessShell, executablePath } =
@@ -197,7 +200,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
                 console.warn(
                     'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
                 );
-            } else if (!hasHeadlessShell && !warnedMissingHeadlessShellPaths.has(executablePath)) {
+            } else if (requireHeadlessShell && !hasHeadlessShell && !warnedMissingHeadlessShellPaths.has(executablePath)) {
                 warnedMissingHeadlessShellPaths.add(executablePath);
                 console.warn(
                     `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing for ${executablePath}. E2E tests may fail.`
@@ -212,7 +215,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         return;
     }
 
-    if (hasChromiumAssets(browser)) {
+    if (hasChromiumAssets(browser, { requireHeadlessShell })) {
         return;
     }
 
@@ -237,7 +240,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
     });
 
     const postInstallAssets = getChromiumAssetStatus(browser);
-    if (!postInstallAssets.hasChromium || !postInstallAssets.hasHeadlessShell) {
+    if (!postInstallAssets.hasChromium || (requireHeadlessShell && !postInstallAssets.hasHeadlessShell)) {
         const missingAsset = !postInstallAssets.hasChromium
             ? 'chromium executable'
             : 'chromium headless shell';

--- a/outages/2026-04-29-playwright-headless-shell-warning.json
+++ b/outages/2026-04-29-playwright-headless-shell-warning.json
@@ -4,7 +4,11 @@
   "component": "frontend-e2e",
   "symptom": "Grouped Playwright E2E runs repeatedly logged that chromium headless shell was still missing after installation, even when tests passed.",
   "rootCause": "The browser bootstrap helper treated headless shell as mandatory for all Chromium runs and warned after each group, but the test configuration runs Chromium with --headless=new where the shell artifact is optional.",
-  "fix": "Updated Playwright browser asset detection to require only Chromium by default and require headless shell only when PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1 is explicitly set.",
+  "resolution": "Updated Playwright browser asset detection to require only Chromium by default and require headless shell only when PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1 is explicitly set.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts"
+  ],
   "verification": [
     "npm run test:e2e:groups",
     "npm test",

--- a/outages/2026-04-29-playwright-headless-shell-warning.json
+++ b/outages/2026-04-29-playwright-headless-shell-warning.json
@@ -1,0 +1,17 @@
+{
+  "id": "2026-04-29-playwright-headless-shell-warning",
+  "date": "2026-04-29",
+  "component": "frontend-e2e",
+  "symptom": "Grouped Playwright E2E runs repeatedly logged that chromium headless shell was still missing after installation, even when tests passed.",
+  "rootCause": "The browser bootstrap helper treated headless shell as mandatory for all Chromium runs and warned after each group, but the test configuration runs Chromium with --headless=new where the shell artifact is optional.",
+  "fix": "Updated Playwright browser asset detection to require only Chromium by default and require headless shell only when PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1 is explicitly set.",
+  "verification": [
+    "npm run test:e2e:groups",
+    "npm test",
+    "npm run lint",
+    "npm run type-check",
+    "npm run build",
+    "node scripts/link-check.mjs"
+  ],
+  "whyTestsPassed": "Playwright launched successfully with the installed Chromium executable, so tests executed normally despite the helper's overly strict post-install warning."
+}

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -483,6 +483,82 @@ describe('ensurePlaywrightBrowsers', () => {
     }
   });
 
+  it('warns once in strict skip-download mode when headless shell is missing', async () => {
+    const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
+    const chromeExecutable = path.join(
+      cacheRoot,
+      'chromium-1181',
+      'chrome-linux',
+      'chrome'
+    );
+    const headlessUnderscore = path.join(
+      cacheRoot,
+      'chromium_headless_shell-1181',
+      'chrome-linux',
+      'headless_shell'
+    );
+    const existsSync = vi.fn((candidate: string) => {
+      if (candidate === chromeExecutable) {
+        return true;
+      }
+      if (candidate === headlessUnderscore) {
+        return false;
+      }
+      return false;
+    });
+    const execFileSync = vi.fn();
+    const executablePath = vi.fn(() => chromeExecutable);
+    const browser = { executablePath };
+
+    vi.doMock('node:child_process', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:child_process')>(
+          'node:child_process'
+        );
+      return {
+        ...actual,
+        execFileSync,
+        default: { ...actual, execFileSync },
+      };
+    });
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        existsSync,
+        default: { ...actual, existsSync },
+      };
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
+      const strictSkipEnv = {
+        ...process.env,
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+        PLAYWRIGHT_REQUIRE_HEADLESS_SHELL: '1',
+      };
+
+      await ensurePlaywrightBrowsers({
+        cwd: frontendRoot,
+        browser,
+        env: strictSkipEnv,
+      });
+      await ensurePlaywrightBrowsers({
+        cwd: frontendRoot,
+        browser,
+        env: strictSkipEnv,
+      });
+
+      expect(execFileSync).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing for ${chromeExecutable}. E2E tests may fail.`
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('skips install when chromium and headless shell already exist', async () => {
     const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
     const chromeExecutable = path.join(

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -302,7 +302,7 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('installs missing headless shell when chromium executable already exists', async () => {
+  it('skips install when chromium executable already exists and headless shell is optional', async () => {
     const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
     const chromeExecutable = path.join(
       cacheRoot,
@@ -384,15 +384,8 @@ describe('ensurePlaywrightBrowsers', () => {
         env: { ...process.env, PLAYWRIGHT_SKIP_INSTALL_DEPS: '0' },
       });
 
-      expect(execFileSync).toHaveBeenCalledTimes(2);
-      expect(execFileSync.mock.calls[0][1]).toEqual([cliPath, 'install-deps']);
-      expect(execFileSync.mock.calls[1][1]).toEqual([
-        cliPath,
-        'install',
-        'chromium',
-        'chromium-headless-shell',
-      ]);
-      expect(executablePath).toHaveBeenCalledTimes(2);
+      expect(execFileSync).not.toHaveBeenCalled();
+      expect(executablePath).toHaveBeenCalledTimes(1);
       expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
       expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
       expect(warnSpy).not.toHaveBeenCalledWith(

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -386,11 +386,98 @@ describe('ensurePlaywrightBrowsers', () => {
 
       expect(execFileSync).not.toHaveBeenCalled();
       expect(executablePath).toHaveBeenCalledTimes(1);
-      expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
-      expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
-      expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Proceeding with chromium binary only')
-      );
+      expect(existsSync).not.toHaveBeenCalledWith(headlessHyphen);
+      expect(existsSync).not.toHaveBeenCalledWith(headlessUnderscore);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('installs headless shell in strict mode when chromium executable exists', async () => {
+    const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
+    const chromeExecutable = path.join(
+      cacheRoot,
+      'chromium-1181',
+      'chrome-linux',
+      'chrome'
+    );
+    const headlessUnderscore = path.join(
+      cacheRoot,
+      'chromium_headless_shell-1181',
+      'chrome-linux',
+      'headless_shell'
+    );
+    const cliPath = path.join(
+      frontendRoot,
+      'node_modules',
+      '@playwright',
+      'test',
+      'cli.js'
+    );
+    let headlessInstalled = false;
+    let depsSentinelExists = false;
+    const existsSync = vi.fn((candidate: string) => {
+      if (candidate === cliPath || candidate === chromeExecutable) {
+        return true;
+      }
+      if (candidate === headlessUnderscore) {
+        return headlessInstalled;
+      }
+      if (candidate === path.join(frontendRoot, '.playwright-deps-installed')) {
+        return depsSentinelExists;
+      }
+      return false;
+    });
+    const execFileSync = vi.fn((_cmd, args) => {
+      const joinedArgs = Array.isArray(args) ? args.join(' ') : '';
+      if (joinedArgs.includes('install chromium chromium-headless-shell')) {
+        headlessInstalled = true;
+      }
+    });
+    const writeFileSync = vi.fn(() => {
+      depsSentinelExists = true;
+    });
+    const executablePath = vi.fn(() => chromeExecutable);
+    const browser = { executablePath };
+
+    vi.doMock('node:child_process', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:child_process')>(
+          'node:child_process'
+        );
+      return {
+        ...actual,
+        execFileSync,
+        default: { ...actual, execFileSync },
+      };
+    });
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        existsSync,
+        writeFileSync,
+        default: { ...actual, existsSync },
+      };
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { ensurePlaywrightBrowsers } = await import(MODULE_PATH);
+
+      await ensurePlaywrightBrowsers({
+        cwd: frontendRoot,
+        browser,
+        platform: 'linux',
+        env: {
+          ...process.env,
+          PLAYWRIGHT_REQUIRE_HEADLESS_SHELL: '1',
+          PLAYWRIGHT_SKIP_INSTALL_DEPS: '0',
+        },
+      });
+
+      expect(execFileSync).toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }
@@ -459,7 +546,7 @@ describe('ensurePlaywrightBrowsers', () => {
 
     expect(execFileSync).not.toHaveBeenCalled();
     expect(executablePath).toHaveBeenCalledTimes(1);
-    expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
+    expect(existsSync).not.toHaveBeenCalledWith(headlessHyphen);
   });
 
   it('prefers underscore headless directories when present', async () => {


### PR DESCRIPTION
### Motivation
- Grouped E2E runs repeatedly printed “Playwright chromium headless shell is still missing after installation” even though Playwright launched the Chromium executable and tests passed, producing noisy, misleading logs. 
- The helper treated the headless-shell artifact as mandatory for all Chromium runs even when the runtime can use the installed Chromium binary with `--headless=new`.

### Description
- Changed `frontend/scripts/utils/ensure-playwright-browsers.js` to make the headless-shell optional by default and to accept `PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1` to opt into strict headless-shell requirement. 
- Introduced an optional `requireHeadlessShell` flag in `hasChromiumAssets` and used it to gate warnings and install decisions. 
- Kept existing checks and warnings for genuinely missing Chromium executables and for `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` cases, preserving actionable failures. 
- Updated unit tests in `scripts/tests/ensurePlaywrightBrowsers.test.ts` to assert the new default behavior (no install when Chromium exists and headless shell is optional). 
- Added an outage record at `outages/2026-04-29-playwright-headless-shell-warning.json` documenting symptom, root cause, fix, verification, and why tests still passed.

### Testing
- Ran the focused unit test suite for the helper with `npx vitest run scripts/tests/ensurePlaywrightBrowsers.test.ts`, and the tests passed. 
- Ran the repository secret scan on staged changes with `./scripts/scan-secrets.py` and it reported no findings. 
- The outage file and verification commands were added to the repo; follow the listed verification commands (for example `npm run test:e2e:groups` and `npm test`) to validate in CI where grouped E2E runs execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ff0a31c832f8a911ac537323360)