### PR TITLE
docs: add DSPACE Sugarkube release runbook and CI image tag summary

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -446,6 +446,20 @@ jobs:
             dspace-verify:latest \
             node /scripts/verify-chat-build-stamp.mjs
 
+      - name: Summarize published image tags
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        run: |
+          {
+            echo "## DSPACE image tags"
+            echo
+            echo "| Type | Value |"
+            echo "| --- | --- |"
+            echo "| Short SHA | \`${{ steps.tags.outputs.short_sha }}\` |"
+            echo "| Immutable image tag | \`${{ steps.tags.outputs.sha_tag }}\` |"
+            echo "| Mutable branch convenience tag | \`${{ steps.tags.outputs.latest_tag }}\` |"
+            echo "| Version tag | \`${{ steps.tags.outputs.version_tag }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fail if both image pushes failed
         if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
         run: exit 1

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Create quests, items, and processes for the game:
 - [Raspberry Pi 9-node topology](./docs/raspi_cluster_topology_9_nodes.md) - Inventory and role map
 - [Power budget and load test](./docs/power_budget_load_test.md) - Verify PoE headroom
 - [Kubernetes Deployment](./docs/charts.md) - Helm chart installation
+- [DSPACE Sugarkube Release Runbook](./docs/ops/sugarkube-release.md) - GHCR artifact selection, staging deployment, production promotion, and rollback
 - k3s + Sugarkube runbooks: [dev](./docs/k3s-sugarkube-dev.md) / [staging](./docs/k3s-sugarkube-staging.md) / [prod](./docs/k3s-sugarkube-prod.md)
 
 ### Verification (environment split)
@@ -165,6 +166,7 @@ Prompts for AI-assisted development:
 We welcome contributions! See our [Contributing Guide](./CONTRIBUTING.md) to get started.
 
 Key contribution areas:
+
 - Create quests, items, and processes
 - Improve documentation
 - Fix bugs and add features

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -2,6 +2,9 @@
 
 The `charts/dspace` Helm chart deploys the DSPACE application with sensible defaults for
 Traefik-based ingress, HTTP health checks, and optional configuration via ConfigMaps or Secrets.
+For Sugarkube staging and production releases, use the steady-state
+[DSPACE Sugarkube release runbook](./ops/sugarkube-release.md) rather than ad hoc local image
+builds.
 It is a lightweight chart intended for direct Helm usage; Flux-managed environments continue to
 use the existing production chart at `deploy/charts/dspace/`, which includes additional features
 like network policies, metrics, and production ingress/TLS automation. The chart uses the
@@ -26,7 +29,7 @@ settings.
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
   `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-  RuntimeDefault`.
+RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for
@@ -65,7 +68,11 @@ Replace `dspace.example.com` with a domain routed to your Traefik ingress contro
 
 ## Install from GHCR (OCI)
 
-The chart is published to the GitHub Container Registry on `v3` pushes. Install it directly
+For the mature DSPACE Sugarkube release path, follow the
+[DSPACE Sugarkube release runbook](./ops/sugarkube-release.md), which ties the GHCR image tag,
+chart version, staging validation, production promotion, and rollback steps together.
+
+The chart is published to the GitHub Container Registry on `v3` and `main` pushes. Install it directly
 from the OCI registry using the latest version (currently `3.0.1`; see
 `docs/apps/dspace.version` or the registry for available versions):
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -9,6 +9,7 @@ incidents, or performing maintenance.
 - [Backup system](./backup_system.md)
 - [Cloudflare load balancing](./cloudflare_load_balancing.md)
 - [Deployments](./deploy/)
+- [DSPACE Sugarkube release runbook](./sugarkube-release.md)
 - [Release procedure](../merge-plan.md)
 - Release-management QA quick links:
   - [Patch checklist (`v3.0.1`)](../qa/v3.0.1.md)

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,134 @@
+# DSPACE Sugarkube release and deployment runbook
+
+DSPACE is the mature Sugarkube baseline. Its staging and production path already works, so this
+runbook documents the current contract instead of replacing it. Keep runtime behavior, image tags,
+chart packaging, Cloudflare routing, and the existing `dspace-*` Sugarkube recipes intact unless a
+future coordinated Sugarkube migration explicitly changes them.
+
+Use this page as the steady-state source of truth for releasing DSPACE from GitHub Container
+Registry (GHCR) artifacts into Sugarkube-managed Kubernetes environments.
+
+## Artifact contract
+
+- **Image workflow:** `.github/workflows/ci-image.yml` builds and publishes multi-architecture
+  images to `ghcr.io/democratizedspace/dspace` on supported branches, including `main` and `v3`.
+- **Image tags:** keep the existing tag shapes:
+  - immutable branch/SHA tag, such as `main-REPLACE_SHORTSHA` or `v3-REPLACE_SHORTSHA`
+  - mutable branch convenience tag, such as `main-latest` or `v3-latest`
+  - package-version tag, currently shaped as `v<package.version>` such as `v3.0.1`
+- **Chart workflow:** `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to
+  `oci://ghcr.io/democratizedspace/charts/dspace`.
+- **Chart version:** confirm the chart version in `charts/dspace/Chart.yaml` and, when needed, the
+  matching publish workflow run before deploying.
+
+Use immutable branch/SHA image tags for staging validation, production promotion, and rollback.
+Mutable branch tags are convenient for discovery, but they are not the preferred audit trail for a
+signed-off release.
+
+## Release checklist
+
+1. Open the **Build and publish GHCR image** (`ci-image.yml`) workflow run for the desired commit
+   and branch.
+2. Confirm the workflow succeeded, including the image push job and smoke validation.
+3. Copy the immutable image tag printed in the workflow summary or shown in GHCR, for example
+   `main-REPLACE_SHORTSHA` or `v3-REPLACE_SHORTSHA`.
+4. Confirm the chart version in `charts/dspace/Chart.yaml` and/or the **Publish Helm chart**
+   (`ci-helm.yml`) workflow run.
+5. Deploy staging from the Sugarkube checkout:
+
+   ```bash
+   cd ~/sugarkube
+   just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+   ```
+
+   Use the branch prefix that matches the workflow run when needed:
+
+   ```bash
+   just dspace-oci-deploy env=staging tag=v3-REPLACE_SHORTSHA
+   ```
+
+6. Validate staging with the commands below.
+7. Promote production from Sugarkube after staging sign-off. The existing compatibility recipe
+   accepts a release-style tag:
+
+   ```bash
+   just dspace-oci-promote-prod tag=3.0.1
+   ```
+
+   Or promote the immutable branch/SHA tag that passed staging:
+
+   ```bash
+   just dspace-oci-promote-prod tag=main-REPLACE_SHORTSHA
+   ```
+
+8. Validate production with the commands below.
+
+## Future generic Sugarkube commands
+
+After Sugarkube P5 lands, app-generic recipes should be available alongside the existing DSPACE
+compatibility shims. The intended generic equivalents are:
+
+```bash
+cd ~/sugarkube
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+```
+
+Until those generic recipes exist in Sugarkube, continue using the known-good `dspace-oci-*`
+commands above.
+
+## Validation commands
+
+Run the staging checks after the deployment rollout completes:
+
+```bash
+curl -fsS https://staging.democratized.space/config.json | jq .
+curl -fsS https://staging.democratized.space/healthz | jq .
+curl -fsS https://staging.democratized.space/livez | jq .
+```
+
+Run the production checks after promotion completes:
+
+```bash
+curl -fsS https://democratized.space/config.json | jq .
+curl -fsS https://democratized.space/healthz | jq .
+curl -fsS https://democratized.space/livez | jq .
+```
+
+If a response fails, first inspect rollout and pod status from the Sugarkube cluster context before
+changing artifacts:
+
+```bash
+kubectl -n dspace rollout status deploy/dspace --timeout=180s
+kubectl -n dspace get deploy,po,svc,ingress
+```
+
+## Rollback
+
+Rollback is artifact-first: redeploy the prior known-good immutable tag.
+
+```bash
+cd ~/sugarkube
+just dspace-oci-deploy env=staging tag=main-PREVIOUS_SHORTSHA
+```
+
+For production rollback, use the same prior immutable tag with the production promotion recipe:
+
+```bash
+just dspace-oci-promote-prod tag=main-PREVIOUS_SHORTSHA
+```
+
+After rollback, rerun the relevant staging or production validation commands from this runbook.
+
+## Cloudflare routing and DNS
+
+Keep Cloudflare route, tunnel, DNS, and load-balancer setup separate from Helm deployment. The Helm
+release should assume that the target hostname is already routed to the cluster ingress. If route or
+DNS setup needs repair, use the Cloudflare and Sugarkube infrastructure runbooks first, then return
+to this release runbook for app deployment.
+
+## Local Docker builds
+
+Local Docker builds are for local development, debugging, and CI smoke coverage only. They are not
+the normal Sugarkube staging or production release path. Staging and production should consume the
+GHCR image and Helm chart artifacts published by the workflows described above.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -2,7 +2,8 @@
 
 These manifests deploy the `dspace-app` container built from the root `Dockerfile`. They match the
 k3s + sugarkube deployment documented in [`docs/k3s-sugarkube-staging.md`](../../docs/k3s-sugarkube-staging.md)
-for the staging cluster.
+for the staging cluster. For staged and production Sugarkube releases, use the
+[DSPACE Sugarkube release runbook](../../docs/ops/sugarkube-release.md) as the source of truth.
 
 The container exposes port **8080** and provides health endpoints at `/healthz` (readiness)
 and `/livez` (liveness).
@@ -17,7 +18,8 @@ kubectl apply -f infra/k8s/
 
 ## Building locally
 
-To build and load the image locally for k3s:
+Local Docker builds are useful for development and debugging only; they are not the normal
+Sugarkube staging or production release path. To build and load the image locally for k3s:
 
 ```bash
 docker build -t dspace-app:latest .


### PR DESCRIPTION
### Motivation

- Provide a single, explicit Sugarkube release/deploy runbook for DSPACE that documents the existing mature flow and maps it to the shared Sugarkube contract, without changing runtime behavior. 
- Make GHCR image/chart selection, staging deployment, production promotion, validation, and rollback steps discoverable and consistent with other apps targeted by Sugarkube work.

### Description

- Add `docs/ops/sugarkube-release.md` which documents the artifact contract, immutable/mutable tag shapes, staging deploy (`just dspace-oci-deploy env=staging tag=...`), prod promotion (`just dspace-oci-promote-prod tag=...`), validation checks, rollback guidance, Cloudflare separation, and future generic `just app-*` commands. 
- Link the new runbook from `README.md`, `docs/charts.md`, and `docs/ops/README.md`, and point `infra/k8s/README.md` at the runbook as the steady-state Sugarkube source of truth while keeping existing k8s docs. 
- Make a low-risk CI improvement in `.github/workflows/ci-image.yml` that appends a readable step summary with `short_sha`, immutable image tag, branch convenience tag, and version tag to the GitHub Actions run summary after a successful image publish. 
- No application runtime code or chart packaging behavior was changed; this is documentation + small CI-summary only.

### Testing

- Ran `git diff --check` and confirmed no whitespace/check failures. 
- Ran `pnpm install --frozen-lockfile --reporter=append-only` which completed successfully. 
- Ran formatting and style checks with `pnpm run format:check` and `pnpm exec prettier --check ...` and fixed formatting where required, all checked files now pass Prettier. 
- Ran link validation with `pnpm run link-check` and confirmed local markdown links resolved. 
- Verified presence of the new command examples with `rg -n "app-deploy app=dspace"` and `rg -n "dspace-oci-deploy env=staging"` which both returned matches. 
- Attempted `pnpm run helm:lint` and `pnpm run helm:template` but both were blocked because `helm` is not installed in the execution environment (observed `sh: 1: helm: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb2002b0832fbe7ffd860a482b38)