### PR TITLE
🧹 Suppress expected Playwright service worker warning noise

### DIFF
--- a/frontend/e2e/cloud-sync.spec.ts
+++ b/frontend/e2e/cloud-sync.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { clearUserData, waitForHydration } from './test-helpers';
 
+const isExpectedPlaywrightServiceWorkerWarning = (message: string) =>
+    message.trim() === 'Service Worker registration blocked by Playwright';
+
 test.describe('Cloud Sync', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
@@ -52,6 +55,12 @@ test.describe('Cloud Sync', () => {
                 const locationHint = location?.url
                     ? ` @ ${location.url}:${location.lineNumber}`
                     : '';
+                if (
+                    message.type() === 'warning' &&
+                    isExpectedPlaywrightServiceWorkerWarning(message.text())
+                ) {
+                    return;
+                }
                 console.log(`[console.${message.type()}] ${message.text()}${locationHint}`);
             }
         });

--- a/frontend/e2e/manage-processes.spec.ts
+++ b/frontend/e2e/manage-processes.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { clearUserData, waitForHydration } from './test-helpers';
 
+const isExpectedPlaywrightServiceWorkerWarning = (message: string) =>
+    message.trim() === 'Service Worker registration blocked by Playwright';
+
 test.describe('Manage Processes', () => {
     test.beforeEach(async ({ page }) => {
         page.on('pageerror', (error) => {
@@ -11,6 +14,12 @@ test.describe('Manage Processes', () => {
         });
 
         page.on('console', (message) => {
+            if (
+                message.type() === 'warning' &&
+                isExpectedPlaywrightServiceWorkerWarning(message.text())
+            ) {
+                return;
+            }
             console.log(`[console.${message.type()}] ${message.text()}`);
         });
 

--- a/frontend/e2e/process-preview.spec.ts
+++ b/frontend/e2e/process-preview.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
 import { clearUserData, waitForHydration, navigateWithRetry } from './test-helpers';
 
+const isExpectedPlaywrightServiceWorkerWarning = (message: string) =>
+    message.trim() === 'Service Worker registration blocked by Playwright';
+
 type ToggleDebugState = {
     calls: number;
     before: string;
@@ -61,6 +64,12 @@ test.describe('Process preview', () => {
         });
 
         page.on('console', (message) => {
+            if (
+                message.type() === 'warning' &&
+                isExpectedPlaywrightServiceWorkerWarning(message.text())
+            ) {
+                return;
+            }
             console.log(`[console.${message.type()}] ${message.text()}`);
         });
 

--- a/outages/2026-04-30-playwright-service-worker-registration-warning-noise.json
+++ b/outages/2026-04-30-playwright-service-worker-registration-warning-noise.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-04-30-playwright-service-worker-registration-warning-noise",
+  "date": "2026-04-30",
+  "severity": "low",
+  "summary": "Playwright E2E logs printed expected blocked-service-worker warnings repeatedly.",
+  "impact": "Warning noise reduced observability for unexpected console warnings during grouped E2E runs.",
+  "rootCause": "Spec-local console listeners printed all browser warnings, including Playwright's expected warning when service workers are blocked.",
+  "resolution": "Added an exact-match warning filter in affected E2E console listeners while preserving all other warning/error logging.",
+  "verification": [
+    "rg \"Service Worker registration blocked by Playwright\"",
+    "npm --prefix frontend run test:e2e:groups",
+    "npm test",
+    "npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs"
+  ],
+  "warningOnly": true
+}

--- a/outages/2026-04-30-playwright-service-worker-registration-warning-noise.md
+++ b/outages/2026-04-30-playwright-service-worker-registration-warning-noise.md
@@ -1,0 +1,29 @@
+# Outage: Playwright service-worker registration warning noise in E2E logs
+
+- **Date**: 2026-04-30
+- **Severity**: low
+- **Component**: `frontend/e2e/*` console listeners
+- **Incident ID**: `2026-04-30-playwright-service-worker-registration-warning-noise`
+
+## Symptom
+
+`npm run test:e2e:groups` emitted repeated `[console.warning] Service Worker registration blocked by Playwright` lines in otherwise passing suites.
+
+## Root cause
+
+Some E2E specs log browser console warnings verbatim for debugging. Playwright's blocked-service-worker warning is expected under `serviceWorkers: 'block'`, but those spec-local listeners did not filter this known warning.
+
+## Fix
+
+Added a narrow exact-string filter in affected spec console handlers to ignore only `Service Worker registration blocked by Playwright` when message type is `warning`. All other warning/error console output remains unchanged.
+
+## Verification commands
+
+- `rg "Service Worker registration blocked by Playwright"`
+- `npm --prefix frontend run test:e2e:groups`
+- `npm test`
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+
+## Why this was warning-only
+
+Test behavior and assertions were already passing; the issue was log noise from expected platform behavior in Playwright, not an application failure.


### PR DESCRIPTION
### Motivation
- Grouped Playwright E2E runs were emitting repeated `[console.warning] Service Worker registration blocked by Playwright` lines which cluttered QA logs despite tests passing.
- The warning is expected under the test environment because Playwright is configured with `serviceWorkers: 'block'`, so the app should not treat this specific failure as an unexpected warning in automation.
- Make logs readable without weakening real console-warning/error visibility or changing production service worker behavior.

### Description
- Added an exact-match helper `isExpectedPlaywrightServiceWorkerWarning` and applied it to console listeners in `frontend/e2e/manage-processes.spec.ts`, `frontend/e2e/process-preview.spec.ts`, and `frontend/e2e/cloud-sync.spec.ts` so warnings exactly equal to `Service Worker registration blocked by Playwright` are ignored during E2E runs.
- The console handlers now only skip that single expected warning when `message.type() === 'warning'`, preserving all other console warnings and errors.
- Added a new outage record documenting the symptom, root cause, fix, verification commands, and the fact this was warning-only as `outages/2026-04-30-playwright-service-worker-registration-warning-noise.md` and `.json`.

### Testing
- Verified code locations and occurrences with `rg "Service Worker registration blocked by Playwright"` which shows the new helper usage and outage files.
- Attempted to run grouped E2E via `npm --prefix frontend run test:e2e:groups`, but the job could not complete in this environment due to Playwright/apt browser install network failures (Playwright browser download `ENETUNREACH`), so the E2E run was blocked and could not demonstrate runtime suppression here.
- No other automated test changes were required; local unit/Jest tests covering `offlineWorkerRegistration` remain unchanged and continue to assert logging behavior for expected vs unexpected registration failures. Please run `npm --prefix frontend run test:e2e:groups`, `npm run lint`, and `npm test` in CI or a network-enabled environment to fully verify the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ff5cf244832f9f23962c68bb78e1)