### PR TITLE
📝 Assign rc.5 production deploy owner

### DIFF
--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -98,7 +98,7 @@ git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..92a1bcb847cb5c8ec3d0d6
 - [x] QA owner + timestamp: `Cursor agent + Codex automation, 2026-05-17 UTC`
 - [x] Staging sign-off owner + timestamp: `Codex automation, 2026-05-18 UTC`
   (`main-92a1bcb`, `env:"staging"` from staging health/livez)
-- [ ] Production deploy owner + timestamp: `Pending human production deploy owner assignment (required before promotion)`
+- [x] Production deploy owner + timestamp: `@futuroptimist assigned for production promotion readiness, 2026-05-19 01:07 UTC (owner assignment only; deployment verification remains in Section 11)`
 - [x] Previous known-good rollback tag: `v3.0.0` (`3ec45a5517a35c96767f6b946c01104e6ec88f93`)
 - [x] Release notes include only user-visible patch deltas
 - [x] Candidate-specific user-visible checks below have owner/timestamp evidence before final QA signoff


### PR DESCRIPTION
### Motivation
- Record the human production deploy owner for `v3.0.1-rc.5` in the QA checklist so promotion readiness is not blocked by an unspecified owner.

### Description
- Update `docs/qa/v3.0.1.md` to check the production deploy owner/timestamp box and record `@futuroptimist` with the UTC timestamp `2026-05-19 01:07 UTC`, with an explicit note that this is owner assignment only and that deployment verification remains in Section 11.

### Testing
- Verified the change with `git diff -- docs/qa/v3.0.1.md`, ran `node scripts/link-check.mjs` (all local markdown links resolved), and `npm run lint` (frontend lint invoked) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb7d03e00832fba07f029568274c1)