### PR TITLE
docs: add DSPACE Sugarkube release runbook and CI image-tag summary

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -324,6 +324,21 @@ jobs:
           echo "version_tag=${version_tag}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
 
+      - name: Summarize image tags
+        run: |
+          {
+            echo "## DSPACE image tags"
+            echo ""
+            echo "| Purpose | Value |"
+            echo "| --- | --- |"
+            echo "| Immutable image tag | `${{ steps.tags.outputs.sha_tag }}` |"
+            echo "| Mutable branch convenience tag | `${{ steps.tags.outputs.latest_tag }}` |"
+            echo "| Version convenience tag | `${{ steps.tags.outputs.version_tag }}` |"
+            echo "| Short SHA | `${{ steps.tags.outputs.short_sha }}` |"
+            echo ""
+            echo "Use the immutable branch/SHA tag for Sugarkube staging sign-off."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Set image build version
         id: build_version
         run: |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Create quests, items, and processes for the game:
 ### Operations & Deployment
 
 - [Operations Runbooks](./docs/ops/README.md) - Deployment and maintenance procedures
+  - [Sugarkube Release Runbook](./docs/ops/sugarkube-release.md) - Staging/prod release flow
+    from GHCR image and OCI chart artifacts
   - [Raspberry Pi Deployment](./docs/ops/RPI_DEPLOYMENT_GUIDE.md) - Deploy on Raspberry Pi with k3s
   - [Docker Deployment](./docs/ops/deploy/docker.md) - Container-based deployment
   - [Monitoring Setup](./docs/ops/monitoring_setup.md) - Prometheus and Grafana
@@ -165,6 +167,7 @@ Prompts for AI-assisted development:
 We welcome contributions! See our [Contributing Guide](./CONTRIBUTING.md) to get started.
 
 Key contribution areas:
+
 - Create quests, items, and processes
 - Improve documentation
 - Fix bugs and add features

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -25,8 +25,8 @@ settings.
 - `serviceAccount.create`: Create a service account for the deployment. Defaults to `true` with
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
-  `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-  RuntimeDefault`.
+  `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and
+  `seccompProfile: RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for
@@ -40,6 +40,13 @@ settings.
 
 For development, `charts/dspace/values.dev.yaml` enables ingress and sets a placeholder host:
 `dspace-v3.example.dev`. Override this host for your own environment.
+
+## Sugarkube release source of truth
+
+For staging and production releases, use the mature Sugarkube flow documented in
+[`docs/ops/sugarkube-release.md`](./ops/sugarkube-release.md). This chart page stays focused on
+Helm chart values and direct install examples; the runbook owns the image tag selection, staging
+deploy, production promotion, validation, and rollback steps.
 
 ## Common commands
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -10,6 +10,7 @@ incidents, or performing maintenance.
 - [Cloudflare load balancing](./cloudflare_load_balancing.md)
 - [Deployments](./deploy/)
 - [Release procedure](../merge-plan.md)
+- [Sugarkube release and deploy runbook](./sugarkube-release.md)
 - Release-management QA quick links:
   - [Patch checklist (`v3.0.1`)](../qa/v3.0.1.md)
   - [Feature checklist (`v3.1`)](../qa/v3.1.md)

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,0 +1,141 @@
+# DSPACE Sugarkube release and deploy runbook
+
+DSPACE is the mature Sugarkube baseline. Keep the release path boring: publish the existing
+GHCR image and Helm chart from this repository, then deploy those immutable artifacts from a
+Sugarkube checkout. This page is the steady-state release source of truth; the older dev,
+staging, and production runbooks remain useful for environment details and troubleshooting.
+
+## Release contract
+
+| Artifact        | Current DSPACE location                         | Notes                                                                  |
+| --------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| Image           | `ghcr.io/democratizedspace/dspace`              | Published by `.github/workflows/ci-image.yml` on `main` and `v3`.      |
+| Chart           | `oci://ghcr.io/democratizedspace/charts/dspace` | Published by `.github/workflows/ci-helm.yml` from `charts/dspace`.     |
+| Chart version   | `charts/dspace/Chart.yaml`                      | Keep in sync with `docs/apps/dspace.version` for Sugarkube automation. |
+| Staging host    | `https://staging.democratized.space`            | Uses Sugarkube staging values and QA-friendly staging config.          |
+| Production host | `https://democratized.space`                    | Uses Sugarkube production values and QA cheats off.                    |
+
+## Image tags to preserve
+
+The image workflow intentionally publishes all of these tags. Do not remove or rename them when
+polishing release docs or workflow summaries.
+
+- Immutable branch/SHA tag: `main-<shortsha>` or `v3-<shortsha>`.
+- Mutable branch convenience tag: `main-latest` or `v3-latest`.
+- Version convenience tag: `v<package.version>` such as `v3.0.1`.
+
+For staging and production sign-off, prefer the immutable branch/SHA tag. Mutable tags are useful
+for discovery and quick checks, but they should not be the tag recorded as an approved release
+candidate.
+
+## Current release workflow
+
+1. Open the **Build and publish GHCR image** (`ci-image.yml`) workflow run for the desired commit
+   and branch (`main` or `v3`).
+2. Confirm the image workflow succeeded, including the image push and image verification steps.
+3. Copy the immutable image tag printed in the workflow summary, for example
+   `ghcr.io/democratizedspace/dspace:main-REPLACE_SHORTSHA`. If the run predates the summary,
+   copy the branch/SHA tag from GHCR.
+4. Confirm the chart version in `charts/dspace/Chart.yaml` and/or the **Publish Helm chart**
+   (`ci-helm.yml`) workflow run. The current chart is deployed from
+   `oci://ghcr.io/democratizedspace/charts/dspace`.
+5. From a Sugarkube checkout, deploy staging with the DSPACE compatibility recipe:
+
+   ```bash
+   cd ~/sugarkube
+   just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+   ```
+
+   Use the appropriate branch prefix for the artifact you copied, for example:
+
+   ```bash
+   just dspace-oci-deploy env=staging tag=v3-REPLACE_SHORTSHA
+   ```
+
+6. Promote production only after staging sign-off. Use the existing DSPACE production promotion
+   recipe with either the current release/chart-aligned tag:
+
+   ```bash
+   just dspace-oci-promote-prod tag=3.0.1
+   ```
+
+   Or promote the exact immutable candidate that passed staging:
+
+   ```bash
+   just dspace-oci-promote-prod tag=main-REPLACE_SHORTSHA
+   ```
+
+7. After Sugarkube P5 lands, the generic app recipes should become the preferred spelling while
+   the app-specific DSPACE commands remain compatibility shims:
+
+   ```bash
+   just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+   just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+   ```
+
+## Validate staging
+
+After a staging deploy, verify rollout status from Sugarkube or with the environment-specific
+staging runbook, then check the public runtime endpoints:
+
+```bash
+curl -fsS https://staging.democratized.space/config.json | jq .
+curl -fsS https://staging.democratized.space/healthz | jq .
+curl -fsS https://staging.democratized.space/livez | jq .
+```
+
+Record the immutable image tag, commit SHA, chart version, validation timestamp, and QA checklist
+result before promoting production.
+
+## Validate production
+
+After promotion, verify production with the same runtime endpoints:
+
+```bash
+curl -fsS https://democratized.space/config.json | jq .
+curl -fsS https://democratized.space/healthz | jq .
+curl -fsS https://democratized.space/livez | jq .
+```
+
+If production validation fails, capture logs and roll back to the prior known-good immutable tag.
+
+## Rollback
+
+Rollback is an explicit redeploy of the previous immutable tag. Do not roll back by guessing a
+mutable tag such as `main-latest`.
+
+```bash
+cd ~/sugarkube
+just dspace-oci-deploy env=staging tag=main-PREVIOUS_SHORTSHA
+just dspace-oci-promote-prod tag=main-PREVIOUS_SHORTSHA
+```
+
+After Sugarkube P5, the generic spelling should be equivalent:
+
+```bash
+just app-deploy app=dspace env=staging tag=main-PREVIOUS_SHORTSHA
+just app-promote-prod app=dspace tag=main-PREVIOUS_SHORTSHA
+```
+
+## Cloudflare, DNS, and tunnels are separate
+
+Helm deploys the DSPACE Kubernetes release. Cloudflare DNS records, load-balancer settings, and
+tunnel lifecycle are separate infrastructure concerns. Keep route or DNS changes in the relevant
+Cloudflare/Sugarkube operations flow, then return to this runbook for image/chart deploys.
+
+## Local Docker builds
+
+Local Docker builds are for development, smoke testing, and debugging only. They are not the
+normal Sugarkube staging or production release path. Staging and production should consume the
+multi-arch GHCR image from `ci-image.yml` and the OCI Helm chart from `ci-helm.yml`.
+
+For local-only testing, use the Docker and Kubernetes development docs, but do not treat a local
+image tag as a release artifact unless it has gone through the GHCR publishing workflow above.
+
+## Related docs
+
+- [Helm chart docs](../charts.md)
+- [Kubernetes manifests](../../infra/k8s/README.md)
+- [Sugarkube staging runbook](../k3s-sugarkube-staging.md)
+- [Sugarkube production runbook](../k3s-sugarkube-prod.md)
+- [Operations runbook index](./README.md)

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,7 +1,9 @@
 # Kubernetes Manifests for DSPACE
 
-These manifests deploy the `dspace-app` container built from the root `Dockerfile`. They match the
-k3s + sugarkube deployment documented in [`docs/k3s-sugarkube-staging.md`](../../docs/k3s-sugarkube-staging.md)
+These manifests deploy the `dspace-app` container built from the root `Dockerfile`. For the
+steady-state Sugarkube staging and production release path, use the shared
+[Sugarkube release runbook](../../docs/ops/sugarkube-release.md). Environment-specific
+k3s details remain documented in [`docs/k3s-sugarkube-staging.md`](../../docs/k3s-sugarkube-staging.md)
 for the staging cluster.
 
 The container exposes port **8080** and provides health endpoints at `/healthz` (readiness)
@@ -17,7 +19,8 @@ kubectl apply -f infra/k8s/
 
 ## Building locally
 
-To build and load the image locally for k3s:
+Local Docker builds are for local development and debugging only; they are not the normal
+Sugarkube staging or production release path. To build and load the image locally for k3s:
 
 ```bash
 docker build -t dspace-app:latest .


### PR DESCRIPTION
### Motivation

- Provide a single, steady-state runbook that documents the mature DSPACE Sugarkube release flow (GHCR image + OCI Helm chart) so releases align with the shared Sugarkube contract used by other apps. 
- Preserve the existing, validated DSPACE release behavior (branch-SHA immutable tags, branch-latest, version tags, and chart publishing) while making the operator steps explicit for staging/prod and future generic Sugarkube commands.

### Description

- Add `docs/ops/sugarkube-release.md` as the canonical Sugarkube release/deploy runbook describing image/chart locations, preserved tag formats, staging deploy, production promotion, validation endpoints, rollback, Cloudflare/DNS separation, and local-Docker scope. 
- Link the new runbook from `docs/ops/README.md`, the repo `README.md` operations index, `docs/charts.md`, and `infra/k8s/README.md` so documentation discovery points to the runbook as the release source of truth. 
- Add a low-risk summary step to `.github/workflows/ci-image.yml` that writes the immutable image tag, mutable branch tag, version tag, and short SHA to the GitHub Actions step summary for operator convenience. 
- Make only documentation and workflow-summary edits; no runtime code, Dockerfile, chart publishing, or chart/default behavior changes were made, and existing branch/tag support is preserved.

### Testing

- Ran `git diff --check` with no issues reported. (passed)
- Ran `pnpm install --frozen-lockfile --reporter=append-only` to validate lockfile and workspace; installation completed successfully. (passed)
- Attempted `pnpm run helm:lint` and `pnpm run helm:template` but both were blocked because `helm` is not installed in the environment; charts were not modified and CI will run these steps. (blocked: `helm` not found)
- Ran formatting and link checks: `pnpm run format:check` and `npm run link-check` and `npx prettier --check ...` which succeeded after minor automated formatting; all local markdown links resolved and Prettier checks passed. (passed)
- Verified docs/search strings with ripgrep: `rg -n "app-deploy app=dspace" docs README.md infra || true` and `rg -n "dspace-oci-deploy env=staging" docs README.md infra` to confirm examples exist in docs. (passed)

Residual notes

- The change intentionally keeps the existing image/chart publish flows and tag shapes; operators should continue to copy the immutable `branch-shortsha` tag from the `ci-image.yml` run or GHCR and use the existing `just dspace-oci-deploy` / `just dspace-oci-promote-prod` recipes until Sugarkube P5 introduces generic `just app-*` recipes.
- `helm`-dependent checks could not be run in this environment and should be validated in CI or a local environment with `helm` installed before merging if required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb2002b0832fbe7ffd860a482b38)