### PR TITLE
Fix Cloud Sync auth readiness race

### DIFF
--- a/frontend/e2e/authentication-flow.spec.ts
+++ b/frontend/e2e/authentication-flow.spec.ts
@@ -42,11 +42,12 @@ test('Authentication flow saves and clears token', async ({ page }) => {
 
     const token = 'ghp_' + 'a'.repeat(36);
     await page.goto('/cloudsync');
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
 
     const tokenInput = page.getByLabel(/GitHub Token/i);
     await tokenInput.fill(token);
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByTestId('save-token').click();
     await expect(page.getByTestId('sync-success')).toHaveText(/Token saved and validated/i);
 
     const getStoredToken = async () =>
@@ -86,7 +87,8 @@ test('Authentication flow saves and clears token', async ({ page }) => {
     await expect.poll(getStoredToken, { timeout: 30_000 }).toBe(token);
 
     await page.reload();
-    await waitForHydration(page);
+    await waitForHydration(page, 'data-testid=cloud-sync-form');
+    await expect.poll(() => page.evaluate(() => window.__cloudSyncReady === true)).toBeTruthy();
     await expect(tokenInput).toHaveValue(token);
 
     // clear token and verify removal

--- a/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
+++ b/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
@@ -92,6 +92,60 @@ describe('Cloud Sync token save flow', () => {
         expect(fetchBackupListMock).toHaveBeenCalledWith(savedCredential);
     });
 
+    it('ignores stale startup backup results after saving a different token', async () => {
+        const savedCredential = `ghp_${'b'.repeat(36)}`;
+        const newCredential = `ghp_${'c'.repeat(36)}`;
+        let resolveSavedBackups: (backups: unknown[]) => void = () => {};
+        let resolveNewBackups: (backups: unknown[]) => void = () => {};
+        loadGitHubTokenMock.mockResolvedValue(savedCredential);
+        fetchBackupListMock.mockImplementation((requestedToken: string) => {
+            if (requestedToken === savedCredential) {
+                return new Promise((resolve) => {
+                    resolveSavedBackups = resolve;
+                });
+            }
+            if (requestedToken === newCredential) {
+                return new Promise((resolve) => {
+                    resolveNewBackups = resolve;
+                });
+            }
+            return Promise.resolve([]);
+        });
+
+        const { getByLabelText, getByTestId, queryByTestId } = render(Syncer);
+        const tokenInput = getByLabelText(/GitHub Token/i) as HTMLInputElement;
+        const saveButton = getByTestId('save-token');
+
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await waitFor(() => expect(fetchBackupListMock).toHaveBeenCalledWith(savedCredential));
+
+        await fireEvent.input(tokenInput, { target: { value: newCredential } });
+        await fireEvent.click(saveButton);
+
+        await waitFor(() => expect(fetchBackupListMock).toHaveBeenCalledWith(newCredential));
+        resolveNewBackups([
+            {
+                id: 'new-backup',
+                filename: 'New token backup',
+                htmlUrl: 'https://example.com/new',
+                createdAt: '2026-05-15T00:00:00.000Z',
+            },
+        ]);
+
+        await waitFor(() => expect(getByTestId('backup-link-new-backup')).toBeInTheDocument());
+        resolveSavedBackups([
+            {
+                id: 'saved-backup',
+                filename: 'Saved token backup',
+                htmlUrl: 'https://example.com/saved',
+                createdAt: '2026-05-14T00:00:00.000Z',
+            },
+        ]);
+
+        await waitFor(() => expect(getByTestId('backup-link-new-backup')).toBeInTheDocument());
+        expect(queryByTestId('backup-link-saved-backup')).not.toBeInTheDocument();
+    });
+
     it('waits for initialization before Save and preserves a token typed during startup', async () => {
         let resolveLoadedCredential: (credential: string) => void = () => {};
         loadGitHubTokenMock.mockReturnValue(

--- a/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
+++ b/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
@@ -44,6 +44,54 @@ describe('Cloud Sync token save flow', () => {
         delete (window as typeof window & { __cloudSyncReady?: boolean }).__cloudSyncReady;
     });
 
+    it('resets the global readiness flag on remount until the current startup finishes', async () => {
+        const cloudSyncWindow = window as typeof window & { __cloudSyncReady?: boolean };
+        let resolveLoadedCredential: (credential: string) => void = () => {};
+        loadGitHubTokenMock.mockReturnValue(
+            new Promise<string>((resolve) => {
+                resolveLoadedCredential = resolve;
+            })
+        );
+        cloudSyncWindow.__cloudSyncReady = true;
+
+        const { getByTestId, unmount } = render(Syncer);
+
+        expect(cloudSyncWindow.__cloudSyncReady).toBe(false);
+        expect(getByTestId('save-token')).toBeDisabled();
+
+        resolveLoadedCredential('');
+        await waitFor(() => expect(cloudSyncWindow.__cloudSyncReady).toBe(true));
+
+        unmount();
+        expect(cloudSyncWindow.__cloudSyncReady).toBe(false);
+    });
+
+    it('enables the form and marks readiness when startup storage fails', async () => {
+        const cloudSyncWindow = window as typeof window & { __cloudSyncReady?: boolean };
+        loadGitHubTokenMock.mockRejectedValue(new Error('storage unavailable'));
+
+        const { getByTestId } = render(Syncer);
+
+        await waitFor(() => expect(getByTestId('save-token')).toBeEnabled());
+        expect(cloudSyncWindow.__cloudSyncReady).toBe(true);
+        expect(getByTestId('sync-error')).toHaveTextContent('storage unavailable');
+    });
+
+    it('marks readiness before the saved-token backup refresh completes', async () => {
+        const cloudSyncWindow = window as typeof window & { __cloudSyncReady?: boolean };
+        const savedCredential = `ghp_${'b'.repeat(36)}`;
+        loadGitHubTokenMock.mockResolvedValue(savedCredential);
+        fetchBackupListMock.mockReturnValue(new Promise(() => {}));
+
+        const { getByLabelText, getByTestId } = render(Syncer);
+        const tokenInput = getByLabelText(/GitHub Token/i) as HTMLInputElement;
+
+        await waitFor(() => expect(getByTestId('save-token')).toBeEnabled());
+        expect(cloudSyncWindow.__cloudSyncReady).toBe(true);
+        expect(tokenInput).toHaveValue(savedCredential);
+        expect(fetchBackupListMock).toHaveBeenCalledWith(savedCredential);
+    });
+
     it('waits for initialization before Save and preserves a token typed during startup', async () => {
         let resolveLoadedCredential: (credential: string) => void = () => {};
         loadGitHubTokenMock.mockReturnValue(

--- a/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
+++ b/frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Syncer from '../svelte/Syncer.svelte';
+
+const loadGitHubTokenMock = vi.fn();
+const saveGitHubTokenMock = vi.fn();
+const clearGitHubTokenMock = vi.fn();
+const clearCloudGistIdMock = vi.fn();
+const fetchBackupListMock = vi.fn();
+const validateTokenMock = vi.fn();
+
+vi.mock('../../../utils/githubToken.js', () => ({
+    ['clearGitHubToken']: (...args: unknown[]) => clearGitHubTokenMock(...args),
+    ['isValidGitHubToken']: (candidate?: string) =>
+        /^gh[pousr]_[A-Za-z0-9_]{36,}$/i.test(candidate ?? ''),
+    ['loadGitHubToken']: (...args: unknown[]) => loadGitHubTokenMock(...args),
+    ['saveGitHubToken']: (...args: unknown[]) => saveGitHubTokenMock(...args),
+}));
+
+vi.mock('../../../utils/cloudSync.js', () => ({
+    clearCloudGistId: (...args: unknown[]) => clearCloudGistIdMock(...args),
+    downloadGameStateFromGist: vi.fn(),
+    fetchBackupList: (...args: unknown[]) => fetchBackupListMock(...args),
+    uploadGameStateToGist: vi.fn(),
+}));
+
+vi.mock('../../../lib/cloudsync/githubGists', () => ({
+    ['validateToken']: (...args: unknown[]) => validateTokenMock(...args),
+}));
+
+describe('Cloud Sync token save flow', () => {
+    beforeEach(() => {
+        loadGitHubTokenMock.mockResolvedValue('');
+        saveGitHubTokenMock.mockResolvedValue(undefined);
+        clearGitHubTokenMock.mockResolvedValue(undefined);
+        clearCloudGistIdMock.mockResolvedValue(undefined);
+        fetchBackupListMock.mockResolvedValue([]);
+        validateTokenMock.mockResolvedValue(true);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        delete (window as typeof window & { __cloudSyncReady?: boolean }).__cloudSyncReady;
+    });
+
+    it('waits for initialization before Save and preserves a token typed during startup', async () => {
+        let resolveLoadedCredential: (credential: string) => void = () => {};
+        loadGitHubTokenMock.mockReturnValue(
+            new Promise<string>((resolve) => {
+                resolveLoadedCredential = resolve;
+            })
+        );
+
+        const { getByLabelText, getByTestId } = render(Syncer);
+        const tokenInput = getByLabelText(/GitHub Token/i) as HTMLInputElement;
+        const saveButton = getByTestId('save-token');
+        const typedCredential = `ghp_${'a'.repeat(36)}`;
+
+        await fireEvent.input(tokenInput, { target: { value: typedCredential } });
+        expect(saveButton).toBeDisabled();
+
+        resolveLoadedCredential('');
+
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        expect(tokenInput).toHaveValue(typedCredential);
+        expect(fetchBackupListMock).not.toHaveBeenCalled();
+
+        await fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(getByTestId('sync-success')).toHaveTextContent('Token saved and validated');
+        });
+        expect(validateTokenMock).toHaveBeenCalledWith(typedCredential);
+        expect(saveGitHubTokenMock).toHaveBeenCalledWith(typedCredential);
+    });
+});

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -30,6 +30,7 @@
     let refreshing = false;
     let backups = [];
     let backupError = '';
+    let initializing = true;
 
     const announce = (text, type = '') => {
         message = text;
@@ -59,13 +60,18 @@
     };
 
     onMount(async () => {
-        token = await loadGitHubToken();
+        const savedCredential = await loadGitHubToken();
+        const enteredCredential = token;
+        if (!enteredCredential) {
+            token ||= savedCredential;
+        }
         gistId = '';
         await clearCloudGistId();
-        root?.setAttribute('data-hydrated', 'true');
-        if (token) {
-            await loadBackups(token);
+        if (!enteredCredential && savedCredential) {
+            await loadBackups(savedCredential);
         }
+        initializing = false;
+        root?.setAttribute('data-hydrated', 'true');
         if (typeof window !== 'undefined') {
             window.__cloudSyncReady = true;
         }
@@ -195,7 +201,7 @@
                         text={savingToken ? 'Saving…' : 'Save'}
                         onClick={saveToken}
                         inverted={true}
-                        disabled={savingToken}
+                        disabled={initializing || savingToken}
                         dataTestId="save-token"
                     >
                         {#if savingToken}
@@ -207,7 +213,7 @@
                         onClick={clearTokenLocal}
                         hazard={true}
                         dataTestId="clear-sync-token"
-                        disabled={savingToken || uploading || downloading}
+                        disabled={initializing || savingToken || uploading || downloading}
                     />
                 </div>
             </div>
@@ -231,7 +237,7 @@
                     onClick={clearGistId}
                     hazard={true}
                     dataTestId="clear-gist-id"
-                    disabled={uploading || downloading}
+                    disabled={initializing || uploading || downloading}
                 />
             </div>
             <p class="hint">Optional: paste a gist ID if you need a manual restore.</p>
@@ -241,7 +247,7 @@
                 text={uploading ? 'Uploading…' : 'Upload'}
                 onClick={handleUpload}
                 inverted={true}
-                disabled={uploading || savingToken}
+                disabled={initializing || uploading || savingToken}
             >
                 {#if uploading}
                     <span class="spinner" aria-hidden="true"></span>
@@ -250,7 +256,7 @@
             <Chip
                 text={downloading && downloadingId === 'manual' ? 'Downloading…' : 'Download'}
                 onClick={handleDownload}
-                disabled={downloading || savingToken}
+                disabled={initializing || downloading || savingToken}
             >
                 {#if downloading && downloadingId === 'manual'}
                     <span class="spinner" aria-hidden="true"></span>
@@ -277,7 +283,7 @@
                     text={refreshing ? 'Refreshing…' : 'Refresh'}
                     onClick={() => loadBackups()}
                     inverted={true}
-                    disabled={refreshing || !token}
+                    disabled={initializing || refreshing || !token}
                     dataTestId="refresh-backups"
                 >
                     {#if refreshing}
@@ -317,7 +323,7 @@
                                             : 'Restore'}
                                         onClick={() => handleDownload(backup.id)}
                                         inverted={true}
-                                        disabled={downloading || savingToken}
+                                        disabled={initializing || downloading || savingToken}
                                         dataTestId={`restore-backup-${backup.id}`}
                                     >
                                         {#if downloading && downloadingId === backup.id}

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -59,22 +59,55 @@
         }
     };
 
-    onMount(async () => {
-        const savedCredential = await loadGitHubToken();
-        const enteredCredential = token;
-        if (!enteredCredential) {
-            token ||= savedCredential;
-        }
-        gistId = '';
-        await clearCloudGistId();
-        if (!enteredCredential && savedCredential) {
-            await loadBackups(savedCredential);
-        }
+    const markReady = () => {
         initializing = false;
         root?.setAttribute('data-hydrated', 'true');
         if (typeof window !== 'undefined') {
             window.__cloudSyncReady = true;
         }
+    };
+
+    onMount(() => {
+        let mounted = true;
+        if (typeof window !== 'undefined') {
+            window.__cloudSyncReady = false;
+        }
+
+        const initialize = async () => {
+            let savedCredential = '';
+            let shouldRefreshBackups = false;
+            try {
+                savedCredential = await loadGitHubToken();
+                const enteredCredential = token;
+                if (!enteredCredential) {
+                    token ||= savedCredential;
+                    shouldRefreshBackups = Boolean(savedCredential);
+                }
+                gistId = '';
+                await clearCloudGistId();
+            } catch (err) {
+                const startupMessage =
+                    err?.message || 'Cloud Sync startup failed. You can retry manually.';
+                backupError = startupMessage;
+                announce(startupMessage, 'error');
+            } finally {
+                if (mounted) {
+                    markReady();
+                    if (shouldRefreshBackups && savedCredential) {
+                        void loadBackups(savedCredential);
+                    }
+                }
+            }
+        };
+
+        void initialize();
+
+        return () => {
+            mounted = false;
+            if (typeof window !== 'undefined') {
+                window.__cloudSyncReady = false;
+            }
+        };
     });
 
     const saveToken = async () => {

--- a/frontend/src/pages/cloudsync/svelte/Syncer.svelte
+++ b/frontend/src/pages/cloudsync/svelte/Syncer.svelte
@@ -31,6 +31,7 @@
     let backups = [];
     let backupError = '';
     let initializing = true;
+    let backupRefreshSequence = 0;
 
     const announce = (text, type = '') => {
         message = text;
@@ -48,14 +49,23 @@
     const loadBackups = async (providedToken = token) => {
         const trimmedToken = providedToken?.trim?.();
         if (!trimmedToken) return;
+
+        const refreshId = ++backupRefreshSequence;
         refreshing = true;
         backupError = '';
         try {
-            backups = await fetchBackupList(trimmedToken);
+            const nextBackups = await fetchBackupList(trimmedToken);
+            if (refreshId === backupRefreshSequence && token.trim() === trimmedToken) {
+                backups = nextBackups;
+            }
         } catch (err) {
-            backupError = err?.message || 'Unable to load backups right now.';
+            if (refreshId === backupRefreshSequence && token.trim() === trimmedToken) {
+                backupError = err?.message || 'Unable to load backups right now.';
+            }
         } finally {
-            refreshing = false;
+            if (refreshId === backupRefreshSequence) {
+                refreshing = false;
+            }
         }
     };
 
@@ -132,8 +142,11 @@
     };
 
     const clearTokenLocal = async () => {
+        backupRefreshSequence += 1;
         token = '';
         backups = [];
+        backupError = '';
+        refreshing = false;
         await clearGitHubToken();
     };
 

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.json
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.json
@@ -1,0 +1,24 @@
+{
+    "id": "2026-05-15-authentication-flow-sync-success-timeout",
+    "date": "2026-05-15",
+    "component": "frontend/e2e/authentication-flow.spec.ts and Cloud Sync token form",
+    "impact": "The full local validation sequence could fail during grouped Structure Tests even though token validation and persistence still worked in isolation.",
+    "rootCause": "The authentication-flow E2E test interacted with the Cloud Sync form after a generic hydration wait. That wait could complete before the Syncer component finished loading saved credentials and marking itself ready. In parallel grouped runs, the test could fill and save while component startup was still in flight, allowing startup state to race the typed token and preventing the stable sync-success status from being observed.",
+    "resolution": "The Cloud Sync form now keeps token actions disabled until initialization completes, preserves a token typed during startup, and only marks the form hydrated after its token startup work is done. The E2E test now waits for the Cloud Sync form readiness sentinel and clicks the explicit save-token control before asserting the sync-success status.",
+    "verification": [
+        "npm --prefix frontend run test:e2e -- authentication-flow.spec.ts",
+        "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts",
+        "npm test",
+        "npm run lint",
+        "npm run type-check",
+        "npm run build",
+        "node scripts/link-check.mjs",
+        "npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs"
+    ],
+    "references": [
+        "frontend/e2e/authentication-flow.spec.ts",
+        "frontend/src/pages/cloudsync/svelte/Syncer.svelte",
+        "frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts"
+    ],
+    "longForm": "outages/2026-05-15-authentication-flow-sync-success-timeout.md"
+}

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.json
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.json
@@ -4,8 +4,10 @@
     "component": "frontend/e2e/authentication-flow.spec.ts and Cloud Sync token form",
     "impact": "The full local validation sequence could fail during grouped Structure Tests even though token validation and persistence still worked in isolation.",
     "rootCause": "The authentication-flow E2E test interacted with the Cloud Sync form after a generic hydration wait. That wait could complete before the Syncer component finished loading saved credentials and marking itself ready. In parallel grouped runs, the test could fill and save while component startup was still in flight, allowing startup state to race the typed token and preventing the stable sync-success status from being observed.",
-    "resolution": "The Cloud Sync form now keeps token actions disabled until initialization completes, preserves a token typed during startup, and only marks the form hydrated after its token startup work is done. The E2E test now waits for the Cloud Sync form readiness sentinel and clicks the explicit save-token control before asserting the sync-success status.",
+    "resolution": "The Cloud Sync form now keeps token actions disabled until initialization completes, preserves a token typed during startup, resets the global readiness sentinel on mount/unmount, and only marks the form hydrated after token startup work is done. Startup failures finalize readiness so the user can recover, saved-token backup refresh runs after readiness instead of blocking the form, and the E2E test waits for the Cloud Sync form readiness sentinel before clicking the explicit save-token control and asserting the sync-success status.",
     "verification": [
+        "npm run test:root -- frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts",
+        "npm run test:root -- frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts",
         "npm --prefix frontend run test:e2e -- authentication-flow.spec.ts",
         "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts",
         "npm test",

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.md
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.md
@@ -41,8 +41,13 @@ then race the typed token, so the test did not reliably observe the production s
 
 - Keep Cloud Sync token actions disabled until component initialization completes.
 - Preserve a token typed during startup instead of overwriting it with the late-loaded saved token.
-- Mark `data-hydrated="true"` and `window.__cloudSyncReady` only after Cloud Sync startup work
-  completes.
+- Reset `window.__cloudSyncReady` on Cloud Sync mount/unmount so reloads and remounts observe the
+  newly loaded page state instead of a stale previous readiness value.
+- Mark `data-hydrated="true"` and `window.__cloudSyncReady` only after Cloud Sync token startup
+  work completes, and finalize readiness in the startup cleanup path so storage failures do not leave
+  the form permanently disabled.
+- Start saved-token backup refresh after readiness is marked so a slow backup listing does not block
+  token actions.
 - Update `authentication-flow.spec.ts` to wait for the Cloud Sync form's own hydration/readiness
   sentinel and click `data-testid="save-token"`.
 - Add focused component regression coverage for typing a token during startup and saving it after
@@ -50,8 +55,9 @@ then race the typed token, so the test did not reliably observe the production s
 
 ## Verification commands
 
+- `npm run test:root -- frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+- `npm run test:root -- frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts`
 - `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`
-- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
 - `npm test`
 - `npm run lint`
 - `npm run type-check`

--- a/outages/2026-05-15-authentication-flow-sync-success-timeout.md
+++ b/outages/2026-05-15-authentication-flow-sync-success-timeout.md
@@ -1,0 +1,59 @@
+# Outage: Authentication flow E2E sync-success timeout
+
+- **Date**: 2026-05-15
+- **Severity**: medium
+- **Component**: `frontend/e2e/authentication-flow.spec.ts` and the Cloud Sync token form
+- **Incident ID**: `2026-05-15-authentication-flow-sync-success-timeout`
+
+## Symptom
+
+The combined local verification command could fail during `npm test`:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+The failing test was `frontend/e2e/authentication-flow.spec.ts`. Playwright timed out waiting for
+`getByTestId('sync-success')` to contain `Token saved and validated`:
+
+```text
+Timed out 15000ms waiting for expect(locator).toHaveText(expected)
+Locator: getByTestId('sync-success')
+Expected pattern: /Token saved and validated/i
+Received: <element(s) not found>
+```
+
+The failure appeared in the grouped Structure Tests run where `authentication-flow.spec.ts` runs in
+parallel with other structure and smoke specs.
+
+## Root cause
+
+The E2E spec used the generic hydration helper for `/cloudsync`. That helper can return after any
+hydrated node on the page is ready, not necessarily after the Cloud Sync `Syncer` component has
+finished its own startup work.
+
+`Syncer` loaded the saved GitHub token asynchronously in `onMount`, but the Save action was enabled
+while that startup work was still pending. In a busy grouped Playwright run, the test could fill the
+GitHub token field and click Save while the component was still initializing. Startup state could
+then race the typed token, so the test did not reliably observe the production success status.
+
+## Fix
+
+- Keep Cloud Sync token actions disabled until component initialization completes.
+- Preserve a token typed during startup instead of overwriting it with the late-loaded saved token.
+- Mark `data-hydrated="true"` and `window.__cloudSyncReady` only after Cloud Sync startup work
+  completes.
+- Update `authentication-flow.spec.ts` to wait for the Cloud Sync form's own hydration/readiness
+  sentinel and click `data-testid="save-token"`.
+- Add focused component regression coverage for typing a token during startup and saving it after
+  initialization.
+
+## Verification commands
+
+- `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `node scripts/link-check.mjs`


### PR DESCRIPTION
### Motivation
- Stabilize the authentication E2E which intermittently timed out waiting for the `sync-success` message by removing a race between component startup and the test's Save action.
- Record the incident in the outage catalog so future regressions and triage have context and verification steps.

### Description
- Cloud Sync `Syncer.svelte`: added an `initializing` sentinel, preserved any token typed while startup runs, defer `data-hydrated="true"` and `window.__cloudSyncReady` until startup completes, and disable token/backup actions while `initializing` is true.
- E2E `authentication-flow.spec.ts`: wait for the Cloud Sync form readiness sentinel (`data-testid=cloud-sync-form` and `window.__cloudSyncReady`) and click the explicit `data-testid="save-token"` control before asserting `sync-success` to avoid selector/timing races.
- Tests: added a focused component regression test `frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts` that verifies typing during startup preserves the value and that Save remains disabled until initialization finishes.
- Documentation: added an outage record and markdown under `outages/` describing the symptom, root cause, fix summary, and verification steps.

### Testing
- Ran `npm run test:root -- frontend/src/pages/cloudsync/__tests__/Syncer.spec.ts tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and the three test files passed.
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, all of which succeeded in this environment.
- Attempted `npm --prefix frontend run test:e2e -- authentication-flow.spec.ts` but Playwright could not download Chromium in this environment (network `ENETUNREACH`), so full browser-level E2E verification was blocked; the added unit/regression coverage exercises the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a46964fc832f95c5aff3adb80b32)