### PR TITLE
📝 Update April changelog with v3.1 coverage and close v3.0.1 audit signoff

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -61,7 +61,16 @@ git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae22
 git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e
 ```
 
-- [ ] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+- [x] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+  - Evidence: Codex audit on 2026-05-17 ran `git log --oneline`, `git diff --name-only`, and
+    `git diff --stat` for the candidate range
+    `3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e`
+    and the broader `3ec45a5517a35c96767f6b946c01104e6ec88f93..main` delta, then compared
+    the changes against this checklist, `frontend/src/pages/docs/md/changelog/20260401.md`,
+    `docs/releases.md`, and `docs/merge-plan.md`. The v3.0.1 checklist scope still matches the
+    audited patch gates, and the April changelog now carries v3.1 mainline coverage for the
+    user-visible audited delta without closing staging, production, rollback, or release-closeout
+    boxes.
 
 ---
 

--- a/frontend/src/pages/docs/md/changelog/20260401.md
+++ b/frontend/src/pages/docs/md/changelog/20260401.md
@@ -135,9 +135,93 @@ forward.
 
 ---
 
+## v3.1 mainline update (coverage for work after the v3 baseline)
+
+This section tracks the user-visible work that has landed on `main` since the v3 baseline
+`3ec45a5517a35c96767f6b946c01104e6ec88f93`. It includes the v3.0.1 patch-candidate work plus
+follow-up hardening already merged to `main`; it does **not** claim a staging signoff, production
+promotion, or final v3.1 release.
+
+### Faster, calmer `/quests`
+
+- The quest list now prioritizes time-to-interactive: built-in, actionable quest cards render first,
+  then custom quests merge in after local custom-content storage finishes loading.
+- Built-in and custom quests now coexist more reliably: custom quests no longer displace built-ins,
+  completed custom quests are grouped with completed quests, and duplicate/custom IDs are guarded in
+  the list flow.
+- Quest card states were cleaned up so locked or unavailable quests do not flash as playable, the
+  old card-level `Start` label was removed, and status text remains accessible after refreshes.
+- Custom quest tile links are sanitized so unsafe route values fall back to internal quest links
+  instead of navigating to attacker-controlled or malformed destinations.
+- The rocketry preflight-check flow no longer dead-ends behind an unavailable wind-evidence item
+  gate, and quest reward docs were aligned with the quest data.
+- The v3.0.1 launch-gate perf audit measured the optimized quest list as dramatically faster than
+  the v3 baseline:
+  - Cold run: list visible 30.3 ms → 0.3 ms; full reconciliation 72.6 ms → 0.7 ms.
+  - 4x CPU-throttled run: list visible 115.5 ms → 1.9 ms; full reconciliation 262.6 ms → 6.2 ms.
+
+### Lighter `/processes` lists with full detail controls retained
+
+- `/processes` now uses summary-first list rows: the list focuses on process title, duration, and
+  compact requires/consumes/creates previews instead of hydrating every runtime control in every row.
+- Interactive controls such as `Start`, `Pause`, `Resume`, `Collect`, and `Buy required items` remain
+  on process detail routes, including the legacy `/process/:slug` path where supported.
+- Process previews no longer show unresolved item IDs while metadata is still loading, reducing
+  flicker and confusing placeholder content.
+- `Buy required items` behavior was hardened for consume-only processes, stale metadata, missing
+  fallback requirements, embedded item-page process views, and mixed custom/built-in process states.
+- Custom processes continue to merge into the list after built-ins load, with detail links preserved
+  for both built-in and custom content.
+
+### More responsive `/docs` and docs-backed `/chat`
+
+- `/docs` now loads its browse index first and defers the full-text corpus until the first keyword
+  search, making the default browse view useful without downloading every document body up front.
+- Metadata-only `has:` searches such as `has:link` and `has:image` work immediately without waiting
+  for the deferred corpus.
+- If the full-text corpus fetch fails, docs search degrades gracefully and can retry instead of
+  leaving the browse experience broken.
+- Snippet rendering and long-token wrapping were tightened so search results stay readable after the
+  deferred-corpus split.
+- dChat retrieval was rechecked against the docs corpus changes so docs-backed questions about Cloud
+  Sync, Backups, quest submission, and custom-content bundles continue to produce grounded answers.
+- Retrieval design docs now capture the next steps for improving dChat grounding and actionability
+  without representing those future improvements as shipped behavior.
+
+### Custom content, saves, settings, and account flows
+
+- Custom content imports and shop links were hardened against unsafe HTML/link rendering while
+  preserving the in-game creator workflows for quests, items, processes, and bundles.
+- Stored item counts are normalized and unknown item containers are rejected, reducing bad-save edge
+  cases that could leak into inventory or process previews.
+- Legacy v2 save migration coverage was restored against a real fixture, keeping the local-first v3
+  save migration path safer for returning players.
+- Cloud Sync readiness and backup refresh races were hardened so authenticated sync state is less
+  likely to present stale or premature backup actions.
+- Logout/authentication coverage was tightened around saved credentials and token persistence so the
+  account flow is less flaky across browser sessions.
+- `/settings` now uses a responsive two-column grid at wider widths and more consistent card styling
+  across the page.
+
+### Launch-readiness and operator-facing polish
+
+- Release history, QA checklist, and promotion/rollback runbooks now point at the mainline release
+  flow and immutable artifact expectations for staging and production.
+- Remote smoke coverage was strengthened for live chat, custom item creation/deletion, custom item
+  mutations, and real legacy-save migration checks.
+- Docker/build/runtime packaging was hardened around the frontend canvas dependency and generated
+  docs/RAG artifacts so container smoke tests better match the deployed app.
+- CI and Playwright harness output is quieter and more deterministic, reducing false alarms from
+  expected service-worker, Browserlist, npm-update, Node warning, and headless-shell messages.
+- Security-oriented maintenance in the audited delta includes safer process/custom-content preview
+  images, stricter container validation, pinned privileged emulator setup, and dependency override
+  updates.
+
+---
+
 ## June 1, 2026 — DSPACE v3.0.1 (patch addendum)
 
-`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening across the audited delta `3ec45a5517a35c96767f6b946c01104e6ec88f93..899fcb93f705d0fe4051d7ecb74ee242cb8ab59c`.
+`v3.0.1` is a patch update to the April 1 v3 release, focused on launch-readiness hardening across the audited delta `3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e`.
 
 ### Patch notes
 


