### PR TITLE
Add e2e coverage for completed custom quest listing and Completed Quests section

### DIFF
--- a/frontend/e2e/custom-quest-chat.spec.ts
+++ b/frontend/e2e/custom-quest-chat.spec.ts
@@ -43,6 +43,67 @@ test.describe('Custom quest chat rendering', () => {
         await expect(page.locator('text=Custom quest next node.')).toBeVisible();
     });
 
+    test('moves completed custom quests to Completed Quests after refresh without active duplicates', async ({
+        page,
+    }) => {
+        const questId = await seedCustomQuest(page, {
+            id: 'completed-custom-quest-chat',
+            title: 'Completed Custom Quest Chat',
+            description: 'Quest created for completed custom quest placement testing.',
+            route: '/quests/completed-custom-quest-chat',
+            image: '/assets/quests/howtodoquests.jpg',
+            npc: '/assets/npc/dChat.jpg',
+            start: 'start',
+            dialogue: [
+                {
+                    id: 'start',
+                    text: 'Complete this custom quest for list placement.',
+                    options: [{ type: 'finish', text: 'Finish completed custom quest' }],
+                },
+            ],
+            requiresQuests: [],
+        });
+
+        await page.goto(`/quests/${questId}`);
+        await waitForHydration(page);
+        await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+
+        await page.getByRole('button', { name: /Finish completed custom quest/ }).click();
+        await expect(page.getByRole('heading', { name: 'Quest Complete!' })).toBeVisible();
+
+        await page.goto('/quests');
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
+            'data-merge-complete',
+            'true'
+        );
+
+        await page.reload();
+        await waitForHydration(page);
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
+            'data-merge-complete',
+            'true'
+        );
+        await expect(page.getByTestId('custom-quests-merge-status')).toHaveAttribute(
+            'data-custom-count',
+            '0'
+        );
+
+        const completedSection = page.getByTestId('completed-quests-section');
+        const completedQuestCard = completedSection.locator(`a[data-questid="${questId}"]`);
+        await expect(completedSection).toBeVisible();
+        await expect(completedQuestCard).toHaveCount(1);
+        await expect(completedQuestCard).toContainText('Completed Custom Quest Chat');
+        await expect(completedQuestCard).toContainText('Status: Completed');
+
+        await expect(
+            page.getByTestId('quests-grid').locator(`a[data-questid="${questId}"]`)
+        ).toHaveCount(0);
+        await expect(
+            page.getByTestId('custom-quests-section').locator(`a[data-questid="${questId}"]`)
+        ).toHaveCount(0);
+        await expect(page.locator(`a[data-questid="${questId}"]`)).toHaveCount(1);
+    });
+
     test('built-in quest chat still renders', async ({ page }) => {
         await page.goto('/quests/welcome/howtodoquests');
         await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();

--- a/frontend/src/pages/quests/svelte/Quests.svelte
+++ b/frontend/src/pages/quests/svelte/Quests.svelte
@@ -262,12 +262,14 @@
     {/if}
 
     {#if completedQuests.length > 0}
-        <h2>Completed Quests</h2>
-        {#each completedQuests as quest}
-            <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
-                <Quest {quest} compact={true} status={quest.status} />
-            </a>
-        {/each}
+        <section class="completed-section" data-testid="completed-quests-section">
+            <h2>Completed Quests</h2>
+            {#each completedQuests as quest}
+                <a href={quest.route} aria-label={quest.title} data-questid={quest.id}>
+                    <Quest {quest} compact={true} status={quest.status} />
+                </a>
+            {/each}
+        </section>
     {/if}
 </div>
 


### PR DESCRIPTION
### Motivation
- Add automated coverage for an rc.5 QA item verifying completed custom quests are moved to the Completed Quests list and are not duplicated in active/custom sections after refresh. 
- Make the Completed Quests area reliably selectable in tests by adding a stable test id wrapper to the UI to avoid brittle heading-based selectors.

### Description
- Add a Playwright test `frontend/e2e/custom-quest-chat.spec.ts` that seeds a custom quest, completes it via the QuestChat flow, refreshes `/quests`, and asserts the quest appears exactly once under the Completed Quests section and not in active or custom lists. 
- Add `data-testid="completed-quests-section"` wrapper to `frontend/src/pages/quests/svelte/Quests.svelte` so e2e assertions can target the Completed Quests list reliably. 
- Test uses existing helpers (`seedCustomQuest`, `waitForHydration`, `clearUserData`) and asserts `data-testid="custom-quests-merge-status"` attributes to verify merge behavior.

### Testing
- Ran `npm run lint` (frontend lint invoked) and it completed successfully. 
- Ran `npm run type-check` and the TypeScript checks completed successfully. 
- Attempted end-to-end run with `npm --prefix frontend run test:e2e -- custom-quest-chat.spec.ts`, but Playwright browser installation/download failed due to network reachability errors (`ENETUNREACH`) when attempting to download Chromium/headless_shell, so the Playwright tests could not complete in this environment. 
- Repository secret-scan step passed (`git diff --cached | ./scripts/scan-secrets.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55fc763c832fac5eb6310a47d78d)