### PR TITLE
📝 Update April changelog with v3.1 mainline addendum and close v3.0.1 audit

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -61,7 +61,14 @@ git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae22
 git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e
 ```
 
-- [ ] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+- [x] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+  - Evidence (2026-05-17 UTC): audited
+    `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` with `git log --oneline`,
+    `git diff --name-only`, and `git diff --stat`; compared that delta against this checklist,
+    `frontend/src/pages/docs/md/changelog/20260401.md`, `docs/releases.md`, and
+    `docs/merge-plan.md`; confirmed the v3.0.1 checklist still matches the release-critical
+    candidate scope while the changelog now carries v3.1 mainline coverage for the broader
+    user-visible delta.
 
 ---
 

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -135,9 +135,78 @@ forward.
 
 ---
 
+## May 17, 2026 — DSPACE v3.1 (mainline addendum)
+
+`v3.1` tracks the user-visible work that has landed on `main` after the April 1 v3
+baseline. This section is changelog coverage for the mainline delta, not a claim that staging or
+production promotion has already completed.
+
+### Faster day-to-day gameplay
+
+- **`/quests` gets to useful content faster:** the quest list now prioritizes immediately
+  actionable built-in quests, avoids premature `Start`/`Continue` labels while progress is still
+  reconciling, and keeps custom quests from displacing built-in cards when local custom content
+  merges in after initial load.
+- **Custom and completed quests are clearer:** custom quests coexist with built-ins across refresh
+  and navigation, custom completed quests appear with the rest of completed quest history, and
+  unavailable quest states use clearer status labels instead of misleading action text.
+- **Quest-route safety and polish improved:** unsafe custom quest tile links are routed back to
+  internal quest pages, locked/custom visibility regressions were fixed, quest gate flashes on
+  refresh were reduced, and the rocketry preflight-check flow no longer depends on a dead-end
+  wind-evidence item gate.
+- **`/processes` is lighter on list pages:** `/processes` now renders summary-first rows with
+  titles, duration, and requires/consumes/creates counts so browsing the catalog is faster and less
+  cluttered. Full runtime controls stay on the detail route.
+- **Process details keep the power tools:** `/processes/:processId` retains `Start`, `Pause`,
+  `Resume`, `Cancel`, `Collect`, and `Buy required items` controls, with fixes for metadata-loading
+  fallbacks, consume-only requirements, merged require/consume shopping lists, and hidden placeholder
+  IDs while previews are still resolving.
+
+### Docs, search, and chat
+
+- **`/docs` opens with a smaller initial payload:** the docs index can be browsed immediately from
+  metadata while the full-text corpus waits until the first keyword search.
+- **Search behavior is more resilient:** `has:` queries such as `has:link` and `has:image` continue
+  to work without fetching the corpus, keyword search retries after a corpus-load failure, snippets
+  keep rendering cleanly, and long docs titles/tokens wrap more gracefully.
+- **dChat stays grounded after docs-index changes:** docs-backed retrieval and launch-check prompts
+  were regression-tested after the corpus split so chat responses still find relevant DSPACE docs
+  instead of behaving like an empty-index result.
+- **Reference docs caught up with gameplay:** release, QA, runbook, geothermal, rocketry, testing,
+  contributor, and custom-content guidance now better match the current routes, gates, rewards, and
+  launch checks.
+
+### Custom content, saves, and UI hardening
+
+- **Custom content import is safer:** bundle/import validation rejects more malformed custom content,
+  shopping links are sanitized, and compact item/process preview images fall back safely when custom
+  data provides unsafe or missing image references.
+- **Inventory data is stricter:** stored item counts are normalized and unknown item containers are
+  rejected so local saves are less likely to accumulate impossible inventory state.
+- **Cloud sync and auth flows are steadier:** GitHub/Gist-backed cloud sync readiness, backup
+  refresh timing, token-save flows, logout credential persistence, and related authentication checks
+  were hardened for fewer false failures during normal use.
+- **Settings and quest/chat UI polish:** settings cards use a more responsive layout, QuestChat
+  readiness/unmount behavior is safer, and loading/status copy was tightened so refreshes and route
+  changes feel less jumpy.
+
+### Launch-readiness and operations
+
+- **Release evidence is easier to audit:** v3.0.1 QA docs, release-history links, rollback and
+  promotion runbooks, and compare-based release references were tightened without marking staging or
+  production gates complete before evidence exists.
+- **Smoke and CI paths are less noisy:** remote smoke checks, Docker/runtime dependency handling,
+  Playwright browser bootstrapping, workflow sentinels, Browserslist metadata, npm update notices,
+  and expected service-worker/Node warning filters were updated so launch checks surface real
+  user-impacting failures more clearly.
+
+---
+
 ## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
 
-`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening across the audited delta `3ec45a5517a35c96767f6b946c01104e6ec88f93..899fcb93f705d0fe4051d7ecb74ee242cb8ab59c`.
+`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness
+hardening across the audited delta
+`3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e`.
 
 ### Patch notes
 


### PR DESCRIPTION
### Motivation
- Bring the April 2026 changelog up to date with the user-visible work that landed on `main` after the v3 baseline so release notes reflect what users actually see. 
- Allow the v3.0.1 QA checklist commit-range audit to be closed honestly by recording the audited delta and brief evidence in the checklist. 
- Preserve changelog style and avoid claiming staging/production promotion or completion where repo evidence is not present.

### Description
- Added a `v3.1` mainline addendum to `frontend/src/pages/docs/md/changelog/20260401.md` that summarizes user-visible changes on `main` since the April v3 baseline (covering `/quests`, `/processes`, `/docs`, `/chat`, custom content, saves/cloud sync/auth, UI polish, and launch-readiness/ops notes). 
- Updated the existing `v3.0.1` patch addendum in the same changelog file to reference the audited candidate commit range that the QA run targets (range end updated to the current rc.4 candidate). 
- Updated `docs/qa/v3.0.1.md` to mark the commit-range audit checkbox as checked and added a concise evidence note stating the audited commands and the comparison targets (`git log --oneline`, `git diff --name-only`, `git diff --stat` against the changelog and release docs). 
- Kept changes limited to documentation and checklist text only, preserved the rule not to mark staging/production signoff boxes complete, and adjusted the addendum date for clarity.

### Testing
- Ran `node scripts/link-check.mjs` to validate local markdown links and it completed successfully. 
- Ran the targeted changelog/unit checks with `npm run test:root -- tests/changelogHistoryGuard.test.ts tests/changelogDocsReleaseChecklist.test.ts` and both tests passed. 
- Ran the repository secrets scan on the staged diff with `git diff --cached | ./scripts/scan-secrets.py` and it returned no findings. 
- Note: a full `npm test` / long root test run was started earlier but entered the full root flow and was not completed in this edit-cycle; the targeted checks above were used to validate the modified docs and changelog guard behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0961f56890832f89c90e6aba40ecd4)