### PR TITLE
Add e2e regression: verify completed custom quests move to Completed Quests

### DIFF
--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -43,6 +43,57 @@ test.describe('Custom quest chat rendering', () => {
         await expect(page.locator('text=Custom quest next node.')).toBeVisible();
     });
 
+    test('moves completed custom quests to Completed Quests after refreshing /quests', async ({
+        page,
+    }) => {
+        await page.goto('/');
+
+        const questId = await seedCustomQuest(page, {
+            id: 'custom-quest-chat-completed',
+            title: 'Custom Quest Chat Completed',
+            description: 'Quest created for completed custom quest regression test.',
+            route: '/quests/custom-quest-chat-completed',
+            image: '/assets/quests/howtodoquests.jpg',
+            npc: '/assets/npc/dChat.jpg',
+            start: 'start',
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'Complete this custom quest from chat.',
+                    options: [{ type: 'finish', text: 'Finish custom quest' }],
+                },
+            ],
+            requiresQuests: [],
+        });
+
+        await page.goto(`/quests/${questId}`);
+        await waitForHydration(page);
+        await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Finish custom quest' }).click();
+        await expect(page.getByText('Complete', { exact: true })).toBeVisible();
+
+        await page.goto('/quests');
+        await page.reload();
+        await waitForHydration(page);
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
+            'data-merge-complete',
+            'true'
+        );
+
+        const customSection = page.getByTestId('custom-quests-section');
+        await expect(customSection).toHaveCount(0);
+
+        const completedSection = page.getByTestId('completed-quests-section');
+        await expect(completedSection).toBeVisible();
+        await expect(completedSection.locator(`a[data-questid='${questId}']`)).toHaveCount(1);
+        await expect(completedSection).toContainText('Custom Quest Chat Completed');
+        await expect(
+            completedSection.locator(`a[data-questid='${questId}']`).getByText('Status: Completed')
+        ).toHaveCount(1);
+        await expect(page.locator(`a[data-questid='${questId}']`)).toHaveCount(1);
+    });
+
     test('built-in quest chat still renders', async ({ page }) => {
         await page.goto('/quests/welcome/howtodoquests');
         await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -262,12 +262,14 @@
     {/if}
 
     {#if completedQuests.length > 0}
-        <h2>Completed Quests</h2>
-        {#each completedQuests as quest}
-            <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
-                <Quest {quest} compact={true} status={quest.status} />
-            </a>
-        {/each}
+        <section data-testid="completed-quests-section">
+            <h2>Completed Quests</h2>
+            {#each completedQuests as quest}
+                <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
+                    <Quest {quest} compact={true} status={quest.status} />
+                </a>
+            {/each}
+        </section>
     {/if}
 </div>
 


### PR DESCRIPTION
### Motivation
- Prevent regressions where completed custom quests remain in the Custom Quests list or appear duplicated in Active listings by exercising the full flow (seed → complete via QuestChat → refresh `/quests`).

### Description
- Add a Playwright e2e test `frontend/e2e/custom-quest-chat.spec.ts` that seeds a custom quest, completes it from the QuestChat UI, refreshes `/quests`, and asserts the quest appears exactly once under the Completed Quests section with accessible completed status text and no active custom duplicate. 
- Expose a stable test hook by wrapping the Completed Quests list in `frontend/src/pages/quests/svelte/Quests.svelte` with `data-testid="completed-quests-section"` so the regression can target that section reliably. 
- Keep the change surface minimal (one e2e spec and one small Svelte markup change) and reuse existing in-repo images for the seeded quest to avoid adding binary assets. 

### Testing
- `npm run lint` — passed. 
- `npm run type-check` — passed. 
- `git diff --cached | ./scripts/scan-secrets.py` — passed. 
- `npm --prefix frontend run test:e2e -- custom-quest-chat.spec.ts` — attempted but blocked because Playwright could not download Chromium/headless-shell in this environment (network `ENETUNREACH` errors), so the Playwright spec could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55fc763c832fac5eb6310a47d78d)