### PR TITLE
Refresh Browserslist (caniuse-lite) metadata and document build warning

### DIFF
--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-05-16-browserslist-caniuse-lite-build-warning",
+  "date": "2026-05-16",
+  "component": "frontend:astro-build-browserslist",
+  "longForm": "outages/2026-05-16-browserslist-caniuse-lite-build-warning.md",
+  "symptom": "`npm run build` printed `Browserslist: browsers data (caniuse-lite) is 11 months old` before Astro completed successfully.",
+  "rootCause": "The repo uses pnpm workspaces for dependency resolution, but the pnpm caniuse-lite override floor and lockfile metadata had not been advanced to the latest Browserslist dataset. When that resolved dataset aged past Browserslist's staleness threshold, Astro/Vite build output emitted the warning even though the application build still succeeded.",
+  "resolution": "Ran the Browserslist database update flow, preserved the pnpm package-manager convention, raised the pnpm caniuse-lite override floor to >=1.0.30001792, and regenerated only the caniuse-lite lockfile entries needed for Browserslist consumers.",
+  "verification": [
+    "npm run build",
+    "npm run lint",
+    "npm run type-check",
+    "npm test",
+    "node scripts/link-check.mjs",
+    "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts"
+  ],
+  "impact": "warning-only",
+  "gateFailure": false,
+  "references": [
+    "package.json",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "outages/2026-05-16-browserslist-caniuse-lite-build-warning.md"
+  ]
+}

--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
@@ -1,0 +1,52 @@
+# Browserslist caniuse-lite build warning
+
+## Symptom
+
+The normal production build command:
+
+```bash
+npm run build
+```
+
+completed successfully, but printed this warning before Astro build output:
+
+```text
+Browserslist: browsers data (caniuse-lite) is 11 months old
+```
+
+That made the validation sequence look noisy even though the application bundle was still built.
+
+## Root cause
+
+The repository's package-manager metadata is mixed at rest: root scripts are run with `npm`, but
+`package.json` declares `pnpm@9.0.0` and the workspace dependency graph is resolved by
+`pnpm-lock.yaml`. There is no separate Browserslist policy file in the repo, so consumers inherit
+the defaults from build tooling.
+
+The stale warning was caused by caniuse-lite metadata drift in the pnpm dependency graph. The repo
+already uses a pnpm override floor for caniuse-lite to keep Browserslist data fresh, but that floor
+and the lockfile entries had not been advanced to the latest dataset. Once the resolved dataset was
+old enough, Browserslist warned during the Astro/Vite build path.
+
+## Fix
+
+Ran the Browserslist database update flow and kept the existing pnpm convention. The fix raises the
+pnpm caniuse-lite override floor to `>=1.0.30001792` and refreshes the corresponding
+`pnpm-lock.yaml` entries for `autoprefixer`, `browserslist`, and `caniuse-api` consumers. No browser
+support policy was changed, and no broad dependency upgrade was introduced.
+
+`package-lock.json` was inspected but left unchanged because the update flow selected pnpm from the
+root `packageManager` declaration and the stale build path is governed by the pnpm workspace lock.
+
+## Verification
+
+Run:
+
+```bash
+npm run build
+npm run lint
+npm run type-check
+npm test
+node scripts/link-check.mjs
+npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts
+```

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "pnpm": {
     "overrides": {
-      "caniuse-lite": ">=1.0.30001791",
+      "caniuse-lite": ">=1.0.30001792",
       "esbuild": "0.25.8",
       "@esbuild/linux-x64": "0.25.8",
       "glob": "13.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  caniuse-lite: '>=1.0.30001791'
+  caniuse-lite: '>=1.0.30001792'
   esbuild: 0.25.8
   '@esbuild/linux-x64': 0.25.8
   glob: 13.0.6
@@ -2378,8 +2378,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   canvas@3.1.2:
     resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
@@ -7895,7 +7895,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -8046,7 +8046,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -8098,11 +8098,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001792: {}
 
   canvas@3.1.2:
     dependencies:


### PR DESCRIPTION
### Motivation
- The `npm run build` output produced a Browserslist stale-data warning (`caniuse-lite` dataset age), creating noisy build logs that could obscure real issues. 
- The repository uses pnpm workspaces for frontend dependency resolution, so the fix needed to respect the existing package-manager convention and avoid broad dependency upgrades. 

### Description
- Raised the root pnpm override floor for `caniuse-lite` to `>=1.0.30001792` in `package.json` and updated the corresponding `pnpm-lock.yaml` entries so Browserslist consumers resolve the refreshed dataset. 
- Regenerated minimal pnpm lockfile metadata for `caniuse-lite` (no broad dependency bumps) so the build path no longer triggers the stale-data warning. 
- Added an outage record `outages/2026-05-16-browserslist-caniuse-lite-build-warning.json` and companion write-up `outages/2026-05-16-browserslist-caniuse-lite-build-warning.md` documenting symptom, root cause, fix summary, verification steps, and references. 

### Testing
- Ran `npm run build` and confirmed the Astro/Vite build completes without the Browserslist stale-data warning. 
- Ran `npm run lint` and `npm run type-check`, both of which passed. 
- Ran `SKIP_E2E=1 npm test` (to avoid environment Playwright browser install in this container) and the test suite passed; a full `npm test` attempt ran root tests but Playwright E2E stalled due to Chromium/headless-shell installation in this environment. 
- Ran `node scripts/link-check.mjs` and `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`, both of which passed and validate the new outage record and conventions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f9f03e74832f825f2690fa6cf476)