### PR DESCRIPTION
### Motivation

- Ensure the April 2026 changelog (`frontend/src/pages/docs/md/changelog/20260401.md`) documents the user-visible work that landed on `main` after the v3 baseline so the release notes reflect what shipped to `main` without asserting deployment status. 
- Provide a concise, auditable evidence note so the v3.0.1 QA commit-range audit can honestly close its signoff checkbox while leaving staging/production/promote/rollback boxes open. 

### Description

- Added a new `v3.1 mainline update` section to `frontend/src/pages/docs/md/changelog/20260401.md` summarizing user-visible changes on `main` since the v3 baseline `3ec45a5517a35c96767f6b946c01104e6ec88f93`, covering `/quests`, `/processes`, `/docs` (deferred corpus), `/chat` RAG checks, custom content, saves/settings/auth flows, and operator/CI/runbook polish. 
- Updated the v3.0.1 patch addendum commit-range in the same changelog to point to the rc.4 candidate SHA (`2d7f93daa4869ae223825cbd00a37bc83ac5703e`). 
- Ticked the commit-range audit checkbox in `docs/qa/v3.0.1.md` and added a concise evidence note describing the audit commands and scope (candidate-range and broader `main` delta were inspected), without closing any staging/production/rollback/release-closeout items. 
- Only documentation files were changed: `frontend/src/pages/docs/md/changelog/20260401.md` and `docs/qa/v3.0.1.md`, and no behavioral code was modified. 

### Testing

- Ran local link validation with `node scripts/link-check.mjs`; result: All local markdown links resolved. 
- Rebuilt generated artifacts used by tests with `npm run build:meta` and `npm run build:docs-rag` (these generated the `frontend/src/generated/rag/` artifacts used by the test harness). 
- Executed targeted changelog/QA tests with Vitest: `npx vitest run --config vitest.config.mts --testTimeout 20000 --maxWorkers=1 tests/changelogHistoryGuard.test.ts tests/changelogDocsReleaseChecklist.test.ts`; result: both tests passed. 
- Ran repository test harness (`npm test`) which runs pretest build steps and the full test matrix; result: test run completed and test suites passed in this environment (root unit tests, quest validations, many frontend/unit tests and the relevant changelog guards all passed). 
- Performed a secrets-scan on the staged diff with `git diff --cached | ./scripts/scan-secrets.py`; result: no secret-like strings flagged. 

Files modified

- `frontend/src/pages/docs/md/changelog/20260401.md` (inserted v3.1 mainline coverage and updated v3.0.1 range)
- `docs/qa/v3.0.1.md` (checked commit-range audit and added evidence note)

Notes

- The changelog text explicitly avoids claiming staging or production promotion or closing promotion/rollback steps; those QA boxes remain open unless independent deployment evidence is recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0961f56890832f89c90e6aba40ecd4)