### PR TITLE
📝 Update v3.0.1 QA checklist to use v3.0.1-rc.5

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -2,7 +2,7 @@
 
 > Release intent: `v3.0.1` validates the patch delta merged after `v3.0.0`
 > (`3ec45a5517a35c96767f6b946c01104e6ec88f93`) and before production promotion;
-> current candidate under validation: `v3.0.1-rc.4`.
+> current candidate under validation: `v3.0.1-rc.5`.
 
 Related docs:
 
@@ -20,11 +20,12 @@ Related docs:
 ## 0) Release metadata
 
 > Broader release history is maintained in [docs/releases.md](../releases.md).
-> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.4`.
+> This section records the v3.0.1 QA snapshot, including the current candidate `v3.0.1-rc.5`.
 
 | Tag name                                                                            | Commit SHA                                 | Notes                                                              |
 | ----------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
-| [v3.0.1-rc.4](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.4) | `2d7f93daa4869ae223825cbd00a37bc83ac5703e` | Candidate that supersedes rc.3 for final validation/signoff.       |
+| [v3.0.1-rc.5](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.5) | `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc` | Candidate that supersedes rc.4 for final validation/signoff.       |
+| [v3.0.1-rc.4](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.4) | `2d7f93daa4869ae223825cbd00a37bc83ac5703e` | Candidate that superseded rc.3 for final validation/signoff.       |
 | [v3.0.1-rc.3](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) | `899fcb93f705d0fe4051d7ecb74ee242cb8ab59c` | Candidate that supersedes rc.2 for final validation/signoff.       |
 | [v3.0.1-rc.2](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) | `a7d99da9bbf9085aa33fd9f99da83b04f812c261` | Patch candidate that supersedes rc.1 for final validation/signoff. |
 | [v3.0.1-rc.1](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.1) | `4cd600734718dedf4225f67ed1e9f4d6f412e2fd` | Initial v3.0.1 release candidate baseline.                         |
@@ -50,40 +51,47 @@ Derive this checklist from the audited patch delta first, then execute QA agains
 Run these exact commands and attach output to release evidence:
 
 ```bash
-git log --oneline 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e
+git log --oneline 3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.5
 ```
 
 ```bash
-git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e
+git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.5
 ```
 
 ```bash
-git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e
+git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.5
 ```
 
-- [ ] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
-  - Evidence: Codex audited
-    `3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e`
-    for the v3.0.1 candidate on 2026-05-17. That audit identified additional rc.4-specific
-    user-visible checks that must be executed before this gate closes: completed custom quests in
-    the completed section, `/settings` responsive layout, and QuestChat readiness/status behavior.
-    The April 2026 changelog patch addendum references the same audited rc.4 range without closing
-    staging, production, rollback, or release-closeout gates.
+- [x] QA signoff confirms this checklist and executed test scope were derived from the audited commit delta above
+  - Evidence: Codex fetched the remote `v3.0.1-rc.5` tag and confirmed
+    `git rev-parse v3.0.1-rc.5` resolves to
+    `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc`, matching `HEAD`, on 2026-05-17.
+    Codex then audited `3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.5`
+    with `git log --oneline`, `git diff --name-only`, and `git diff --stat`. The audited
+    changed-file themes span the previously scoped `/quests`, `/processes`, `/docs`, `/chat`,
+    `/settings`, migration/data-integrity, release-governance, and smoke-test areas, plus
+    rc.5-specific launch-relevant hardening for custom-content import/link sanitization, cloud-sync
+    authentication readiness, auth/logout route stability, service-worker/offline-worker warning
+    handling, Playwright/browser bootstrap reliability, Browserslist/package-manager metadata,
+    Node/npm warning suppression, generated docs/build metadata setup, and CI/workflow checks.
+    The checklist below now includes explicit unchecked rc.5 validation items for those additional
+    themes, so this signoff closes commit-range scope coverage only; it does not close staging,
+    production, rollback, release-tagging, release-closeout, or feature/regression validation gates.
 
 ---
 
 ## 2) Release metadata + signoff
 
 - [x] Target version: `v3.0.1`
-- [x] Candidate tag under test: `v3.0.1-rc.4`
-- [x] Commit SHA: `2d7f93daa4869ae223825cbd00a37bc83ac5703e`
-- [x] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..2d7f93daa4869ae223825cbd00a37bc83ac5703e`
+- [x] Candidate tag under test: `v3.0.1-rc.5`
+- [x] Commit SHA: `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc`
+- [x] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.5`
 - [x] QA owner + timestamp: `Codex automation (GPT-5.3-Codex), 2026-05-17 UTC`
-- [ ] Staging sign-off owner + timestamp: `Pending rc.4 staging deployment evidence + owner/timestamp`
+- [ ] Staging sign-off owner + timestamp: `Pending rc.5 staging deployment evidence + owner/timestamp`
 - [ ] Production deploy owner + timestamp: `Pending human production deploy owner assignment (required before promotion)`
 - [x] Previous known-good rollback tag: `v3.0.0` (`3ec45a5517a35c96767f6b946c01104e6ec88f93`)
 - [x] Release notes include only user-visible patch deltas
-- [ ] rc.4-specific user-visible checks below have owner/timestamp evidence before final QA signoff
+- [ ] rc.5-specific user-visible and launch-relevant checks below have owner/timestamp evidence before final QA signoff
 
 ---
 
@@ -161,8 +169,8 @@ Evidence captured in Codex session (2026-04-11 UTC, staging state aligned with `
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
 - Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match the current candidate `v3.0.1-rc.4`; keep the expected-version checkbox open until the
