### PR TITLE
🛠️ fix: stabilize quest debug flag across build and test setup

### DIFF
--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -46,12 +46,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 
-// Ensure the quest graph debug handle is available in test builds
-// even though Astro builds with production settings for preview.
-// This flag is read at build time, so we need to default it here.
-if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
-    process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = 'true';
-}
+// Keep quest-graph debug flag opt-in. setup-test-env must not force a different
+// build-time PUBLIC_* value than the preceding root build, otherwise we trigger
+// an avoidable rebuild during launch-gate checks.
 
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.

--- a/outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.json
+++ b/outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.json
@@ -1,0 +1,14 @@
+{
+  "id": "2026-04-30-quest-graph-debug-flag-mismatch-rebuild",
+  "date": "2026-04-30",
+  "component": "frontend-test-setup-and-astro-build-reuse",
+  "longForm": "outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.md",
+  "rootCause": "Test setup forced PUBLIC_ENABLE_QUEST_GRAPH_DEBUG=true, creating a mismatch with the previous build marker and triggering an unnecessary rebuild.",
+  "resolution": "Stopped forcing the debug flag in setup-test-env, retained mismatch detection for real config drift, and added focused ensure-astro-build tests for match/mismatch behavior.",
+  "references": [
+    "frontend/scripts/setup-test-env.js",
+    "frontend/scripts/ensure-astro-build.mjs",
+    "tests/ensure-astro-build-quest-debug-flag.test.ts",
+    "outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.md"
+  ]
+}

--- a/outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.md
+++ b/outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.md
@@ -1,0 +1,36 @@
+# Quest graph debug flag mismatch rebuild noise during test setup
+
+## Symptom
+
+After a successful `npm run build`, running `npm test` immediately logged:
+`Quest graph debug flag mismatch detected. Rebuilding Astro app...` and ran a second Astro build.
+
+## Root cause
+
+`frontend/scripts/setup-test-env.js` force-set `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG=true` even when
+no test explicitly opted into quest-graph debug mode.
+
+The normal root build path (`npm run build` via `scripts/build-with-sha.mjs`) keeps
+`PUBLIC_ENABLE_QUEST_GRAPH_DEBUG` opt-in/off by default, so the existing build marker in
+`frontend/dist/.quest-graph-debug-flag` was often `false`.
+
+When test setup later forced the env flag to `true`, `frontend/scripts/ensure-astro-build.mjs`
+correctly detected a build-time config mismatch and rebuilt.
+
+## Fix
+
+- Stopped forcing `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG` inside `frontend/scripts/setup-test-env.js`.
+- Kept mismatch-rebuild safeguard intact in `frontend/scripts/ensure-astro-build.mjs`.
+- Added targeted tests for marker/env match and mismatch behavior.
+
+## Verification commands
+
+- `npm run build; npm test`
+- `npm run test:e2e:groups`
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+
+## Why this was warning/noise rather than a gate failure
+
+The safeguard-triggered rebuild was functioning as designed and tests still passed, so this was not
+an incorrect result. The problem was determinism and runtime cost: launch-gate workflows paid for an
+unnecessary second Astro build and emitted confusing mismatch logs despite no intentional flag change.

--- a/tests/ensure-astro-build-quest-debug-flag.test.ts
+++ b/tests/ensure-astro-build-quest-debug-flag.test.ts
@@ -12,10 +12,7 @@ const createBuiltArtifacts = (root: string) => {
     fs.writeFileSync(path.join(root, 'dist', 'client', '_astro', 'asset.js'), 'console.log("ok");');
 };
 
