### PR TITLE
🧹 fix: suppress expected Playwright SW warning noise

### DIFF
--- a/frontend/e2e/cloud-sync.spec.ts
+++ b/frontend/e2e/cloud-sync.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, isExpectedPlaywrightSwWarning, waitForHydration } from './test-helpers';
 
 test.describe('Cloud Sync', () => {
     test.beforeEach(async ({ page }) => {
@@ -52,7 +52,9 @@ test.describe('Cloud Sync', () => {
                 const locationHint = location?.url
                     ? ` @ ${location.url}:${location.lineNumber}`
                     : '';
-                console.log(`[console.${message.type()}] ${message.text()}${locationHint}`);
+                if (!(message.type() === 'warning' && isExpectedPlaywrightSwWarning(message.text()))) {
+                    console.log(`[console.${message.type()}] ${message.text()}${locationHint}`);
+                }
             }
         });
 

--- a/frontend/e2e/manage-processes.spec.ts
+++ b/frontend/e2e/manage-processes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, logBrowserConsoleMessage, waitForHydration } from './test-helpers';
 
 test.describe('Manage Processes', () => {
     test.beforeEach(async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('Manage Processes', () => {
         });
 
         page.on('console', (message) => {
-            console.log(`[console.${message.type()}] ${message.text()}`);
+            logBrowserConsoleMessage(message);
         });
 
         await clearUserData(page);

--- a/frontend/e2e/process-preview.spec.ts
+++ b/frontend/e2e/process-preview.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
-import { clearUserData, waitForHydration, navigateWithRetry } from './test-helpers';
+import { clearUserData, logBrowserConsoleMessage, waitForHydration, navigateWithRetry } from './test-helpers';
 
 type ToggleDebugState = {
     calls: number;
@@ -61,7 +61,7 @@ test.describe('Process preview', () => {
         });
 
         page.on('console', (message) => {
-            console.log(`[console.${message.type()}] ${message.text()}`);
+            logBrowserConsoleMessage(message);
         });
 
         await clearUserData(page);

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -5,6 +5,21 @@ import { ITEM_SELECTOR_OPTION_LOCATORS } from './utils/itemSelectors';
 export type { Page };
 const E2E_DEBUG_LOGS = process.env.E2E_DEBUG_LOGS === '1';
 
+const PLAYWRIGHT_EXPECTED_SW_BLOCK_WARNING = 'Service Worker registration blocked by Playwright';
+
+export function isExpectedPlaywrightSwWarning(messageText: string): boolean {
+    return messageText.trim() === PLAYWRIGHT_EXPECTED_SW_BLOCK_WARNING;
+}
+
+export function logBrowserConsoleMessage(message: { type(): string; text(): string }): void {
+    const text = message.text();
+    if (message.type() === 'warning' && isExpectedPlaywrightSwWarning(text)) {
+        return;
+    }
+
+    console.log(`[console.${message.type()}] ${text}`);
+}
+
 export function debugLog(...args: unknown[]): void {
     if (E2E_DEBUG_LOGS) {
         console.log(...args);

--- a/frontend/src/pages/docs/md/outages/2026-04-30-playwright-sw-registration-warning-noise.md
+++ b/frontend/src/pages/docs/md/outages/2026-04-30-playwright-sw-registration-warning-noise.md
@@ -1,0 +1,25 @@
+---
+title: 'Playwright service worker registration warning noise (2026-04-30)'
+slug: '2026-04-30-playwright-sw-registration-warning-noise'
+summary: 'Filtered expected Playwright-only service worker block warnings from E2E console logging while preserving service worker behavior checks.'
+---
+
+# Playwright service worker registration warning noise (2026-04-30)
+
+- **Symptom**: `npm run test:e2e:groups` emitted repeated `[console.warning] Service Worker registration blocked by Playwright` lines in otherwise passing groups.
+- **Root cause**:
+    - Some E2E suites attach `page.on('console', ...)` handlers that print browser warnings to test output.
+    - Playwright intentionally blocks service workers in default contexts, and the app surfaces that expected block condition.
+    - The exact expected warning message was being forwarded verbatim into group logs as noise.
+- **Fix**:
+    - Added a narrow helper to identify the exact expected warning text: `Service Worker registration blocked by Playwright`.
+    - Updated E2E console forwarding to suppress only that exact warning while preserving all other console warnings/errors.
+    - Kept explicit service worker coverage unchanged, including tests that allow service workers and verify registration/update behavior.
+- **Verification commands**:
+    - `rg "Service Worker registration blocked by Playwright"`
+    - `npm run test:e2e:groups`
+    - `npm test`
+    - `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+- **Why warning-only**:
+    - The warning reflects Playwright test-environment configuration rather than a runtime production failure.
+    - Functional E2E assertions were passing; only console output signal-to-noise was degraded.


### PR DESCRIPTION
### Motivation
- Reduce noise in E2E logs by suppressing the repeated, expected message `Service Worker registration blocked by Playwright` without weakening service-worker tests or hiding other console warnings.

### Description
- Add a narrow helper in `frontend/e2e/test-helpers.ts`: `PLAYWRIGHT_EXPECTED_SW_BLOCK_WARNING`, `isExpectedPlaywrightSwWarning()` and `logBrowserConsoleMessage()` to identify and filter the exact expected warning. 
- Route noisy test suites to the helper by replacing direct `console` forwarding with `logBrowserConsoleMessage()` in `frontend/e2e/manage-processes.spec.ts` and `frontend/e2e/process-preview.spec.ts`.
- Narrowly suppress the exact warning in the cloud-sync console handler by importing and using `isExpectedPlaywrightSwWarning()` in `frontend/e2e/cloud-sync.spec.ts`.
- Add an outage document at `frontend/src/pages/docs/md/outages/2026-04-30-playwright-sw-registration-warning-noise.md` describing symptom, root cause, fix, verification commands, and why this was warning-only.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Verified the presence of the new helper with `rg "Service Worker registration blocked by Playwright"` against `frontend/e2e`, `frontend/public/scripts`, and `frontend/__tests__` which returned the expected matches. 
- Attempted to run targeted Playwright suites (`npx playwright test manage-processes.spec.ts process-preview.spec.ts --reporter=dot`) but the run was blocked by the environment (network failure during Playwright browser install) and a missing generated artifact (`../generated/rag/docs_chunks.json`), so E2E execution could not complete in this environment; the change preserves explicit SW tests (they still use `test.use({ serviceWorkers: 'allow' })` where appropriate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ff5cf244832f9f23962c68bb78e1)