-  rc.4 artifact is deployed (or documented as commit-equivalent).
+  not match the current candidate `v3.0.1-rc.5`; keep the expected-version checkbox open until the
+  rc.5 artifact is deployed (or documented as commit-equivalent).
 
 ---
 
@@ -219,7 +227,7 @@ Required marks/measures:
 - [x] Mixed-state scenario: use an account with built-in quest progress already in-flight, then import/load custom quests and confirm both sets remain actionable through refresh + navigation
 - [ ] Completed custom quest scenario: complete an imported custom quest, refresh `/quests`, and confirm it is listed only under Completed Quests with accessible status text and no duplicate active card
 
-### 5.4 QuestChat readiness/status behavior (rc.4-specific)
+### 5.4 QuestChat readiness/status behavior (rc.4/rc.5-carried)
 
 - [ ] QuestChat readiness initializes without showing stale loading/status copy after the quest and chat state are ready
 - [ ] QuestChat status labels remain stable across hydration, interaction, and component unmount/remount
@@ -270,9 +278,9 @@ Suggested manual checks:
 
 ---
 
-## 8) `/settings` responsive layout checks (rc.4-specific)
+## 8) `/settings` responsive layout checks (rc.4/rc.5-carried)
 
-Goal: confirm the rc.4 settings layout changes remain usable across narrow and wide viewports.
+Goal: confirm the settings layout changes carried into rc.5 remain usable across narrow and wide viewports.
 
 - [ ] `/settings` cards keep readable spacing and do not overlap at mobile viewport widths
 - [ ] `/settings` controls remain reachable by keyboard and pointer after responsive reflow
@@ -283,6 +291,45 @@ Suggested viewport checks:
 1. Mobile/narrow viewport around 375 px wide.
 2. Tablet viewport around 768 px wide.
 3. Desktop viewport at 1280 px or wider.
+
+### 8.1 Custom content import and link-safety checks (rc.5-specific)
+
+Goal: confirm the rc.5 hardening around imported custom content, compact previews, and shop/process
+links prevents unsafe rendering while preserving valid creator workflows.
+
+- [ ] Import malicious custom-content bundles containing scriptable HTML/URL payloads and confirm
+      quest/item/process previews render escaped/safe text instead of executable markup
+- [ ] Verify unsafe custom quest tile routes, protocol-relative URLs, and slash-backslash variants
+      still fall back to internal `/quests/{id}` links
+- [ ] Confirm shop and compact process/item preview links render safe destinations for valid content
+      and do not navigate to untrusted protocols
+
+### 8.2 Authentication, cloud sync, and logout stability checks (rc.5-specific)
+
+Goal: confirm the rc.5 authentication-readiness fixes and route-mocking hardening do not regress
+player login, sync, backup refresh, or logout flows.
+
+- [ ] GitHub-token save/auth flow persists credentials and reaches sync-ready state without timeout
+- [ ] Cloud Sync backup refresh handles auth-readiness races without stale backup lists or duplicate
+      refreshes
+- [ ] Logout clears authenticated state and credentials without leaving Cloud Sync controls in a
+      misleading ready/loading state
+
+### 8.3 Launch-gate infrastructure checks (rc.5-specific)
+
+Goal: confirm the rc.5 CI/test/build hardening remains quiet and deterministic enough for release
+signoff while preserving real failure visibility.
+
+- [ ] Playwright browser bootstrap installs or detects the required headless shell and writes the
+      dependency sentinel in fresh environments
+- [ ] Service-worker/offline-worker expected warning filters suppress only known benign Playwright
+      noise and do not hide unexpected console errors
+- [ ] Node experimental-warning, npm update-notifier, Browserslist/caniuse-lite, Astro unsupported
+      file, and ESLint warning filters remain narrowly scoped to documented expected noise
+- [ ] CI-generated docs/build metadata setup runs before lint/type-check/build/test jobs that consume
+      generated artifacts
+- [ ] Package-manager and `.npmrc` checks still reject repository-level package-manager proxy or
+      update-notifier settings that would make validation output environment-dependent
 
 ---
 