-const loadEnsureAstroBuild = async (
-    questGraphDebug: 'true' | 'false' | undefined,
-    variant: 'a' | 'b'
-) => {
+const loadEnsureAstroBuild = async (questGraphDebug: 'true' | 'false' | undefined) => {
     vi.resetModules();
 
     if (questGraphDebug === undefined) {
@@ -24,16 +21,13 @@ const loadEnsureAstroBuild = async (
         process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = questGraphDebug;
     }
 
-    if (variant === 'a') {
-        return await import('../frontend/scripts/ensure-astro-build.mjs?case=a');
-    }
-
-    return await import('../frontend/scripts/ensure-astro-build.mjs?case=b');
+    return await import('../frontend/scripts/ensure-astro-build.mjs');
 };
 
 describe('ensureAstroBuild quest graph debug marker matching', () => {
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.resetModules();
         delete process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
     });
 
@@ -43,7 +37,7 @@ describe('ensureAstroBuild quest graph debug marker matching', () => {
             createBuiltArtifacts(root);
             fs.writeFileSync(path.join(root, 'dist', '.quest-graph-debug-flag'), 'false');
 
-            const { ensureAstroBuild } = await loadEnsureAstroBuild('false', 'a');
+            const { ensureAstroBuild } = await loadEnsureAstroBuild('false');
             const execSpy = vi.fn();
             const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
@@ -62,7 +56,7 @@ describe('ensureAstroBuild quest graph debug marker matching', () => {
             createBuiltArtifacts(root);
             fs.writeFileSync(path.join(root, 'dist', '.quest-graph-debug-flag'), 'false');
 
-            const { ensureAstroBuild } = await loadEnsureAstroBuild('true', 'b');
+            const { ensureAstroBuild } = await loadEnsureAstroBuild('true');
             const execSpy = vi.fn();
             const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 

--- a/tests/ensure-astro-build-quest-debug-flag.test.ts
+++ b/tests/ensure-astro-build-quest-debug-flag.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const createTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-astro-build-quest-flag-'));
+
+const createBuiltArtifacts = (root: string) => {
+    fs.mkdirSync(path.join(root, 'dist', 'server'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'dist', 'server', 'entry.mjs'), 'export default {};');
+    fs.mkdirSync(path.join(root, 'dist', 'client', '_astro'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'dist', 'client', '_astro', 'asset.js'), 'console.log("ok");');
+};
+
+const loadEnsureAstroBuild = async (
+    questGraphDebug: 'true' | 'false' | undefined,
+    variant: 'a' | 'b'
+) => {
+    vi.resetModules();
+
+    if (questGraphDebug === undefined) {
+        delete process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
+    } else {
+        process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = questGraphDebug;
+    }
+
+    if (variant === 'a') {
+        return await import('../frontend/scripts/ensure-astro-build.mjs?case=a');
+    }
+
+    return await import('../frontend/scripts/ensure-astro-build.mjs?case=b');
+};
+
+describe('ensureAstroBuild quest graph debug marker matching', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
+    });
+
+    it('skips rebuild when existing artifacts marker matches env flag', async () => {
+        const root = createTempDir();
+        try {
+            createBuiltArtifacts(root);
+            fs.writeFileSync(path.join(root, 'dist', '.quest-graph-debug-flag'), 'false');
+
+            const { ensureAstroBuild } = await loadEnsureAstroBuild('false', 'a');
+            const execSpy = vi.fn();
+            const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+            ensureAstroBuild({ root, exec: execSpy, logger });
+
+            expect(execSpy).not.toHaveBeenCalled();
+            expect(logger.log).toHaveBeenCalledWith('Astro build artifacts detected. Skipping rebuild.');
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('rebuilds when existing artifacts marker differs from env flag', async () => {
+        const root = createTempDir();
+        try {
+            createBuiltArtifacts(root);
+            fs.writeFileSync(path.join(root, 'dist', '.quest-graph-debug-flag'), 'false');
+
+            const { ensureAstroBuild } = await loadEnsureAstroBuild('true', 'b');
+            const execSpy = vi.fn();
+            const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+            ensureAstroBuild({ root, exec: execSpy, logger });
+
+            expect(execSpy).toHaveBeenCalledTimes(1);
+            expect(logger.log).toHaveBeenCalledWith(
+                'Quest graph debug flag mismatch detected. Rebuilding Astro app...'
+            );
+            expect(fs.readFileSync(path.join(root, 'dist', '.quest-graph-debug-flag'), 'utf8').trim()).toBe(
+                'true'
+            );
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
### Motivation
- Running `npm run build` followed by `npm test` frequently triggered an unnecessary Astro rebuild due to `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG` being forced during test setup, which made the launch-gate sequence non-deterministic and noisy.
- The rebuild safeguard in `ensure-astro-build.mjs` is desirable for real debug-flag changes, so the goal was to avoid false positives without removing the safety check.

### Description
- Stop forcing `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG` in `frontend/scripts/setup-test-env.js` so test setup does not mutate build-time public flags and will respect the previous root build's flag state.
- Preserve existing mismatch-detection and rebuild behavior in `frontend/scripts/ensure-astro-build.mjs` so a genuine change to the debug flag still triggers a rebuild.
- Add unit tests `tests/ensure-astro-build-quest-debug-flag.test.ts` that verify both the skip and rebuild paths for marker/env matches and mismatches.
- Add an outage note `outages/2026-04-30-quest-graph-debug-flag-mismatch-rebuild.md` documenting symptom, root cause, fix, verification, and why this was warning/noise rather than a failing gate.

### Testing
- Ran the targeted Vitest suite with `npm run test:root -- tests/ensure-astro-build-retry.test.ts tests/ensure-astro-build-quest-debug-flag.test.ts`, and all tests passed (4 tests, 4 passed).
- The new tests exercise `ensureAstroBuild` behavior for both matching and differing `.quest-graph-debug-flag` marker states and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30bd1f9e0832f8d072aae55762a46)