### PR TITLE
🔧 Fix quest graph debug mismatch rebuild during test setup

### DIFF
--- a/frontend/scripts/ensure-astro-build.mjs
+++ b/frontend/scripts/ensure-astro-build.mjs
@@ -7,7 +7,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRootDir = path.resolve(__dirname, '..');
 
-const questGraphDebugEnvFlag = process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG === 'true';
+function getRequestedQuestGraphDebugFlag() {
+    const raw = process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
+
+    if (raw === 'true') {
+        return true;
+    }
+
+    if (raw === 'false') {
+        return false;
+    }
+
+    return null;
+}
+
+
 
 function hasClientAssets(rootDir, logger) {
     const clientAssetsDir = path.join(rootDir, 'dist', 'client', '_astro');
@@ -55,10 +69,13 @@ export function ensureAstroBuild(options = {}) {
     const serverBuilt = fs.existsSync(serverEntrypoint);
     const clientBuilt = hasClientAssets(root, logger);
     const questGraphDebugMarker = getQuestGraphDebugMarker(root);
+    const requestedQuestGraphDebugFlag = getRequestedQuestGraphDebugFlag();
     const buildConfigMismatch =
-        questGraphDebugMarker === null
-            ? questGraphDebugEnvFlag
-            : questGraphDebugMarker !== questGraphDebugEnvFlag;
+        requestedQuestGraphDebugFlag === null
+            ? false
+            : questGraphDebugMarker === null
+              ? true
+              : questGraphDebugMarker !== requestedQuestGraphDebugFlag;
 
     if (serverBuilt && clientBuilt && !buildConfigMismatch) {
         logger.log?.('Astro build artifacts detected. Skipping rebuild.');
@@ -75,7 +92,7 @@ export function ensureAstroBuild(options = {}) {
 
     try {
         runBuild();
-        writeQuestGraphDebugMarker(root, questGraphDebugEnvFlag);
+        writeQuestGraphDebugMarker(root, requestedQuestGraphDebugFlag === true);
     } catch (error) {
         const errorOutput =
             (error instanceof Error ? error.message : '') +
@@ -98,7 +115,7 @@ export function ensureAstroBuild(options = {}) {
         try {
             fs.rmSync(path.join(root, 'dist'), { recursive: true, force: true });
             runBuild();
-            writeQuestGraphDebugMarker(root, questGraphDebugEnvFlag);
+            writeQuestGraphDebugMarker(root, requestedQuestGraphDebugFlag === true);
         } catch (retryError) {
             (logger.error ?? console.error)(
                 'Failed to build Astro project required for Playwright preview (retry after dist/ removal).'

--- a/frontend/scripts/setup-test-env.js
+++ b/frontend/scripts/setup-test-env.js
@@ -46,13 +46,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 
-// Ensure the quest graph debug handle is available in test builds
-// even though Astro builds with production settings for preview.
-// This flag is read at build time, so we need to default it here.
-if (!process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG) {
-    process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = 'true';
-}
-
+// Respect caller-provided quest graph debug state.
+// Do not force-enable here: setup-test-env runs after standalone builds, and
+// forcing this flag would create artificial build-marker mismatches.
 // Do *not* touch Playwright here; this file is used by unit tests too.
 // Playwright browser management is handled by playwright.config.ts for E2E tests only.
 const { ensureAstroBuild } = await import('./ensure-astro-build.mjs');

--- a/outages/2026-04-30-quest-graph-debug-flag-mismatch-test-setup.md
+++ b/outages/2026-04-30-quest-graph-debug-flag-mismatch-test-setup.md
@@ -1,0 +1,37 @@
+# Outage: redundant Astro rebuild from quest graph debug mismatch during test setup
+
+- **Date:** 2026-04-30
+- **Symptom:** `npm test` printed `Quest graph debug flag mismatch detected. Rebuilding Astro app...` immediately after a successful `npm run build`.
+- **Severity:** Warning / log noise (non-gating)
+
+## Impact
+
+Launch-gate runs paid an extra Astro rebuild during `setup-test-env`, which increased runtime and log noise.
+Tests still passed, so this did not fail CI gates directly.
+
+## Root cause
+
+`frontend/scripts/setup-test-env.js` force-set `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG=true` before calling
+`ensure-astro-build`. After a standard `npm run build` (which typically bakes debug flag `false` unless
+explicitly requested), this produced an artificial marker mismatch and triggered a redundant rebuild.
+
+## Fix
+
+1. Removed force-defaulting of `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG` in `setup-test-env`.
+2. Updated `frontend/scripts/ensure-astro-build.mjs` mismatch logic to treat the debug flag as
+   **tri-state**:
+   - `true` / `false` when explicitly requested,
+   - `null` when unset (do not enforce marker mismatch in this mode).
+3. Kept safeguard behavior: explicit debug flag changes still trigger rebuild.
+4. Added focused tests for both no-flag skip behavior and explicit mismatch rebuild behavior.
+
+## Verification commands
+
+- `npm run build; npm test`
+- `npm --prefix frontend run test:e2e:groups`
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+
+## Why this was warning/noise (not gate failure)
+
+The rebuild path was functioning as designed once mismatch was detected, so the pipeline remained green.
+The outage was unnecessary rebuild churn caused by inconsistent defaulting, not a correctness failure.

--- a/tests/ensure-astro-build-retry.test.ts
+++ b/tests/ensure-astro-build-retry.test.ts
@@ -8,6 +8,7 @@ import { ensureAstroBuild } from '../frontend/scripts/ensure-astro-build.mjs';
 const createTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-astro-build-retry-'));
 
 describe('ensureAstroBuild retry behavior', () => {
+    const originalQuestGraphDebugFlag = process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
     let tempDir: string;
     let logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
 
@@ -21,8 +22,53 @@ describe('ensureAstroBuild retry behavior', () => {
     });
 
     afterEach(() => {
+        if (originalQuestGraphDebugFlag === undefined) {
+            delete process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
+        } else {
+            process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = originalQuestGraphDebugFlag;
+        }
+
         vi.restoreAllMocks();
         fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('skips rebuild when artifacts exist and debug flag is not explicitly requested', () => {
+        delete process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG;
+
+        const serverDir = path.join(tempDir, 'dist', 'server');
+        const clientDir = path.join(tempDir, 'dist', 'client', '_astro');
+        fs.mkdirSync(serverDir, { recursive: true });
+        fs.mkdirSync(clientDir, { recursive: true });
+        fs.writeFileSync(path.join(serverDir, 'entry.mjs'), 'export default {};');
+        fs.writeFileSync(path.join(clientDir, 'asset.js'), 'console.log(1);');
+
+        const execSpy = vi.fn();
+
+        ensureAstroBuild({ root: tempDir, exec: execSpy, logger });
+
+        expect(execSpy).not.toHaveBeenCalled();
+        expect(logger.log).toHaveBeenCalledWith('Astro build artifacts detected. Skipping rebuild.');
+    });
+
+    it('rebuilds when debug flag is explicitly true and marker is false', () => {
+        process.env.PUBLIC_ENABLE_QUEST_GRAPH_DEBUG = 'true';
+
+        const serverDir = path.join(tempDir, 'dist', 'server');
+        const clientDir = path.join(tempDir, 'dist', 'client', '_astro');
+        fs.mkdirSync(serverDir, { recursive: true });
+        fs.mkdirSync(clientDir, { recursive: true });
+        fs.writeFileSync(path.join(serverDir, 'entry.mjs'), 'export default {};');
+        fs.writeFileSync(path.join(clientDir, 'asset.js'), 'console.log(1);');
+        fs.writeFileSync(path.join(tempDir, 'dist', '.quest-graph-debug-flag'), 'false');
+
+        const execSpy = vi.fn();
+
+        ensureAstroBuild({ root: tempDir, exec: execSpy, logger });
+
+        expect(execSpy).toHaveBeenCalledTimes(1);
+        expect(logger.log).toHaveBeenCalledWith(
+            'Quest graph debug flag mismatch detected. Rebuilding Astro app...'
+        );
     });
 
     it('cleans dist/ once and retries once when first build failure contains ENOENT', () => {


### PR DESCRIPTION
### Motivation
- Prevent a redundant Astro rebuild during test setup caused by an artificial quest-graph debug marker mismatch that only produced noisy logs and extra build time.
- Make build/test behavior deterministic across the normal `npm run build` → `npm test` launch-gate while preserving intentional rebuilds when the debug flag actually changes.

### Description
- Stop forcing `PUBLIC_ENABLE_QUEST_GRAPH_DEBUG=true` from `frontend/scripts/setup-test-env.js` so test setup respects the caller-provided debug state.
- Change `frontend/scripts/ensure-astro-build.mjs` to treat the debug flag as tri-state via `getRequestedQuestGraphDebugFlag()` (true / false / null) and only enforce marker parity when the flag is explicitly set; also write the debug marker after any successful build using the requested value.
- Add tests in `tests/ensure-astro-build-retry.test.ts` to cover: skip-rebuild when the flag is unset, rebuild when the flag is explicitly true but marker is false, and existing retry-on-ENOENT behavior.
- Add a new outage note `outages/2026-04-30-quest-graph-debug-flag-mismatch-test-setup.md` documenting symptom, root cause, fix and verification steps.

### Testing
- Ran unit tests for the change: `npx vitest run tests/ensure-astro-build-retry.test.ts` — 4 tests passed.
- Ran type checking: `npm run type-check` — succeeded.
- Ran a full local build: `npm run build` — succeeded and wrote build metadata as expected.
- Started the repository test harness `npm run test` during verification; the command was launched but did not complete within the interactive session timeout (no failing test output from the change set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30bd1f9e0832f8d072aae55762a46)