### PR TITLE
Refresh Browserslist caniuse-lite metadata

### DIFF
--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
@@ -1,0 +1,14 @@
+{
+  "id": "2026-05-16-browserslist-caniuse-lite-build-warning",
+  "date": "2026-05-16",
+  "component": "frontend:astro-build-browserslist",
+  "longForm": "outages/2026-05-16-browserslist-caniuse-lite-build-warning.md",
+  "rootCause": "The pnpm override floor and npm/pnpm lock metadata still resolved Browserslist consumers to caniuse-lite 1.0.30001791, allowing stale browser-compat data to be installed for Astro/Vite build tooling.",
+  "resolution": "Raised the caniuse-lite override floor to >=1.0.30001792 and refreshed both package-lock.json and pnpm-lock.yaml to caniuse-lite 1.0.30001792 without changing browser support policy or broad dependency versions.",
+  "references": [
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "outages/2026-05-16-browserslist-caniuse-lite-build-warning.md"
+  ]
+}

--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
@@ -1,0 +1,37 @@
+# Outage: Browserslist caniuse-lite build warning
+
+## Symptom
+
+`npm run build` completed, but the Astro build log printed:
+
+```text
+Browserslist: browsers data (caniuse-lite) is 11 months old
+```
+
+## Impact
+
+This was warning-only build noise, but it kept the normal local and CI verification sequence from
+being clean and made it harder to spot real build regressions.
+
+## Root cause
+
+The repository uses pnpm as the declared package manager while retaining an npm lockfile for mixed
+local workflows. The pnpm override floor and both lockfiles still resolved Browserslist consumers to
+`caniuse-lite` `1.0.30001791`, so installs could continue to hydrate stale browser-compat metadata
+for Astro/Vite build tooling.
+
+## Fix
+
+Ran the Browserslist database update flow for the pnpm workspace, then raised the repository
+`caniuse-lite` override floor to `>=1.0.30001792` and refreshed the npm and pnpm lock metadata to
+`caniuse-lite` `1.0.30001792`. No browser support policy changed and no broad dependency upgrades
+were introduced.
+
+## Verification commands
+
+- `npm run build`
+- `npm run lint`
+- `npm run type-check`
+- `npm test`
+- `node scripts/link-check.mjs`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -99,13 +99,14 @@
     "openai": "^5.16.0"
   },
   "overrides": {
+    "caniuse-lite": ">=1.0.30001792",
     "esbuild": "0.25.8",
     "@esbuild/linux-x64": "0.25.8",
     "glob": "13.0.6"
   },
   "pnpm": {
     "overrides": {
-      "caniuse-lite": ">=1.0.30001791",
+      "caniuse-lite": ">=1.0.30001792",
       "esbuild": "0.25.8",
       "@esbuild/linux-x64": "0.25.8",
       "glob": "13.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  caniuse-lite: '>=1.0.30001791'
+  caniuse-lite: '>=1.0.30001792'
   esbuild: 0.25.8
   '@esbuild/linux-x64': 0.25.8
   glob: 13.0.6
@@ -2378,8 +2378,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   canvas@3.1.2:
     resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
@@ -7895,7 +7895,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -8046,7 +8046,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -8098,11 +8098,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001792: {}
 
   canvas@3.1.2:
     dependencies:


### PR DESCRIPTION
### Motivation

- The Astro/Vite build emitted a Browserslist stale-data warning (`caniuse-lite` old) which created noisy build logs and obscured other warnings during `npm run build`.
- Refresh the Browserslist dataset with the smallest, targeted dependency metadata changes so builds are clean without changing browser support policy.

### Description

- Raised the `caniuse-lite` override floor to `>=1.0.30001792` in `package.json` and `pnpm.overrides` so pnpm resolution favors the refreshed dataset.
- Updated lock metadata in `package-lock.json` and `pnpm-lock.yaml` so consumers resolve `caniuse-lite` `1.0.30001792` (no broad dependency upgrades were introduced).
- Ran the Browserslist update flow and regenerated lockfile metadata to ensure local/pnpm installs provide fresh browser-compat data to Astro/Vite build tooling.
- Added an outage record `outages/2026-05-16-browserslist-caniuse-lite-build-warning.{md,json}` documenting the symptom, root cause, fix, and verification commands.

### Testing

- `npm run build` completed and no longer prints the stale Browserslist/caniuse-lite warning, confirming the fix.
- `npm run lint` and `npm run type-check` both succeeded with no regressions observed.
- `node scripts/link-check.mjs` and `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` passed, validating the new outage record format and docs prompt requirements.
- `npm test` root/unit suites passed, but E2E test groups were blocked in this environment by Playwright Chromium download failures (`ENETUNREACH` to Playwright CDN IPv6 endpoints), which is an environment/network issue unrelated to the dependency change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f9f03e74832f825f2690fa6cf476)