### PR TITLE
Add E2E coverage for completed custom quest listing

### DIFF
--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -95,7 +95,7 @@ test.describe('Custom quest chat rendering', () => {
             `[data-testid="custom-quests-section"] [data-questid="${questId}"]`
         );
         const completedCustomQuestCard = page.locator(
-            `xpath=//h2[normalize-space(.)="Completed Quests"]/following-sibling::a[@data-questid="${questId}"]`
+            `h2:has-text("Completed Quests") ~ a[data-questid="${questId}"]`
         );
 
         await expect(activeCustomQuestCard).toHaveCount(0);

--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { clearUserData, seedCustomQuest, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    flushGameStateWrites,
+    seedCustomQuest,
+    waitForHydration,
+} from './test-helpers';
 
 test.describe('Custom quest chat rendering', () => {
     test.beforeEach(async ({ page }) => {
@@ -41,6 +46,64 @@ test.describe('Custom quest chat rendering', () => {
         await optionButton.click();
 
         await expect(page.locator('text=Custom quest next node.')).toBeVisible();
+    });
+
+    test('moves completed custom quests out of the active custom list after refreshing /quests', async ({
+        page,
+    }) => {
+        await page.goto('/');
+
+        const questId = await seedCustomQuest(page, {
+            id: 'custom-quest-completion-regression',
+            title: 'Custom Quest Completion Regression',
+            description: 'Quest created for completed custom quest listing regression coverage.',
+            image: '/assets/quests/howtodoquests.jpg',
+            npc: '/assets/npc/dChat.jpg',
+            start: 'start',
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'Finish this custom quest to verify completed list placement.',
+                    options: [{ type: 'finish', text: 'Finish custom quest' }],
+                },
+            ],
+            requiresQuests: [],
+        });
+
+        await page.goto(`/quests/${questId}`);
+        await waitForHydration(page);
+
+        await page.getByRole('button', { name: /Finish custom quest/ }).click();
+        await expect(page.getByRole('heading', { name: 'Quest Complete!' })).toBeVisible();
+        await flushGameStateWrites(page);
+
+        await page.goto('/quests');
+        await waitForHydration(page);
+        await expect(page.locator('[data-testid="custom-quests-merge-status"]')).toHaveAttribute(
+            'data-merge-complete',
+            'true'
+        );
+
+        await page.reload();
+        await waitForHydration(page);
+        await expect(page.locator('[data-testid="custom-quests-merge-status"]')).toHaveAttribute(
+            'data-merge-complete',
+            'true'
+        );
+
+        const activeCustomQuestCard = page.locator(
+            `[data-testid="custom-quests-section"] [data-questid="${questId}"]`
+        );
+        const completedCustomQuestCard = page.locator(
+            `xpath=//h2[normalize-space(.)="Completed Quests"]/following-sibling::a[@data-questid="${questId}"]`
+        );
+
+        await expect(activeCustomQuestCard).toHaveCount(0);
+        await expect(completedCustomQuestCard).toHaveCount(1);
+        await expect(
+            completedCustomQuestCard.locator('[data-testid="quest-tile"]')
+        ).toHaveAttribute('data-status', 'completed');
+        await expect(completedCustomQuestCard).toContainText('Status: Completed');
     });
 
     test('built-in quest chat still renders', async ({ page }) => {

--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -79,21 +79,23 @@ test.describe('Custom quest chat rendering', () => {
 
         await page.goto('/quests');
         await waitForHydration(page);
-        await expect(page.locator('[data-testid="custom-quests-merge-status"]')).toHaveAttribute(
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
             'data-merge-complete',
             'true'
         );
 
         await page.reload();
         await waitForHydration(page);
-        await expect(page.locator('[data-testid="custom-quests-merge-status"]')).toHaveAttribute(
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
             'data-merge-complete',
             'true'
         );
 
-        const activeCustomQuestCard = page.locator(
-            `[data-testid="custom-quests-section"] [data-questid="${questId}"]`
-        );
+        await expect(page.getByRole('heading', { name: 'Completed Quests' })).toBeVisible();
+
+        const activeCustomQuestCard = page
+            .getByTestId('custom-quests-section')
+            .locator(`[data-questid="${questId}"]`);
         const completedCustomQuestCard = page.locator(
             `h2:has-text("Completed Quests") ~ a[data-questid="${questId}"]`
         );
@@ -103,7 +105,7 @@ test.describe('Custom quest chat rendering', () => {
         await expect(
             completedCustomQuestCard.locator('[data-testid="quest-tile"]')
         ).toHaveAttribute('data-status', 'completed');
-        await expect(completedCustomQuestCard).toContainText('Status: Completed');
+        await expect(completedCustomQuestCard.getByText('Status: Completed')).toBeVisible();
     });
 
     test('built-in quest chat still renders', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Add regression coverage for a known rc.5 issue where completed custom quests remained visible in the Custom Quests section instead of being shown only under Completed Quests.
- Ensure the UI correctly reconciles persisted game state after finishing a custom quest and refreshing `/quests` so users do not see duplicate active/completed cards.

### Description
- Add a Playwright test in `frontend/e2e/custom-quest-chat.spec.ts` that seeds a custom quest, completes it via the QuestChat finish option, flushes persisted game-state writes, navigates to `/quests`, reloads, and verifies the quest is absent from the Custom Quests grid and appears once under the Completed Quests section with `data-status="completed"` and accessible status text.
- Import and use `flushGameStateWrites` from test helpers to wait for pending game-state persistence before verifying the list reconciliation.
- Add assertions that wait for the custom-quests merge to be complete (`[data-testid="custom-quests-merge-status"][data-merge-complete="true"]`) before checking active/completed placement.

### Testing
- ⚠️ Attempted to run `npm --prefix frontend run test:e2e -- custom-quest-chat.spec.ts`, but Playwright browser installation failed in this environment due to network errors (`ENETUNREACH`) so the E2E run could not complete here.
- ✅ Ran `npm run lint` (frontend lint) which completed successfully.
- ✅ Ran `npm run type-check` which completed successfully.
- The new E2E test is present and should pass in CI or a local environment where Playwright browsers are installed (run `npx playwright install` / `npm --prefix frontend run playwright:install` before executing the Playwright suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55fc763c832fac5eb6310a47d78d)