### PR TITLE
Add outage entry for Playwright service-worker registration warning noise

### DIFF
--- a/outages/2026-04-30-playwright-service-worker-registration-warning-noise.json
+++ b/outages/2026-04-30-playwright-service-worker-registration-warning-noise.json
@@ -1,0 +1,24 @@
+{
+  "id": "2026-04-30-playwright-service-worker-registration-warning-noise",
+  "date": "2026-04-30",
+  "component": "frontend/public/scripts/offlineWorkerRegistration.js",
+  "symptom": "Grouped Playwright E2E output repeatedly printed '[console.warning] Service Worker registration blocked by Playwright' even when suites passed.",
+  "rootCause": "Playwright intentionally blocks service worker registration for most suites via serviceWorkers='block', and the registration catch-path emitted that expected automation-only block as a warning.",
+  "fix": "Treat only the exact expected Playwright registration-block failure as an informational skip in automation mode while retaining warning logs for all other registration failures.",
+  "verification": [
+    "rg 'Service Worker registration blocked by Playwright'",
+    "npm --prefix frontend run test:e2e:groups",
+    "npm test",
+    "npm run lint",
+    "npm run type-check",
+    "npm run build",
+    "node scripts/link-check.mjs"
+  ],
+  "whyWarningOnly": "The warning did not indicate functional regressions: E2E groups passed and explicit service-worker coverage remains in service-worker-update suites that opt into serviceWorkers='allow'.",
+  "references": [
+    "frontend/public/scripts/offlineWorkerRegistration.js",
+    "frontend/__tests__/offlineWorkerRegistration.test.js",
+    "frontend/e2e/service-worker-update.spec.ts",
+    "frontend/playwright.config.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Record and document the noisy but expected Playwright console warning emitted when service workers are intentionally blocked during grouped E2E runs so triage and QA logs are clearer.

### Description
- Add `outages/2026-04-30-playwright-service-worker-registration-warning-noise.json` which captures the symptom, root cause, narrow fix (log as informational skip in automation for the exact Playwright block), verification steps, and references to the involved files.

### Testing
- Ran `rg 'Service Worker registration blocked by Playwright'` to verify the targeted string and references were present.
- Ran the unit-suite for the registration logic with `npx vitest run -c vitest.config.mts frontend/__tests__/offlineWorkerRegistration.test.js` and all tests passed.
- Attempted `npm --prefix frontend run test:e2e:groups` but full E2E verification could not complete in this environment due to Playwright browser install/network errors (browser download/install failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ff5cf244832f9f23962c68bb78e1)