### PR TITLE
✅ test: cover completed custom quest listing

### DIFF
--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -43,6 +43,57 @@ test.describe('Custom quest chat rendering', () => {
         await expect(page.locator('text=Custom quest next node.')).toBeVisible();
     });
 
+    test('moves completed custom quests to Completed Quests without active duplicates after refresh', async ({
+        page,
+    }) => {
+        await page.goto('/');
+
+        const questTitle = `Completed Custom Quest ${Date.now()}`;
+        const questId = await seedCustomQuest(page, {
+            id: `custom-quest-completion-${Date.now()}`,
+            title: questTitle,
+            description: 'Quest created for completed custom quest listing test.',
+            image: '/assets/quests/howtodoquests.jpg',
+            npc: '/assets/npc/dChat.jpg',
+            start: 'start',
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'Complete this custom quest for list classification.',
+                    options: [{ type: 'finish', text: 'Finish custom quest' }],
+                },
+            ],
+            requiresQuests: [],
+        });
+
+        await page.goto(`/quests/${questId}`);
+        await waitForHydration(page);
+        await page.getByRole('button', { name: 'Finish custom quest' }).click();
+        await expect(page.getByRole('heading', { name: 'Quest Complete!' })).toBeVisible();
+
+        const assertCompletedQuestPlacement = async () => {
+            await expect(page.getByRole('heading', { name: 'Completed Quests' })).toBeVisible();
+            await expect(
+                page.locator(
+                    `a[data-questid="${questId}"] [data-testid="quest-tile"][data-status="completed"]`
+                )
+            ).toBeVisible();
+            await expect(
+                page.getByTestId('quests-grid').locator(`a[data-questid="${questId}"]`)
+            ).toHaveCount(0);
+            await expect(
+                page.getByTestId('custom-quests-section').locator(`a[data-questid="${questId}"]`)
+            ).toHaveCount(0);
+            await expect(page.locator(`a[data-questid="${questId}"]`)).toHaveCount(1);
+        };
+
+        await page.goto('/quests');
+        await assertCompletedQuestPlacement();
+
+        await page.reload();
+        await assertCompletedQuestPlacement();
+    });
+
     test('built-in quest chat still renders', async ({ page }) => {
         await page.goto('/quests/welcome/howtodoquests');
         await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();


### PR DESCRIPTION
### Motivation

- Add automated E2E coverage for an rc.5 QA item that verifies completed custom quests are shown under `Completed Quests` and do not remain duplicated in the active/custom lists. 
- Prevent regressions where completed custom quest tiles remained visible in the Custom Quests section or active grid after completion and refresh.

### Description

- Added a Playwright test to `frontend/e2e/custom-quest-chat.spec.ts` that seeds a custom quest, completes it via the Quest UI, then asserts the quest appears in the `Completed Quests` section and is not present in the active built-in grid or `Custom Quests` section. 
- The test also reloads `/quests` and re-checks placement to catch stale-merge or hydration regressions. 
- No application logic changes were made; this PR contains test-only changes to expand regression coverage for custom-quest completion placement.

### Testing

- ⚠️ Attempted to run `npm --prefix frontend run test:e2e -- custom-quest-chat.spec.ts` but the E2E run was blocked because Playwright could not download/install Chromium and system deps in this environment (network `ENETUNREACH`), leaving the browser executable missing. 
- ✅ Ran `npm run lint` which completed successfully. 
- ✅ Ran `npm run type-check` which completed successfully. 
- ✅ Verified staged changes with the repository secret scan hook (`git diff --cached | ./scripts/scan-secrets.py`) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55fc763c832fac5eb6310a47d78d)