### PR TITLE
Clarify Browserslist caniuse-lite outage entry

### DIFF
--- a/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
+++ b/outages/2026-05-16-browserslist-caniuse-lite-build-warning.md
@@ -5,7 +5,9 @@
 `npm run build` completed, but the Astro build log printed:
 
 ```text
-Browserslist: browsers data (caniuse-lite) is 11 months old
+Browserslist: browsers data (caniuse-lite) is 11 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 ```
 
 ## Impact
@@ -24,8 +26,9 @@ for Astro/Vite build tooling.
 
 Ran the Browserslist database update flow for the pnpm workspace, then raised the repository
 `caniuse-lite` override floor to `>=1.0.30001792` and refreshed the npm and pnpm lock metadata to
-`caniuse-lite` `1.0.30001792`. No browser support policy changed and no broad dependency upgrades
-were introduced.
+`caniuse-lite` `1.0.30001792`. A follow-up `npx update-browserslist-db@latest` check reported
+`1.0.30001792` as the latest available dataset, so no browser support policy changed and no broad
+dependency upgrades were introduced.
 
 ## Verification commands
 


### PR DESCRIPTION
### Motivation
- Clean up the remaining QA signal by addressing the Browserslist/caniuse-lite stale-database build warning while preserving the repository's browser support policy and keeping the change minimal and mechanical.

### Description
- Reused and clarified the existing outage record `outages/2026-05-16-browserslist-caniuse-lite-build-warning.md` by expanding the symptom to include the full stale database warning and documenting that a follow-up `npx update-browserslist-db@latest` check confirmed `caniuse-lite` `1.0.30001792` was the latest dataset; no browser targets or broad dependency upgrades were introduced.

### Testing
- Ran the relevant automated checks: `npm run build` (no Browserslist warning observed), `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` (passed), `npm run lint` (passed), `npm run type-check` (passed), `node scripts/link-check.mjs` (passed), and verified root/unit suites in `npm test` passed while Playwright E2E in this environment was blocked by an external browser-download `ENETUNREACH` network error unrelated to the outage doc change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08256374a0832f9232053f52ae10a9)