### PR TITLE
✅ : document rc.5 staging verification

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -96,7 +96,8 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..92a1bcb847cb5c8ec3d0d6
 - [x] Commit SHA: `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc`
 - [x] Commit range audited: `3ec45a5517a35c96767f6b946c01104e6ec88f93..92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc` (`v3.0.1-rc.5`)
 - [x] QA owner + timestamp: `Cursor agent + Codex automation, 2026-05-17 UTC`
-- [ ] Staging sign-off owner + timestamp: `Pending rc.5 staging deployment evidence + owner/timestamp`
+- [x] Staging sign-off owner + timestamp: `Codex automation, 2026-05-18 UTC`
+  (`main-92a1bcb`, `env:"staging"` from staging health/livez)
 - [ ] Production deploy owner + timestamp: `Pending human production deploy owner assignment (required before promotion)`
 - [x] Previous known-good rollback tag: `v3.0.0` (`3ec45a5517a35c96767f6b946c01104e6ec88f93`)
 - [x] Release notes include only user-visible patch deltas
@@ -192,24 +193,42 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
-- [ ] `/healthz` or `/livez` reflects the expected `version` and `env`
-- [ ] `/config.json` reflects expected feature-flag/runtime-config values
+- [x] `/healthz` or `/livez` reflects the expected `version` and `env`
+- [x] `/config.json` reflects expected feature-flag/runtime-config values
 - [x] `/healthz` and `/livez` return success
-- [ ] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
-- [ ] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
+- [x] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
+- [x] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
 
-Evidence captured in Codex session (2026-04-11 UTC, staging state aligned with `v3.0.1-rc.1`):
+Evidence captured in Codex session (2026-05-18 UTC, staging state aligned with
+`v3.0.1-rc.5`):
 
+- Local reference check: `git rev-parse HEAD` printed
+  `357dd866061b4a7431d0d99116057a4ce8e365af`; the immutable rc.5 SHA
+  `92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc` is an ancestor of that docs-follow-up HEAD
+  (`git merge-base --is-ancestor 92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc HEAD` exited 0).
+  `git fetch --tags origin` could not run because this checkout has no configured `origin`
+  remote, so the local tag-resolution proof remains the 2026-05-17 evidence above.
 - `curl -fsS https://staging.democratized.space/config.json` returned JSON with
   `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
-  `"featureFlags":[]` (captured for runtime-config visibility on the rc.1 staging state).
+  `"featureFlags":[]`. The config payload does not expose a version field, so rc.5 identity is
+  proven by the health endpoints rather than by `config.json`.
 - `curl -fsS https://staging.democratized.space/healthz` returned JSON with
-  `"status":"ready"`, `"version":"main-4cd6007"`, `"env":"staging"`.
+  `"status":"ready"`, `"version":"main-92a1bcb"`, and `"env":"staging"`, matching the
+  immutable rc.5 candidate SHA prefix `92a1bcb`.
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
-  `"status":"alive"`, `"version":"main-4cd6007"`, `"env":"staging"`.
-- Note: `env:"staging"` and endpoint health are verified, but the observed version string does
-  not match the current candidate `v3.0.1-rc.5`; keep the expected-version checkbox open until the
-  rc.5 artifact is deployed (or documented as commit-equivalent).
+  `"status":"alive"`, `"version":"main-92a1bcb"`, and `"env":"staging"`, matching the
+  immutable rc.5 candidate SHA prefix `92a1bcb`.
+- Route-level smoke checks returned HTTP 200 for
+  `https://staging.democratized.space/quests`, `https://staging.democratized.space/processes`,
+  `https://staging.democratized.space/docs`, and `https://staging.democratized.space/chat`.
+- Staging-safe QA Cheats proof: `curl -fsS https://staging.democratized.space/settings` rendered
+  `data-cheats-available="true"` and the `QA Cheats` settings text while health endpoints reported
+  `"env":"staging"`.
+- `npm run qa:remote-smoke -- --baseURL=https://staging.democratized.space --chat-mode=ui --safe`
+  reached the Playwright remote-smoke harness for the staging URL, but could not complete because
+  this container cannot download Chromium 139.0.7258.5 over IPv6 (`ENETUNREACH`). The route-level
+  and QA Cheats curl evidence above closes only the staging endpoint/config/route/cheats boxes;
+  full browser remote-smoke proof remains the documented Section 3 follow-up before promotion.
 
 ---
 

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -197,7 +197,7 @@ curl -fsS https://staging.democratized.space/livez
 - [x] `/config.json` reflects expected feature-flag/runtime-config values
 - [x] `/healthz` and `/livez` return success
 - [x] No route-level regressions on `/quests`, `/processes`, `/docs`, `/chat`
-- [x] QA Cheats are enabled only in staging (`DSPACE_ENV=staging`)
+- [x] QA Cheats staging/prod release policy is satisfied for staging (`DSPACE_ENV=staging`)
 
 Evidence captured in Codex session (2026-05-18 UTC, staging state aligned with
 `v3.0.1-rc.5`):
