### PR TITLE
Fix cloud sync authentication E2E hydration race

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -42,7 +42,7 @@ test('Authentication flow saves and clears token', async ({ page }) => {
 
     const token = 'ghp_' + 'a'.repeat(36);
     await page.goto('/cloudsync');
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
 
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
@@ -86,7 +86,7 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     await expect.poll(getStoredToken, { timeout: 30_000 }).toBe(token);
 
     await page.reload();
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
     await expect(tokenInput).toHaveValue(token);
 
     // clear token and verify removal

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -30,6 +30,7 @@
     let refreshing = false;
     let backups = [];
     let backupError = '';
+    let hydrated = false;
 
     const announce = (text, type = '') => {
         message = text;
@@ -62,6 +63,7 @@
         token = await loadGitHubToken();
         gistId = '';
         await clearCloudGistId();
+        hydrated = true;
         root?.setAttribute('data-hydrated', 'true');
         if (token) {
             await loadBackups(token);
@@ -195,7 +197,7 @@
                         text={savingToken ? 'Saving…' : 'Save'}
                         onClick={saveToken}
                         inverted={true}
-                        disabled={savingToken}
+                        disabled={!hydrated || savingToken}
                         dataTestId="save-token"
                     >
                         {#if savingToken}
@@ -207,7 +209,7 @@
                         onClick={clearTokenLocal}
                         hazard={true}
                         dataTestId="clear-sync-token"
-                        disabled={savingToken || uploading || downloading}
+                        disabled={!hydrated || savingToken || uploading || downloading}
                     />
                 </div>
             </div>
@@ -231,7 +233,7 @@
                     onClick={clearGistId}
                     hazard={true}
                     dataTestId="clear-gist-id"
-                    disabled={uploading || downloading}
+                    disabled={!hydrated || uploading || downloading}
                 />
             </div>
             <p class="hint">Optional: paste a gist ID if you need a manual restore.</p>
@@ -241,7 +243,7 @@
                 text={uploading ? 'Uploading…' : 'Upload'}
                 onClick={handleUpload}
                 inverted={true}
-                disabled={uploading || savingToken}
+                disabled={!hydrated || uploading || savingToken}
             >
                 {#if uploading}
                     <span class="spinner" aria-hidden="true"></span>
@@ -250,7 +252,7 @@
             <Chip
                 text={downloading && downloadingId === 'manual' ? 'Downloading…' : 'Download'}
                 onClick={handleDownload}
-                disabled={downloading || savingToken}
+                disabled={!hydrated || downloading || savingToken}
             >
                 {#if downloading && downloadingId === 'manual'}
                     <span class="spinner" aria-hidden="true"></span>
@@ -277,7 +279,7 @@
                     text={refreshing ? 'Refreshing…' : 'Refresh'}
                     onClick={() => loadBackups()}
                     inverted={true}
-                    disabled={refreshing || !token}
+                    disabled={!hydrated || refreshing || !token}
                     dataTestId="refresh-backups"
                 >
                     {#if refreshing}
@@ -317,7 +319,7 @@
                                             : 'Restore'}
                                         onClick={() => handleDownload(backup.id)}
                                         inverted={true}
-                                        disabled={downloading || savingToken}
+                                        disabled={!hydrated || downloading || savingToken}
                                         dataTestId={`restore-backup-${backup.id}`}
                                     >
                                         {#if downloading && downloadingId === backup.id}

--- a/frontend/src/pages/cloudsync/svelte/__tests__/Syncer.spec.ts
+++ b/frontend/src/pages/cloudsync/svelte/__tests__/Syncer.spec.ts
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import Syncer from '../Syncer.svelte';
+
+const cloudSyncMocks = vi.hoisted(() => ({
+    clearCloudGistId: vi.fn().mockResolvedValue(undefined),
+    downloadGameStateFromGist: vi.fn().mockResolvedValue(undefined),
+    fetchBackupList: vi.fn().mockResolvedValue([]),
+    uploadGameStateToGist: vi.fn().mockResolvedValue({ id: 'backup-1' }),
+}));
+
+const credentialMocks = vi.hoisted(() => ({
+    clearFn: vi.fn().mockResolvedValue(undefined),
+    isValidFn: vi.fn((value?: string) => Boolean(value?.trim())),
+    loadFn: vi.fn<() => Promise<string>>(),
+    saveFn: vi.fn().mockResolvedValue(undefined),
+}));
+
+const gistMocks = vi.hoisted(() => ({
+    validateFn: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../../../utils/cloudSync.js', () => cloudSyncMocks);
+vi.mock('../../../../utils/githubToken.js', () =>
+    Object.fromEntries([
+        ['clearGitHub' + 'Token', credentialMocks.clearFn],
+        ['isValidGitHub' + 'Token', credentialMocks.isValidFn],
+        ['loadGitHub' + 'Token', credentialMocks.loadFn],
+        ['saveGitHub' + 'Token', credentialMocks.saveFn],
+    ])
+);
+vi.mock('../../../../lib/cloudsync/githubGists', () =>
+    Object.fromEntries([['validate' + 'Token', gistMocks.validateFn]])
+);
+
+describe('Cloud Syncer', () => {
+    it('keeps action buttons disabled until client hydration finishes', async () => {
+        let resolveLoadedCredential: (value: string) => void = () => undefined;
+        credentialMocks.loadFn.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveLoadedCredential = resolve;
+            })
+        );
+
+        render(Syncer);
+
+        const saveButton = screen.getByTestId('save-token');
+        const clearButton = screen.getByTestId('clear-sync-token');
+        expect(saveButton).toHaveProperty('disabled', true);
+        expect(clearButton).toHaveProperty('disabled', true);
+
+        resolveLoadedCredential('');
+
+        await waitFor(() => expect(saveButton).toHaveProperty('disabled', false));
+        await waitFor(() => expect(clearButton).toHaveProperty('disabled', false));
+    });
+});

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.json
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-05-15-authentication-flow-sync-success-timeout",
+  "date": "2026-05-15",
+  "component": "frontend cloud sync authentication E2E",
+  "impact": "The full local validation command sequence failed during grouped Structure Tests because the authentication-flow E2E clicked the cloud-sync Save action before the Svelte island had finished hydrating.",
+  "rootCause": "The cloud sync form rendered enabled SSR buttons before client hydration attached Svelte click handlers, while frontend/e2e/authentication-flow.spec.ts only waited for generic page hydration. Under parallel Structure Tests, the test could click the inert pre-hydration Save button, so no token validation ran and data-testid=\"sync-success\" was never rendered.",
+  "resolution": "Gate cloud-sync action buttons behind a component-local hydrated flag, mark the form hydrated only after token and gist initialization finish, and make authentication-flow.spec.ts wait for that specific hydrated form before saving the token.",
+  "verification": [
+    "npm --prefix frontend run test:e2e -- authentication-flow.spec.ts",
+    "node frontend/node_modules/@playwright/test/cli.js test page-structure.spec.ts nav-route-smoke.spec.ts error-pages.spec.ts svelte-component-hydration.spec.ts builtin-quests.spec.ts custom-backup.spec.ts authentication-flow.spec.ts header-actions-placement.spec.ts cloud-sync.spec.ts cookie-consent.spec.ts docs-navigation.spec.ts docs-changelog.spec.ts changelog-container.spec.ts homepage-responsive-width.spec.ts failover-status.spec.ts home-page-basic.spec.ts inventory-items-bug.spec.ts indexeddb-availability.spec.ts profile-avatar-selection.spec.ts profile-page.spec.ts service-worker-update.spec.ts mobile-page-overflow.spec.ts mobile-process-form.spec.ts mobile-create-pages-overflow.spec.ts leaderboard.spec.ts settings-page.spec.ts --workers=7 --reporter=dot",
+    "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts",
+    "npm test",
+    "npm run lint",
+    "npm run type-check",
+    "npm run build",
+    "node scripts/link-check.mjs",
+    "npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs"
+  ],
+  "references": [
+    "frontend/src/pages/cloudsync/svelte/Syncer.svelte",
+    "frontend/e2e/authentication-flow.spec.ts",
+    "frontend/src/pages/cloudsync/svelte/__tests__/Syncer.spec.ts"
+  ],
+  "longForm": "outages/2026-05-15-authentication-flow-sync-success-timeout.md"
+}

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.md
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.md
@@ -1,0 +1,41 @@
+# Outage: Authentication flow timed out waiting for cloud sync success
+
+- **Date**: 2026-05-15
+- **Severity**: medium
+- **Component**: `frontend/e2e/authentication-flow.spec.ts` and the `/cloudsync` Svelte island
+- **Incident ID**: `2026-05-15-authentication-flow-sync-success-timeout`
+
+## Symptom
+
+The full local validation command sequence failed during the grouped Structure Tests run:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+The failing test was `frontend/e2e/authentication-flow.spec.ts`. Playwright timed out while waiting for `getByTestId('sync-success')` to contain `Token saved and validated` after clicking Save on `/cloudsync`.
+
+## Root cause
+
+The `/cloudsync` Svelte island server-rendered enabled action buttons before client hydration had attached the Svelte click handlers. The authentication-flow spec waited only for generic page hydration, which could be satisfied by another hydrated node on the page.
+
+When Structure Tests ran in parallel, the spec could fill the GitHub token field and click the pre-hydration Save button. That click was inert, so token validation never ran, no token was persisted, and the `data-testid="sync-success"` status element was never rendered.
+
+## Fix
+
+- Added a component-local `hydrated` flag to `Syncer.svelte`.
+- Kept cloud-sync action buttons disabled until the component finishes its client-side token and gist initialization and marks `data-testid="cloud-sync-form"` as hydrated.
+- Updated the authentication-flow E2E to wait for the specific cloud-sync form hydration marker before clicking Save.
+- Added a focused Svelte regression test that keeps the token-loading promise pending and verifies the Save and Clear actions remain disabled until hydration finishes.
+
+## Verification commands
+
+- `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`
+- `node frontend/node_modules/@playwright/test/cli.js test page-structure.spec.ts nav-route-smoke.spec.ts error-pages.spec.ts svelte-component-hydration.spec.ts builtin-quests.spec.ts custom-backup.spec.ts authentication-flow.spec.ts header-actions-placement.spec.ts cloud-sync.spec.ts cookie-consent.spec.ts docs-navigation.spec.ts docs-changelog.spec.ts changelog-container.spec.ts homepage-responsive-width.spec.ts failover-status.spec.ts home-page-basic.spec.ts inventory-items-bug.spec.ts indexeddb-availability.spec.ts profile-avatar-selection.spec.ts profile-page.spec.ts service-worker-update.spec.ts mobile-page-overflow.spec.ts mobile-process-form.spec.ts mobile-create-pages-overflow.spec.ts leaderboard.spec.ts settings-page.spec.ts --workers=7 --reporter=dot`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `node scripts/link-check.mjs`
+- `npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`


### PR DESCRIPTION
### Motivation
- The Structure Tests E2E run intermittently timed out in `authentication-flow.spec.ts` because the `/cloudsync` Svelte island rendered interactive buttons server-side before client hydration attached handlers, allowing tests to click inert pre-hydration controls.
- The change ensures the save/validate/persist/clear token path is reliably observable by Playwright in parallel/grouped runs without weakening test assertions.

### Description
- Add a component-local `hydrated` flag and mark the cloud-sync form with `data-testid="cloud-sync-form"` only after client-side token/gist initialization completes in `frontend/src/pages/cloudsync/svelte/Syncer.svelte` and gate Save/Clear/Upload/Download/Refresh/Restore buttons behind that flag.
- Update the authentication E2E to wait specifically for the cloud-sync form hydration marker via `waitForHydration(page, 'data-testid=cloud-sync-form')` in `frontend/e2e/authentication-flow.spec.ts` so clicks occur only after handlers are attached.
- Add a focused regression unit test (`frontend/src/pages/cloudsync/svelte/__tests__/Syncer.spec.ts`) that simulates delayed credential loading and asserts action buttons remain disabled until hydration completes.
- Document the incident and the fix with a new outage record `outages/2026-05-15-authentication-flow-sync-success-timeout.{json,md}` describing symptom, root cause, fix, and verification commands.

### Testing
- Ran the focused Svelte regression test: `npm run test:root -- frontend/src/pages/cloudsync/svelte/__tests__/Syncer.spec.ts` and it passed.
- Ran outage-related tests: `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and both passed.
- Project checks `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` completed successfully in this environment.
- Attempted to run the Playwright E2E `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts` and grouped E2E in this container but Playwright could not download Chromium due to a network environment `ENETUNREACH`; E2E runs therefore could not be completed here (local/CI with browsers available should execute the full E2E verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a46964fc832f95c5aff3adb80b32)