### PR TITLE
📝 Document Sugarkube/k3s staging failure cases and point to canonical Sugarkube outage

### DIFF
--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -102,3 +102,46 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 - Keep `environment: dev` in the dev values file so QA Cheats remain enabled.
 - Because dev is single-node and non-HA, expect lower resilience than staging/prod.
 - If public ingress is ever enabled for dev, keep it explicitly non-production and low-trust.
+
+
+## Troubleshooting and recovery notes
+
+- Prefer positional Sugarkube env arguments:
+
+```bash
+just up dev
+just save-logs dev
+```
+
+- Until Sugarkube tunnel parsing is fixed, avoid
+  `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`; prefer:
+
+```bash
+just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"
+```
+
+- If dev is rebuilt from scratch, run install first. Use upgrade only after release exists.
+  Running upgrade too early fails with `UPGRADE FAILED: "dspace" has no deployed releases`.
+- If chart pulls fail with `403 denied: denied`, re-authenticate GHCR and verify:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+- After rebuilding dev cluster internals, verify base services before app debugging:
+
+```bash
+just cluster-status
+just traefik-status
+just traefik-crd-doctor
+```
+
+  Run `just traefik-install` only if needed.
+- For DHCP/IP reassignment and cluster-internal recovery paths, follow Sugarkube docs and outage
+  record as canonical:
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -120,3 +120,53 @@ curl -fsS https://prod.democratized.space/healthz
 ```
 
 If rehearsal succeeds and you proceed to production, switch back to `docs/examples/dspace.values.prod.yaml` for the real prod deployment.
+
+
+## Troubleshooting and recovery notes
+
+- Prefer positional Sugarkube env arguments in operator commands (for example `just up prod`
+  and `just save-logs prod`) to avoid legacy named-arg parsing pitfalls.
+- Until the Sugarkube tunnel parsing fix lands, avoid
+  `just cf-tunnel-install env=prod token="$CF_TUNNEL_TOKEN"`; prefer:
+
+```bash
+just cf-tunnel-install prod token="$CF_TUNNEL_TOKEN"
+```
+
+- On fresh or rebuilt clusters, run install first and upgrade second:
+
+```bash
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+  If upgrade is run first on a fresh cluster, Helm returns
+  `UPGRADE FAILED: "dspace" has no deployed releases`.
+- If GHCR Helm OCI pulls fail with `403 denied: denied`, rotate/re-login with a PAT that has
+  `read:packages`, then verify access:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+- After cluster rebuilds, verify Traefik and Cloudflare tunnel plumbing before app-level
+  troubleshooting:
+
+```bash
+just cluster-status
+just traefik-status
+just traefik-crd-doctor
+```
+
+  Run `just traefik-install` only if required, then reinstall tunnel with positional env.
+- For DHCP/IP reassignment and other cluster-internal RCA, use Sugarkube docs/outage records as
+  canonical sources:
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`
+  - `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`
+- During staging-only cycles, explicitly verify prod remains on the intended tag after staging
+  validation.
+- Never deploy RC/staging tags (for example `3.0.1-rc.*`) to apex production.

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -102,6 +102,101 @@ cd ~/sugarkube
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag=<previous-immutable-tag>
 ```
 
