### PR TITLE
🛠️ Reduce noisy Playwright headless-shell warnings in grouped E2E

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -237,12 +237,9 @@ export async function ensurePlaywrightBrowsers(options = {}) {
     });
 
     const postInstallAssets = getChromiumAssetStatus(browser);
-    if (!postInstallAssets.hasChromium || !postInstallAssets.hasHeadlessShell) {
-        const missingAsset = !postInstallAssets.hasChromium
-            ? 'chromium executable'
-            : 'chromium headless shell';
+    if (!postInstallAssets.hasChromium) {
         console.warn(
-            `Playwright ${missingAsset} is still missing after installation. Tests may fail if browsers are unavailable.`
+            'Playwright chromium executable is still missing after installation. Tests may fail if browsers are unavailable.'
         );
     }
 }

--- a/frontend/tests/ensure-playwright-browsers.test.ts
+++ b/frontend/tests/ensure-playwright-browsers.test.ts
@@ -324,6 +324,49 @@ describe('ensurePlaywrightBrowsers', () => {
         expect(writeFileSyncMock).toHaveBeenCalled();
     });
 
+
+    it('does not warn when chromium exists but headless shell is absent after install', async () => {
+        let browserInstalled = false;
+        existsSyncMock.mockImplementation((target: string) => {
+            if (target === cliPath) {
+                return true;
+            }
+            if (target === chromiumPath) {
+                return browserInstalled;
+            }
+            if (target.includes('chromium-headless-shell-1234')) {
+                return false;
+            }
+            return false;
+        });
+
+        execFileSyncMock.mockImplementation((_command, args: string[]) => {
+            if (args[1] === 'install') {
+                browserInstalled = true;
+            }
+        });
+
+        const { ensurePlaywrightBrowsers } = await importModule();
+
+        await ensurePlaywrightBrowsers({
+            cwd,
+            env: { ...process.env },
+            platform: 'darwin',
+            installSystemDeps: false,
+            exec: execFileSyncMock,
+            fs: {
+                existsSync: existsSyncMock,
+                mkdirSync: mkdirSyncMock,
+                writeFileSync: writeFileSyncMock,
+            },
+        });
+
+        expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+        expect(console.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining('headless shell is still missing after installation')
+        );
+    });
+
     it('uses provided env for skip-download behavior', async () => {
         const chromiumPath = '/root/.cache/ms-playwright/chromium-1234/chrome';
         existsSyncMock.mockImplementation((target: string) => target === chromiumPath);

--- a/outages/2026-04-29-playwright-headless-shell-repeat-warning.json
+++ b/outages/2026-04-29-playwright-headless-shell-repeat-warning.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-04-29-playwright-headless-shell-repeat-warning",
+  "date": "2026-04-29",
+  "component": "frontend:playwright-bootstrap",
+  "longForm": "outages/2026-04-29-playwright-headless-shell-repeat-warning.md",
+  "symptom": "Grouped E2E runs repeatedly logged 'Playwright chromium headless shell is still missing after installation' even though tests passed.",
+  "rootCause": "The bootstrap helper warned whenever chromium-headless-shell was absent after install, even when Chromium itself was available and sufficient for the current Playwright launch path. Because Playwright config loads per group invocation, the warning repeated across groups.",
+  "resolution": "Adjusted post-install validation to warn only when the Chromium executable is still missing. This preserves actionable failure signaling while eliminating false-positive headless-shell noise in successful grouped runs.",
+  "verification": [
+    "npm run test:root -- frontend/tests/ensure-playwright-browsers.test.ts",
+    "npm run test:e2e:groups"
+  ],
+  "whyTestsPassed": "Playwright could still launch tests with the installed Chromium executable, so test groups succeeded despite the headless-shell warning.",
+  "references": [
+    "frontend/scripts/utils/ensure-playwright-browsers.js",
+    "frontend/tests/ensure-playwright-browsers.test.ts",
+    "outages/2026-04-29-playwright-headless-shell-repeat-warning.md"
+  ]
+}

--- a/outages/2026-04-29-playwright-headless-shell-repeat-warning.md
+++ b/outages/2026-04-29-playwright-headless-shell-repeat-warning.md
@@ -1,0 +1,30 @@
+# Outage: Repeated Playwright headless-shell missing warnings during grouped E2E
+
+## Symptom
+
+Grouped E2E runs printed this warning repeatedly:
+
+- `Playwright chromium headless shell is still missing after installation. Tests may fail if browsers are unavailable.`
+
+The warning appeared for multiple groups even when all tests passed.
+
+## Root cause
+
+`ensurePlaywrightBrowsers` treated a missing `chromium-headless-shell` artifact as a post-install warning condition, even when Chromium was present and runnable for the active test launch path.
+
+Because Playwright configuration executes in each grouped invocation, this warning was emitted repeatedly and looked like an install failure loop.
+
+## Fix
+
+- Kept browser installation logic intact.
+- Narrowed the post-install warning condition to only missing Chromium executable.
+- Added regression coverage asserting we do not emit the post-install headless-shell warning when Chromium exists.
+
+## Verification commands
+
+- `npm run test:root -- frontend/tests/ensure-playwright-browsers.test.ts`
+- `npm run test:e2e:groups`
+
+## Why tests passed despite warning
+
+Playwright can run the configured tests with the Chromium executable already present; the missing headless-shell warning was noisy but non-blocking for this configuration.


### PR DESCRIPTION
### Motivation

- Grouped E2E runs repeatedly printed `Playwright chromium headless shell is still missing after installation` for every Playwright invocation, creating noisy logs that obscured actionable failures.
- The goal was to remove the false-positive noise while preserving useful warnings when browsers are truly missing.

### Description

- Changed the post-install validation in `frontend/scripts/utils/ensure-playwright-browsers.js` to only warn when the Chromium executable is still missing (no warning when only `chromium-headless-shell` is absent).
- Added a regression test in `frontend/tests/ensure-playwright-browsers.test.ts` that simulates “Chromium installed but headless shell absent” and asserts the noisy post-install warning is not emitted.
- Added an outage record (`outages/2026-04-29-playwright-headless-shell-repeat-warning.json` and `.md`) documenting symptom, root cause, fix, verification commands, and why tests passed despite the warning.

### Testing

- Ran `npm run test:root -- frontend/tests/ensure-playwright-browsers.test.ts` and the focused tests passed (regression coverage for the changed behavior succeeded).
- Attempted `npm run test:e2e:groups` in the local container but the run could not complete due to environment network/APT reachability errors during Playwright dependency installation, so grouped E2E verification was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ff0a31c832f8a911ac537323360)