### PR TITLE
Refresh Browserslist metadata (caniuse-lite -> 1.0.30001792)

### DIFF
--- a/outages/2026-05-16-browserslist-caniuse-lite-refresh.json
+++ b/outages/2026-05-16-browserslist-caniuse-lite-refresh.json
@@ -1,0 +1,25 @@
+{
+  "id": "2026-05-16-browserslist-caniuse-lite-refresh",
+  "date": "2026-05-16",
+  "component": "frontend:astro-build-browserslist",
+  "longForm": "outages/2026-05-16-browserslist-caniuse-lite-refresh.md",
+  "symptom": "`npm run build` printed `Browserslist: browsers data (caniuse-lite) is 11 months old` before Astro completed successfully.",
+  "rootCause": "The repository lockfiles still resolved Browserslist consumers to caniuse-lite metadata older than the latest published dataset, and the pnpm override floor still allowed the previous dataset floor.",
+  "resolution": "Refreshed npm and pnpm lock metadata to caniuse-lite 1.0.30001792 and raised the pnpm override floor to >=1.0.30001792 without changing browser support policy or performing broad package upgrades.",
+  "verification": [
+    "npm run build",
+    "npm run lint",
+    "npm run type-check",
+    "npm test",
+    "node scripts/link-check.mjs",
+    "npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts"
+  ],
+  "impact": "warning-only",
+  "gateFailure": false,
+  "references": [
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "outages/2026-05-16-browserslist-caniuse-lite-refresh.md"
+  ]
+}

--- a/outages/2026-05-16-browserslist-caniuse-lite-refresh.md
+++ b/outages/2026-05-16-browserslist-caniuse-lite-refresh.md
@@ -1,0 +1,41 @@
+# Browserslist caniuse-lite metadata refresh for build output
+
+## Symptom
+
+`npm run build` completed the Astro production build, but printed the Browserslist stale-data
+warning before the build summary:
+
+```text
+Browserslist: browsers data (caniuse-lite) is 11 months old
+```
+
+## Impact
+
+This was warning-only build noise, not a compile failure. The warning made the standard validation
+sequence harder to scan and left an outstanding issue in otherwise successful build output.
+
+## Root cause
+
+The repository lockfiles still resolved Browserslist consumers to `caniuse-lite` metadata older
+than the latest published dataset. The pnpm override floor also still referenced the previous
+metadata floor, so the pnpm lock path could keep reusing the older Browserslist database even after
+running the normal build command.
+
+## Fix
+
+Refreshed the Browserslist database metadata to `caniuse-lite` `1.0.30001792` in both lockfiles and
+raised the pnpm override floor to the same version. No browser support policy was changed and no
+broad dependency upgrade was introduced.
+
+## Verification
+
+Run:
+
+```bash
+npm run build
+npm run lint
+npm run type-check
+npm test
+node scripts/link-check.mjs
+npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "pnpm": {
     "overrides": {
-      "caniuse-lite": ">=1.0.30001791",
+      "caniuse-lite": ">=1.0.30001792",
       "esbuild": "0.25.8",
       "@esbuild/linux-x64": "0.25.8",
       "glob": "13.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  caniuse-lite: '>=1.0.30001791'
+  caniuse-lite: '>=1.0.30001792'
   esbuild: 0.25.8
   '@esbuild/linux-x64': 0.25.8
   glob: 13.0.6
@@ -2378,8 +2378,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   canvas@3.1.2:
     resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
@@ -7895,7 +7895,7 @@ snapshots:
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -8046,7 +8046,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -8098,11 +8098,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.1
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001792: {}
 
   canvas@3.1.2:
     dependencies:


### PR DESCRIPTION
### Motivation
- The production build emitted a noisy Browserslist warning: `Browserslist: browsers data (caniuse-lite) is 11 months old`, which obscures clean validation output.
- The goal is to refresh the Browserslist dataset with minimal, targeted lockfile changes so `npm run build` no longer prints the stale-data warning.

### Description
- Bumped `caniuse-lite` metadata to `1.0.30001792` in both npm and pnpm lock paths by updating `package-lock.json` and `pnpm-lock.yaml` so Browserslist consumers see fresh data.
- Raised the pnpm override floor to `>=1.0.30001792` in `package.json` to prevent pnpm resolution from falling back to older datasets.
- Adjusted pnpm snapshots where `autoprefixer`, `browserslist`, and `caniuse-api` reference the refreshed `caniuse-lite` version.
- Added an outage record documenting the warning and remediation at `outages/2026-05-16-browserslist-caniuse-lite-refresh.md` with a matching `.json` metadata file.

### Testing
- `npm run build` completed and no longer printed the `Browserslist: browsers data (caniuse-lite) ... old` warning (verification log confirmed absence of the warning).
- `npm run lint` succeeded with no new issues.
- `npm run type-check` (`tsc --noEmit`) succeeded.
- `SKIP_E2E=1 npm test` completed successfully in this environment, and root/unit test suites passed when run via `npm run test:root` for the outage-related tests.
- `node scripts/link-check.mjs` succeeded and `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` passed, validating the new outage files against repository conventions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f9f03e74832f825f2690fa6cf476)