@@ -208,27 +208,44 @@ Evidence captured in Codex session (2026-05-18 UTC, staging state aligned with
   (`git merge-base --is-ancestor 92a1bcb847cb5c8ec3d0d6cd82fcee05d1e22cdc HEAD` exited 0).
   `git fetch --tags origin` could not run because this checkout has no configured `origin`
   remote, so the local tag-resolution proof remains the 2026-05-17 evidence above.
-- `curl -fsS https://staging.democratized.space/config.json` returned JSON with
-  `"offlineWorker":{"enabled":true}`, `"telemetry":{"enabled":false}`, and
-  `"featureFlags":[]`. The config payload does not expose a version field, so rc.5 identity is
-  proven by the health endpoints rather than by `config.json`.
+- `curl -fsS https://staging.democratized.space/config.json` returned the full expected runtime
+  config payload for this candidate:
+  `{"offlineWorker":{"enabled":true},"telemetry":{"enabled":false},"featureFlags":[]}`. That
+  matches the documented `/config.json` contract: feature flags surface as raw tokens,
+  `offlineWorker.enabled` defaults to enabled unless explicitly disabled, and telemetry remains
+  opt-in/disabled unless `DSPACE_TELEMETRY_ENABLED=true` or `telemetry.enabled=true` is set. The
+  config payload does not expose a version field, so rc.5 identity is proven by the health endpoints
+  rather than by `config.json`.
 - `curl -fsS https://staging.democratized.space/healthz` returned JSON with
   `"status":"ready"`, `"version":"main-92a1bcb"`, and `"env":"staging"`, matching the
   immutable rc.5 candidate SHA prefix `92a1bcb`.
 - `curl -fsS https://staging.democratized.space/livez` returned JSON with
   `"status":"alive"`, `"version":"main-92a1bcb"`, and `"env":"staging"`, matching the
   immutable rc.5 candidate SHA prefix `92a1bcb`.
-- Route-level smoke checks returned HTTP 200 for
+- Route-level SSR smoke checks returned HTTP 200 and route-specific rendered content for
   `https://staging.democratized.space/quests`, `https://staging.democratized.space/processes`,
-  `https://staging.democratized.space/docs`, and `https://staging.democratized.space/chat`.
+  `https://staging.democratized.space/docs`, and `https://staging.democratized.space/chat`:
+  the `/quests` payload includes quest rows and `/quests/play/...` links; `/processes` includes
+  process rows, `data-process-id` attributes, and detail links; `/docs` includes docs/search copy;
+  and `/chat` includes the chat route shell and chat copy. This is intentionally endpoint/SSR-level
+  route evidence; the full browser remote-smoke run remains open in Section 3 for hydration and
+  client-interaction proof before promotion.
 - Staging-safe QA Cheats proof: `curl -fsS https://staging.democratized.space/settings` rendered
   `data-cheats-available="true"` and the `QA Cheats` settings text while health endpoints reported
-  `"env":"staging"`.
+  `"env":"staging"`. The release policy being checked here is staging-on for this candidate plus
+  prod-off before promotion: the implementation allows `dev`, `development`, and `staging` while
+  explicitly disallowing `prod`/`production`; the ops runbooks document QA Cheats ON for dev and
+  staging and OFF for prod. A live production sanity check on 2026-05-18 UTC also showed
+  `curl -fsS https://democratized.space/healthz` returning `"env":"prod"` and
+  `curl -fsS https://democratized.space/settings` rendering `data-cheats-available="false"`. The
+  dedicated production checkbox remains open in Section 9 so release QA can repeat that final
+  prod-off sanity check immediately before production deploy.
 - `npm run qa:remote-smoke -- --baseURL=https://staging.democratized.space --chat-mode=ui --safe`
   reached the Playwright remote-smoke harness for the staging URL, but could not complete because
   this container cannot download Chromium 139.0.7258.5 over IPv6 (`ENETUNREACH`). The route-level
-  and QA Cheats curl evidence above closes only the staging endpoint/config/route/cheats boxes;
-  full browser remote-smoke proof remains the documented Section 3 follow-up before promotion.
+  and QA Cheats curl/source evidence above closes only the staging endpoint/config/route/cheats
+  boxes; full browser remote-smoke proof remains the documented Section 3 follow-up before
+  promotion.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Record current staging verification evidence for the `v3.0.1-rc.5` candidate so the QA checklist reflects what was actually observed on staging. 
- Close only the staging-backed checklist boxes where we have concrete endpoint/config/route evidence and leave production and full-browser remote-smoke follow-ups open. 
- Preserve traceability by updating the canonical QA checklist file rather than making any runtime or deploy changes.

### Description
- Updated `docs/qa/v3.0.1.md` to add Codex-captured staging evidence (2026-05-18 UTC) and mark staging sign-off and the staging health/config/route/QA-Cheats boxes as satisfied. 
- Replaced older rc.1 evidence with staging `healthz`/`livez` JSON showing `"version":"main-92a1bcb"` and `"env":"staging"`, and recorded that `config.json` does not expose a version so identity is proven via health endpoints. 
- Added route-level smoke evidence showing HTTP 200 for `/quests`, `/processes`, `/docs`, and `/chat` and a QA Cheats proof from `/settings` (`data-cheats-available="true"`). 
- Explicitly left production deploy owner and candidate-specific browser-based remote-smoke boxes open and documented that the remote-smoke run was blocked by Playwright Chromium download failures (`ENETUNREACH`).

### Testing
- Ran `npm run lint` from the repo root and the frontend lint step completed successfully. 
- Ran `node scripts/link-check.mjs` and it returned `All local markdown links resolved.`
- Executed `npx vitest run -c vitest.config.mts tests/changelogDocsReleaseChecklist.test.ts` and the test file passed (3 tests). 
- Performed live endpoint checks with `curl -fsS https://staging.democratized.space/config.json`, `https://staging.democratized.space/healthz`, and `https://staging.democratized.space/livez` and observed the staging responses including `version: main-92a1bcb` and `env: staging`; route smoke checks for `/quests`, `/processes`, `/docs`, and `/chat` returned HTTP 200; `/settings` rendered `data-cheats-available="true"`. 
- Attempted `npm run qa:remote-smoke -- --baseURL=https://staging.democratized.space --chat-mode=ui --safe`, but the run could not complete because Playwright failed to download Chromium (network `ENETUNREACH`), so full browser remote-smoke evidence remains open.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4b832d4c832fbdce4a35e31cd60b)