### PR TITLE
📝 docs: add Sugarkube/k3s deploy failure guidance and point to canonical outage

### DIFF
--- a/docs/k3s-sugarkube-dev.md
+++ b/docs/k3s-sugarkube-dev.md
@@ -102,3 +102,50 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 - Keep `environment: dev` in the dev values file so QA Cheats remain enabled.
 - Because dev is single-node and non-HA, expect lower resilience than staging/prod.
 - If public ingress is ever enabled for dev, keep it explicitly non-production and low-trust.
+
+## Troubleshooting and recovery notes
+
+### Prefer positional env arguments for Sugarkube commands
+
+Use positional env form in dev operations:
+
+```bash
+just up dev
+just save-logs dev
+```
+
+### Cloudflare tunnel install caveat
+
+If/when dev tunnel routing is used, prefer positional env form:
+
+```bash
+just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"
+```
+
+Avoid `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"` until Sugarkube tunnel parsing
+fixes are fully rolled out.
+
+### Fresh cluster install before upgrade
+
+After node reset or namespace wipe, run install before upgrade. If you run upgrade first, expect:
+`UPGRADE FAILED: "dspace" has no deployed releases`
+
+### GHCR Helm OCI auth failure handling
+
+If Helm OCI pulls fail with `403 denied: denied`, re-login to GHCR using a PAT with
+`read:packages`, then verify chart access:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+### Cluster-level remediation ownership
+
+For k3s/Sugarkube cluster internals (DHCP/IP churn, control-plane instability, Traefik/tunnel
+recovery), follow Sugarkube docs and outage records instead of duplicating RCA here:
+
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md>

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -120,3 +120,50 @@ curl -fsS https://prod.democratized.space/healthz
 ```
 
 If rehearsal succeeds and you proceed to production, switch back to `docs/examples/dspace.values.prod.yaml` for the real prod deployment.
+
+## Troubleshooting and recovery notes
+
+### Keep prod release scope strict
+
+- Do not deploy staging RC tags to production unless explicitly promoted.
+- For staging-only deploy windows, verify production/apex remains on the intended stable release
+  by checking `https://democratized.space/config.json`.
+
+### Prefer positional env arguments for Sugarkube commands
+
+Use positional env form:
+
+```bash
+just up prod
+just save-logs prod
+```
+
+### Fresh cluster install vs. existing release upgrade
+
+If prod cluster state is rebuilt and the `dspace` release is missing, use install first:
+
+```bash
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.prod.yaml version_file=docs/apps/dspace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+Then return to `helm-oci-upgrade` for steady-state releases. Running upgrade first on a wiped
+cluster can fail with `UPGRADE FAILED: "dspace" has no deployed releases`.
+
+### GHCR Helm OCI auth failure handling
+
+If chart pulls fail with `403 denied: denied`, re-auth to GHCR with a PAT that has
+`read:packages`:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+### Cluster-level failures: use Sugarkube canonical docs/outage
+
+DSPACE runbooks cover app deploy flows; Sugarkube owns cluster-level RCA and remediation:
+
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md>
+- <https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md>

--- a/docs/k3s-sugarkube-staging.md
+++ b/docs/k3s-sugarkube-staging.md
@@ -112,3 +112,90 @@ Promote only after staging sign-off. Hand off:
 - rollback tag confirmed
 
 Prod should deploy the same approved immutable artifact (not `main-latest`).
+
+## Troubleshooting and recovery notes (v3.0.1-rc.5 lessons)
+
+### Scope boundary: DSPACE app deploy vs. Sugarkube cluster recovery
+
+- Use this runbook for DSPACE application deployment and verification.
+- For cluster-level recovery (for example, DHCP/IP reassignment fallout, k3s quorum
+  instability, or tunnel/Traefik rebuilds), treat Sugarkube docs and outages as canonical:
+  - <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md>
+  - <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_operations.md>
+  - <https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md>
+  - <https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md>
+  - <https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json>
+
+### Prefer positional env arguments for Sugarkube commands
+
+Use positional env form in operator commands:
+
+```bash
+just up staging
+just save-logs staging
+```
+
+Avoid relying on named env form in legacy troubleshooting notes (for example `just up env=staging`)
+because older Sugarkube behavior could parse malformed values prior to PR #2165.
+
+### Cloudflare tunnel install: avoid named env form until tunnel parsing fix lands
+
+Prefer:
+
+```bash
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+Avoid:
+
+```bash
+just cf-tunnel-install env=staging token="$CF_TUNNEL_TOKEN"
+```
+
+The named form may create malformed tunnel names (for example `sugarkube-env=staging`).
+
+### Fresh cluster install vs. steady-state upgrade
+
+- Fresh/rebuilt cluster (no deployed `dspace` release): use `helm-oci-install` first.
+- Existing deployed release: use `helm-oci-upgrade`.
+- If you run upgrade first on a wiped cluster, you can hit:
+  `UPGRADE FAILED: "dspace" has no deployed releases`
+
+### GHCR Helm OCI auth failure handling
+
+If Helm pulls fail with `403 denied: denied`, rotate/re-auth your token and log in again:
+
+```bash
+helm registry login ghcr.io
+```
+
+Use a PAT with `read:packages`, then verify pullability:
+
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+```
+
+### Re-verify Traefik and tunnel plumbing after cluster rebuild
+
+After cluster recovery/rebuild, verify control-plane and ingress dependencies before app triage:
+
+```bash
+just cluster-status
+just traefik-status
+just traefik-crd-doctor
+```
+
+Install/reinstall only when appropriate:
+
+```bash
+just traefik-install
+just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
+```
+
+### Staging deploy verification and production safety checks
+
+For staging-only deploys (for example `v3.0.1-rc.5`), verify:
+
+- `https://staging.democratized.space/config.json` reports the expected deployed SHA/tag.
+- prod/apex remains pinned to its intended release (for example `v3.0.0` during staging-only
+  validation) by checking `https://democratized.space/config.json`.


### PR DESCRIPTION
### Motivation

- Capture operator lessons from the v3.0.1-rc.5 staging rebuild so DSPACE runbooks surface the failure modes operators will actually hit. 
- Avoid duplicating Sugarkube cluster-level RCA in DSPACE and point operators at the canonical Sugarkube outage and docs. 

### Description

- Added a `Troubleshooting and recovery notes` section to `docs/k3s-sugarkube-staging.md` that documents positional env usage (`just up staging`), the `cf-tunnel-install` named-env caveat, fresh-cluster `helm-oci-install` vs steady-state `helm-oci-upgrade`, GHCR Helm OCI `403` triage with `helm show chart`, Traefik/tunnel re-verification commands, and post-deploy verification guidance. 
- Added matching, environment-adapted troubleshooting sections to `docs/k3s-sugarkube-prod.md` and `docs/k3s-sugarkube-dev.md` that preserve runbook structure and use copy-paste-ready command examples. 
- Replaced DSPACE-level RCA duplication with explicit links to the canonical Sugarkube records at `futuroptimist/sugarkube` (including `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `.json`) and confirmed the duplicate DSPACE outage files are not present so no full duplicate narrative remains in this repo. 

### Testing

- Ran `npm run link-check` and local markdown link resolution succeeded. 
- Ran `git diff --cached | python3 scripts/scan-secrets.py` against staged changes and found no secrets. 
- Ran repository greps for `cf-tunnel-install env=`, `just up env=`, `save-logs env=` and for the outage identifiers to confirm only intentional "avoid" examples and canonical links exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e615bb250832fb7be26ecbd16d343)