### PR TITLE
docs: design token.place Chat integration for v3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,17 +357,24 @@ Run `npm test` to verify configuration stays in sync.
 
 ## Historical changelog policy
 
+- Default: do not create, update, or append changelog entries unless the human task prompt
+  explicitly requests changelog work. Do not infer that a feature, fix, patch, minor release,
+  major release, or release-like change requires a changelog update.
+- Human release-engineer instructions control SemVer level and changelog scope. Do not infer
+  major/minor/patch level, invent a release date, create a changelog file, or append changelog
+  notes without explicit human direction. If this AGENTS.md guidance and a narrower human task
+  prompt conflict, the explicit human task prompt controls for that task.
+- When the human task prompt explicitly names a new changelog file/date, create or use that file
+  exactly as requested.
+- When the human task prompt explicitly requests a patch changelog update without naming a new
+  file, append/update the appropriate existing changelog entry.
 - Treat published changelog markdown under `frontend/src/pages/docs/md/changelog/` as
   immutable narrative history.
 - Only fix typos, spacing, or broken links in historical files — document those adjustments in
   `frontend/tests/fixtures/changelogCorrections.json` and refresh the associated snapshots.
-- Patch updates append addenda or UI notes to the latest relevant changelog entry instead of
-  creating a new dated changelog file. When you need to reference newer context from an older
-  release, add an entry to `frontend/src/utils/changelogNotes.ts` so the UI appends a note at
-  render time instead of editing the archived markdown body.
-- Major and minor versions require new dated changelog markdown files under
-  `frontend/src/pages/docs/md/changelog/` (for example, `20260801.md` for a dated v3.1 minor
-  release entry).
+- When explicitly requested changelog work needs to reference newer context from an older release,
+  add an entry to `frontend/src/utils/changelogNotes.ts` so the UI appends a note at render time
+  instead of editing the archived markdown body.
 
 ## Additional Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,9 +361,13 @@ Run `npm test` to verify configuration stays in sync.
   immutable narrative history.
 - Only fix typos, spacing, or broken links in historical files — document those adjustments in
   `frontend/tests/fixtures/changelogCorrections.json` and refresh the associated snapshots.
-- When you need to reference newer context from an older release, add an entry to
-  `frontend/src/utils/changelogNotes.ts` so the UI appends a note at render time instead of
-  editing the archived markdown body.
+- Patch updates append addenda or UI notes to the latest relevant changelog entry instead of
+  creating a new dated changelog file. When you need to reference newer context from an older
+  release, add an entry to `frontend/src/utils/changelogNotes.ts` so the UI appends a note at
+  render time instead of editing the archived markdown body.
+- Major and minor versions require new dated changelog markdown files under
+  `frontend/src/pages/docs/md/changelog/` (for example, `20260801.md` for a dated v3.1 minor
+  release entry).
 
 ## Additional Resources
 

--- a/docs/design/token-place-chat-v3.1.md
+++ b/docs/design/token-place-chat-v3.1.md
@@ -7,8 +7,8 @@ OpenAI API key, and no per-token cost concern. The default chat provider must be
 token.place API v1. OpenAI remains supported only as an explicit opt-in provider selected from
 `/settings` with the user's own API key.
 
-This document is planning-only for prompts 2-7. It should make the later implementation prompts
-safe without changing production behavior yet.
+This document is planning-only for the staged implementation sequence below. It should make the
+later implementation work safe without changing production behavior yet.
 
 Non-goals and hard constraints:
 
@@ -16,7 +16,9 @@ Non-goals and hard constraints:
 - Do not add streaming; API v1 is non-streaming and rejects `stream: true`.
 - Do not use the token.place npm package or add a token.place runtime dependency.
 - Do not send, store, or request a token.place API key.
-- Do not use legacy `/api/chat`, `/chat`, relay sink/source/faucet, or other legacy relay paths.
+- Do not use legacy token.place/backend `/api/chat`, token.place/backend `/chat`, relay
+  sink/source/faucet, or other legacy relay paths. This does not prohibit the DSPACE `/chat`
+  UI route.
 - Do not reintroduce OpenAI as the default provider during rollback.
 
 ## Current DSPACE Chat state
@@ -31,10 +33,11 @@ parallel token.place panel:
   `TokenPlaceChat` when `isTokenPlaceEnabled()` returns true. When token.place is disabled it
   shows a banner saying token.place is coming in v3.1.
 - `frontend/src/pages/chat/svelte/OpenAIChat.svelte` owns the full production NPC chat UI:
-  persona selector, welcome messages, avatars, save-snapshot hints, debug/prompt UI,
+  persona selector, welcome messages, avatars, save-snapshot hints, debug payload UI,
   docs-RAG build metadata, spinner/error banners, shared chat stores, and response source display.
-- `frontend/src/utils/openAI.js` owns the mature prompt/RAG/player-state pipeline:
-  `buildChatPrompt()`, persona system prompts, `PlayerState` snapshots, curated knowledge pack,
+- `frontend/src/utils/openAI.js` owns the mature message-building/RAG/player-state pipeline:
+  the existing chat message builder, persona system messages, `PlayerState` snapshots, curated
+  knowledge pack,
   docs RAG, context source merging, response validation/sanitization, OpenAI error summaries,
   and `GPT5ChatV2()`.
 - `frontend/src/pages/chat/svelte/TokenPlaceChat.svelte` is a simpler parallel chat UI with a
@@ -57,7 +60,7 @@ parallel token.place panel:
   upgrade, and data reset panels, but not chat provider selection or OpenAI key management.
 - `frontend/__tests__/tokenPlace.test.js` tests the legacy opt-in flag, legacy `/chat` endpoint,
   `{ reply }` parsing, and disabled-by-default behavior. Those tests should be replaced or
