### PR TITLE
📝 docs(k3s): add Sugarkube deploy failure guidance and point to canonical outage

### DIFF
--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -121,7 +121,7 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
   ```bash
   helm registry login ghcr.io
-  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  CHART_VERSION="$(grep -E "^[0-9]+\.[0-9]+\.[0-9]+" docs/apps/dspace.version | head -n1)"
   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -113,8 +113,9 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
   - preferred: `just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"`
   - avoid: `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`
 - Fresh cluster/dev namespace bootstrap must use install first:
-  - first deploy: `just helm-oci-install ... values=docs/examples/dspace.values.dev.yaml ...`
-  - later deploys: `just helm-oci-upgrade ... values=docs/examples/dspace.values.dev.yaml ...`
+  - pattern examples only; use the full copy-paste-ready `just helm-oci-*` commands documented earlier in this runbook.
+  - first deploy pattern: `just helm-oci-install ... values=docs/examples/dspace.values.dev.yaml ...`
+  - later deploy pattern: `just helm-oci-upgrade ... values=docs/examples/dspace.values.dev.yaml ...`
   - wrong-first-step symptom: `UPGRADE FAILED: "dspace" has no deployed releases`
 - GHCR Helm OCI auth failures typically show `403 denied: denied`. Re-authenticate and verify:
 

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -120,7 +120,8 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
   ```bash
   helm registry login ghcr.io
-  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 
 - If dev is rebuilt and ingress was enabled, verify infrastructure dependencies first:

--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -102,3 +102,46 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 - Keep `environment: dev` in the dev values file so QA Cheats remain enabled.
 - Because dev is single-node and non-HA, expect lower resilience than staging/prod.
 - If public ingress is ever enabled for dev, keep it explicitly non-production and low-trust.
+
+
+## Troubleshooting and recovery notes
+
+- Use positional Sugarkube env args for day-to-day operations:
+  - `just up dev`
+  - `just save-logs dev`
+- For Cloudflare tunnels, prefer positional env form until named env parsing is fully fixed:
+  - preferred: `just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"`
+  - avoid: `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`
+- Fresh cluster/dev namespace bootstrap must use install first:
+  - first deploy: `just helm-oci-install ... values=docs/examples/dspace.values.dev.yaml ...`
+  - later deploys: `just helm-oci-upgrade ... values=docs/examples/dspace.values.dev.yaml ...`
+  - wrong-first-step symptom: `UPGRADE FAILED: "dspace" has no deployed releases`
+- GHCR Helm OCI auth failures typically show `403 denied: denied`. Re-authenticate and verify:
+
+  ```bash
+  helm registry login ghcr.io
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  ```
+
+- If dev is rebuilt and ingress was enabled, verify infrastructure dependencies first:
+
+  ```bash
+  just cluster-status
+  just traefik-status
+  just traefik-crd-doctor
+  ```
+
+  Reinstall only if needed:
+
+  ```bash
+  just traefik-install
+  just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"
+  ```
+
+- Cluster-level DHCP/IP reassignment and multi-node k3s failure remediation is maintained in
+  Sugarkube docs/outages (canonical source):
+  - [Sugarkube setup](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+  - [Sugarkube operations](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+  - [Sugarkube troubleshooting](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+  - [Canonical outage markdown](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+  - [Canonical outage JSON](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -120,3 +120,47 @@ curl -fsS https://prod.democratized.space/healthz
 ```
 
 If rehearsal succeeds and you proceed to production, switch back to `docs/examples/dspace.values.prod.yaml` for the real prod deployment.
+
+
+## Troubleshooting and cross-environment guardrails
+
+- Use positional Sugarkube env args in operator commands (`just up prod`, `just save-logs prod`)
+  for consistency with staging/dev runbooks.
+- For Cloudflare tunnel install, prefer positional form until named env parsing is fully fixed:
+  - preferred: `just cf-tunnel-install prod token="$CF_TUNNEL_TOKEN"`
+  - avoid: `just cf-tunnel-install env=prod token="$CF_TUNNEL_TOKEN"`
+- If cluster state is rebuilt, install first and upgrade later:
+  - fresh state: `just helm-oci-install ... values=docs/examples/dspace.values.prod.yaml ...`
+  - existing release: `just helm-oci-upgrade ... values=docs/examples/dspace.values.prod.yaml ...`
+  - fresh-state symptom when using upgrade too early: `UPGRADE FAILED: "dspace" has no deployed releases`
+- If GHCR auth fails with `403 denied: denied`, run `helm registry login ghcr.io` with a PAT
+  containing `read:packages`, then verify with:
+
+  ```bash
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  ```
+
+- After infra churn/rebuild, verify cluster ingress components before app-level rollback:
+
+  ```bash
+  just cluster-status
+  just traefik-status
+  just traefik-crd-doctor
+  ```
+
+  Reinstall only if required:
+
+  ```bash
+  just traefik-install
+  just cf-tunnel-install prod token="$CF_TUNNEL_TOKEN"
+  ```
+
+- Do not deploy staging RC tags to prod by accident. For staging-only validation windows, verify:
+  - `https://staging.democratized.space/config.json` is on the intended candidate SHA/tag
+  - `https://democratized.space/config.json` remains on the intended production release
+- Cluster-level DHCP/IP reassignment failures are canonicalized in Sugarkube docs/outages:
+  - [Sugarkube setup](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+  - [Sugarkube operations](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+  - [Sugarkube troubleshooting](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+  - [Canonical outage markdown](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+  - [Canonical outage JSON](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -130,8 +130,9 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
   - preferred: `just cf-tunnel-install prod token="$CF_TUNNEL_TOKEN"`
   - avoid: `just cf-tunnel-install env=prod token="$CF_TUNNEL_TOKEN"`
 - If cluster state is rebuilt, install first and upgrade later:
-  - fresh state: `just helm-oci-install ... values=docs/examples/dspace.values.prod.yaml ...`
-  - existing release: `just helm-oci-upgrade ... values=docs/examples/dspace.values.prod.yaml ...`
+  - pattern examples only; use the full copy-paste-ready `just helm-oci-*` commands documented earlier in this runbook.
+  - fresh state pattern: `just helm-oci-install ... values=docs/examples/dspace.values.prod.yaml ...`
+  - existing release pattern: `just helm-oci-upgrade ... values=docs/examples/dspace.values.prod.yaml ...`
   - fresh-state symptom when using upgrade too early: `UPGRADE FAILED: "dspace" has no deployed releases`
 - If GHCR auth fails with `403 denied: denied`, run `helm registry login ghcr.io` with a PAT
   containing `read:packages`, then verify with:

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -138,7 +138,7 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
   containing `read:packages`, then verify with:
 
   ```bash
-  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  CHART_VERSION="$(grep -E "^[0-9]+\.[0-9]+\.[0-9]+" docs/apps/dspace.version | head -n1)"
   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -61,7 +61,7 @@ kubectl -n dspace rollout status deploy/dspace --timeout=180s
 ```
 
 ```bash
-curl -fsS https://democratized.space/config.json
+curl -fsS https://democratized.space/healthz
 ```
 
 ```bash
@@ -137,7 +137,8 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
   containing `read:packages`, then verify with:
 
   ```bash
-  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 
 - After infra churn/rebuild, verify cluster ingress components before app-level rollback:
@@ -156,8 +157,8 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
   ```
 
 - Do not deploy staging RC tags to prod by accident. For staging-only validation windows, verify:
-  - `https://staging.democratized.space/config.json` is on the intended candidate SHA/tag
-  - `https://democratized.space/config.json` remains on the intended production release
+  - `https://staging.democratized.space/healthz` is on the intended candidate SHA/tag
+  - `https://democratized.space/healthz` remains on the intended production release
 - Cluster-level DHCP/IP reassignment failures are canonicalized in Sugarkube docs/outages:
   - [Sugarkube setup](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
   - [Sugarkube operations](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -112,3 +112,56 @@ Promote only after staging sign-off. Hand off:
 - rollback tag confirmed
 
 Prod should deploy the same approved immutable artifact (not `main-latest`).
+
+## Troubleshooting and recovery notes
+
+- Prefer positional environment arguments in Sugarkube commands:
+  - `just up staging`
+  - `just save-logs staging`
+- Legacy named syntax (`just up env=staging`) had malformed env parsing before
+  Sugarkube PR #2165; keep using positional form for operator consistency.
+- For Cloudflare tunnel install, use positional env form until the named env parser fix lands:
+  - preferred: `just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"`
+  - avoid: `just cf-tunnel-install env=staging token="$CF_TUNNEL_TOKEN"`
+    (`sugarkube-env=staging` tunnel-name bug)
+- After a cluster wipe/rebuild, use `helm-oci-install` first.
+  `helm-oci-upgrade` is for steady-state updates and fails on fresh state with
+  `UPGRADE FAILED: "dspace" has no deployed releases`.
+- If Helm OCI pulls fail with `403 denied: denied`, rotate/re-login GHCR credentials:
+
+  ```bash
+  helm registry login ghcr.io
+  ```
+
+  Use a PAT with `read:packages`, then verify access:
+
+  ```bash
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  ```
+
+- After rebuilds, verify cluster networking/ingress before blaming app release content:
+
+  ```bash
+  just cluster-status
+  just traefik-status
+  just traefik-crd-doctor
+  ```
+
+  Reinstall only if required:
+
+  ```bash
+  just traefik-install
+  just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+  ```
+
+- Cluster-level failures after DHCP/IP reassignment are owned by Sugarkube operations.
+  Use Sugarkube docs and canonical outage RCA for remediation details:
+  - [Sugarkube setup guide](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+  - [Sugarkube operations guide](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+  - [Sugarkube troubleshooting guide](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+  - [Canonical outage markdown](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+  - [Canonical outage JSON](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+- For staging-only deploys (for example `v3.0.1-rc.5` validation), verify that:
+  - `https://staging.democratized.space/config.json` reports the expected SHA/tag
+  - `https://democratized.space/config.json` remains on the intended prod release (for example `3.0.0`)

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -147,7 +147,7 @@ Prod should deploy the same approved immutable artifact (not `main-latest`).
   Use a PAT with `read:packages`, then verify access:
 
   ```bash
-  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  CHART_VERSION="$(grep -E "^[0-9]+\.[0-9]+\.[0-9]+" docs/apps/dspace.version | head -n1)"
   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -67,7 +67,7 @@ kubectl -n dspace rollout status deploy/dspace --timeout=180s
 ```
 
 ```bash
-curl -fsS https://staging.democratized.space/config.json
+curl -fsS https://staging.democratized.space/healthz
 ```
 
 ```bash
@@ -136,7 +136,8 @@ Prod should deploy the same approved immutable artifact (not `main-latest`).
   Use a PAT with `read:packages`, then verify access:
 
   ```bash
-  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+  CHART_VERSION="$(cat docs/apps/dspace.version)"
+  helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
   ```
 
 - After rebuilds, verify cluster networking/ingress before blaming app release content:
@@ -163,5 +164,5 @@ Prod should deploy the same approved immutable artifact (not `main-latest`).
   - [Canonical outage JSON](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
 
 - For staging-only deploys (for example `v3.0.1-rc.5` validation), verify that:
-  - `https://staging.democratized.space/config.json` reports the expected SHA/tag
-  - `https://democratized.space/config.json` remains on the intended prod release (for example `3.0.0`)
+  - `https://staging.democratized.space/healthz` reports the expected SHA/tag
+  - `https://democratized.space/healthz` remains on the intended prod release (for example `3.0.0`)

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -127,6 +127,17 @@ Prod should deploy the same approved immutable artifact (not `main-latest`).
 - After a cluster wipe/rebuild, use `helm-oci-install` first.
   `helm-oci-upgrade` is for steady-state updates and fails on fresh state with
   `UPGRADE FAILED: "dspace" has no deployed releases`.
+  Fresh/rebuilt staging cluster example:
+
+  ```bash
+  just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=3.0.1-rc.5
+  ```
+
+  Existing staging release example:
+
+  ```bash
+  just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=3.0.1-rc.5
+  ```
 - If Helm OCI pulls fail with `403 denied: denied`, rotate/re-login GHCR credentials:
 
   ```bash

--- a/docs/qa/v3.0.1.md
+++ b/docs/qa/v3.0.1.md
@@ -73,7 +73,7 @@ git diff --name-only 3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.6
 git diff --stat 3ec45a5517a35c96767f6b946c01104e6ec88f93..v3.0.1-rc.6
 ```
 
-- [x] QA signoff confirms the audited commit delta above resolves to the immutable rc.6 SHA and
+- [ ] QA signoff confirms the audited commit delta above resolves to the immutable rc.6 SHA and
       audited range (SHA/range resolution gate only; does not certify execution of every mapped
       checklist item)
   - Evidence (2026-05-19 UTC, maintainer checkout with `origin` configured):
@@ -218,11 +218,12 @@ curl -fsS https://staging.democratized.space/livez
 Evidence captured in Codex sessions (2026-05-18 through 2026-05-19 UTC, staging runtime currently
 reporting `main-8a1fa6c` for the active rc.6 candidate):
 
-- Local reference check: this detached checkout does not carry the rc.6 tag namespace (`origin`
-  unavailable), so immutable tag-resolution proof is still pending for Section 1.1. Staging
-  `/healthz` + `/livez` report `main-8a1fa6c` for runtime identity, and release owner follow-up is
-  to rerun `git fetch --tags origin`, `git ls-remote --tags origin v3.0.1-rc.6`, and
-  `git rev-parse v3.0.1-rc.6` in a remote-connected checkout before production promotion.
+- Local reference check: this detached checkout has no configured `origin` remote (`origin`
+  unavailable), so immutable tag-resolution proof is still pending for Section 1.1. Release QA
+  must attach remote tag proof before promotion by rerunning `git fetch --tags origin`,
+  `git ls-remote --tags origin v3.0.1-rc.6`, and `git rev-parse v3.0.1-rc.6` in a
+  remote-connected checkout. Staging `/healthz` + `/livez` currently report `main-8a1fa6c` for
+  runtime identity while that remote tag proof is being attached.
 - `curl -fsS https://staging.democratized.space/config.json` returned the full expected runtime
   config payload for this candidate:
   `{"offlineWorker":{"enabled":true},"telemetry":{"enabled":false},"featureFlags":[]}`. That


### PR DESCRIPTION
### Motivation

- Document operator-facing failure and recovery lessons observed during the v3.0.1-rc.5 staging rebuild so DSPACE operators can discover them in the runbooks. 
- Ensure DSPACE does not duplicate the Sugarkube cluster-level RCA and instead redirects operators to the canonical Sugarkube outage record. 
- Make staging/prod/dev runbooks consistent about `just` usage, fresh-cluster vs steady-state Helm OCI semantics, GHCR auth symptoms, and ingress/tunnel verification steps.

### Description

- Added a concise `Troubleshooting and recovery notes` section to `docs/k3s-sugarkube-staging.md` that documents positional `just` env args, the `cf-tunnel-install` caveat, `helm-oci-install` vs `helm-oci-upgrade` guidance, GHCR `403 denied` remediation (`helm registry login ghcr.io` + `helm show chart ...`), Traefik/tunnel verification commands, and links to Sugarkube setup/operations/troubleshooting docs and the canonical Sugarkube outage files. 
- Added matching cross-environment guidance to `docs/k3s-sugarkube-prod.md` that emphasizes not accidentally promoting staging RCs to prod and includes the same install/upgrade and GHCR verification commands adapted for `prod`. 
- Added a matching `Troubleshooting and recovery notes` section to `docs/k3s-sugarkube-dev.md` with `dev`-appropriate examples and the same verification/reinstall guidance. 
- Confirmed the duplicate DSPACE outage files referenced in the task were not present in this branch, and updated docs to point to the canonical Sugarkube outage record at `futuroptimist/sugarkube/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.{md,json}` rather than duplicating the full RCA.

### Testing

- Ran `npm run link-check` which completed successfully and reported all local markdown links resolved. 
- Ran repository searches with `rg` for the key patterns (`k3s-sugarkube`, `helm-oci`, `cf-tunnel-install`, `GHCR`, `traefik`, `sugarkube-ha-staging-dhcp-ip-reassignment`) and for known-bad forms (`just up env=`, `cf-tunnel-install env=`) to ensure advice and anti-patterns were present/avoided as intended. 
- Verified there is no duplicate full outage narrative remaining in `outages/` in this branch and no secrets or tokens were added to the docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e615bb250832fb7be26ecbd16d343)