### PR TITLE
Suppress npm update-notifier banner in validation output

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 packageManager=pnpm@9.0.0
 legacy-peer-deps=true
+update-notifier=false

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+update-notifier=false

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.json
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-05-16-npm-update-notifier-validation-noise",
+  "date": "2026-05-16",
+  "component": "validation-tooling:npm-config",
+  "longForm": "outages/2026-05-16-npm-update-notifier-validation-noise.md",
+  "rootCause": "Root and frontend project-level .npmrc files did not disable npm's update notifier, and root scripts delegate to nested npm commands from frontend/ where the frontend npm config is used.",
+  "resolution": "Added update-notifier=false to both root and frontend .npmrc files so repo-local validation and nested frontend npm scripts suppress only npm's version-update banner while preserving normal command behavior and failure output.",
+  "references": [
+    ".npmrc",
+    "frontend/.npmrc",
+    "package.json",
+    "frontend/package.json",
+    "outages/2026-05-16-npm-update-notifier-validation-noise.md"
+  ]
+}

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -1,0 +1,43 @@
+# Outage: npm update-notifier validation noise
+
+## Symptom
+
+The normal validation sequence:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+could complete successfully, but npm printed an update-notifier banner during local verification:
+
+```text
+npm notice New major version of npm available! 10.9.0 -> 11.14.1
+```
+
+## Impact
+
+This was warning-only command-output noise. It made otherwise-clean validation logs look like they
+had outstanding follow-up work and made it harder to notice real script failures.
+
+## Root cause
+
+The repository already had root and frontend `.npmrc` files for repo-local npm behavior, but neither
+file disabled npm's update notifier. Root scripts commonly delegate to nested frontend npm scripts
+with `cd frontend && npm run ...`, so the frontend project-level npm config also needed the same
+repo-local setting; otherwise npm commands launched from `frontend/` could still evaluate their own
+configuration without the root project file.
+
+## Fix
+
+Added `update-notifier=false` to both the root and frontend `.npmrc` files. This disables only npm's
+version-update banner for repo-local root and nested frontend workflows while preserving normal npm
+script execution and failure output.
+
+## Verification commands
+
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `npm test`
+- `node scripts/link-check.mjs`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`


### PR DESCRIPTION
### Motivation
- The normal validation sequence (`npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs`) printed npm's update-notifier banner which created noisy logs and obscured real failures. 
- Provide a minimal, repo-local configuration change so nested `frontend` npm invocations also inherit the suppression and avoid changing global tooling or user configs.

### Description
- Added `update-notifier=false` to the root `.npmrc` so repo-local npm runs do not print the version-update banner. 
- Added `update-notifier=false` to `frontend/.npmrc` so `cd frontend && npm run ...` nested workflows also suppress the banner. 
- Added a machine-readable outage record `outages/2026-05-16-npm-update-notifier-validation-noise.json` and a companion long-form report `outages/2026-05-16-npm-update-notifier-validation-noise.md` documenting symptom, root cause, fix, and verification steps.

### Testing
- Ran `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` and those commands completed successfully. 
- Ran the outage convention checks with `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` and they passed, validating the new outage files. 
- Ran `npm test` (full test suite) and the root/unit portions passed, but Playwright E2E groups failed due to an external `ENETUNREACH` error preventing Chromium download; this E2E failure is environmental and unrelated to the `update-notifier=false` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08102ef164832fa1cf87b470692297)