-  updated in prompt 2.
+  updated in the client-layer phase.
 - Relevant Playwright coverage currently assumes OpenAI by default in specs such as
   `frontend/e2e/chat-message-flow.spec.ts`, `frontend/e2e/chat-rag-context.spec.ts`, and
   `frontend/e2e/chat-persona-switching.spec.ts`. `frontend/e2e/token-place-chat-banners.spec.ts`
@@ -99,7 +102,7 @@ Implementation should use direct HTTPS `fetch` calls to token.place API v1:
 Forbidden integration targets:
 
 - No `/api/chat`.
-- No bare `/chat`.
+- No bare token.place/backend `/chat`.
 - No legacy `/sink`, `/source`, `/faucet`, `/retrieve`, or `/next_server` fallbacks.
 - No API v2 routes such as `/api/v2/chat/completions` or `/v2/chat/completions`.
 - No streaming/SSE code paths.
@@ -129,13 +132,14 @@ Normalization rules:
 - Do not migrate or rename existing OpenAI keys in v3.1; simply continue reading/writing
   `openAI.apiKey` from the new settings panel.
 - Treat old `state.tokenPlace.enabled` and `VITE_TOKEN_PLACE_ENABLED` behavior as legacy only.
-  Those flags must not disable default v3.1 Chat. Prompt 2 can keep compatibility helpers for old
-  tests if needed, but provider selection should not depend on `tokenPlace.enabled`.
+  Those flags must not disable default v3.1 Chat. The client-layer phase can keep compatibility
+  helpers for old tests if needed, but provider selection should not depend on
+  `tokenPlace.enabled`.
 - A token.place base URL may be read from an environment variable such as `VITE_TOKEN_PLACE_URL`
   or the existing compatibility field `state.tokenPlace.url`. Normalize it as an origin:
   `https://token.place` by default, `https://staging.token.place` for staging, or an explicit test
   override. The API client appends `/api/v1/chat/completions`.
-- There must be no `tokenPlace.apiKey`, token.place credential prompt, or token.place
+- There must be no `tokenPlace.apiKey`, token.place credential form, or token.place
   `Authorization` header.
 - Recommended optional model override: `VITE_TOKEN_PLACE_CHAT_MODEL`, defaulting to
   `gpt-5-chat-latest`. Do not make the model a user-facing key-management setting in v3.1.
@@ -162,7 +166,7 @@ UI ownership changes:
   simpler UI.
 - The active panel should expose a stable provider marker such as
   `data-provider="token-place"` or `data-provider="openai"` for Playwright tests.
-- The persona selector, welcome messages, avatars, save-snapshot hints, debug prompt payload,
+- The persona selector, welcome messages, avatars, save-snapshot hints, debug message payload,
   docs-RAG metadata, source display, and player-state summary should continue to work regardless
   of provider.
 - Debug payload should show the actual message payload sent to the selected provider. For
@@ -172,9 +176,9 @@ UI ownership changes:
 
 ## Proposed implementation sequence
 
-This sequence matches prompts 2-7 and keeps each PR reviewable:
+This sequence keeps each implementation PR reviewable:
 
-1. **Prompt 2: token.place API v1 client layer**
+1. **Phase 1: token.place API v1 client layer**
    - Replace legacy `/chat` fetch logic with a `POST /api/v1/chat/completions` client.
    - Build direct `fetch` requests with `Content-Type: application/json` only.
    - Include `model` and OpenAI-compatible `messages`.
@@ -184,31 +188,33 @@ This sequence matches prompts 2-7 and keeps each PR reviewable:
      content policy, rate limit, URL normalization, model default, abort signal, and absence of
      Authorization/token.place API key headers.
 
-2. **Prompt 3: Settings provider configuration**
+2. **Phase 2: Settings provider configuration**
    - Add `settings.chatProvider` normalization/defaulting.
    - Move OpenAI key management to `/settings` while continuing to store `openAI.apiKey`.
    - Add a settings panel for provider selection: token.place default, OpenAI opt-in.
    - Persist provider preference and key changes through existing game-state storage.
 
-3. **Prompt 4: Single NPC chat UI**
+3. **Phase 3: Single NPC chat UI**
    - Refactor the full NPC/persona/debug UI into one provider-aware chat panel.
    - Default fresh users to token.place.
    - Use OpenAI only when `settings.chatProvider === 'openai'`.
    - Remove `OpenAIAPIKeySettings` from `/chat`.
    - Retire or reduce `TokenPlaceChat.svelte` to a compatibility wrapper only if needed.
 
-4. **Prompt 5: Unit and e2e coverage**
+4. **Phase 4: Unit and e2e coverage**
    - Update OpenAI-by-default Playwright tests to select OpenAI in settings when testing OpenAI.
    - Add fresh-user token.place default tests with fetch stubs.
    - Add settings persistence and provider switching tests.
    - Add error banner tests for token.place network/provider/content-policy/rate-limit failures.
 
-5. **Prompt 6: User-facing docs and release QA**
+5. **Phase 5: User-facing docs and release QA**
    - Update Chat and Settings docs for token.place default and OpenAI opt-in.
-   - Create the `20260801` changelog entry following the historical changelog policy.
+   - Create the `frontend/src/pages/docs/md/changelog/20260801.md` changelog entry for the v3.1
+     minor release. The historical changelog policy only appends patch updates to existing
+     changelog files; major and minor versions require new dated changelog files.
    - Flesh out `docs/qa/v3.1.md` with staging/prod verification steps and expected results.
 
-6. **Prompt 7: Cleanup and hardening**
+6. **Phase 6: Cleanup and hardening**
    - Audit legacy routes and stale flags.
    - Remove dead token.place `/chat` assumptions.
    - Verify staging/prod base URLs, model override, and no credential leakage.
@@ -226,9 +232,12 @@ This sequence matches prompts 2-7 and keeps each PR reviewable:
   `status`, `error.type`, `error.code`, `error.param`, and `error.message`, and map known cases to
   clear banners. HTTP 429 should be a rate-limit banner. `content_policy_violation` should explain
   that token.place blocked the request by policy.
