### PR TITLE
Disable npm update-notifier in repo .npmrc and add outage record

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 packageManager=pnpm@9.0.0
 legacy-peer-deps=true
+update-notifier=false

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+update-notifier=false

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.json
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-05-16-npm-update-notifier-validation-noise",
+  "date": "2026-05-16",
+  "component": "validation-tooling:npm-config",
+  "longForm": "outages/2026-05-16-npm-update-notifier-validation-noise.md",
+  "rootCause": "The repo-local npm configuration did not disable npm's update notifier, so npm could print the global CLI upgrade banner during otherwise successful root and nested frontend validation scripts when the installed npm 10.9.0 detected npm 11.14.1 was available.",
+  "resolution": "Added update-notifier=false to both the root and frontend .npmrc files so normal repo validation commands and nested frontend npm invocations suppress only npm's update-notifier banner while preserving normal script output and failure reporting.",
+  "references": [
+    ".npmrc",
+    "frontend/.npmrc",
+    "outages/2026-05-16-npm-update-notifier-validation-noise.md"
+  ]
+}

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -1,0 +1,46 @@
+# Outage: npm update-notifier validation noise
+
+## Symptom
+
+The normal validation sequence:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+completed far enough to reach lint output, but npm printed its update-notifier banner:
+
+```text
+npm notice New major version of npm available! 10.9.0 -> 11.14.1
+```
+
+## Impact
+
+The notice was not a repo failure, but it made local and CI validation output noisy and obscured
+whether the command sequence was clean. It also appeared during nested npm script execution, such as
+root scripts that `cd frontend && npm run ...`.
+
+## Root cause
+
+The root `.npmrc` and `frontend/.npmrc` already carried repo-local npm behavior, but neither file
+set `update-notifier=false`. When the installed npm CLI detected that npm `11.14.1` was available
+while npm `10.9.0` was installed, npm emitted the upgrade banner even though the underlying script
+was still behaving normally.
+
+## Fix
+
+Added `update-notifier=false` to the root `.npmrc` and the frontend `.npmrc`. The root setting covers
+root-level commands such as `npm run type-check`, `npm run build`, and `npm test`; the frontend
+setting covers nested frontend commands launched by root wrappers such as `npm run lint`.
+
+This suppresses only npm's update-notifier banner. It does not redirect command output, hide npm
+install or script errors, upgrade global npm, or change the package-manager convention.
+
+## Verification commands
+
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `npm test`
+- `node scripts/link-check.mjs`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -41,6 +41,9 @@ install or script errors, upgrade global npm, or change the package-manager conv
 - `npm run lint`
 - `npm run type-check`
 - `npm run build`
-- `npm test`
 - `node scripts/link-check.mjs`
 - `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
+
+`npm test` was also attempted as a full-suite check, but it did not complete in this
+environment because Playwright could not download Chromium due to an unrelated network
+`ENETUNREACH` error.

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -41,9 +41,10 @@ install or script errors, upgrade global npm, or change the package-manager conv
 - `npm run lint`
 - `npm run type-check`
 - `npm run build`
+- `npm test`
 - `node scripts/link-check.mjs`
 - `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`
 
-`npm test` was also attempted as a full-suite check, but it did not complete in this
-environment because Playwright could not download Chromium due to an unrelated network
-`ENETUNREACH` error.
+In the authoring environment, `npm test` reached Playwright setup but could not complete
+because Chromium download failed with `ENETUNREACH`; rerun in an environment with
+Playwright browsers available or network access before merge.


### PR DESCRIPTION
### Motivation

- Prevent npm's interactive update-notifier banner from polluting the standard validation output when running nested repo scripts.
- Keep validation logs clean so real failures remain easy to spot in local runs and CI.

### Description

- Added `update-notifier=false` to the root `.npmrc` and `frontend/.npmrc` so both root-level and nested frontend `npm` invocations suppress the npm upgrade banner. 
- Added a new outage record `outages/2026-05-16-npm-update-notifier-validation-noise.json` and companion long-form `outages/2026-05-16-npm-update-notifier-validation-noise.md` documenting the symptom, root cause, fix, and verification commands.

### Testing

- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, which completed successfully and no longer emitted the npm update-notifier banner during those steps. 
- Ran `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`, and those outage-convention tests passed. 
- Attempted full `npm test`, but the Playwright E2E stage failed due to an environment network error (`ENETUNREACH`) while downloading Chromium; this failure is unrelated to the npm config changes and pre-existing in this environment.
- Verified `git diff --cached --check` and repository secret scan passed for the staged changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08102ef164832fa1cf87b470692297)