### PR TITLE
Bump caniuse-lite to 1.0.30001792 — refresh Browserslist metadata

### DIFF
--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.json
@@ -1,0 +1,14 @@
+{
+  "id": "2026-05-16-browserslist-caniuse-lite-build-warning",
+  "date": "2026-05-16",
+  "component": "frontend:astro-build-browserslist",
+  "longForm": "outages/2026-05-16-browserslist-caniuse-lite-build-warning.md",
+  "rootCause": "The repository is pnpm-managed and normal builds resolve Browserslist data through the pnpm lockfile. The pnpm caniuse-lite override floor and pnpm-lock.yaml still resolved caniuse-lite 1.0.30001791 while the Browserslist database update flow reported 1.0.30001792 as the current dataset, allowing stale-data warnings such as `Browserslist: browsers data (caniuse-lite) is 11 months old` to appear during `npm run build` when local installs drifted behind the current Browserslist metadata.",
+  "resolution": "Ran `npx update-browserslist-db@latest`, preserved the repo's pnpm package-manager convention, bumped only the pnpm caniuse-lite override floor to `>=1.0.30001792`, regenerated the pnpm lock metadata, and aligned the existing npm lockfile caniuse-lite entry to the same dataset so both checked-in lockfiles carry current Browserslist data without changing browser support policy or broadly upgrading packages.",
+  "references": [
+    "package.json",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "frontend/package.json"
+  ]
+}

--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
@@ -1,0 +1,54 @@
+# Browserslist caniuse-lite build warning
+
+## Symptom
+
+The normal build command completed successfully but printed stale Browserslist metadata noise:
+
+```bash
+npm run build
+```
+
+```text
+Browserslist: browsers data (caniuse-lite) is 11 months old
+```
+
+## Impact
+
+This was warning-only build noise, not an application build failure. It made the validation sequence
+look unhealthy and could hide new warnings in otherwise successful Astro/Vite build logs.
+
+## Root cause
+
+The repository declares `pnpm@9.0.0` as its package manager and the root build delegates into the
+frontend workspace. The Browserslist database update flow selected the pnpm updater path, then
+reported `caniuse-lite` `1.0.30001792` as the current dataset.
+
+The pnpm override floor and `pnpm-lock.yaml` still resolved `caniuse-lite` `1.0.30001791`. That
+left normal pnpm-backed installs free to use stale Browserslist metadata, producing warnings such as
+`Browserslist: browsers data (caniuse-lite) is 11 months old` during `npm run build` when the local
+install had drifted behind the current database.
+
+## Fix
+
+Refreshed the Browserslist database through the repo's existing pnpm workflow, then made the minimal
+persistent metadata change:
+
+- bumped `pnpm.overrides.caniuse-lite` to `>=1.0.30001792`;
+- regenerated only the related `pnpm-lock.yaml` `caniuse-lite` resolution/snapshot entries;
+- aligned the existing `package-lock.json` `caniuse-lite` entry to the same dataset;
+- left browser support policy and unrelated dependencies unchanged.
+
+The root `package-lock.json` and `frontend/package.json` were inspected as part of the mixed
+npm-script/pnpm-install setup. The durable install policy remains pnpm, while the checked-in npm
+lockfile now mirrors the refreshed `caniuse-lite` dataset for consistency.
+
+## Verification commands
+
+```bash
+npm run build
+npm run lint
+npm run type-check
+npm test
+node scripts/link-check.mjs
+npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "pnpm": {
     "overrides": {
-      "caniuse-lite": ">=1.0.30001791",
+      "caniuse-lite": ">=1.0.30001792",
       "esbuild": "0.25.8",
       "@esbuild/linux-x64": "0.25.8",
       "glob": "13.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  caniuse-lite: '>=1.0.30001791'
+  caniuse-lite: '>=1.0.30001792'
   esbuild: 0.25.8
   '@esbuild/linux-x64': 0.25.8
   glob: 13.0.6
@@ -2378,8 +2378,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   canvas@3.1.2:
     resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
@@ -7895,7 +7895,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -8046,7 +8046,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -8098,11 +8098,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001792: {}
 
   canvas@3.1.2:
     dependencies:


### PR DESCRIPTION
### Motivation

- The Astro/Vite build emitted `Browserslist: browsers data (caniuse-lite) is N months old` warnings because the checked-in lock metadata was behind the current Browserslist dataset. 
- The repo is pnpm-managed and the durable fix is to refresh the Browserslist dataset and align the small lockfile/override metadata so normal `npm run build` output is clean.

### Description

- Ran the Browserslist updater (`npx update-browserslist-db@latest`) and preserved the repo's pnpm install convention. 
- Raised the pnpm override floor for `caniuse-lite` to `>=1.0.30001792` and regenerated the pnpm lock metadata so pnpm resolution uses the refreshed dataset. 
- Aligned the `package-lock.json` `caniuse-lite` entry to the same dataset (`1.0.30001792`) so both checked-in lockfiles carry current Browserslist data; no other package versions or browser support policy were changed. 
- Added an outage record (`outages/2026-05-16-browserslist-caniuse-lite-build-warning.{md,json}`) documenting the symptom, root cause, fix summary, and verification commands.

### Testing

- Ran `npx update-browserslist-db@latest`, `pnpm install --ignore-scripts`, and `npm install --package-lock-only --ignore-scripts` to refresh lock metadata with no broad upgrades, and these completed successfully. 
- Verified `npm run build`, `npm run lint`, `npm run type-check`, and `node scripts/link-check.mjs` completed without emitting the stale Browserslist warning. 
- Root/unit CI tests and the outage convention tests (`npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`) passed. 
- Full `npm test` (Playwright E2E groups) failed in this environment due to inability to download Playwright browsers (`ENETUNREACH`) and is unrelated to the Browserslist metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f9f03e74832f825f2690fa6cf476)