### PR TITLE
Fix cloud sync auth E2E hydration race

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -42,11 +42,12 @@ test('Authentication flow saves and clears token', async ({ page }) => {
 
     const token = 'ghp_' + 'a'.repeat(36);
     await page.goto('/cloudsync');
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
 
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByTestId('save-token').click();
     await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
 
     const getStoredToken = async () =>
@@ -86,7 +87,8 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     await expect.poll(getStoredToken, { timeout: 30_000 }).toBe(token);
 
     await page.reload();
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
     await expect(tokenInput).toHaveValue(token);
 
     // clear token and verify removal

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.json
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-05-15-authentication-flow-sync-success-timeout",
+  "date": "2026-05-15",
+  "component": "frontend-cloudsync-e2e-authentication-flow",
+  "longForm": "outages/2026-05-15-authentication-flow-sync-success-timeout.md",
+  "rootCause": "The authentication-flow E2E used the generic hydration helper, which can return after any hydrated component appears; in parallel Structure Tests this allowed the Save click to race ahead of the Cloud Sync component's client handler, so no sync-success status was rendered.",
+  "resolution": "Wait for the Cloud Sync form's own hydration marker and readiness flag before filling and saving the token, then click the stable save-token test id while preserving validation, persistence, reload, and clear coverage.",
+  "references": [
+    "frontend/e2e/authentication-flow.spec.ts",
+    "frontend/src/pages/cloudsync/svelte/Syncer.svelte",
+    "outages/2026-05-15-authentication-flow-sync-success-timeout.md"
+  ]
+}

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.md
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.md
@@ -1,0 +1,44 @@
+# Authentication flow sync-success timeout in grouped E2E runs
+
+## Symptom
+
+The full local verification sequence:
+
+`npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+
+failed during the grouped Playwright E2E phase. The failing test was
+`frontend/e2e/authentication-flow.spec.ts`.
+
+Playwright timed out waiting for `getByTestId('sync-success')` to contain
+`Token saved and validated`; the locator was not found before the 15 second assertion timeout.
+
+## Root cause
+
+The test navigated to `/cloudsync` and called the generic `waitForHydration(page)` helper before
+clicking Save. That helper intentionally returns when any hydrated island on the page reports
+`data-hydrated="true"`.
+
+In the parallel Structure Tests group, that was not specific enough for the Cloud Sync form. The
+test could fill the server-rendered token field and click the server-rendered Save button before the
+Cloud Sync Svelte component had attached its client-side click handler. When that happened, the
+validation mock was never exercised, the token was never saved, and the success status element was
+never rendered.
+
+## Fix
+
+- Wait for the Cloud Sync form's own `data-testid="cloud-sync-form"` hydration marker.
+- Wait for the page-level `window.__cloudSyncReady` readiness flag that the Cloud Sync component sets
+  after completing its mount work.
+- Click the stable `data-testid="save-token"` control instead of a generic role/name lookup.
+- Preserve the existing assertions that validate the token, persist it, reload it from storage, and
+  clear it.
+
+## Verification commands
+
+- `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `node scripts/link-check.mjs`


### PR DESCRIPTION
### Motivation
- Resolve a flaky E2E failure where the authentication-flow test timed out waiting for the Cloud Sync success message because the Save click could race ahead of the Svelte component attaching its client handler in grouped/parallel runs. 
- Record the incident and remediation so CI/team members can trace the symptom, root cause, and verification steps via an `outages/` entry.

### Description
- Tighten the authentication E2E by waiting for the Cloud Sync form's own hydration marker and readiness flag before interacting with it, using `waitForHydration(page, 'data-testid=cloud-sync-form')` and polling `window.__cloudSyncReady`. 
- Use the stable save control via `getByTestId('save-token')` instead of a generic role/name lookup so the click targets the client-attached handler. 
- Add an outage record (`outages/2026-05-15-authentication-flow-sync-success-timeout.{json,md}`) documenting the failing command, failing test, symptom, root cause, fix summary, and verification commands.

### Testing
- Ran outage convention and prompts docs tests with `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and they passed. 
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` and each completed successfully. 
- Attempted `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`, but the environment failed to download/install Playwright Chromium (network/ENETUNREACH), so the E2E run was blocked rather than failing due to the change. 
- `npm test` was not completed in this environment because Playwright browser installation prevented running the full E2E suite; the PR preserves the targeted E2E assertions and should allow the test to be reliably green when Playwright browsers are available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a46964fc832f95c5aff3adb80b32)