@@ -296,6 +343,10 @@ Prerequisite: execute this section only after Section 7 validates `/docs` browse
 - [x] Launch-check prompts grounded in existing docs still return relevant, non-empty responses
 - [x] Responses continue to reference expected docs topics/pages when appropriate
 - [x] No obvious delayed-index/empty-corpus failure pattern appears in chat responses
+- [ ] OpenAIChat runtime metadata warnings remain limited to expected missing-build-meta cases and
+      do not mask real chat initialization failures (rc.5-specific)
+- [ ] Chat route/component teardown removes browser event listeners cleanly without window-listener
+      errors after navigation or unmount/remount (rc.5-specific)
 
 Suggested docs-backed launch prompts:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,6 +22,7 @@ This is the canonical list of all historical DSPACE release tags.
 | `v3.0.1-rc.2` | Release candidate | [`v3.0.1-rc.2`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.2) |
 | `v3.0.1-rc.3` | Release candidate | [`v3.0.1-rc.3`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.3) |
 | `v3.0.1-rc.4` | Release candidate | [`v3.0.1-rc.4`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.4) |
+| `v3.0.1-rc.5` | Release candidate | [`v3.0.1-rc.5`](https://github.com/democratizedspace/dspace/releases/tag/v3.0.1-rc.5) |
 
 ## QA checklists tracked separately (not a tag list)
 


### PR DESCRIPTION
### Motivation
- The active v3.0.1 candidate moved from `v3.0.1-rc.4` to `v3.0.1-rc.5` and the QA checklist must reference the real candidate and audited delta. 
- The commit-range audit needs to reflect the baseline→rc.5 delta so signoff only closes the commit-range scope that was actually audited. 
- The rc.5 audit surfaced additional launch-relevant hardening themes that require explicit (unchecked) validation entries in the checklist.

### Description
- Updated `docs/qa/v3.0.1.md` to name `v3.0.1-rc.5` as the active candidate, record its resolved SHA `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc`, and switch the commit-range audit references to use the baseline through `v3.0.1-rc.5` (audit evidence language and dated note added). 
- Added explicit unchecked rc.5 validation checklist items for newly audited launch-relevant themes (custom-content import/link safety, auth/cloud-sync/logout stability, Playwright/CI/build hardening, chat teardown/runtime-warning checks) while preserving existing checklist style and leaving non-commit-range gates open. 
- Updated `docs/releases.md` to include a `v3.0.1-rc.5` row so the canonical release history does not contradict the QA checklist. 
- Changes are limited to QA/release docs (no code changes) and preserve the prior staging/production/closeout gates as open per constraints.

### Testing
- Resolved the `v3.0.1-rc.5` tag and confirmed it points at `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc` (matches `HEAD`), and ran the commit-range audit (commit list, `name-only`, and `stat`) for the baseline→rc.5 range and reviewed changed-file themes covering `/quests`, `/processes`, `/docs`, `/chat`, `/settings`, migration/data-integrity, and CI/workflow areas. 
- Ran `npm run lint` (frontend eslint/a11y checks as invoked by the repo script) and it completed successfully. 
- Ran `node scripts/link-check.mjs` and it reported all local markdown links resolved. 
- Scanned the staged diff with the repo `scan-secrets.py` script and found no secret-like strings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4e0b0cf4832fbb65f794c386c77a)