### PR TITLE
Fix cloud-sync auth E2E hydration race and document outage

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -42,7 +42,8 @@ test('Authentication flow saves and clears token', async ({ page }) => {
 
     const token = 'ghp_' + 'a'.repeat(36);
     await page.goto('/cloudsync');
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
 
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
@@ -86,7 +87,8 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     await expect.poll(getStoredToken, { timeout: 30_000 }).toBe(token);
 
     await page.reload();
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
     await expect(tokenInput).toHaveValue(token);
 
     // clear token and verify removal

--- a/outages/2026-05-15-authentication-flow-cloudsync-hydration-race.json
+++ b/outages/2026-05-15-authentication-flow-cloudsync-hydration-race.json
@@ -1,0 +1,24 @@
+{
+    "id": "2026-05-15-authentication-flow-cloudsync-hydration-race",
+    "date": "2026-05-15",
+    "component": "frontend/e2e authentication flow",
+    "impact": "The full local validation sequence could fail during grouped Structure Tests even though token validation and persistence still worked when the cloud sync form was fully hydrated.",
+    "rootCause": "frontend/e2e/authentication-flow.spec.ts waited for any hydrated node on /cloudsync, which could be the shared shell instead of the cloud-sync form. Under parallel grouped E2E load, Playwright could click the server-rendered Save button before Syncer.svelte finished mounting and attaching the saveToken handler, so no success status was rendered.",
+    "resolution": "Changed the authentication-flow E2E to wait for the cloud sync form's data-hydrated marker and __cloudSyncReady flag before saving the token, and repeated the targeted wait after reload before asserting the persisted token value.",
+    "verification": [
+        "npm --prefix frontend run test:e2e -- authentication-flow.spec.ts",
+        "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts",
+        "npm test",
+        "npm run lint",
+        "npm run type-check",
+        "npm run build",
+        "node scripts/link-check.mjs",
+        "npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs"
+    ],
+    "references": [
+        "frontend/e2e/authentication-flow.spec.ts",
+        "frontend/src/pages/cloudsync/svelte/Syncer.svelte",
+        "frontend/e2e/test-helpers.ts"
+    ],
+    "longForm": "outages/2026-05-15-authentication-flow-cloudsync-hydration-race.md"
+}

--- a/outages/2026-05-15-authentication-flow-cloudsync-hydration-race.md
+++ b/outages/2026-05-15-authentication-flow-cloudsync-hydration-race.md
@@ -1,0 +1,37 @@
+# Outage: Authentication-flow E2E cloud-sync hydration race
+
+- **Date**: 2026-05-15
+- **Severity**: medium
+- **Component**: `frontend/e2e/authentication-flow.spec.ts`
+- **Incident ID**: `2026-05-15-authentication-flow-cloudsync-hydration-race`
+
+## Symptom
+
+The local pre-PR validation sequence failed during the grouped Structure Tests run:
+
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`
+
+The failing test was `frontend/e2e/authentication-flow.spec.ts`. Playwright timed out waiting for `getByTestId('sync-success')` to contain `Token saved and validated` after clicking Save on `/cloudsync`.
+
+## Root cause
+
+`authentication-flow.spec.ts` called the generic `waitForHydration(page)` helper before interacting with the cloud-sync form. Without a target, that helper only requires some node on the page to have `data-hydrated="true"`; on `/cloudsync`, the shared layout or menu can satisfy that condition before `Syncer.svelte` finishes its own mount sequence.
+
+When the Structure Tests group ran in parallel, the test could click the server-rendered Save button before `Syncer.svelte` had completed mounting, loaded local token state, set `data-hydrated="true"` on `data-testid="cloud-sync-form"`, and exposed `window.__cloudSyncReady`. That early click had no hydrated `saveToken` handler to run, so the token was never validated, saved, or announced, and the `sync-success` status node never appeared.
+
+## Fix
+
+The authentication-flow E2E now waits specifically for the cloud-sync form to report `data-hydrated="true"` and for `window.__cloudSyncReady` before clicking Save. The same targeted readiness wait runs after reload before asserting that the token persisted back into the field.
+
+This keeps coverage for saving, validating, persisting, and clearing the token while removing the hydration race that made the success status unobservable.
+
+## Verification commands
+
+- `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `node scripts/link-check.mjs`
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`


### PR DESCRIPTION
### Motivation
- The authentication E2E intermittently timed out waiting for the cloud-sync success message because the test could click the server-rendered Save button before the `Syncer.svelte` component finished mounting and attached its save handler.

### Description
- Tightened readiness checks in `frontend/e2e/authentication-flow.spec.ts` to wait for the cloud-sync form's own `data-hydrated="true"` marker and to `poll` `window.__cloudSyncReady` before clicking Save and after reload.
- Added an outage record `outages/2026-05-15-authentication-flow-cloudsync-hydration-race.json` and companion `*.md` documenting the symptom, root cause, fix summary, and verification commands.

### Testing
- Ran `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and the tests passed.
- Verified `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` succeeded; full E2E verification (`npm --prefix frontend run test:e2e -- authentication-flow.spec.ts` and grouped `npm test`) could not complete in this environment because Playwright browser downloads failed with network `ENETUNREACH`, so please run the E2E verification in CI or a network-enabled local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a46964fc832f95c5aff3adb80b32)