-- **Preserving RAG/player-state/persona behavior:** reuse `buildChatPrompt()` or extract its
-  provider-neutral pieces so token.place receives the same system/persona/player-state/docs-RAG
-  context as OpenAI. Do not regress debug payload, source display, or response sanitization.
+- **Preserving RAG/player-state/persona behavior:** before sharing the existing message-building
+  path with token.place, update or remove provider-specific reality guidance such as the
+  `providerRealityLine` that says OpenAI is the v3 provider and token.place is deferred. Then
+  reuse only provider-neutral message-building pieces, or extract them, so token.place receives
+  accurate system/persona/player-state/docs-RAG context. Update guardrail tests for the new
+  provider reality and do not regress debug payload, source display, or response sanitization.
 - **No OpenAI key or Authorization header to token.place:** keep token.place and OpenAI client
   functions separate. token.place requests should set only content headers and should never read
   `state.openAI.apiKey`. Unit tests must assert no `Authorization` header and no token.place API
@@ -275,7 +284,7 @@ Playwright/e2e tests:
 - Existing chat persona, debug navigation, build stamp, and docs-RAG tests are updated to run
   against the provider-aware panel or explicitly opt into OpenAI where needed.
 
-Manual/staging checks for prompt 6/7:
+Manual/staging checks for release QA and hardening:
 
 - Staging `/chat` defaults to token.place against `https://staging.token.place` when configured.
 - Production `/chat` defaults to `https://token.place`.
@@ -293,7 +302,7 @@ Manual/staging checks for prompt 6/7:
   opt-in to OpenAI.
 - Keep the v3.1 data model stable so future fixes do not churn saved settings.
 
-## Implementation checklist for later prompts
+## Implementation checklist for later phases
 
 - [ ] token.place default provider is represented as `settings.chatProvider = 'token-place'`.
 - [ ] OpenAI opt-in is represented as `settings.chatProvider = 'openai'` plus `openAI.apiKey`.
@@ -302,4 +311,4 @@ Manual/staging checks for prompt 6/7:
 - [ ] token.place requests use `POST /api/v1/chat/completions`.
 - [ ] token.place responses parse `choices[0].message.content`.
 - [ ] API v2, streaming, token.place npm package integration, token.place auth/API keys, and
-      legacy `/api/chat` or `/chat` endpoints are absent.
+      legacy token.place/backend `/api/chat` or `/chat` endpoints are absent.

--- a/docs/design/token-place-chat-v3.1.md
+++ b/docs/design/token-place-chat-v3.1.md
@@ -212,8 +212,8 @@ This sequence keeps each implementation PR reviewable:
 5. **Phase 5: User-facing docs and release QA**
    - Update Chat and Settings docs for token.place default and OpenAI opt-in.
    - Create the `frontend/src/pages/docs/md/changelog/20260801.md` changelog entry for the v3.1
-     minor release. The historical changelog policy only appends patch updates to existing
-     changelog files; major and minor versions require new dated changelog files.
+     minor release (this is an explicit human-requested minor-release changelog entry, not a
+     general license for agents to create or update changelogs).
    - Flesh out `docs/qa/v3.1.md` with staging/prod verification steps and expected results.
 
 6. **Phase 6: Cleanup and hardening**

--- a/docs/design/token-place-chat-v3.1.md
+++ b/docs/design/token-place-chat-v3.1.md
@@ -85,22 +85,45 @@ Implementation should use direct HTTPS `fetch` calls to token.place API v1:
 ```
 
 - Response parsing: read `choices[0].message.content` from the OpenAI-compatible response.
+- Client return-shape contract:
+  - Keep `tokenPlaceChat(messages, options)` as a string-returning compatibility helper only if
+    existing callers/tests need it.
+  - Add or expose a richer helper that returns a stable object shaped exactly as
+    `{ text, contextSources, usage, metadata }`.
+  - `text` comes from `choices[0].message.content`.
+  - `contextSources` comes from DSPACE prompt/RAG context-source handling, not from token.place.
+  - `usage` comes from the token.place OpenAI-compatible response `usage` object when present.
+  - `metadata` comes from the token.place response `metadata` object when present.
 - API v1 is non-streaming. Do not send `stream: true`; if a future helper accepts options, force
   or omit `stream` rather than passing user-provided streaming options through.
+- API v1 rejects `stream: true` with a structured OpenAI-style error whose `param` is `stream`.
 - Prefer model `gpt-5-chat-latest` for DSPACE compatibility. token.place's public integration
   test sends a DSPACE-style request with this model and asserts the same response model and a
   non-empty `choices[0].message.content`; token.place's model aliases route
   `gpt-5-chat-latest` to the canonical API v1 launch backend.
 - API v1 returns structured OpenAI-style errors as `{ error: { message, type, param?, code? } }`.
   The client should preserve status/type/code/message for UI summaries and tests.
+- API v1 validates `model` and `messages`; validation failures should stay classified as
+  structured provider errors internally.
 - Content moderation can return `error.type = "content_policy_violation"` and
   `error.code = "content_blocked"`.
 - Rate limits and daily quotas may surface as HTTP 429 provider errors. Preserve response status
   even when parsing fails.
+- Metadata behavior is limited to the current API v1 JSON echo behavior:
+  - token.place echoes request `metadata` into the response only when request `metadata` is a
+    non-empty object.
+  - token.place `tests/integration/test_dspace_chat_alias.py` includes a metadata round-trip test
+    using `{ client: "dspace", conversation_id: "conv-42" }`.
+  - DSPACE may send safe, non-secret metadata for correlation, for example
+    `{ client: "dspace", provider: "token.place" }` plus a local conversation id if useful.
+  - Metadata must not contain OpenAI keys, token.place credentials, player inventory details, raw
+    save data, or any secret.
+  - Do not treat metadata as arbitrary telemetry, analytics, auth, or billing metadata beyond the
+    current request/response JSON echo behavior.
 
 Forbidden integration targets:
 
-- No `/api/chat`.
+- No legacy token.place/backend `/api/chat`.
 - No bare token.place/backend `/chat`.
 - No legacy `/sink`, `/source`, `/faucet`, `/retrieve`, or `/next_server` fallbacks.
 - No API v2 routes such as `/api/v2/chat/completions` or `/v2/chat/completions`.
@@ -134,10 +157,15 @@ Normalization rules:
   Those flags must not disable default v3.1 Chat. The client-layer phase can keep compatibility
   helpers for old tests if needed, but provider selection should not depend on
   `tokenPlace.enabled`.
-- A token.place base URL may be read from an environment variable such as `VITE_TOKEN_PLACE_URL`
-  or the existing compatibility field `state.tokenPlace.url`. Normalize it as an origin:
-  `https://token.place` by default, `https://staging.token.place` for staging, or an explicit test
-  override. The API client appends `/api/v1/chat/completions`.
+- The token.place origin/base URL must use the existing DSPACE compatibility environment variable
+  `VITE_TOKEN_PLACE_URL`, or the existing compatibility field `state.tokenPlace.url` when needed.
+  Default to `https://token.place`; DSPACE staging should configure
+  `VITE_TOKEN_PLACE_URL=https://staging.token.place`; production should omit the override or
+  configure `VITE_TOKEN_PLACE_URL=https://token.place`.
+- Normalize token.place URL values before appending `/api/v1/chat/completions`: accept
+  origin-style values such as `https://token.place`, strip trailing slashes, tolerate legacy
+  `https://token.place/api` by normalizing it to the origin, and never produce
+  `/api/api/v1/chat/completions`.
 - There must be no `tokenPlace.apiKey`, token.place credential form, or token.place
   `Authorization` header.
 - Recommended optional model override: `VITE_TOKEN_PLACE_CHAT_MODEL`, defaulting to
