### PR TITLE
docs: add Sugarkube release runbook and CI image tag summary

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -446,6 +446,20 @@ jobs:
             dspace-verify:latest \
             node /scripts/verify-chat-build-stamp.mjs
 
+      - name: Summarize published image tags
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        run: |
+          {
+            echo "## Published DSPACE image"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Immutable image tag | `${{ steps.tags.outputs.sha_tag }}` |"
+            echo "| Mutable branch convenience tag | `${{ steps.tags.outputs.latest_tag }}` |"
+            echo "| Version tag | `${{ steps.tags.outputs.version_tag }}` |"
+            echo "| Short SHA | `${{ steps.tags.outputs.short_sha }}` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fail if both image pushes failed
         if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
         run: exit 1

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Create quests, items, and processes for the game:
 ### Operations & Deployment
 
 - [Operations Runbooks](./docs/ops/README.md) - Deployment and maintenance procedures
+  - [Sugarkube Release Runbook](./docs/ops/sugarkube-release.md) - Standard GHCR image/chart release, staging deployment, production promotion, validation, and rollback flow
   - [Raspberry Pi Deployment](./docs/ops/RPI_DEPLOYMENT_GUIDE.md) - Deploy on Raspberry Pi with k3s
   - [Docker Deployment](./docs/ops/deploy/docker.md) - Container-based deployment
   - [Monitoring Setup](./docs/ops/monitoring_setup.md) - Prometheus and Grafana

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -63,6 +63,14 @@ helm install dspace charts/dspace \
 
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
 
+## Sugarkube releases
+
+For the standard staging and production flow, use the
+[DSPACE Sugarkube release runbook](./ops/sugarkube-release.md). That page is the source of truth
+for selecting immutable GHCR image tags, confirming the published OCI chart version, deploying
+staging from Sugarkube, promoting production, validating runtime endpoints, and rolling back. The
+direct Helm examples below remain useful when operating outside Sugarkube.
+
 ## Install from GHCR (OCI)
 
 The chart is published to the GitHub Container Registry on `v3` pushes. Install it directly

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -10,6 +10,7 @@ incidents, or performing maintenance.
 - [Cloudflare load balancing](./cloudflare_load_balancing.md)
 - [Deployments](./deploy/)
 - [Release procedure](../merge-plan.md)
+- [Sugarkube release and deployment](./sugarkube-release.md) - GHCR image/chart selection, staging deploy, production promotion, validation, and rollback
 - Release-management QA quick links:
   - [Patch checklist (`v3.0.1`)](../qa/v3.0.1.md)
   - [Feature checklist (`v3.1`)](../qa/v3.1.md)

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,139 @@
+# DSPACE Sugarkube release and deployment runbook
+
+DSPACE already has a mature, validated Sugarkube staging and production flow. This runbook makes
+that flow explicit so DSPACE follows the shared Sugarkube release contract while preserving the
+known-good image, chart, and deployment behavior.
+
+Use this page as the steady-state release source of truth. The older environment runbooks remain
+useful for environment-specific details, QA cheat settings, and cluster troubleshooting:
+
+- [DSPACE dev runbook](../k3s-sugarkube-dev.md)
+- [DSPACE staging runbook](../k3s-sugarkube-staging.md)
+- [DSPACE production runbook](../k3s-sugarkube-prod.md)
+
+## Release contract
+
+| Artifact       | Canonical location                                        | Notes                                                          |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------------- |
+| Image          | `ghcr.io/democratizedspace/dspace`                        | Built by `.github/workflows/ci-image.yml` for `main` and `v3`. |
+| Chart          | `oci://ghcr.io/democratizedspace/charts/dspace`           | Packaged by `.github/workflows/ci-helm.yml`.                   |
+| Chart version  | `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` | Keep these in sync; current version is `3.0.1`.                |
+| Runtime health | `/config.json`, `/healthz`, `/livez`                      | Validate these after every deploy and promotion.               |
+
+The image workflow publishes the existing tag set that Sugarkube deployments consume:
+
+- Immutable branch/SHA tag: `main-<shortsha>` or `v3-<shortsha>`.
+- Mutable branch convenience tag: `main-latest` or `v3-latest`.
+- Version tag: `v<package.version>` (currently `v3.0.1`).
+
+Prefer immutable branch/SHA tags for staging, production promotion, and rollback because they point
+to one exact image build.
+
+## Release workflow
+
+1. Open the **Build and publish GHCR image** (`ci-image.yml`) workflow run for the desired commit
+   and branch (`main` or `v3`).
+2. Confirm the workflow succeeded. The run must publish the multi-architecture image before any
+   staging or production deployment uses that tag.
+3. Copy the immutable image tag from the workflow summary or from GHCR, for example
+   `main-REPLACE_SHORTSHA` or `v3-REPLACE_SHORTSHA`.
+4. Confirm the chart version in `charts/dspace/Chart.yaml`, `docs/apps/dspace.version`, and/or the
+   **Publish Helm chart** (`ci-helm.yml`) workflow run.
+5. From a Sugarkube checkout, deploy staging with the current DSPACE-specific compatibility recipe:
+
+   ```bash
+   cd ~/sugarkube
+   just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+   ```
+
+   Use the appropriate branch prefix for the source branch, for example:
+
+   ```bash
+   just dspace-oci-deploy env=staging tag=v3-REPLACE_SHORTSHA
+   ```
+
+6. Promote production after staging validation. Use the image tag that matches the release decision:
+
+   ```bash
+   just dspace-oci-promote-prod tag=3.0.1
+   ```
+
+   Or promote the exact branch/SHA image that passed staging:
+
+   ```bash
+   just dspace-oci-promote-prod tag=main-REPLACE_SHORTSHA
+   ```
+
+   `main-REPLACE_SHORTSHA` and `v3-REPLACE_SHORTSHA` are immutable image tags. The bare `3.0.1`
+   form is the existing Sugarkube compatibility path for the current DSPACE release version.
+
+## Future generic Sugarkube commands
+
+After Sugarkube P5 lands, the app-generic recipes should become the preferred entry points while
+the DSPACE-specific recipes remain compatibility shims:
+
+```bash
+cd ~/sugarkube
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+```
+
+Use `v3-REPLACE_SHORTSHA` instead of `main-REPLACE_SHORTSHA` when the validated image came from the
+`v3` branch.
+
+## Post-deploy validation
+
+Run the staging checks after every staging deployment:
+
+```bash
+curl -fsS https://staging.democratized.space/config.json | jq .
+curl -fsS https://staging.democratized.space/healthz | jq .
+curl -fsS https://staging.democratized.space/livez | jq .
+```
+
+Run the production checks immediately after promotion:
+
+```bash
+curl -fsS https://democratized.space/config.json | jq .
+curl -fsS https://democratized.space/healthz | jq .
+curl -fsS https://democratized.space/livez | jq .
+```
+
+If any endpoint fails, capture the failing command, response, and relevant Sugarkube/cluster logs
+before rolling back or making additional changes.
+
+## Rollback
+
+Rollback by redeploying the prior known-good immutable tag through the same Sugarkube path. For
+example, if staging or production was promoted from `main-abc1234` and the previous known-good image
+was `main-def5678`, redeploy `main-def5678` rather than a mutable `main-latest` tag.
+
+Current DSPACE-specific rollback pattern:
+
+```bash
+cd ~/sugarkube
+just dspace-oci-deploy env=staging tag=main-def5678
+just dspace-oci-promote-prod tag=main-def5678
+```
+
+Future generic rollback pattern after Sugarkube P5:
+
+```bash
+cd ~/sugarkube
+just app-deploy app=dspace env=staging tag=main-def5678
+just app-promote-prod app=dspace tag=main-def5678
+```
+
+## Cloudflare routes and DNS
+
+Keep Cloudflare route and DNS setup separate from Helm deployment. Sugarkube Helm commands deploy
+or upgrade the DSPACE Kubernetes release; they do not replace Cloudflare tunnel, DNS, or load
+balancer configuration procedures. Use the Cloudflare and environment-specific runbooks when a
+release also requires route or DNS changes.
+
+## Local Docker builds
+
+Local Docker builds are for local development, smoke testing, and debugging only. They are not the
+normal Sugarkube staging or production release path. Staging and production should deploy images
+published by `ci-image.yml` to `ghcr.io/democratizedspace/dspace` and charts published by
+`ci-helm.yml` to `oci://ghcr.io/democratizedspace/charts/dspace`.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,15 +1,17 @@
 # Kubernetes Manifests for DSPACE
 
 These manifests deploy the `dspace-app` container built from the root `Dockerfile`. They match the
-k3s + sugarkube deployment documented in [`docs/k3s-sugarkube-staging.md`](../../docs/k3s-sugarkube-staging.md)
-for the staging cluster.
+k3s + Sugarkube deployment model documented in the
+[DSPACE Sugarkube release runbook](../../docs/ops/sugarkube-release.md) and the
+[staging environment runbook](../../docs/k3s-sugarkube-staging.md).
 
 The container exposes port **8080** and provides health endpoints at `/healthz` (readiness)
 and `/livez` (liveness).
 
 ## Using GHCR images (recommended)
 
-The deployment uses pre-built images from GHCR by default:
+The deployment uses pre-built images from GHCR by default. For staging and production, prefer the
+Sugarkube release flow instead of applying these manifests directly.
 
 ```bash
 kubectl apply -f infra/k8s/
@@ -17,7 +19,8 @@ kubectl apply -f infra/k8s/
 
 ## Building locally
 
-To build and load the image locally for k3s:
+Local builds are for development and debugging only; they are not the normal Sugarkube staging or
+production release path. To build and load the image locally for k3s:
 
 ```bash
 docker build -t dspace-app:latest .


### PR DESCRIPTION
### Motivation

- Make the DSPACE release story explicit and align docs with the shared Sugarkube release contract while preserving the existing, validated DSPACE staging/prod flow and tag shapes.
- Provide a single steady-state runbook for GHCR image/chart selection, Sugarkube staging deploys, production promotion, validation, and rollback so other app repos can reference the same contract.

### Description

- Add `docs/ops/sugarkube-release.md` documenting the canonical artifacts (`ghcr.io/democratizedspace/dspace` and `oci://ghcr.io/democratizedspace/charts/dspace`), tag shapes (`branch-<shortsha>`, `branch-latest`, `v<package.version>`), Sugarkube `just` commands (`dspace-oci-deploy`, `dspace-oci-promote-prod`) and future generic `just app-*` equivalents, validation `curl` checks, rollback guidance, Cloudflare/DNS guidance, and local-Docker caveats.
- Link the new runbook from `docs/charts.md`, `docs/ops/README.md`, `infra/k8s/README.md`, and `README.md` so the new page is the steady-state source of truth while preserving the existing environment runbooks.
- Add a small, low-risk GitHub Actions summary step in `.github/workflows/ci-image.yml` that prints the immutable image tag, mutable branch convenience tag, version tag, and short SHA to the workflow summary after a successful image publish.
- Make small wording updates in `infra/k8s/README.md` to recommend the Sugarkube release flow for staging/prod and clarify that local builds are for development/debug only; no runtime code, Dockerfile, or chart defaults were changed.

### Testing

- Ran `git diff --check` which returned no issues.
- Ran `pnpm install --frozen-lockfile --reporter=append-only` which completed successfully in this environment.
- Ran `pnpm run helm:lint` and `pnpm run helm:template` but both were blocked because `helm` is not installed in the execution environment (commands failed with `helm: not found`).
- Ran `pnpm run format:check` and `pnpm run link-check` which both completed successfully, and `rg` checks confirm the new `app-deploy`/`dspace-oci-deploy` examples exist in docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb2002b0832fbe7ffd860a482b38)