### PR TITLE
📝 docs: document Sugarkube/k3s deploy failure cases and canonical outage ownership

### DIFF
--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -102,3 +102,34 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 - Keep `environment: dev` in the dev values file so QA Cheats remain enabled.
 - Because dev is single-node and non-HA, expect lower resilience than staging/prod.
 - If public ingress is ever enabled for dev, keep it explicitly non-production and low-trust.
+
+## Troubleshooting and recovery notes
+
+For Sugarkube cluster-level failures (for example DHCP/IP reassignment fallout, k3s quorum or
+control-plane health issues), use Sugarkube docs and outage records as the source of truth:
+
+- [raspi_cluster_setup.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+- [raspi_cluster_operations.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+- [raspi_cluster_troubleshooting.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+- [Canonical outage record (.md)](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+- [Canonical outage record (.json)](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+DSPACE runbooks should troubleshoot app release/deploy workflow here; Sugarkube owns cluster
+rebuild internals.
+
+### Command patterns to avoid known failure modes
+
+- Prefer positional env args in Sugarkube commands (for example `just up dev`,
+  `just save-logs dev`).
+- For tunnel install, prefer positional form (for example
+  `just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"`) and avoid the named form
+  `cf-tunnel-install env=dev` until the parsing/naming fix lands.
+- Fresh cluster bootstraps should use `just helm-oci-install ...` first; use
+  `just helm-oci-upgrade ...` only after release creation to avoid
+  `UPGRADE FAILED: "<release>" has no deployed releases`.
+- If GHCR Helm OCI access fails with `403 denied: denied`, re-run:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -120,3 +120,34 @@ curl -fsS https://prod.democratized.space/healthz
 ```
 
 If rehearsal succeeds and you proceed to production, switch back to `docs/examples/dspace.values.prod.yaml` for the real prod deployment.
+
+## Troubleshooting and recovery notes
+
+For Sugarkube cluster-level failures (for example DHCP/IP reassignment fallout, k3s quorum or
+control-plane health issues), use Sugarkube docs and outage records as the source of truth:
+
+- [raspi_cluster_setup.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+- [raspi_cluster_operations.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+- [raspi_cluster_troubleshooting.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+- [Canonical outage record (.md)](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+- [Canonical outage record (.json)](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+DSPACE runbooks should troubleshoot app release/deploy workflow here; Sugarkube owns cluster
+rebuild internals.
+
+### Command patterns to avoid known failure modes
+
+- Prefer positional env args in Sugarkube commands (for example `just up prod`,
+  `just save-logs prod`).
+- For tunnel install, prefer positional form (for example
+  `just cf-tunnel-install prod token="$CF_TUNNEL_TOKEN"`) and avoid the named form
+  `cf-tunnel-install env=prod` until the parsing/naming fix lands.
+- Fresh cluster bootstraps should use `just helm-oci-install ...` first; use
+  `just helm-oci-upgrade ...` only after release creation to avoid
+  `UPGRADE FAILED: "<release>" has no deployed releases`.
+- If GHCR Helm OCI access fails with `403 denied: denied`, re-run:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -112,3 +112,87 @@ Promote only after staging sign-off. Hand off:
 - rollback tag confirmed
 
 Prod should deploy the same approved immutable artifact (not `main-latest`).
+
+## Troubleshooting and recovery notes (v3.0.1-rc.5 lessons)
+
+Cluster-level failures after DHCP/IP reassignment are owned by Sugarkube operations (not DSPACE app
+release logic). For cluster rebuild/remediation steps, use Sugarkube docs first:
+
+- [raspi_cluster_setup.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md)
+- [raspi_cluster_operations.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md)
+- [raspi_cluster_troubleshooting.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
+- Canonical outage record:
+  - [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+  - [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+### Use positional Sugarkube environment arguments
+
+Prefer positional environment arguments in Sugarkube commands:
+
+```bash
+just up staging
+just save-logs staging
+```
+
+Legacy named form (`just up env=staging`) previously produced malformed env values before
+Sugarkube PR #2165. Prefer positional form for operator consistency.
+
+### Cloudflare tunnel install: avoid named env form for now
+
+Use positional env argument:
+
+```bash
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+Avoid `just cf-tunnel-install env=staging token="$CF_TUNNEL_TOKEN"` until the Sugarkube tunnel
+parsing/naming fix lands, because it can produce malformed names like `sugarkube-env=staging`.
+
+### Fresh cluster vs steady state Helm command choice
+
+After cluster wipe/rebuild, run install first, then upgrade on later deploys:
+
+- Fresh cluster / no release yet: `just helm-oci-install ...`
+- Existing deployed release: `just helm-oci-upgrade ...`
+
+If you run upgrade on a fresh cluster, expect:
+
+`UPGRADE FAILED: "<release>" has no deployed releases`
+
+### GHCR Helm OCI auth failures
+
+If Helm chart pulls fail with `403 denied: denied`, rotate/re-login GHCR credentials:
+
+```bash
+helm registry login ghcr.io
+```
+
+Use a PAT that includes `read:packages`, then verify:
+
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+### Re-verify ingress stack after rebuild
+
+After k3s rebuild, verify cluster health and ingress plumbing before blaming DSPACE app deploys:
+
+```bash
+just cluster-status
+just traefik-status
+just traefik-crd-doctor
+```
+
+Use reinstall commands only when needed:
+
+```bash
+just traefik-install
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+### Post-deploy verification guardrails
+
+For staging-only deploys (including RCs like `v3.0.1-rc.5`), verify both:
+
+1. `https://staging.democratized.space` reports the expected deployed SHA/tag.
+2. `https://democratized.space` (apex/prod) remains on the intended production release.


### PR DESCRIPTION
### Motivation

- Capture operator-facing lessons from the `v3.0.1-rc.5` staging rebuild so DSPACE runbooks surface the failure modes operators will encounter. 
- Avoid duplicating the cluster-level RCA inside DSPACE by pointing to the canonical Sugarkube outage record and Sugarkube cluster docs. 
- Keep staging/prod/dev runbooks consistent while clarifying which remediation steps are app-release vs cluster-rebuild responsibilities.

### Description

- Added a ``Troubleshooting and recovery notes`` section to `docs/k3s-sugarkube-staging.md` documenting: positional env usage (e.g. `just up staging`), the `cf-tunnel-install` named-arg caveat, fresh-cluster `helm-oci-install` vs steady-state `helm-oci-upgrade`, GHCR Helm OCI auth rotation and verification (including `helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0`), Traefik/CF-tunnel re-verification commands, and post-deploy verification guardrails for staging vs prod. 
- Added matching concise troubleshooting sections to `docs/k3s-sugarkube-prod.md` and `docs/k3s-sugarkube-dev.md` that link to Sugarkube cluster docs and the canonical outage record at `futuroptimist/sugarkube` rather than reproducing the full RCA. 
- Verified that the duplicate DSPACE outage files named in the task are not present in this repo snapshot, so no local full-RCA copy was left in DSPACE; runbooks now explicitly point operators to the canonical Sugarkube outage links.

### Testing

- Ran link validation with `npm run link-check` and it completed successfully. 
- Normalized formatting with `npx prettier --write` and verified with `npx prettier --check` for the three edited docs; formatting checks passed. 
- Searched docs for known-bad or sentinel strings using ripgrep and verified updates: `rg -n "cf-tunnel-install env=|just up env=|save-logs env=|sugarkube-ha-staging-dhcp-ip-reassignment|UPGRADE FAILED|403 denied: denied|helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0" docs outages` and confirmed guidance and links are present and that the duplicate outage files are absent. 
- All automated checks above completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e615bb250832fb7be26ecbd16d343)