@@ -175,13 +203,21 @@ UI ownership changes:
 - Any reuse or extraction from `buildChatPrompt()` must first audit, update, or remove the current
   `providerRealityLine` text that says v3 chat uses OpenAI and token.place is deferred to v3.1,
   so token.place default requests do not send stale provider-reality instructions.
+- Hard shared prompt/RAG requirement: token.place and OpenAI should receive the same DSPACE
+  persona, `PlayerState`, curated DSPACE knowledge, docs RAG, and context-source handling by
+  reusing or extracting the existing `buildChatPrompt()` path, but only after provider-reality
+  guidance is v3.1-accurate and either provider-neutral or provider-aware.
+- Test requirement: token.place request payloads and debug prompt payloads must not contain
+  "token.place is deferred", "chat uses OpenAI" as a default-provider claim, or equivalent stale
+  v3.0 wording.
 
 ## Proposed implementation sequence
 
 This sequence keeps each implementation PR reviewable:
 
 1. **Phase 1: token.place API v1 client layer**
-   - Replace legacy `/chat` fetch logic with a `POST /api/v1/chat/completions` client.
+   - Replace legacy token.place/backend `/chat` fetch logic with a
+     `POST /api/v1/chat/completions` client.
    - Build direct `fetch` requests with `Content-Type: application/json` only.
    - Include `model` and OpenAI-compatible `messages`.
    - Parse `choices[0].message.content`.
@@ -189,6 +225,8 @@ This sequence keeps each implementation PR reviewable:
    - Add unit tests for success parsing, malformed responses, network failure, HTTP errors,
      content policy, rate limit, URL normalization, model default, abort signal, and absence of
      Authorization/token.place API key headers.
+   - Cover the richer `{ text, contextSources, usage, metadata }` return shape, including API v1
+     `usage`/`metadata` passthrough and DSPACE-owned `contextSources`.
 
 2. **Phase 2: Settings provider configuration**
    - Add `settings.chatProvider` normalization/defaulting.
@@ -232,8 +270,11 @@ This sequence keeps each implementation PR reviewable:
   live network.
 - **Structured provider errors and rate limits:** parse JSON error payloads first, preserve
   `status`, `error.type`, `error.code`, `error.param`, and `error.message`, and map known cases to
-  clear banners. HTTP 429 should be a rate-limit banner. `content_policy_violation` should explain
-  that token.place blocked the request by policy.
+  internal classification while rendering only safe user-facing summaries rather than raw relay or
+  provider internals. HTTP 429 should be a rate/quota banner. Provider 5xx should be a
+  token.place/server unavailable banner. Malformed HTTP 200 responses missing usable
+  `choices[0].message.content` should be a malformed/provider response banner.
+  `content_policy_violation` should explain that token.place blocked the request by policy.
 - **Preserving RAG/player-state/persona behavior:** before sharing the existing message-building
   path with token.place, update or remove provider-specific reality guidance such as the
   `providerRealityLine` that says v3 chat uses OpenAI and token.place is deferred to v3.1. Then
@@ -294,7 +335,12 @@ Manual/staging checks for release QA and hardening:
 
 - Staging `/chat` defaults to token.place against `https://staging.token.place` when configured.
 - Production `/chat` defaults to `https://token.place`.
-- Browser devtools show no token.place `Authorization` header.
+- Local/dev tests use fetch stubs or explicit local/test overrides, not live token.place calls in
+  CI.
+- Browser devtools show `POST https://token.place/api/v1/chat/completions` in production, or the
+  staging equivalent, with no token.place `Authorization` header.
+- Browser devtools show a JSON body with `model`, `messages`, optional safe `metadata`, and
+  `stream` absent or `false`, never `true`.
 - Browser storage contains no token.place credential.
 - OpenAI remains available only after selecting OpenAI and saving an OpenAI key in `/settings`.
 

