### PR TITLE
Fix repeated Playwright headless-shell missing warnings during grouped E2E

### DIFF
--- a/frontend/scripts/utils/ensure-playwright-browsers.js
+++ b/frontend/scripts/utils/ensure-playwright-browsers.js
@@ -154,8 +154,8 @@ export function hasChromiumExecutable(browser) {
 }
 
 export function hasChromiumAssets(browser) {
-    const { hasChromium, hasHeadlessShell } = getChromiumAssetStatus(browser);
-    return hasChromium && hasHeadlessShell;
+    const { hasChromium } = getChromiumAssetStatus(browser);
+    return hasChromium;
 }
 
 async function getChromiumBrowser() {
@@ -179,6 +179,7 @@ export async function ensurePlaywrightBrowsers(options = {}) {
         depsStampPath,
         exec = execFileSync,
         fs = { existsSync, mkdirSync, writeFileSync },
+        requireHeadlessShell = env.PLAYWRIGHT_REQUIRE_HEADLESS_SHELL === '1',
     } = options;
 
     const sanitizedEnv = withPlaywrightNetworkEnv(sanitizeProxyEnv(env));
@@ -197,7 +198,11 @@ export async function ensurePlaywrightBrowsers(options = {}) {
                 console.warn(
                     'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium browser is missing. E2E tests may fail.'
                 );
-            } else if (!hasHeadlessShell && !warnedMissingHeadlessShellPaths.has(executablePath)) {
+            } else if (
+                requireHeadlessShell &&
+                !hasHeadlessShell &&
+                !warnedMissingHeadlessShellPaths.has(executablePath)
+            ) {
                 warnedMissingHeadlessShellPaths.add(executablePath);
                 console.warn(
                     `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 but Playwright chromium headless shell is missing for ${executablePath}. E2E tests may fail.`
@@ -237,10 +242,8 @@ export async function ensurePlaywrightBrowsers(options = {}) {
     });
 
     const postInstallAssets = getChromiumAssetStatus(browser);
-    if (!postInstallAssets.hasChromium || !postInstallAssets.hasHeadlessShell) {
-        const missingAsset = !postInstallAssets.hasChromium
-            ? 'chromium executable'
-            : 'chromium headless shell';
+    if (!postInstallAssets.hasChromium || (requireHeadlessShell && !postInstallAssets.hasHeadlessShell)) {
+        const missingAsset = !postInstallAssets.hasChromium ? 'chromium executable' : 'chromium headless shell';
         console.warn(
             `Playwright ${missingAsset} is still missing after installation. Tests may fail if browsers are unavailable.`
         );

--- a/outages/2026-04-29-playwright-headless-shell-warning-repeat.md
+++ b/outages/2026-04-29-playwright-headless-shell-warning-repeat.md
@@ -1,0 +1,40 @@
+# Outage: repeated Playwright headless-shell missing warnings during grouped E2E
+
+- **Date:** 2026-04-29
+- **Component:** `frontend/scripts/utils/ensure-playwright-browsers.js`
+- **Severity:** low (log-noise, not functional failure)
+
+## Symptom
+
+`npm run test:e2e:groups` repeatedly logged:
+
+`Playwright chromium headless shell is still missing after installation. Tests may fail if browsers are unavailable.`
+
+The warning appeared in each Playwright invocation group, even though tests still passed.
+
+## Root cause
+
+The bootstrap helper treated `chromium-headless-shell` as a required asset for success checks.
+However, this suite runs Chromium with `--headless=new`, which uses the regular Chromium binary.
+In that mode, the headless shell artifact is optional for these tests, so the detector produced false
+missing-asset warnings.
+
+Because grouped runs spawn Playwright multiple times, the same false warning was emitted repeatedly.
+
+## Fix
+
+- Updated Playwright asset validation to require Chromium executable presence by default.
+- Kept headless-shell checks available behind an explicit opt-in (`PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1`)
+  for environments that truly depend on shell-mode validation.
+- Updated helper regression coverage to assert the new default behavior.
+
+## Verification commands
+
+- `npx vitest run -c vitest.config.mts frontend/tests/ensure-playwright-browsers.test.ts scripts/tests/ensurePlaywrightBrowsers.test.ts`
+- `npm run test:e2e:groups`
+- `npm test`
+
+## Why tests passed despite the warning
+
+The warning was a false positive from bootstrap validation logic. Playwright still had a usable Chromium
+binary and successfully launched tests in modern headless mode.

--- a/scripts/tests/ensurePlaywrightBrowsers.test.ts
+++ b/scripts/tests/ensurePlaywrightBrowsers.test.ts
@@ -302,7 +302,7 @@ describe('ensurePlaywrightBrowsers', () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('installs missing headless shell when chromium executable already exists', async () => {
+  it('skips install when chromium executable already exists even if headless shell is missing', async () => {
     const cacheRoot = path.join(path.sep, 'root', '.cache', 'ms-playwright');
     const chromeExecutable = path.join(
       cacheRoot,
@@ -384,15 +384,8 @@ describe('ensurePlaywrightBrowsers', () => {
         env: { ...process.env, PLAYWRIGHT_SKIP_INSTALL_DEPS: '0' },
       });
 
-      expect(execFileSync).toHaveBeenCalledTimes(2);
-      expect(execFileSync.mock.calls[0][1]).toEqual([cliPath, 'install-deps']);
-      expect(execFileSync.mock.calls[1][1]).toEqual([
-        cliPath,
-        'install',
-        'chromium',
-        'chromium-headless-shell',
-      ]);
-      expect(executablePath).toHaveBeenCalledTimes(2);
+      expect(execFileSync).not.toHaveBeenCalled();
+      expect(executablePath).toHaveBeenCalledTimes(1);
       expect(existsSync).toHaveBeenCalledWith(headlessHyphen);
       expect(existsSync).toHaveBeenCalledWith(headlessUnderscore);
       expect(warnSpy).not.toHaveBeenCalledWith(


### PR DESCRIPTION
### Motivation
- Grouped E2E runs repeatedly printed `Playwright chromium headless shell is still missing after installation` even though Chromium binary launched successfully, producing noisy logs that obscured real issues. 
- The bootstrap helper was treating the `chromium-headless-shell` artifact as required by default while modern Playwright headless mode can use the regular Chromium binary. 
- Reduce log noise while preserving actionable warnings for environments that genuinely require the headless shell.

### Description
- Changed `frontend/scripts/utils/ensure-playwright-browsers.js` so the default asset check requires the Chromium executable only (`hasChromiumAssets` now returns presence of Chromium). 
- Added an opt-in flag `PLAYWRIGHT_REQUIRE_HEADLESS_SHELL=1` (exposed as `requireHeadlessShell`) so headless-shell validation remains available when explicitly required. 
- Adjusted warning and post-install logic to only warn/retry for headless-shell absence when `PLAYWRIGHT_REQUIRE_HEADLESS_SHELL` is set. 
- Updated regression test `scripts/tests/ensurePlaywrightBrowsers.test.ts` to match the new default behavior and added an `outages/2026-04-29-playwright-headless-shell-warning-repeat.md` entry documenting symptom, root cause, fix, and verification commands.

### Testing
- Ran `npx vitest run -c vitest.config.mts frontend/tests/ensure-playwright-browsers.test.ts scripts/tests/ensurePlaywrightBrowsers.test.ts` and all tests passed. 
- Verified the grouped E2E harness by running `npm run test:e2e:groups` as part of verification commands described in the outage doc (logs no longer emit the repeated headless-shell missing warning). 
- Confirmed repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` completed without exposing secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ff0a31c832f8a911ac537323360)