+
+## Troubleshooting and recovery notes (v3.0.1-rc.5 lessons)
+
+### Use positional Sugarkube environment arguments
+
+Use positional env arguments for Sugarkube commands:
+
+```bash
+just up staging
+just save-logs staging
+```
+
+Legacy named form (`just up env=staging`) previously produced malformed values before
+Sugarkube PR #2165. Prefer positional form in operator runbooks.
+
+### Cloudflare tunnel command caveat
+
+Until the Sugarkube tunnel parsing fix lands, prefer positional env for tunnel install:
+
+```bash
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+Avoid `just cf-tunnel-install env=staging token="$CF_TUNNEL_TOKEN"` for now because it can
+create malformed tunnel names such as `sugarkube-env=staging`.
+
+### Fresh cluster install vs upgrade
+
+If k3s state was wiped or the namespace was rebuilt, run install first:
+
+```bash
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=3.0.1-rc.5
+```
+
+Use upgrade only after the release exists:
+
+```bash
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=3.0.1-rc.5
+```
+
+If you run upgrade first on a fresh cluster, Helm reports:
+
+```
+UPGRADE FAILED: "dspace" has no deployed releases
+```
+
+### GHCR Helm OCI authentication failures
+
+If GHCR auth is stale or PAT scope is wrong, you can see `403 denied: denied` during chart
+pulls. Re-login with a token that has `read:packages`:
+
+```bash
+helm registry login ghcr.io
+```
+
+Then verify chart access:
+
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+### Validate cluster add-ons after rebuild
+
+After cluster rebuilds, validate infra before blaming DSPACE app deploys:
+
+```bash
+just cluster-status
+just traefik-status
+just traefik-crd-doctor
+```
+
+Run `just traefik-install` only when Traefik is missing or broken, then reinstall tunnel as
+needed:
+
+```bash
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+For cluster-level remediation after DHCP/IP reassignment incidents, use Sugarkube docs and the
+canonical Sugarkube outage record instead of duplicating RCA in DSPACE:
+
+- `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md`
+- `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md`
+- `https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md`
+- `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`
+- `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`
+
+### Post-deploy release verification
+
+For staging-only deploys, confirm both outcomes:
+
+1. `https://staging.democratized.space/config.json` shows the expected deployed SHA/tag.
+2. `https://democratized.space/config.json` remains on the intended production release (for the
+   v3.0.1-rc.5 cycle, prod remained on v3.0.0).
+
 ## Promotion handoff to prod
 
 Promote only after staging sign-off. Hand off:


### PR DESCRIPTION
### Motivation

- Make the staging v3.0.1-rc.5 failure modes and operator recovery steps discoverable from DSPACE runbooks and avoid duplicating cluster-level RCA that belongs in the Sugarkube repo.\
- Ensure prod/dev runbooks contain the same actionable operator guidance adapted to their environment contexts.\
- Remove or avoid maintaining a second full copy of the Sugarkube outage narrative in DSPACE so Sugarkube remains the single source of truth for cluster incidents.

### Description

- Added a focused "Troubleshooting and recovery notes" section to `docs/k3s-sugarkube-staging.md` documenting: positional Sugarkube env argument usage, the `cf-tunnel-install env=` caveat and preferred positional form, fresh-cluster `helm-oci-install` vs steady-state `helm-oci-upgrade` behavior and the `UPGRADE FAILED: "dspace" has no deployed releases` symptom, GHCR Helm OCI `403 denied: denied` troubleshooting with `helm registry login ghcr.io` and `helm show chart ...` verification, Traefik/Cloudflare tunnel post-rebuild checks, and post-deploy verification guidance (staging SHA and prod/apex unchanged).\
- Added matching, environment-appropriate troubleshooting sections to `docs/k3s-sugarkube-prod.md` and `docs/k3s-sugarkube-dev.md` with the same guidance adapted for `prod`/`dev` commands.\
- Cross-linked to the canonical Sugarkube cluster docs and the canonical outage record at: `https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` (and corresponding `.json`) instead of copying the full RCA into DSPACE.\
- Duplicate DSPACE outage files requested for cleanup were not present in this branch/repo state at runtime, so no deletion/stub was applied; the docs explicitly point operators to the Sugarkube outage record as canonical.\

### Testing

- Ran lint with `npm run lint` (frontend ESLint + repo lint pipeline) and it succeeded.\
- Verified local markdown links with `npm run link-check` which reported "All local markdown links resolved."\
- Performed grep/link and content checks to ensure coverage and absence of the known-bad patterns using `rg`/`grep` queries for `cf-tunnel-install env=`, Sugarkube/GHCR/Traefik references, and the outage slug, and confirmed the new guidance was present and the known-bad forms were not newly introduced.\
- Scanned the staged diff for secrets with `git diff --cached | ./scripts/scan-secrets.py` and found no secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e615bb250832fb7be26ecbd16d343)