--- a/docs/design/token-place-chat-v3.1.md
+++ b/docs/design/token-place-chat-v3.1.md
@@ -36,8 +36,7 @@ parallel token.place panel:
   persona selector, welcome messages, avatars, save-snapshot hints, debug payload UI,
   docs-RAG build metadata, spinner/error banners, shared chat stores, and response source display.
 - `frontend/src/utils/openAI.js` owns the mature message-building/RAG/player-state pipeline:
-  the existing chat message builder, persona system messages, `PlayerState` snapshots, curated
-  knowledge pack,
+  `buildChatPrompt()`, persona system messages, `PlayerState` snapshots, curated knowledge pack,
   docs RAG, context source merging, response validation/sanitization, OpenAI error summaries,
   and `GPT5ChatV2()`.
 - `frontend/src/pages/chat/svelte/TokenPlaceChat.svelte` is a simpler parallel chat UI with a
@@ -173,6 +172,9 @@ UI ownership changes:
   token.place this should be the OpenAI-compatible `messages` array sent to API v1.
 - token.place responses should pass through the same DSPACE response validation and source-link
   sanitization currently used for OpenAI responses.
+- Any reuse or extraction from `buildChatPrompt()` must first audit, update, or remove the current
+  `providerRealityLine` text that says v3 chat uses OpenAI and token.place is deferred to v3.1,
+  so token.place default requests do not send stale provider-reality instructions.
 
 ## Proposed implementation sequence
 
@@ -234,10 +236,12 @@ This sequence keeps each implementation PR reviewable:
   that token.place blocked the request by policy.
 - **Preserving RAG/player-state/persona behavior:** before sharing the existing message-building
   path with token.place, update or remove provider-specific reality guidance such as the
-  `providerRealityLine` that says OpenAI is the v3 provider and token.place is deferred. Then
+  `providerRealityLine` that says v3 chat uses OpenAI and token.place is deferred to v3.1. Then
   reuse only provider-neutral message-building pieces, or extract them, so token.place receives
   accurate system/persona/player-state/docs-RAG context. Update guardrail tests for the new
-  provider reality and do not regress debug payload, source display, or response sanitization.
+  provider reality; token.place default requests and debug/system payloads must not contain stale
+  v3 OpenAI-default wording. Do not regress debug payload, source display, or response
+  sanitization.
 - **No OpenAI key or Authorization header to token.place:** keep token.place and OpenAI client
   functions separate. token.place requests should set only content headers and should never read
   `state.openAI.apiKey`. Unit tests must assert no `Authorization` header and no token.place API
@@ -264,6 +268,8 @@ Unit tests:
   `content_policy_violation` payloads.
 - token.place client does not include an `Authorization` header, OpenAI API key, or token.place API
   key in headers/body.
+- token.place default request payloads and debug/system payload views do not include stale
+  provider guidance that says v3 chat uses OpenAI or token.place is deferred to v3.1.
 - provider selection helper chooses token.place for fresh/invalid settings and OpenAI only for
   explicit `settings.chatProvider === 'openai'`.
 - OpenAI selected without a saved key returns a guidance state instead of calling OpenAI.

