### PR TITLE
🔧 Suppress npm update-notifier validation noise

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-packageManager=pnpm@9.0.0
 legacy-peer-deps=true
+update-notifier=false

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+update-notifier=false

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.json
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-05-16-npm-update-notifier-validation-noise",
+  "date": "2026-05-16",
+  "component": "npm-validation-scripts",
+  "longForm": "outages/2026-05-16-npm-update-notifier-validation-noise.md",
+  "rootCause": "npm's default update notifier remained enabled for root and frontend npm script invocations, so local validation could print an npm 10.9.0 to 11.14.1 upgrade banner even when commands succeeded. The root .npmrc also duplicated the pnpm package-manager pin that already belongs in package.json, which made newer npm versions treat it as an unknown project config.",
+  "resolution": "Disabled npm's update notifier in the repository-local root and frontend .npmrc files, and kept the pnpm package-manager pin only in package.json so normal root scripts and nested frontend npm scripts keep their usual behavior and failure output without npm banner noise.",
+  "references": [
+    ".npmrc",
+    "frontend/.npmrc",
+    "package.json",
+    "tests/packageManager.test.ts",
+    "outages/2026-05-16-npm-update-notifier-validation-noise.md"
+  ]
+}

--- a/outages/2026-05-16-npm-update-notifier-validation-noise.md
+++ b/outages/2026-05-16-npm-update-notifier-validation-noise.md
@@ -1,0 +1,59 @@
+# Outage: npm update-notifier validation noise
+
+## Symptom
+
+The normal local verification sequence completed without a repository failure, but npm could append
+an update-notifier banner to the output:
+
+```bash
+npm run lint; npm run type-check; npm run build; npm test; node scripts/link-check.mjs
+```
+
+```text
+npm notice
+npm notice New major version of npm available! 10.9.0 -> 11.14.1
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.14.1
+npm notice To update run: npm install -g npm@11.14.1
+npm notice
+```
+
+## Impact
+
+The banner was informational, but it made the validation sequence look noisy after lint, type-check,
+build, test, and link-check work had otherwise completed. It also obscured real failures in command
+logs because the final output could be an unrelated global npm upgrade notice.
+
+## Root cause
+
+npm's update notifier is enabled by default. The root verification scripts invoke nested npm scripts
+under `frontend/`, and neither the root `.npmrc` nor `frontend/.npmrc` disabled the notifier. Because
+npm reads the project config for the current working directory, frontend script invocations needed a
+frontend-local setting in addition to the root setting.
+
+The investigation also found that the root `.npmrc` duplicated the pnpm package-manager pin that
+already lives in `package.json`. Newer npm versions treat that `.npmrc` key as an unknown project
+config, so keeping the pin in `package.json` avoids an additional npm warning while preserving the
+repository package-manager declaration.
+
+## Fix
+
+Set `update-notifier=false` in both repository-local npm config files:
+
+- `.npmrc` for root npm commands.
+- `frontend/.npmrc` for nested commands that run after scripts change into `frontend/`.
+
+Removed the duplicate `packageManager=pnpm@9.0.0` line from `.npmrc`; `package.json` remains the
+Corepack package-manager source of truth. This keeps normal npm script behavior and stderr/stdout
+from the underlying tools intact while only suppressing npm's own banner noise. It does not upgrade
+global npm and does not hide real npm script or install errors.
+
+## Verification commands
+
+- `npm config get update-notifier`
+- `npm --prefix frontend config get update-notifier`
+- `npm run lint`
+- `npm run type-check`
+- `npm run build`
+- `npm test`
+- `node scripts/link-check.mjs`
+- `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`

--- a/tests/packageManager.test.ts
+++ b/tests/packageManager.test.ts
@@ -30,24 +30,34 @@ describe('frontend/package.json', () => {
   });
 });
 
+function readNpmrcLines(...segments: string[]) {
+  const npmrcPath = join(__dirname, '..', ...segments);
+  expect(existsSync(npmrcPath)).toBe(true);
+
+  return readFileSync(npmrcPath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 describe('.npmrc', () => {
-  it('pins pnpm via Corepack configuration', () => {
-    const npmrcPath = join(__dirname, '..', '.npmrc');
-    expect(existsSync(npmrcPath)).toBe(true);
-    const lines = readFileSync(npmrcPath, 'utf8')
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
-    expect(lines).toContain('packageManager=pnpm@9.0.0');
+  it('keeps package-manager pinning in package.json instead of npm project config', () => {
+    const lines = readNpmrcLines('.npmrc');
+    expect(lines).not.toContain('packageManager=pnpm@9.0.0');
+  });
+
+  it('disables npm update-notifier noise for root scripts', () => {
+    const lines = readNpmrcLines('.npmrc');
+    expect(lines).toContain('update-notifier=false');
   });
 
   it('keeps frontend npm peer behavior explicit for local installs', () => {
-    const npmrcPath = join(__dirname, '..', 'frontend', '.npmrc');
-    expect(existsSync(npmrcPath)).toBe(true);
-    const lines = readFileSync(npmrcPath, 'utf8')
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
+    const lines = readNpmrcLines('frontend', '.npmrc');
     expect(lines).toContain('legacy-peer-deps=true');
+  });
+
+  it('disables npm update-notifier noise for frontend scripts', () => {
+    const lines = readNpmrcLines('frontend', '.npmrc');
+    expect(lines).toContain('update-notifier=false');
   });
 });


### PR DESCRIPTION
### Motivation
- Local validation runs printed npm's update-notifier banner (`10.9.0 -> 11.14.1`) which made the normal verification sequence noisy and obscured real failures. 
- The root `.npmrc` duplicated the `packageManager` pin that already lives in `package.json`, causing newer npm versions to treat it as an unknown project config and emit unrelated warnings. 
- Provide a minimal, repo-local fix that keeps normal npm error behaviour while removing only the informational update banner and documenting the incident.

### Description
- Added `update-notifier=false` to both repository-local npm configs in `.npmrc` and `frontend/.npmrc` and removed the duplicate `packageManager=pnpm@9.0.0` entry from the root `.npmrc` so `package.json` remains the Corepack source of truth. 
- Added an outage record and long-form report at `outages/2026-05-16-npm-update-notifier-validation-noise.json` and `.md` documenting symptom, root cause, fix, and verification steps. 
- Updated `tests/packageManager.test.ts` to assert the new expectations: `packageManager` is kept in `package.json`, and `update-notifier=false` is present in both `.npmrc` files while preserving the frontend `legacy-peer-deps=true` setting.

### Testing
- Verified repo-local npm config values with `npm config get update-notifier` and `npm --prefix frontend config get update-notifier`, both returning `false`. 
- Ran validation commands `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs`, which all completed successfully in this environment. 
- Ran targeted test suites with `npm run test:root -- tests/packageManager.test.ts tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts`, and the tests passed; the comprehensive `npm test` run showed unrelated Playwright E2E failures caused by the environment being unable to download Playwright browsers (network/IPv6), not by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08102ef164832fa1cf87b470692297)