### PR TITLE
Suppress npm update-notifier banner during validation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
-packageManager=pnpm@9.0.0
 legacy-peer-deps=true
+
+update-notifier=false

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,3 @@
 legacy-peer-deps=true
+
+update-notifier=false

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.json
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-05-16-npm-update-notifier-validation-noise",
+  "date": "2026-05-16",
+  "component": "validation-tooling:npm-config",
+  "longForm": "outages/2026-05-16-npm-update-notifier-validation-noise.md",
+  "rootCause": "The root and frontend npm scripts run npm from separate package directories, but neither repo-local .npmrc disabled npm's update notifier, allowing the host npm update banner to appear when npm 10.9.0 detected npm 11.14.1; the root .npmrc also duplicated packageManager even though package.json is the package-manager declaration source.",
+  "resolution": "Added update-notifier=false to both the root .npmrc and frontend/.npmrc, and removed the duplicate packageManager config from root .npmrc while leaving package.json as the package-manager declaration source, so normal validation commands suppress only npm's self-update notice while preserving script behavior and real failure output.",
+  "references": [
+    ".npmrc",
+    "frontend/.npmrc",
+    "package.json",
+    "frontend/package.json",
+    "outages/2026-05-16-npm-update-notifier-validation-noise.md"
+  ]
+}

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -1,0 +1,45 @@
+# Outage: npm update-notifier validation noise
+
+## Symptom
+
+The normal validation sequence:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+completed script startup but printed npm's update-notifier banner during validation output:
+
+```text
+npm notice New major version of npm available! 10.9.0 -> 11.14.1
+```
+
+## Impact
+
+The notice was not a project failure, but it kept local and CI-style verification logs from being
+clean and made it easier to miss real lint, type-check, build, test, or link-check failures.
+
+## Root cause
+
+The repository invokes npm from both the root package and nested `frontend` package scripts. Neither
+repo-local npm config file disabled npm's update notifier, so npm could emit its global update banner
+whenever the host's npm version lagged the latest published major release. The root `.npmrc` also
+carried a duplicate `packageManager` entry even though the package-manager declaration belongs in
+`package.json`, which could create unrelated nested npm config warnings during verification.
+
+## Fix
+
+Added the narrow repo-local npm setting `update-notifier=false` to both the root and frontend
+`.npmrc` files. The duplicate `packageManager` npm config entry was removed from the root `.npmrc`
+because `package.json` already declares the package manager. This suppresses npm's self-update
+banner for commands run in either package while preserving normal npm script behavior and failure
+output.
+
+## Verification commands
+
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `npm test`
+- `node scripts/link-check.mjs`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`


### PR DESCRIPTION
### Motivation
- The standard validation sequence printed npm's self-update banner (`New major version of npm available! 10.9.0 -> 11.14.1`), which polluted local and CI verification logs and made it harder to spot real failures.

### Description
- Add `update-notifier=false` to the repo-local `./.npmrc` so root-level npm invocations suppress the update-notifier banner without changing script behavior. 
- Add `update-notifier=false` to `frontend/.npmrc` so nested `cd frontend && npm run ...` commands inherit the suppression. 
- Remove the duplicate `packageManager` entry from the root `.npmrc` (the package manager remains declared in `package.json`).
- Add an outage record (`outages/2026-05-16-npm-update-notifier-validation-noise.md` and `.json`) documenting the symptom, root cause, fix, and verification steps.

### Testing
- Verified `npm config get update-notifier` returned `false` in both root and `frontend` contexts. (passed)
- Ran `npm run lint` and observed normal lint output with the npm update banner suppressed while unrelated `npm warn Unknown env config` proxy warnings (from environment) remained. (passed)
- Ran `npm run type-check` and `npm run build` with the update banner suppressed. (passed)
- Ran `node scripts/link-check.mjs` and confirmed link-check output is clean. (passed)
- Ran targeted outage tests with `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and they passed. (passed)
- Attempted full `npm test` in this environment but the root unit-test phase produced no further output and was terminated to avoid leaving hung processes; this was an environment run-time stall rather than a change-induced test failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08102ef164832fa1cf87b470692297)