--- a/docs/design/token-place-chat-v3.1.md
+++ b/docs/design/token-place-chat-v3.1.md
@@ -1,0 +1,305 @@
+# DSPACE v3.1 token.place Chat Integration Design
+
+## Goal and non-goals
+
+DSPACE v3.1.0 should make `/chat` work immediately for fresh users with no auth, no
+OpenAI API key, and no per-token cost concern. The default chat provider must be
+token.place API v1. OpenAI remains supported only as an explicit opt-in provider selected from
+`/settings` with the user's own API key.
+
+This document is planning-only for prompts 2-7. It should make the later implementation prompts
+safe without changing production behavior yet.
+
+Non-goals and hard constraints:
+
+- Do not use token.place API v2.
+- Do not add streaming; API v1 is non-streaming and rejects `stream: true`.
+- Do not use the token.place npm package or add a token.place runtime dependency.
+- Do not send, store, or request a token.place API key.
+- Do not use legacy `/api/chat`, `/chat`, relay sink/source/faucet, or other legacy relay paths.
+- Do not reintroduce OpenAI as the default provider during rollback.
+
+## Current DSPACE Chat state
+
+The v3.0.1-era chat implementation is split between an OpenAI-first NPC chat and a simpler
+parallel token.place panel:
+
+- `frontend/src/pages/chat/index.astro` renders `TokenBadge` and `Integrations` inside the Chat
+  page shell.
+- `frontend/src/pages/chat/svelte/Integrations.svelte` currently loads the saved OpenAI key,
+  always renders `OpenAIAPIKeySettings` and `OpenAIChat`, and only conditionally renders
+  `TokenPlaceChat` when `isTokenPlaceEnabled()` returns true. When token.place is disabled it
+  shows a banner saying token.place is coming in v3.1.
+- `frontend/src/pages/chat/svelte/OpenAIChat.svelte` owns the full production NPC chat UI:
+  persona selector, welcome messages, avatars, save-snapshot hints, debug/prompt UI,
+  docs-RAG build metadata, spinner/error banners, shared chat stores, and response source display.
+- `frontend/src/utils/openAI.js` owns the mature prompt/RAG/player-state pipeline:
+  `buildChatPrompt()`, persona system prompts, `PlayerState` snapshots, curated knowledge pack,
+  docs RAG, context source merging, response validation/sanitization, OpenAI error summaries,
+  and `GPT5ChatV2()`.
+- `frontend/src/pages/chat/svelte/TokenPlaceChat.svelte` is a simpler parallel chat UI with a
+  fixed dChat persona. It currently calls `tokenPlaceChat()` and does not preserve the full
+  OpenAIChat persona/debug/docs-RAG UX.
+- `frontend/src/utils/tokenPlace.js` currently treats token.place as opt-in via
+  `VITE_TOKEN_PLACE_ENABLED` or `state.tokenPlace.enabled`, defaults to
+  `https://token.place/api`, and posts to the legacy `${baseUrl}/chat` path expecting
+  `{ reply }`.
+- `frontend/src/utils/tokenPlaceErrors.js` maps disabled, network, provider, and unknown errors,
+  but does not yet cover API v1 structured errors such as content policy and rate limits.
+- `frontend/src/pages/chat/svelte/OpenAIAPIKeySettings.svelte` currently lives on `/chat` and
+  saves the key to `state.openAI.apiKey`.
+- `frontend/src/utils/settingsDefaults.js` currently normalizes only
+  `showChatDebugPayload` and `showQuestGraphVisualizer`; there is no `settings.chatProvider`.
+- `frontend/src/utils/gameState/common.js` already normalizes persisted `settings` through
+  `normalizeSettings()`, so adding a chat provider setting belongs there rather than in ad hoc UI
+  state.
+- `frontend/src/pages/settings.astro` currently hosts logout, QA cheats, quest graph, legacy
+  upgrade, and data reset panels, but not chat provider selection or OpenAI key management.
+- `frontend/__tests__/tokenPlace.test.js` tests the legacy opt-in flag, legacy `/chat` endpoint,
+  `{ reply }` parsing, and disabled-by-default behavior. Those tests should be replaced or
+  updated in prompt 2.
+- Relevant Playwright coverage currently assumes OpenAI by default in specs such as
+  `frontend/e2e/chat-message-flow.spec.ts`, `frontend/e2e/chat-rag-context.spec.ts`, and
+  `frontend/e2e/chat-persona-switching.spec.ts`. `frontend/e2e/token-place-chat-banners.spec.ts`
+  covers the existing opt-in token.place panel and banners.
+
+## token.place API v1 contract
+
+Implementation should use direct HTTPS `fetch` calls to token.place API v1:
+
+- Production origin: `https://token.place`
+- Staging origin: `https://staging.token.place`
+- Endpoint: `POST /api/v1/chat/completions`
+- Request body: OpenAI-compatible JSON with at least:
+
+```json
+{
+  "model": "gpt-5-chat-latest",
+  "messages": [
+    { "role": "system", "content": "..." },
+    { "role": "user", "content": "..." }
+  ]
+}
+```
+
+- Response parsing: read `choices[0].message.content` from the OpenAI-compatible response.
+- API v1 is non-streaming. Do not send `stream: true`; if a future helper accepts options, force
+  or omit `stream` rather than passing user-provided streaming options through.
+- Prefer model `gpt-5-chat-latest` for DSPACE compatibility. token.place's public integration
+  test sends a DSPACE-style request with this model and asserts the same response model and a
+  non-empty `choices[0].message.content`; token.place's model aliases route
+  `gpt-5-chat-latest` to the canonical API v1 launch backend.
+- API v1 returns structured OpenAI-style errors as `{ error: { message, type, param?, code? } }`.
+  The client should preserve status/type/code/message for UI summaries and tests.
+- Content moderation can return `error.type = "content_policy_violation"` and
+  `error.code = "content_blocked"`.
+- Rate limits and daily quotas may surface as HTTP 429 provider errors. Preserve response status
+  even when parsing fails.
+
+Forbidden integration targets:
+
+- No `/api/chat`.
+- No bare `/chat`.
+- No legacy `/sink`, `/source`, `/faucet`, `/retrieve`, or `/next_server` fallbacks.
+- No API v2 routes such as `/api/v2/chat/completions` or `/v2/chat/completions`.
+- No streaming/SSE code paths.
+- No token.place npm package integration.
+- No token.place `Authorization` header or token.place API key field.
+
+## Proposed DSPACE data model
+
+Add one provider-selection field under persisted settings:
+
+```ts
+type ChatProvider = 'token-place' | 'openai';
+
+settings: {
+  chatProvider: ChatProvider;
+  showChatDebugPayload: boolean;
+  showQuestGraphVisualizer: boolean;
+}
+```
+
+Normalization rules:
+
+- `settings.chatProvider` allowed values are exactly `token-place` and `openai`.
+- Missing, null, unknown, or invalid `settings.chatProvider` normalizes to `token-place`.
+- The default in `DEFAULT_SETTINGS` should be `chatProvider: 'token-place'`.
+- Keep `state.openAI.apiKey` as the OpenAI key storage location for backwards compatibility.
+- Do not migrate or rename existing OpenAI keys in v3.1; simply continue reading/writing
+  `openAI.apiKey` from the new settings panel.
+- Treat old `state.tokenPlace.enabled` and `VITE_TOKEN_PLACE_ENABLED` behavior as legacy only.
+  Those flags must not disable default v3.1 Chat. Prompt 2 can keep compatibility helpers for old
+  tests if needed, but provider selection should not depend on `tokenPlace.enabled`.
+- A token.place base URL may be read from an environment variable such as `VITE_TOKEN_PLACE_URL`
+  or the existing compatibility field `state.tokenPlace.url`. Normalize it as an origin:
+  `https://token.place` by default, `https://staging.token.place` for staging, or an explicit test
+  override. The API client appends `/api/v1/chat/completions`.
+- There must be no `tokenPlace.apiKey`, token.place credential prompt, or token.place
+  `Authorization` header.
+- Recommended optional model override: `VITE_TOKEN_PLACE_CHAT_MODEL`, defaulting to
+  `gpt-5-chat-latest`. Do not make the model a user-facing key-management setting in v3.1.
+
+## Proposed UI and provider flow
+
+`/chat` should show exactly one NPC chat panel:
+
+1. Load normalized settings from game state.
+2. If `settings.chatProvider` is missing or invalid, treat it as `token-place`.
+3. If provider is `token-place`, submit through the token.place API v1 client.
+4. If provider is `openai`, submit through the existing OpenAI client only when
+   `state.openAI.apiKey` is present.
+5. If provider is `openai` and no key is saved, show a helpful guidance state that links to
+   `/settings` and explains that OpenAI requires the user's API key. Do not make a broken OpenAI
+   request with an empty key.
+
+UI ownership changes:
+
+- `/chat` does not show the OpenAI API key form.
+- `/settings` owns provider selection and OpenAI key management.
+- Preserve the mature `OpenAIChat.svelte` NPC/persona/debug UI by refactoring it into a
+  provider-agnostic chat panel or wrapper instead of building from `TokenPlaceChat.svelte`'s
+  simpler UI.
+- The active panel should expose a stable provider marker such as
+  `data-provider="token-place"` or `data-provider="openai"` for Playwright tests.
+- The persona selector, welcome messages, avatars, save-snapshot hints, debug prompt payload,
+  docs-RAG metadata, source display, and player-state summary should continue to work regardless
+  of provider.
+- Debug payload should show the actual message payload sent to the selected provider. For
+  token.place this should be the OpenAI-compatible `messages` array sent to API v1.
+- token.place responses should pass through the same DSPACE response validation and source-link
+  sanitization currently used for OpenAI responses.
+
+## Proposed implementation sequence
+
+This sequence matches prompts 2-7 and keeps each PR reviewable:
+
+1. **Prompt 2: token.place API v1 client layer**
+   - Replace legacy `/chat` fetch logic with a `POST /api/v1/chat/completions` client.
+   - Build direct `fetch` requests with `Content-Type: application/json` only.
+   - Include `model` and OpenAI-compatible `messages`.
+   - Parse `choices[0].message.content`.
+   - Preserve structured errors, status, code, type, and param.
+   - Add unit tests for success parsing, malformed responses, network failure, HTTP errors,
+     content policy, rate limit, URL normalization, model default, abort signal, and absence of
+     Authorization/token.place API key headers.
+
+2. **Prompt 3: Settings provider configuration**
+   - Add `settings.chatProvider` normalization/defaulting.
+   - Move OpenAI key management to `/settings` while continuing to store `openAI.apiKey`.
+   - Add a settings panel for provider selection: token.place default, OpenAI opt-in.
+   - Persist provider preference and key changes through existing game-state storage.
+
+3. **Prompt 4: Single NPC chat UI**
+   - Refactor the full NPC/persona/debug UI into one provider-aware chat panel.
+   - Default fresh users to token.place.
+   - Use OpenAI only when `settings.chatProvider === 'openai'`.
+   - Remove `OpenAIAPIKeySettings` from `/chat`.
+   - Retire or reduce `TokenPlaceChat.svelte` to a compatibility wrapper only if needed.
+
+4. **Prompt 5: Unit and e2e coverage**
+   - Update OpenAI-by-default Playwright tests to select OpenAI in settings when testing OpenAI.
+   - Add fresh-user token.place default tests with fetch stubs.
+   - Add settings persistence and provider switching tests.
+   - Add error banner tests for token.place network/provider/content-policy/rate-limit failures.
+
+5. **Prompt 6: User-facing docs and release QA**
+   - Update Chat and Settings docs for token.place default and OpenAI opt-in.
+   - Create the `20260801` changelog entry following the historical changelog policy.
+   - Flesh out `docs/qa/v3.1.md` with staging/prod verification steps and expected results.
+
+6. **Prompt 7: Cleanup and hardening**
+   - Audit legacy routes and stale flags.
+   - Remove dead token.place `/chat` assumptions.
+   - Verify staging/prod base URLs, model override, and no credential leakage.
+   - Record release-hardening notes and residual risks.
+
+## Risks and mitigations
+
+- **API v1 non-streaming latency:** show the existing spinner, preserve disabled-send behavior while
+  a request is in flight, and avoid adding streaming as a quick fix. Consider copy that says
+  token.place is thinking when latency exceeds a threshold, but keep the request non-streaming.
+- **CORS/network errors:** classify `TypeError`, failed fetch, timeout/abort, and unavailable
+  response bodies as network errors with retry guidance. Keep tests using fetch stubs rather than
+  live network.
+- **Structured provider errors and rate limits:** parse JSON error payloads first, preserve
+  `status`, `error.type`, `error.code`, `error.param`, and `error.message`, and map known cases to
+  clear banners. HTTP 429 should be a rate-limit banner. `content_policy_violation` should explain
+  that token.place blocked the request by policy.
+- **Preserving RAG/player-state/persona behavior:** reuse `buildChatPrompt()` or extract its
+  provider-neutral pieces so token.place receives the same system/persona/player-state/docs-RAG
+  context as OpenAI. Do not regress debug payload, source display, or response sanitization.
+- **No OpenAI key or Authorization header to token.place:** keep token.place and OpenAI client
+  functions separate. token.place requests should set only content headers and should never read
+  `state.openAI.apiKey`. Unit tests must assert no `Authorization` header and no token.place API
+  key field.
+- **Legacy `tokenPlace.enabled` saved states:** ignore legacy disabled flags for provider defaulting
+  so old users are not accidentally blocked from the new default chat. Keep only URL compatibility
+  if safe.
+- **Base URL confusion:** store origins, not endpoint paths. The client should tolerate legacy
+  `https://token.place/api` by normalizing to `https://token.place` before appending
+  `/api/v1/chat/completions`, or explicitly document accepted forms in tests.
+
+## Test plan
+
+Unit tests:
+
+- `normalizeSettings()` defaults missing `settings.chatProvider` to `token-place`.
+- `normalizeSettings()` preserves `openai` and `token-place` and rejects invalid values back to
+  `token-place`.
+- token.place client posts to `/api/v1/chat/completions` with `model` and `messages`.
+- token.place client defaults to `gpt-5-chat-latest`.
+- token.place client parses `choices[0].message.content`.
+- token.place client rejects malformed responses with a provider parse error.
+- token.place client maps network failures, aborts, HTTP 429, provider 5xx, and
+  `content_policy_violation` payloads.
+- token.place client does not include an `Authorization` header, OpenAI API key, or token.place API
+  key in headers/body.
+- provider selection helper chooses token.place for fresh/invalid settings and OpenAI only for
+  explicit `settings.chatProvider === 'openai'`.
+- OpenAI selected without a saved key returns a guidance state instead of calling OpenAI.
+
+Playwright/e2e tests:
+
+- Fresh-user `/chat` renders one `data-provider="token-place"` panel and can send/receive using a
+  token.place fetch stub.
+- `/chat` does not render the OpenAI key form.
+- `/settings` lets users choose token.place or OpenAI and persists the selection across reloads.
+- `/settings` manages the existing `openAI.apiKey` field without changing its storage path.
+- OpenAI opt-in regression: selecting OpenAI with a saved key uses the existing OpenAI mock hook
+  and preserves persona/debug/source behavior.
+- OpenAI selected without a key shows the `/settings` guidance state and does not issue a network
+  request.
+- token.place error banners cover network failure, provider failure, rate limit, and content policy
+  responses.
+- Existing chat persona, debug navigation, build stamp, and docs-RAG tests are updated to run
+  against the provider-aware panel or explicitly opt into OpenAI where needed.
+
+Manual/staging checks for prompt 6/7:
+
+- Staging `/chat` defaults to token.place against `https://staging.token.place` when configured.
+- Production `/chat` defaults to `https://token.place`.
+- Browser devtools show no token.place `Authorization` header.
+- Browser storage contains no token.place credential.
+- OpenAI remains available only after selecting OpenAI and saving an OpenAI key in `/settings`.
+
+## Rollback plan
+
+- Users who need continuity can select OpenAI in `/settings` and use their own key.
+- Deployments can override token.place base URL and model if the production endpoint or alias needs
+  emergency routing.
+- Rollback must not make OpenAI the default again. If token.place has an incident, prefer an
+  environment-level token.place base URL/model override, a clear outage banner, or explicit user
+  opt-in to OpenAI.
+- Keep the v3.1 data model stable so future fixes do not churn saved settings.
+
+## Implementation checklist for later prompts
+
+- [ ] token.place default provider is represented as `settings.chatProvider = 'token-place'`.
+- [ ] OpenAI opt-in is represented as `settings.chatProvider = 'openai'` plus `openAI.apiKey`.
+- [ ] `/chat` renders a single NPC chat UI.
+- [ ] `/settings` owns provider selection and OpenAI key management.
+- [ ] token.place requests use `POST /api/v1/chat/completions`.
+- [ ] token.place responses parse `choices[0].message.content`.
+- [ ] API v2, streaming, token.place npm package integration, token.place auth/API keys, and
+      legacy `/api/chat` or `/chat` endpoints are absent.

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -59,13 +59,16 @@ REQUEST:
    to make them pass. Extend coverage for edge cases when feasible.
 4. Update or remove the original promise (TODO comment, checklist entry, doc note) so the repo no
    longer advertises incomplete work.
