### PR TITLE
🧰 chore: align Helm chart metadata to v3.0.1

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.0.0
+version: 3.0.1
 description: Helm chart for deploying the DSPACE application
 type: application
-appVersion: "v3.0.0"
+appVersion: "v3.0.1"

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: ghcr.io/democratizedspace/dspace
-  tag: v3.0.0
+  tag: v3.0.1
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/charts/dspace/Chart.yaml
+++ b/deploy/charts/dspace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dspace
-version: 0.1.3
+version: 3.0.1
 description: Helm chart for deploying DSPACE v3 on k3s
-appVersion: "3.0.0"
+appVersion: "v3.0.1"
 type: application

--- a/deploy/env/dev/helmrelease.yaml
+++ b/deploy/env/dev/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: dspace
         namespace: flux-system
-      version: 0.1.3
+      version: 3.0.1
       reconcileStrategy: ChartVersion
   install:
     createNamespace: true

--- a/deploy/env/int/helmrelease.yaml
+++ b/deploy/env/int/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: dspace
         namespace: flux-system
-      version: 0.1.3
+      version: 3.0.1
       reconcileStrategy: ChartVersion
   install:
     createNamespace: true

--- a/deploy/env/prod/helmrelease.yaml
+++ b/deploy/env/prod/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: GitRepository
         name: dspace
         namespace: flux-system
-      version: 0.1.3
+      version: 3.0.1
       reconcileStrategy: ChartVersion
   install:
     createNamespace: true

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.0.0
+3.0.1

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -13,7 +13,7 @@ settings.
 - `replicaCount`: Pod replica count. Defaults to `2` for redundancy.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
-- `image.tag`: Image tag to deploy. Defaults to `v3.0.0`, matching the current package version.
+- `image.tag`: Image tag to deploy. Defaults to `v3.0.1`, matching the current package version.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
@@ -58,7 +58,7 @@ Deploy the chart with a custom host and image tag:
 helm install dspace charts/dspace \
   -f charts/dspace/values.dev.yaml \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.0.0
+  --set image.tag=v3.0.1
 ```
 
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
@@ -66,15 +66,15 @@ Replace `dspace.example.com` with a domain routed to your Traefik ingress contro
 ## Install from GHCR (OCI)
 
 The chart is published to the GitHub Container Registry on `v3` pushes. Install it directly
-from the OCI registry using the latest version (currently `3.0.0`; see
+from the OCI registry using the latest version (currently `3.0.1`; see
 `docs/apps/dspace.version` or the registry for available versions):
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.0.0 \
+  --version 3.0.1 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.0.0
+  --set image.tag=v3.0.1
 ```
 
 When installing from the OCI registry, you will not have access to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspace",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspace",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@dspace/feature-flags": "file:packages/feature-flags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": "20 || >=22"


### PR DESCRIPTION
### Motivation
- Ensure the next OCI-published Helm chart and deployment metadata reflect the v3.0.1 prod cutover and avoid mismatches between packaged chart and sugarkube/Flux consumers. 
- Centralize the authoritative chart version so the CI publish job produces `oci://ghcr.io/democratizedspace/charts/dspace:3.0.1` and Flux/Docs reference the same value.

### Description
- Bumped the OCI-published chart metadata in `charts/dspace/Chart.yaml` to `version: 3.0.1` and `appVersion: "v3.0.1"` which is the primary source used by the CI publish workflow. 
- Kept the deploy/Flux chart copy in sync by updating `deploy/charts/dspace/Chart.yaml` to `version: 3.0.1` and `appVersion: "v3.0.1"`. 
- Updated the sugarkube/consumer version file `docs/apps/dspace.version` to `3.0.1` and the Flux HelmRelease pins in `deploy/env/prod/helmrelease.yaml` and `deploy/env/int/helmrelease.yaml` to `version: 3.0.1`. 
- Updated operator-facing docs in `docs/charts.md` to reference `3.0.1`/`v3.0.1` and changed default `image.tag` examples to `v3.0.1` for consistency.

### Testing
- Searched the repo for all chart/version sources with `rg` and validated the packaging flow in `.github/workflows/ci-helm.yml` which packages `charts/dspace` and derives the GHCR tag from `charts/dspace/Chart.yaml:version`. (succeeded)
- Inspected the release consistency guard `scripts/check-dspace-chart-version.sh` and confirmed the script enforces `charts/dspace/Chart.yaml:version` equals the semver in `docs/apps/dspace.version`. (inspection succeeded)
- Printed the modified files with `cat`/`sed` to verify the new values are present in `charts/dspace/Chart.yaml`, `deploy/charts/dspace/Chart.yaml`, `docs/apps/dspace.version`, and the two `helmrelease.yaml` files. (succeeded)
- Attempted local `helm lint` and `helm package` but they could not be run in this environment because the Helm CLI is not installed (`helm: command not found`); CI will run these steps as part of `.github/workflows/ci-helm.yml`. (not runnable here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e998302b0832fb1eaef836b9e3e1c)