### PR TITLE
🛠️ Fix Playwright headless-shell false-missing warnings on macOS

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -96,10 +96,24 @@ export function resolveHeadlessShellPath(executablePath) {
             const executableExtension = path.extname(executablePath);
             const headlessExecutable = `headless_shell${executableExtension}`;
             const relativeDirectory = path.dirname(relativeExecutablePath);
-            const headlessRelativePath =
+            const defaultHeadlessRelativePath =
                 !relativeDirectory || relativeDirectory === '.'
                     ? headlessExecutable
                     : path.join(relativeDirectory, headlessExecutable);
+            const headlessRelativePaths = [defaultHeadlessRelativePath];
+
+            if (relativeExecutablePath.includes(path.join('Chromium.app', 'Contents', 'MacOS'))) {
+                headlessRelativePaths.push(path.join('chrome-mac', headlessExecutable));
+                headlessRelativePaths.push(
+                    path.join(
+                        'chrome-mac',
+                        'HeadlessShell.app',
+                        'Contents',
+                        'MacOS',
+                        headlessExecutable
+                    )
+                );
+            }
 
             const revisionSuffix = revisionBasename.replace(/^chromium[-_]/, '');
             const headlessBasenames = [
@@ -111,17 +125,18 @@ export function resolveHeadlessShellPath(executablePath) {
 
             for (const headlessBasename of headlessBasenames) {
                 const headlessRevisionDir = path.join(parentDir, headlessBasename);
-                const candidatePath = path.join(headlessRevisionDir, headlessRelativePath);
-
-                if (existsSync(candidatePath)) {
-                    return candidatePath;
+                for (const headlessRelativePath of headlessRelativePaths) {
+                    const candidatePath = path.join(headlessRevisionDir, headlessRelativePath);
+                    if (existsSync(candidatePath)) {
+                        return candidatePath;
+                    }
                 }
             }
 
             return path.join(
                 parentDir,
                 `chromium-headless-shell-${revisionSuffix}`,
-                headlessRelativePath
+                headlessRelativePaths[0]
             );
         }
 

--- a/outages/2026-04-29-playwright-headless-shell-path-detection.json
+++ b/outages/2026-04-29-playwright-headless-shell-path-detection.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-04-29-playwright-headless-shell-path-detection",
+  "date": "2026-04-29",
+  "component": "frontend:playwright-bootstrap",
+  "longForm": "outages/2026-04-29-playwright-headless-shell-path-detection.md",
+  "rootCause": "The Playwright browser helper derived headless-shell paths by mirroring Chromium's executable subtree, which produced a false missing status on macOS installations where headless_shell is stored at chrome-mac root.",
+  "resolution": "Updated headless-shell path resolution to probe macOS-specific alternate install layouts and added regression tests so grouped E2E runs stop printing repeated false-missing warnings.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "scripts/tests/ensurePlaywrightBrowsers.test.ts",
+    "outages/2026-04-29-playwright-headless-shell-path-detection.md"
+  ]
+}

--- a/outages/2026-04-29-playwright-headless-shell-path-detection.md
+++ b/outages/2026-04-29-playwright-headless-shell-path-detection.md
@@ -1,0 +1,30 @@
+# Playwright headless shell false-missing warnings during grouped E2E
+
+## Symptom
+During grouped Playwright runs (`npm run test:e2e:groups`), each group printed:
+
+- `Playwright chromium headless shell is still missing after installation. Tests may fail if browsers are unavailable.`
+
+The warning appeared even though Chromium launched and all E2E specs passed.
+
+## Root cause
+`resolveHeadlessShellPath` assumed headless shell binaries always mirrored Chromium's executable
+subpath (including `Chromium.app/...` on macOS). On current Playwright macOS layouts, the
+headless shell may be installed at `chrome-mac/headless_shell` instead, so detection returned a
+false negative.
+
+## Fix
+- Expanded headless shell path detection to probe macOS-specific alternate layouts:
+  - `chrome-mac/headless_shell`
+  - `chrome-mac/HeadlessShell.app/Contents/MacOS/headless_shell`
+- Kept the existing warning behavior unchanged for true missing-browser states.
+- Added regression coverage for the `chrome-mac/headless_shell` layout.
+
+## Verification commands
+- `npm run test -- scripts/tests/ensurePlaywrightBrowsers.test.ts`
+- `npm run test:e2e:groups`
+- `npm test`
+
+## Why tests passed despite the warning
+Playwright tests were launching with a valid Chromium executable. The warning was emitted by the
+helper's path detector only, not by a launcher failure. That made it noisy but non-blocking.

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -550,6 +550,46 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(resolveHeadlessShellPath(macExecutablePath)).toBe(headlessHyphen);
   });
 
+  it('resolves macOS headless shell paths stored at chrome-mac root', async () => {
+    const macCacheRoot = path.join(
+      path.sep,
+      'Users',
+      'dev',
+      'Library',
+      'Caches',
+      'ms-playwright'
+    );
+    const macExecutablePath = path.join(
+      macCacheRoot,
+      'chromium-1181',
+      'chrome-mac',
+      'Chromium.app',
+      'Contents',
+      'MacOS',
+      'Chromium'
+    );
+    const headlessAtChromeMacRoot = path.join(
+      macCacheRoot,
+      'chromium-headless-shell-1181',
+      'chrome-mac',
+      'headless_shell'
+    );
+
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      const check = (candidate: string) => candidate === headlessAtChromeMacRoot;
+      return {
+        ...actual,
+        existsSync: check,
+        default: { ...actual, existsSync: check },
+      };
+    });
+
+    const { resolveHeadlessShellPath } = await import(MODULE_PATH);
+
+    expect(resolveHeadlessShellPath(macExecutablePath)).toBe(headlessAtChromeMacRoot);
+  });
+
   it('includes executable extensions when deriving headless shell path', async () => {
     const winCacheRoot = path.join(
       'C:',


### PR DESCRIPTION
### Motivation
- Grouped E2E runs printed repeated `Playwright chromium headless shell is still missing after installation` warnings even though Chromium launched and tests passed, which indicated a detector false negative on some macOS Playwright layouts.
- Improve detection so the install-check helper no longer emits noisy false-missing warnings while preserving real missing-browser warnings.

### Description
- Expanded `resolveHeadlessShellPath` to probe macOS-specific alternate layouts (`chrome-mac/headless_shell` and `chrome-mac/HeadlessShell.app/...`) in addition to the Chromium.app bundle subtree (`frontend/scripts/utils/ensure-playwright-browsers.js`).
- Iterated candidate relative paths when searching headless-shell revisions to correctly detect headless shells stored at the `chrome-mac` root rather than inside the `Chromium.app` bundle.
- Added a regression test that simulates the `chrome-mac/headless_shell` layout and asserts detection resolves correctly (`scripts/tests/ensurePlaywrightBrowsers.test.ts`).
- Added a new outage record documenting symptom, root cause, fix, verification commands, and rationale (`outages/2026-04-29-playwright-headless-shell-path-detection.md` and `.json`).

### Testing
- Ran the updated tests via `npm run test:root -- scripts/tests/ensurePlaywrightBrowsers.test.ts`, which executed the `ensurePlaywrightBrowsers` tests and passed (`11 tests, 1 file, all passed`).
- Ran the repo secrets scan via `git diff --cached | ./scripts/scan-secrets.py`, which produced no findings.
- Local verification commands listed in the outage file include `npm run test -- scripts/tests/ensurePlaywrightBrowsers.test.ts`, `npm run test:e2e:groups`, and `npm test` for end-to-end verification; the focused unit test above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ff0a31c832f8a911ac537323360)