-5. Refresh related documentation or changelog entries to reflect the shipped behavior. When
-   touching the changelog, do **not** create a new dated file—append your notes to the most
-   recent future-dated entry instead (for example,
-   [`frontend/src/pages/docs/md/changelog/20260401.md`](../../../frontend/src/pages/docs/md/changelog/20260401.md)
-   on the `v3` branch). Never rewrite the body of published changelog markdown; use
-   `frontend/src/utils/changelogNotes.ts` to append clarifying notes and reserve direct edits for
-   spelling, whitespace, or broken link fixes recorded in
+5. Refresh related documentation to reflect the shipped behavior. Do not create, update, or
+   append changelog entries by default; only do changelog work when the human task prompt
+   explicitly requests it. Human release-engineer instructions control SemVer level and changelog
+   scope: if the prompt names a new changelog file/date, create or use that file exactly as
+   requested; if the prompt explicitly requests a patch changelog update without naming a new
+   file, append/update the appropriate existing changelog entry. Never infer a release level,
+   invent a release date, create a changelog file, or append changelog notes on your own. Never
+   rewrite the body of published changelog markdown; use `frontend/src/utils/changelogNotes.ts`
+   only when explicitly requested changelog work needs appended render-time notes, and reserve
+   direct edits for spelling, whitespace, or broken link fixes recorded in
    `frontend/tests/fixtures/changelogCorrections.json`.
 6. Run `npm run audit:ci`, `npm run lint`, `npm run type-check`, `npm run build`, and
    `npm run test:ci`. Install Playwright browsers with


### PR DESCRIPTION
### Motivation
- Define a clear, implementable design for making token.place API v1 the default /chat provider in v3.1 while keeping OpenAI as an explicit opt-in via Settings and avoiding legacy/streaming/npm-package approaches.

### Description
- Add `docs/design/token-place-chat-v3.1.md` which documents the current chat architecture, the token.place API v1 contract (`POST /api/v1/chat/completions`, non-streaming, parse `choices[0].message.content`), the proposed `settings.chatProvider` data model and UI flow, a step-by-step implementation sequence (prompts 2–7), risks/mitigations, test plan, and rollback notes; no production runtime behavior was changed.

### Testing
- Ran formatting and verification checks: `cd frontend && npx prettier --check ../docs/design/token-place-chat-v3.1.md` succeeded and `rg -n "api/v1/chat/completions|chatProvider|token-place|openai|streaming|npm package|/api/chat" docs/design/token-place-chat-v3.1.md` returned expected matches; no unit or e2e test changes were made in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30809ad8ec832f9564c27d131d2630)