### PR TITLE
Implement token.place API v1 chat client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             --exclude "http://localhost"
             --exclude-path ".*node_modules.*"
             --no-progress --verbose
-            "docs/**/*.md" "frontend/src/pages/docs/**/*.md"
+            $(git ls-files 'docs/**/*.md' 'frontend/src/pages/docs/**/*.md')
           format: markdown
           output: lychee/out.md
   root-tests:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,6 +21,6 @@ jobs:
             --max-retries 2
             --retry-wait-time 5
             --no-progress --verbose
-            "**/*.md"
+            $(git ls-files '*.md')
           format: markdown
           output: lychee/out.md

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -23,7 +23,7 @@ Tracking / release gate:
 - [ ] token.place chat completes when enabled
       ([<tokenPlace.test.js:parses assistant text and compatibility helper returns string>](../../frontend/__tests__/tokenPlace.test.js#L146-L154))
 - [ ] OpenAI fallback remains functional while token.place rollout toggles are off
-      ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33),
+      ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L35),
       [<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L96))
 - [ ] Provider selection UX is clear (and defaults are sane)
 - [ ] Failover behavior is defined and tested

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -18,10 +18,10 @@ Tracking / release gate:
 
 - [ ] dspace uses token.place endpoint correctly in staging
 - [ ] token.place endpoint config matches env vars and runtime settings
-      ([<tokenPlace.test.js:uses game state url when configured>](../../frontend/__tests__/tokenPlace.test.js#L28),
-      [<tokenPlace.test.js:falls back to env url when game state missing>](../../frontend/__tests__/tokenPlace.test.js#L34))
+      ([<tokenPlace.test.js:state tokenPlace url compatibility override works>](../../frontend/__tests__/tokenPlace.test.js#L67-L72),
+      [<tokenPlace.test.js:VITE_TOKEN_PLACE_URL override works>](../../frontend/__tests__/tokenPlace.test.js#L61-L65))
 - [ ] token.place chat completes when enabled
-      ([<tokenPlace.test.js:prepends system message and returns response>](../../frontend/__tests__/tokenPlace.test.js#L42))
+      ([<tokenPlace.test.js:parses assistant text and compatibility helper returns string>](../../frontend/__tests__/tokenPlace.test.js#L146-L154))
 - [ ] OpenAI fallback remains functional while token.place rollout toggles are off
       ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33),
       [<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L96))

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -18,10 +18,10 @@ Tracking / release gate:
 
 - [ ] dspace uses token.place endpoint correctly in staging
 - [ ] token.place endpoint config matches env vars and runtime settings
-      ([<tokenPlace.test.js:state tokenPlace url compatibility override works>](../../frontend/__tests__/tokenPlace.test.js#L67-L72),
-      [<tokenPlace.test.js:VITE_TOKEN_PLACE_URL override works>](../../frontend/__tests__/tokenPlace.test.js#L61-L65))
+      ([<tokenPlace.test.js:state tokenPlace url compatibility override works>](../../frontend/__tests__/tokenPlace.test.js#L66-L71),
+      [<tokenPlace.test.js:VITE_TOKEN_PLACE_URL override works>](../../frontend/__tests__/tokenPlace.test.js#L60-L64))
 - [ ] token.place chat completes when enabled
-      ([<tokenPlace.test.js:parses assistant text and compatibility helper returns string>](../../frontend/__tests__/tokenPlace.test.js#L146-L154))
+      ([<tokenPlace.test.js:parses assistant text and compatibility helper returns string>](../../frontend/__tests__/tokenPlace.test.js#L145-L153))
 - [ ] OpenAI fallback remains functional while token.place rollout toggles are off
       ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L35),
       [<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L96))

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:matches default endpoint and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L68-L77))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:supports explicit state and environment overrides>](../../frontend/__tests__/tokenPlace.test.js#L298-L304))
+      ([<tokenPlace.test.js:supports explicit state and environment overrides>](../../frontend/__tests__/tokenPlace.test.js#L317-L323))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:matches default endpoint and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L68-L77))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:supports explicit state and environment overrides>](../../frontend/__tests__/tokenPlace.test.js#L317-L323))
+      ([<tokenPlace.test.js:ignores legacy saved disabled flags>](../../frontend/__tests__/tokenPlace.test.js#L316-L318))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:matches default endpoint and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L68-L77))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:throws when disabled by default>](../../frontend/__tests__/tokenPlace.test.js#L68-L108))
+      ([<tokenPlace.test.js:supports explicit state and environment overrides>](../../frontend/__tests__/tokenPlace.test.js#L298-L304))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -217,7 +217,7 @@ the base image.
       ([<docs-navigation.spec.ts:docs pages should load and display headings>](../../frontend/e2e/docs-navigation.spec.ts#L9))
 - [x] `/chat`
       ([<nav-route-smoke.spec.ts:visits nav routes without console errors>](../../frontend/e2e/nav-route-smoke.spec.ts#L38-L103),
-      [<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33))
+      [<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L35))
 - [x] `/changelog`
 
 ### 3.2 "More" menu / utilities
@@ -1052,7 +1052,7 @@ Local-mode validation status (March 20, 2026):
 ### 9.1 `/chat` UX + stability
 
 - [x] Chat page loads and persona picker works
-      ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33))
+      ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L35))
 - [x] Sending a message:
       ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L138-L143))
   - [x] Shows loading state

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -21,6 +21,7 @@ const {
     tokenPlaceChat,
 } = await import('../src/utils/tokenPlace.js');
 const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
+const { buildChatPrompt } = await import('../src/utils/openAI.js');
 
 const okResponse = (body = {}) => ({
     ok: true,
@@ -191,10 +192,12 @@ describe('token.place API v1 client', () => {
         }
 
         expect(thrownError).toMatchObject({ type: 'malformed' });
-        expect(getTokenPlaceErrorSummary(thrownError)).toEqual({
-            type: 'malformed',
-            message: 'token.place returned an unexpected response. Please try again shortly.',
-        });
+        const summary = getTokenPlaceErrorSummary(thrownError);
+        expect(summary.type).toBe('malformed');
+        expect(summary.message).toBe(
+            'token.place returned an unexpected response. Please try again shortly.'
+        );
+        expect(summary.message).not.toMatch(/OpenAI/i);
     });
 
     test('structured API errors produce expected summaries', async () => {
@@ -247,11 +250,41 @@ describe('token.place API v1 client', () => {
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'network' });
     });
 
-    test('stale provider guidance is absent from token.place request payloads', async () => {
-        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const serialized = JSON.stringify(getFetchCall().body);
-        expect(serialized).not.toMatch(/token\.place is deferred/i);
-        expect(serialized).not.toMatch(/chat uses OpenAI/i);
+    test('abort errors classify safely', async () => {
+        const abortError = new Error('The operation was aborted.');
+        abortError.name = 'AbortError';
+        fetch.mockRejectedValueOnce(abortError);
+
+        let thrownError;
+        try {
+            await tokenPlaceChat([]);
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toMatchObject({ type: 'abort' });
+        const summary = getTokenPlaceErrorSummary(thrownError);
+        expect(summary).toEqual({
+            type: 'abort',
+            message: 'The token.place request was canceled. Please try again.',
+        });
+        expect(summary.message).not.toMatch(/OpenAI/i);
+    });
+
+    test('shared prompt and token.place payload omit stale provider guidance', async () => {
+        const promptPayload = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
+        const serializedPrompt = JSON.stringify({
+            combinedMessages: promptPayload.combinedMessages,
+            debugMessages: promptPayload.debugMessages,
+        });
+
+        expect(serializedPrompt).not.toMatch(/token\.place is deferred/i);
+        expect(serializedPrompt).not.toMatch(/chat uses OpenAI/i);
+
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }], { promptPayload });
+        const serializedRequest = JSON.stringify(getFetchCall().body.messages);
+        expect(serializedRequest).not.toMatch(/token\.place is deferred/i);
+        expect(serializedRequest).not.toMatch(/chat uses OpenAI/i);
     });
 });
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -107,6 +107,7 @@ describe('token.place API v1 client', () => {
         });
         const { init, body } = getFetchCall();
         expect(init.headers.Authorization).toBeUndefined();
+        expect(init.credentials).toBe('omit');
         const serialized = JSON.stringify({ headers: init.headers, body });
         expect(serialized).not.toContain('sk-secret-openai-key');
         expect(serialized).not.toContain('token-place-secret');
@@ -118,12 +119,25 @@ describe('token.place API v1 client', () => {
         });
     });
 
-    test('request body includes model, messages, safe metadata, and no true stream', async () => {
-        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+    test('request body includes model, schema-safe messages, safe metadata, and no true stream', async () => {
+        await TokenPlaceChatV2([
+            {
+                role: 'user',
+                content: 'hello',
+                id: 'ui-message-id',
+                timestamp: 123,
+                tokens: 1,
+                avatar: 'pilot.png',
+            },
+        ]);
         const { body } = getFetchCall();
         expect(body.model).toBe('gpt-5-chat-latest');
         expect(body.messages[0].role).toBe('system');
         expect(body.messages.at(-1)).toEqual({ role: 'user', content: 'hello' });
+        expect(body.messages.at(-1)).not.toHaveProperty('id');
+        expect(body.messages.at(-1)).not.toHaveProperty('timestamp');
+        expect(body.messages.at(-1)).not.toHaveProperty('tokens');
+        expect(body.messages.at(-1)).not.toHaveProperty('avatar');
         expect(body.metadata).toEqual({ client: 'dspace', provider: 'token.place' });
         expect(body.stream).not.toBe(true);
     });
@@ -169,15 +183,18 @@ describe('token.place API v1 client', () => {
 
     test('malformed responses throw and classify safely', async () => {
         fetch.mockResolvedValueOnce(okResponse({ choices: [{ message: { content: '' } }] }));
-        await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
+        let thrownError;
         try {
             await tokenPlaceChat([]);
         } catch (error) {
-            expect(getTokenPlaceErrorSummary(error)).toEqual({
-                type: 'malformed',
-                message: 'token.place returned an unexpected response. Please try again shortly.',
-            });
+            thrownError = error;
         }
+
+        expect(thrownError).toMatchObject({ type: 'malformed' });
+        expect(getTokenPlaceErrorSummary(thrownError)).toEqual({
+            type: 'malformed',
+            message: 'token.place returned an unexpected response. Please try again shortly.',
+        });
     });
 
     test('structured API errors produce expected summaries', async () => {
@@ -239,8 +256,16 @@ describe('token.place API v1 client', () => {
 });
 
 describe('isTokenPlaceEnabled', () => {
-    test('defaults to true and ignores legacy disabled state for v3.1', () => {
+    test('keeps the legacy token.place panel disabled by default', () => {
+        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(false);
+    });
+
+    test('supports explicit legacy opt-in while provider-aware UI is pending', () => {
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
+        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
         expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
+        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
     });
 });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1,4 +1,4 @@
-const { vi } = require('vitest');
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 const jest = vi;
 
 jest.mock('../src/utils/gameState/common.js', () => ({
@@ -6,103 +6,241 @@ jest.mock('../src/utils/gameState/common.js', () => ({
     ready: Promise.resolve(),
 }));
 
-const { tokenPlaceChat, isTokenPlaceEnabled } = require('../src/utils/tokenPlace.js');
-const { loadGameState } = require('../src/utils/gameState/common.js');
+jest.mock('../src/utils/docsRag.js', () => ({
+    searchDocsRag: jest.fn(async () => ({ excerptsText: '', sources: [] })),
+}));
 
-describe('tokenPlaceChat', () => {
+const { loadGameState } = await import('../src/utils/gameState/common.js');
+const {
+    TokenPlaceChatV2,
+    buildTokenPlaceChatCompletionsUrl,
+    extractTokenPlaceAssistantText,
+    getTokenPlaceChatModel,
+    isTokenPlaceEnabled,
+    resolveTokenPlaceBaseUrl,
+    tokenPlaceChat,
+} = await import('../src/utils/tokenPlace.js');
+const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
+
+const okResponse = (body = {}) => ({
+    ok: true,
+    status: 200,
+    json: () =>
+        Promise.resolve({
+            choices: [{ message: { content: 'mocked reply' } }],
+            ...body,
+        }),
+});
+
+const getFetchCall = () => {
+    const [url, init] = fetch.mock.calls[0];
+    return { url, init, body: JSON.parse(init.body) };
+};
+
+describe('token.place API v1 client', () => {
     beforeEach(() => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ reply: 'mocked reply' }),
-            })
-        );
+        global.fetch = jest.fn(() => Promise.resolve(okResponse()));
+        loadGameState.mockReturnValue({});
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
         delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
-    test('uses game state url when configured', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
+    test('fresh/default state posts to token.place API v1 chat completions', async () => {
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
+        const { url, init } = getFetchCall();
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(init.method).toBe('POST');
     });
 
-    test('falls back to env url when game state missing', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('http://env.token/chat', expect.any(Object));
+    test('VITE_TOKEN_PLACE_URL override works', async () => {
+        process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(getFetchCall().url).toBe('https://staging.token.place/api/v1/chat/completions');
     });
 
-    test('prepends system message and returns response', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const result = await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const body = JSON.parse(fetch.mock.calls[0][1].body);
-        expect(body.messages[0].role).toBe('system');
-        expect(result).toBe('mocked reply');
+    test('state tokenPlace url compatibility override works', async () => {
+        process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(getFetchCall().url).toBe('https://state.token.place/api/v1/chat/completions');
     });
 
-    test('passes abort signal to fetch', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const controller = new AbortController();
-        await tokenPlaceChat([], { signal: controller.signal });
-        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
-    });
-
-    test('throws helpful error when request fails', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        fetch.mockResolvedValueOnce({
-            ok: false,
-            json: () => Promise.resolve({ error: 'bad request' }),
-        });
-        await expect(tokenPlaceChat([])).rejects.toThrow(
-            'token.place API request failed: bad request'
+    test('legacy /api base normalizes without /api/api duplication', () => {
+        expect(resolveTokenPlaceBaseUrl({ url: 'https://token.place/api' })).toBe(
+            'https://token.place'
+        );
+        expect(buildTokenPlaceChatCompletionsUrl('https://token.place/api')).toBe(
+            'https://token.place/api/v1/chat/completions'
+        );
+        expect(buildTokenPlaceChatCompletionsUrl('https://token.place/api')).not.toContain(
+            '/api/api/v1/chat/completions'
         );
     });
 
-    test('throws when disabled by default', async () => {
-        loadGameState.mockReturnValue({});
-        await expect(tokenPlaceChat([])).rejects.toThrow('token.place is disabled');
+    test('does not post to legacy token.place backend chat endpoints', async () => {
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(getFetchCall().url).not.toMatch(/\/api\/chat$|\/chat$/);
     });
 
-    test('uses default url when explicitly enabled without overrides', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('https://token.place/api/chat', expect.any(Object));
+    test('uses default model and model override', async () => {
+        expect(getTokenPlaceChatModel()).toBe('gpt-5-chat-latest');
+        process.env.VITE_TOKEN_PLACE_CHAT_MODEL = 'custom-model';
+        expect(getTokenPlaceChatModel()).toBe('custom-model');
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(getFetchCall().body.model).toBe('custom-model');
+    });
+
+    test('request is zero-auth and excludes secrets from headers/body/metadata', async () => {
+        loadGameState.mockReturnValue({ openAI: { apiKey: 'sk-secret-openai-key' } });
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
+            metadata: {
+                conversation_id: 'conv-42',
+                apiKey: 'token-place-secret',
+                playerSave: { raw: true },
+                token: 'hidden',
+            },
+        });
+        const { init, body } = getFetchCall();
+        expect(init.headers.Authorization).toBeUndefined();
+        const serialized = JSON.stringify({ headers: init.headers, body });
+        expect(serialized).not.toContain('sk-secret-openai-key');
+        expect(serialized).not.toContain('token-place-secret');
+        expect(serialized).not.toContain('hidden');
+        expect(body.metadata).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+        });
+    });
+
+    test('request body includes model, messages, safe metadata, and no true stream', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        const { body } = getFetchCall();
+        expect(body.model).toBe('gpt-5-chat-latest');
+        expect(body.messages[0].role).toBe('system');
+        expect(body.messages.at(-1)).toEqual({ role: 'user', content: 'hello' });
+        expect(body.metadata).toEqual({ client: 'dspace', provider: 'token.place' });
+        expect(body.stream).not.toBe(true);
+    });
+
+    test('parses assistant text and compatibility helper returns string', async () => {
+        expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
+            'hi'
+        );
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked reply'
+        );
+    });
+
+    test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {
+        fetch.mockResolvedValueOnce(
+            okResponse({
+                usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+                metadata: { client: 'dspace', conversation_id: 'conv-42' },
+                contextSources: [{ title: 'provider field should not be used' }],
+            })
+        );
+        const dspaceSources = [{ title: 'DSPACE docs', url: '/docs/about' }];
+        const result = await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [{ role: 'user', content: 'hello' }],
+                contextSources: dspaceSources,
+                gameState: {},
+            },
+        });
+        expect(result).toEqual({
+            text: 'mocked reply',
+            contextSources: dspaceSources,
+            usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+        });
+    });
+
+    test('passes abort signal to fetch', async () => {
+        const controller = new AbortController();
+        await tokenPlaceChat([], { signal: controller.signal });
+        expect(getFetchCall().init.signal).toBe(controller.signal);
+    });
+
+    test('malformed responses throw and classify safely', async () => {
+        fetch.mockResolvedValueOnce(okResponse({ choices: [{ message: { content: '' } }] }));
+        await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
+        try {
+            await tokenPlaceChat([]);
+        } catch (error) {
+            expect(getTokenPlaceErrorSummary(error)).toEqual({
+                type: 'malformed',
+                message: 'token.place returned an unexpected response. Please try again shortly.',
+            });
+        }
+    });
+
+    test('structured API errors produce expected summaries', async () => {
+        const cases = [
+            [
+                400,
+                {
+                    error: {
+                        message: 'blocked',
+                        type: 'content_policy_violation',
+                        code: 'content_blocked',
+                    },
+                },
+                'content_policy',
+            ],
+            [429, { error: { message: 'slow down', type: 'rate_limit' } }, 'rate_limit'],
+            [503, { error: { message: 'unavailable', type: 'server_error' } }, 'server'],
+            [
+                400,
+                {
+                    error: {
+                        message: 'stream true rejected',
+                        type: 'invalid_request_error',
+                        param: 'stream',
+                    },
+                },
+                'validation',
+            ],
+            [400, { error: { message: 'bad model', type: 'invalid_request_error' } }, 'provider'],
+        ];
+
+        for (const [status, payload, expectedType] of cases) {
+            fetch.mockResolvedValueOnce({
+                ok: false,
+                status,
+                statusText: 'Bad Request',
+                json: () => Promise.resolve(payload),
+            });
+            try {
+                await tokenPlaceChat([]);
+            } catch (error) {
+                expect(getTokenPlaceErrorSummary(error).type).toBe(expectedType);
+                expect(getTokenPlaceErrorSummary(error).message).not.toMatch(/OpenAI/i);
+            }
+        }
+    });
+
+    test('network errors classify safely', async () => {
+        fetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'network' });
+    });
+
+    test('stale provider guidance is absent from token.place request payloads', async () => {
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        const serialized = JSON.stringify(getFetchCall().body);
+        expect(serialized).not.toMatch(/token\.place is deferred/i);
+        expect(serialized).not.toMatch(/chat uses OpenAI/i);
     });
 });
 
 describe('isTokenPlaceEnabled', () => {
-    afterEach(() => {
-        delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
-    });
-
-    test('is false when no overrides are set', () => {
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
-    });
-
-    test('is false when tokenPlace url exists in state without opt-in', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { url: 'http://tp' } } })).toBe(false);
-    });
-
-    test('is true when tokenPlace is explicitly enabled in state', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
-    });
-
-    test('respects explicit env disable', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
-    });
-
-    test('is true when env override enables it', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
+    test('defaults to true and ignores legacy disabled state for v3.1', () => {
         expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
     });
 });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -289,15 +289,16 @@ describe('token.place API v1 client', () => {
 });
 
 describe('isTokenPlaceEnabled', () => {
-    test('keeps the legacy token.place panel disabled by default', () => {
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
+    test('enables token.place by default unless explicitly disabled', () => {
+        expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: undefined } } })).toBe(true);
         expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(false);
     });
 
-    test('supports explicit legacy opt-in while provider-aware UI is pending', () => {
+    test('supports explicit state and environment overrides', () => {
         expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
         process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
         process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
         expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
     });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -250,6 +250,25 @@ describe('token.place API v1 client', () => {
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'network' });
     });
 
+    test('unexpected fetch errors classify safely', async () => {
+        fetch.mockRejectedValueOnce(new Error('Unexpected token.place failure'));
+
+        let thrownError;
+        try {
+            await tokenPlaceChat([]);
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toMatchObject({ type: 'unknown' });
+        const summary = getTokenPlaceErrorSummary(thrownError);
+        expect(summary).toEqual({
+            type: 'unknown',
+            message: 'token.place hit an unexpected error. Please try again shortly.',
+        });
+        expect(summary.message).not.toMatch(/OpenAI/i);
+    });
+
     test('abort errors classify safely', async () => {
         const abortError = new Error('The operation was aborted.');
         abortError.name = 'AbortError';

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -48,7 +48,6 @@ describe('token.place API v1 client', () => {
         jest.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
         delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
     test('fresh/default state posts to token.place API v1 chat completions', async () => {
@@ -308,17 +307,13 @@ describe('token.place API v1 client', () => {
 });
 
 describe('isTokenPlaceEnabled', () => {
-    test('enables token.place by default unless explicitly disabled', () => {
+    test('enables token.place for fresh or missing legacy state', () => {
+        expect(isTokenPlaceEnabled()).toBe(true);
         expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: undefined } } })).toBe(true);
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(false);
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: undefined } })).toBe(true);
     });
 
-    test('supports explicit state and environment overrides', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
+    test('ignores legacy saved disabled flags', () => {
         expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
     });
 });

--- a/frontend/e2e/chat-debug-build-info.spec.ts
+++ b/frontend/e2e/chat-debug-build-info.spec.ts
@@ -1,10 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    navigateWithRetry,
+    seedOpenAIChatState,
+    waitForHydration,
+} from './test-helpers';
 
 test.describe('Chat debug build metadata', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
+        await seedOpenAIChatState(page);
     });
 
     test('shows prompt/app/docs build info with sync comparison', async ({ page }) => {

--- a/frontend/e2e/chat-debug-navigation.spec.ts
+++ b/frontend/e2e/chat-debug-navigation.spec.ts
@@ -1,10 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    navigateWithRetry,
+    seedOpenAIChatState,
+    waitForHydration,
+} from './test-helpers';
 
 test.describe('Chat debug deep links', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
+        await seedOpenAIChatState(page);
     });
 
     test('Settings debug link opens chat prompt payload panel', async ({ page }) => {

--- a/frontend/e2e/chat-debug-stamp.spec.ts
+++ b/frontend/e2e/chat-debug-stamp.spec.ts
@@ -1,10 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
+import {
+    clearUserData,
+    navigateWithRetry,
+    seedOpenAIChatState,
+    waitForHydration,
+} from './test-helpers';
 
 test.describe('Chat debug build stamp', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
+        await seedOpenAIChatState(page);
     });
 
     test('shows non-missing prompt/app build stamps', async ({ page }) => {

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, seedOpenAIChatState, waitForHydration } from './test-helpers';
 
 const LONG_REPLY =
     'This is a long assistant response that should render in the chat history without breaking the layout or truncating text, even when it spans multiple sentences and needs wrapping across several lines for readability.';
@@ -133,6 +133,7 @@ const sendMessage = async (page: Page, text: string) => {
 test.describe('Chat message flow', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
+        await seedOpenAIChatState(page);
     });
 
     test('shows loading state and renders assistant replies', async ({ page }) => {

--- a/frontend/e2e/chat-persona-switching.spec.ts
+++ b/frontend/e2e/chat-persona-switching.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { npcPersonas } from '../src/data/npcPersonas.js';
-import { waitForHydration } from './test-helpers';
+import { seedOpenAIChatState, waitForHydration } from './test-helpers';
 
 const personaExpectations = npcPersonas.map((persona) => ({
     id: persona.id,
@@ -27,6 +27,8 @@ test.beforeEach(async ({ page }) => {
             }
         }
     });
+
+    await seedOpenAIChatState(page);
 });
 
 test.describe('Chat NPC persona switching', () => {

--- a/frontend/e2e/chat-rag-context.spec.ts
+++ b/frontend/e2e/chat-rag-context.spec.ts
@@ -12,6 +12,7 @@ test.describe('chat RAG context', () => {
                 const gameState = {
                     _meta: { lastUpdated: now },
                     settings: { showChatDebugPayload: true },
+                    openAI: { apiKey: 'e2e-openai-key' },
                     inventory: { [inventoryId]: 2 },
                     quests: {
                         [questId]: { stepId: 2 },

--- a/frontend/e2e/remote-release-smoke.spec.ts
+++ b/frontend/e2e/remote-release-smoke.spec.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'url';
 import { expect, test, type Page } from '@playwright/test';
 import path from 'path';
-import { waitForHydration } from './test-helpers';
+import { seedOpenAIChatState, waitForHydration } from './test-helpers';
 
 const TOP_NAV_ROUTES = [
     '/',
@@ -281,6 +281,7 @@ async function createAndDeleteCustomItem(page: Page): Promise<void> {
 async function verifyChat(page: Page): Promise<void> {
     if (CHAT_MODE === 'live') {
         await configureLiveChatTransport(page);
+        await seedOpenAIChatState(page);
     }
 
     await page.goto('/chat');

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -369,13 +369,19 @@ export async function clearUserData(page: Page): Promise<void> {
     await purgeClientState(page);
 }
 
+const seedOpenAIChatStateInLocalStorage = (key: string) => {
+    const raw = localStorage.getItem('gameState');
+    const state = raw ? JSON.parse(raw) : {};
+    state.openAI = { ...(state.openAI || {}), apiKey: key };
+    localStorage.setItem('gameState', JSON.stringify(state));
+};
+
 export async function seedOpenAIChatState(page: Page, apiKey = 'e2e-openai-key'): Promise<void> {
-    await page.evaluate((key) => {
-        const raw = localStorage.getItem('gameState');
-        const state = raw ? JSON.parse(raw) : {};
-        state.openAI = { ...(state.openAI || {}), apiKey: key };
-        localStorage.setItem('gameState', JSON.stringify(state));
-    }, apiKey);
+    await page.addInitScript(seedOpenAIChatStateInLocalStorage, apiKey);
+
+    if (page.url() !== 'about:blank') {
+        await page.evaluate(seedOpenAIChatStateInLocalStorage, apiKey);
+    }
 }
 
 async function seedCustomEntity(

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -369,20 +369,61 @@ export async function clearUserData(page: Page): Promise<void> {
     await purgeClientState(page);
 }
 
-const seedOpenAIChatStateInLocalStorage = (key: string) => {
-    const raw = localStorage.getItem('gameState');
-    const state = raw ? JSON.parse(raw) : {};
-    const previousMeta = state._meta && typeof state._meta === 'object' ? state._meta : {};
-    state.openAI = { ...(state.openAI || {}), apiKey: key };
-    state._meta = { ...previousMeta, lastUpdated: Date.now() };
-    localStorage.setItem('gameState', JSON.stringify(state));
+const seedOpenAIChatStateInBrowser = async ({
+    key,
+    updateLiveState = false,
+}: {
+    key: string;
+    updateLiveState?: boolean;
+}) => {
+    const applyOpenAIKey = (source: Record<string, unknown> | null | undefined) => {
+        const state = source && typeof source === 'object' ? { ...source } : {};
+        const previousMeta =
+            state._meta && typeof state._meta === 'object' && !Array.isArray(state._meta)
+                ? state._meta
+                : {};
+        state.openAI = {
+            ...((state.openAI && typeof state.openAI === 'object' ? state.openAI : {}) as Record<
+                string,
+                unknown
+            >),
+            apiKey: key,
+        };
+        state._meta = { ...previousMeta, lastUpdated: Date.now() };
+        return state;
+    };
+
+    const readLocalState = () => {
+        const raw = localStorage.getItem('gameState');
+        return raw ? JSON.parse(raw) : {};
+    };
+
+    const seededLocalState = applyOpenAIKey(readLocalState());
+    localStorage.setItem('gameState', JSON.stringify(seededLocalState));
+
+    if (!updateLiveState) {
+        return;
+    }
+
+    try {
+        const gameStateModulePath = '/src/utils/gameState/common.js';
+        const gameStateModule = await import(/* @vite-ignore */ gameStateModulePath);
+        await gameStateModule.ready;
+        const liveState = gameStateModule.loadGameState();
+        await gameStateModule.saveGameState(applyOpenAIKey(liveState));
+    } catch (error) {
+        console.warn(
+            'Failed to seed live OpenAI chat state; localStorage seed remains set.',
+            error
+        );
+    }
 };
 
 export async function seedOpenAIChatState(page: Page, apiKey = 'e2e-openai-key'): Promise<void> {
-    await page.addInitScript(seedOpenAIChatStateInLocalStorage, apiKey);
+    await page.addInitScript(seedOpenAIChatStateInBrowser, { key: apiKey, updateLiveState: false });
 
     if (page.url() !== 'about:blank') {
-        await page.evaluate(seedOpenAIChatStateInLocalStorage, apiKey);
+        await page.evaluate(seedOpenAIChatStateInBrowser, { key: apiKey, updateLiveState: true });
     }
 }
 

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -372,7 +372,9 @@ export async function clearUserData(page: Page): Promise<void> {
 const seedOpenAIChatStateInLocalStorage = (key: string) => {
     const raw = localStorage.getItem('gameState');
     const state = raw ? JSON.parse(raw) : {};
+    const previousMeta = state._meta && typeof state._meta === 'object' ? state._meta : {};
     state.openAI = { ...(state.openAI || {}), apiKey: key };
+    state._meta = { ...previousMeta, lastUpdated: Date.now() };
     localStorage.setItem('gameState', JSON.stringify(state));
 };
 

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -40,7 +40,7 @@ type IndexedDbRequest<T = unknown> = {
 type IndexedDbTransaction = {
     objectStore: (name: string) => {
         clear: () => void;
-        put: (value: unknown) => void;
+        put: (value: unknown, key?: string) => void;
         getAll: () => IndexedDbRequest<unknown[]>;
     };
     oncomplete: (() => void) | null;
@@ -376,6 +376,39 @@ const seedOpenAIChatStateInBrowser = async ({
     key: string;
     updateLiveState?: boolean;
 }) => {
+    const writeIndexedDbState = async (nextState: Record<string, unknown>) => {
+        if (!('indexedDB' in globalThis)) {
+            return;
+        }
+
+        const db = await new Promise<IndexedDbDatabase>((resolve, reject) => {
+            const request = indexedDB.open('dspaceGameState', 2);
+            request.onupgradeneeded = () => {
+                const upgradeDb = request.result as unknown as IndexedDbDatabase;
+                if (!upgradeDb.objectStoreNames.contains('state')) {
+                    upgradeDb.createObjectStore('state');
+                }
+                if (!upgradeDb.objectStoreNames.contains('backup')) {
+                    upgradeDb.createObjectStore('backup');
+                }
+                if (!upgradeDb.objectStoreNames.contains('meta')) {
+                    upgradeDb.createObjectStore('meta');
+                }
+            };
+            request.onsuccess = () => resolve(request.result as unknown as IndexedDbDatabase);
+            request.onerror = () => reject(request.error);
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction('state', 'readwrite');
+            tx.objectStore('state').put(nextState, 'root');
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+        });
+
+        db.close();
+    };
+
     const applyOpenAIKey = (source: Record<string, unknown> | null | undefined) => {
         const state = source && typeof source === 'object' ? { ...source } : {};
         const previousMeta =
@@ -400,6 +433,7 @@ const seedOpenAIChatStateInBrowser = async ({
 
     const seededLocalState = applyOpenAIKey(readLocalState());
     localStorage.setItem('gameState', JSON.stringify(seededLocalState));
+    await writeIndexedDbState(seededLocalState);
 
     if (!updateLiveState) {
         return;

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -369,6 +369,15 @@ export async function clearUserData(page: Page): Promise<void> {
     await purgeClientState(page);
 }
 
+export async function seedOpenAIChatState(page: Page, apiKey = 'e2e-openai-key'): Promise<void> {
+    await page.evaluate((key) => {
+        const raw = localStorage.getItem('gameState');
+        const state = raw ? JSON.parse(raw) : {};
+        state.openAI = { ...(state.openAI || {}), apiKey: key };
+        localStorage.setItem('gameState', JSON.stringify(state));
+    }, apiKey);
+}
+
 async function seedCustomEntity(
     page: Page,
     entity: Record<string, unknown>,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dspace",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "type": "module",
     "description": "A free and open source web-based space exploration idle game",
     "scripts": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -40,6 +40,7 @@ declare const process: {
 
 // Determine important paths for running tests regardless of the current working directory
 const frontendDir = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const nodeWarningFilterRequire = `--require=${fileURLToPath(
     new URL('../scripts/node-warning-filter.cjs', import.meta.url)
 )}`;
@@ -77,7 +78,7 @@ function ensureAstroBuildArtifacts(): void {
 
     console.log('Astro build artifacts not found. Building before Playwright preview.');
     try {
-        execSync('npm run build', { cwd: frontendDir, stdio: 'inherit' });
+        execSync('npm run build', { cwd: repoRoot, stdio: 'inherit' });
     } catch (error) {
         console.error('Failed to build Astro project required for Playwright preview.');
         throw error;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -78,7 +78,7 @@ function ensureAstroBuildArtifacts(): void {
 
     console.log('Astro build artifacts not found. Building before Playwright preview.');
     try {
-        execSync('npm run build', { cwd: repoRoot, stdio: 'inherit' });
+        execSync('npm run build', { cwd: frontendDir, stdio: 'inherit' });
     } catch (error) {
         console.error('Failed to build Astro project required for Playwright preview.');
         throw error;

--- a/frontend/src/pages/chat/svelte/Integrations.svelte
+++ b/frontend/src/pages/chat/svelte/Integrations.svelte
@@ -11,6 +11,10 @@
     const tokenPlaceEnabled = derived(gameState, ($gameState) =>
         isTokenPlaceEnabled({ state: $gameState })
     );
+    const showTokenPlaceChat = derived(
+        [tokenPlaceEnabled, apiKey],
+        ([$tokenPlaceEnabled, $apiKey]) => $tokenPlaceEnabled && !$apiKey
+    );
 
     onMount(async () => {
         await ready;
@@ -26,12 +30,12 @@
             <a href="https://token.place" target="_blank" rel="noopener">token.place</a> — no key needed.
         </div>
     {/if}
-    {#if $tokenPlaceEnabled}
+    <div class="api-container">
+        <OpenAIAPIKeySettings {apiKey} />
+    </div>
+    {#if $showTokenPlaceChat}
         <TokenPlaceChat />
     {:else}
-        <div class="api-container">
-            <OpenAIAPIKeySettings {apiKey} />
-        </div>
         <OpenAIChat />
     {/if}
 </div>

--- a/frontend/src/pages/chat/svelte/Integrations.svelte
+++ b/frontend/src/pages/chat/svelte/Integrations.svelte
@@ -26,12 +26,13 @@
             <a href="https://token.place" target="_blank" rel="noopener">token.place</a> — no key needed.
         </div>
     {/if}
-    <div class="api-container">
-        <OpenAIAPIKeySettings {apiKey} />
-    </div>
-    <OpenAIChat />
     {#if $tokenPlaceEnabled}
         <TokenPlaceChat />
+    {:else}
+        <div class="api-container">
+            <OpenAIAPIKeySettings {apiKey} />
+        </div>
+        <OpenAIChat />
     {/if}
 </div>
 

--- a/frontend/src/pages/chat/svelte/TokenPlaceChat.svelte
+++ b/frontend/src/pages/chat/svelte/TokenPlaceChat.svelte
@@ -12,6 +12,7 @@
     let showSpinner = false;
     let messageCounter = 0;
     let errorBanner = null;
+    let hydrated = false;
     // Default dChat persona; callers can override for other NPCs/personas.
     export let welcomeMessage =
         "Hello, adventurer! I'm dChat! I'm here to answer any questions you may have about DSPACE or nearly any other topic. I may accidentally generate incorrect information, so please double-check anything I say.";
@@ -83,6 +84,7 @@
     }
 
     onMount(() => {
+        hydrated = true;
         if ($messageHistory.length === 0) {
             const welcome = {
                 role: 'assistant',
@@ -97,7 +99,12 @@
     });
 </script>
 
-<div class="chat" data-testid="chat-panel" data-provider="token-place">
+<div
+    class="chat"
+    data-testid="chat-panel"
+    data-provider="token-place"
+    data-hydrated={hydrated ? 'true' : undefined}
+>
     {#if errorBanner}
         <div class="chat-error" role="alert" data-error-type={errorBanner.type}>
             {errorBanner.message}

--- a/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
+++ b/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
@@ -34,7 +34,6 @@ describe('Integrations chat entrypoint', () => {
         mockRefs.baseState.openAI.apiKey = '';
         mockRefs.resetStore();
         delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
     afterEach(() => {

--- a/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
+++ b/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
@@ -9,7 +9,7 @@ vi.mock('svelte/transition', () => ({
 
 const mockRefs = vi.hoisted(() => ({
     baseState: {
-        openAI: { apiKey: 'sk-test' },
+        openAI: { apiKey: '' },
         tokenPlace: undefined,
     },
     resetStore: () => undefined,
@@ -31,6 +31,7 @@ vi.mock('../../../../utils/gameState/common.js', async () => {
 
 describe('Integrations chat entrypoint', () => {
     beforeEach(() => {
+        mockRefs.baseState.openAI.apiKey = '';
         mockRefs.resetStore();
         delete process.env.VITE_TOKEN_PLACE_URL;
         delete process.env.VITE_TOKEN_PLACE_ENABLED;
@@ -40,7 +41,7 @@ describe('Integrations chat entrypoint', () => {
         vi.clearAllMocks();
     });
 
-    it('renders token.place chat by default without the deferred banner', async () => {
+    it('renders token.place chat by default without the deferred banner while keeping OpenAI settings reachable', async () => {
         render(Integrations);
 
         await waitFor(() =>
@@ -50,6 +51,24 @@ describe('Integrations chat entrypoint', () => {
         );
         expect(
             document.querySelector('[data-testid="chat-panel"][data-provider="openai"]')
+        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId('token-place-disabled-banner')).not.toBeInTheDocument();
+        await waitFor(() => expect(screen.getByText(/OpenAI API Key/i)).toBeInTheDocument());
+    });
+
+    it('renders OpenAI chat for users with an existing OpenAI API key', async () => {
+        mockRefs.baseState.openAI.apiKey = 'sk-test';
+        mockRefs.resetStore();
+
+        render(Integrations);
+
+        await waitFor(() =>
+            expect(
+                document.querySelector('[data-testid="chat-panel"][data-provider="openai"]')
+            ).toBeInTheDocument()
+        );
+        expect(
+            document.querySelector('[data-testid="chat-panel"][data-provider="token-place"]')
         ).not.toBeInTheDocument();
         expect(screen.queryByTestId('token-place-disabled-banner')).not.toBeInTheDocument();
     });

--- a/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
+++ b/frontend/src/pages/chat/svelte/__tests__/Integrations.spec.ts
@@ -40,17 +40,17 @@ describe('Integrations chat entrypoint', () => {
         vi.clearAllMocks();
     });
 
-    it('renders OpenAI chat and hides token.place by default', async () => {
+    it('renders token.place chat by default without the deferred banner', async () => {
         render(Integrations);
 
         await waitFor(() =>
             expect(
-                document.querySelector('[data-testid="chat-panel"][data-provider="openai"]')
+                document.querySelector('[data-testid="chat-panel"][data-provider="token-place"]')
             ).toBeInTheDocument()
         );
         expect(
-            document.querySelector('[data-testid="chat-panel"][data-provider="token-place"]')
+            document.querySelector('[data-testid="chat-panel"][data-provider="openai"]')
         ).not.toBeInTheDocument();
-        expect(screen.getByTestId('token-place-disabled-banner')).toBeInTheDocument();
+        expect(screen.queryByTestId('token-place-disabled-banner')).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -4,7 +4,8 @@ slug: 'token-place'
 ---
 
 DSPACE ships with a token.place integration for in-game chat. In v3.1, fresh chat defaults to
-the zero-auth token.place API v1 path, while users with an existing OpenAI API key continue to use
+the zero-auth token.place API v1 endpoint (`https://token.place/api/v1/chat/completions`), while
+users with an existing OpenAI API key continue to use
 the OpenAI-backed flow.
 
 ## How it works
@@ -15,9 +16,9 @@ the OpenAI-backed flow.
 - The default origin is `https://token.place`. Deployments can point to a custom token.place
   origin with `VITE_TOKEN_PLACE_URL`, and legacy saved `tokenPlace.url` values are still honored
   for compatibility.
-- Token.place is the default v3.1 chat provider. Legacy `VITE_TOKEN_PLACE_ENABLED` and
-  `state.tokenPlace.enabled` values are ignored by provider enablement so old saved disabled
-  flags cannot block fresh default token.place chat.
+- Token.place is the default v3.1 chat provider and is not disabled by default. Legacy
+  `VITE_TOKEN_PLACE_ENABLED` and `state.tokenPlace.enabled` values are ignored by provider
+  enablement so old saved disabled flags cannot block fresh default token.place chat.
 - Users with an existing OpenAI API key still use the OpenAI-backed flow, and the OpenAI key
   settings remain available separately (see
   `frontend/src/pages/chat/svelte/OpenAIChat.svelte`).

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -3,46 +3,32 @@ title: 'token.place Integration'
 slug: 'token-place'
 ---
 
-DSPACE ships with a token.place integration for in-game chat, but it is **disabled by default**.
-In v3, the reason is simple: the token.place API v1 is not yet implemented or live in production,
-so DSPACE v3 ships with **OpenAI-only chat** while token.place is deferred to v3.1. After v3 is in
-production, we will finish the token.place API v1 and deploy it; only then does DSPACE v3.1
-complete and enable the integration.
-
-Once token.place API v1 is in production, DSPACE v3.1 will complete the integration and enable
-the opt-in path described below.
+DSPACE ships with a token.place integration for in-game chat. In v3.1, fresh chat defaults to
+the zero-auth token.place API v1 path, while users with an existing OpenAI API key continue to use
+the OpenAI-backed flow.
 
 ## How it works
 
-- The chat client calls `tokenPlaceChat` (see `frontend/src/utils/tokenPlace.js`), which posts to
-  `${baseUrl}/chat` and returns the `reply` field from the JSON response. If the feature is
-  disabled, the helper throws with a message that points back to the opt-in options.
-- The default base URL is `https://token.place/api` (the value of `DEFAULT_URL` in
-  `frontend/src/utils/tokenPlace.js`).
-- The integration is enabled only when an explicit opt-in flag is set via
-  `isTokenPlaceEnabled` (see `getEnabledOverride` and `isTokenPlaceEnabled` in
-  `frontend/src/utils/tokenPlace.js`).
-- The OpenAI API key chat integration is configured separately (see
-  `frontend/src/pages/chat/svelte/OpenAIChat.svelte`), so leaving token.place disabled keeps
-  chat on the OpenAI-backed flow.
+- The chat client calls `tokenPlaceChat` (see `frontend/src/utils/tokenPlace.js`), which posts
+  OpenAI-compatible `messages` and `model` fields to `/api/v1/chat/completions` without sending
+  credentials or an `Authorization` header.
+- The default origin is `https://token.place`. Deployments can point to a custom token.place
+  origin with `VITE_TOKEN_PLACE_URL`, and legacy saved `tokenPlace.url` values are still honored
+  for compatibility.
+- Token.place is the default v3.1 chat provider. Legacy `VITE_TOKEN_PLACE_ENABLED` and
+  `state.tokenPlace.enabled` values are ignored by provider enablement so old saved disabled
+  flags cannot block fresh default token.place chat.
+- Users with an existing OpenAI API key still use the OpenAI-backed flow, and the OpenAI key
+  settings remain available separately (see
+  `frontend/src/pages/chat/svelte/OpenAIChat.svelte`).
 
-## Opt-in options
+## Local URL override
 
-Token.place can be enabled in two ways (once the v1 API is live in production):
-
-- **Environment variable**: set `VITE_TOKEN_PLACE_ENABLED=true`. You can also point to a custom URL
-  with `VITE_TOKEN_PLACE_URL`.
-- **Game state**: persist `tokenPlace.enabled=true` in saved game state. Optionally pair this with
-  a custom `tokenPlace.url`.
+Use `VITE_TOKEN_PLACE_URL` only to point local development at another token.place origin:
 
 ```bash
-VITE_TOKEN_PLACE_ENABLED=true VITE_TOKEN_PLACE_URL=$TOKEN_PLACE_API_URL npm run dev
+VITE_TOKEN_PLACE_URL=$TOKEN_PLACE_API_URL npm run dev
 ```
 
-The environment flag takes precedence over game state (see `getEnabledOverride` and
-`isTokenPlaceEnabled` in `frontend/src/utils/tokenPlace.js`). If you set
-`VITE_TOKEN_PLACE_ENABLED=false`, token.place stays disabled even if game state is enabled. When
-enabled, the URL preference order in `tokenPlaceChat` is `tokenPlace.url` (game state), then
-`VITE_TOKEN_PLACE_URL`, then the default URL.
-
-You can clear the saved URL (or the opt-in flag) by resetting your game state.
+The URL preference order is `tokenPlace.url` (legacy saved game state), then
+`VITE_TOKEN_PLACE_URL`, then `https://token.place`.

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -44,7 +44,8 @@ const fallbackModels = ['gpt-5-mini'];
 export const CHAT_PROMPT_VERSION = getPromptVersionLabel();
 export const SYSTEM_POLICY_VERSION_LINE = 'SYSTEM_POLICY_VERSION=v3.0 never-invent-game-facts';
 export const safeFallbackMessage = "I don't know; please check /docs for the latest details.";
-export const providerRealityLine = 'In v3, chat uses OpenAI. token.place is deferred to v3.1.';
+export const providerRealityLine =
+    'In v3.1, chat supports token.place by default and OpenAI as an explicit opt-in provider.';
 export const fallbackSystemPrompt =
     defaultPersona?.systemPrompt ||
     "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-5, Stable Diffusion, and DALL-E 2. You have curated knowledge about quests, items, processes, and how inventory and progression systems work in general. Use the PlayerState block when provided; if it is missing, ask for a /gamesaves export. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!";

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -56,7 +56,31 @@ export const getTokenPlaceChatModel = (options = {}) =>
         options.model || readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL') || DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-export const isTokenPlaceEnabled = () => true;
+const parseEnabledOverride = (value) => {
+    if (value === true || value === false) return value;
+    if (typeof value !== 'string') return undefined;
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    return undefined;
+};
+
+export const isTokenPlaceEnabled = (options = {}) => {
+    const envOverride = parseEnabledOverride(readEnvValue('VITE_TOKEN_PLACE_ENABLED'));
+    if (envOverride !== undefined) return envOverride;
+
+    const state = options.state || loadGameState();
+    return parseEnabledOverride(state?.tokenPlace?.enabled) === true;
+};
+
+const sanitizeChatMessage = (message) => ({
+    role: typeof message?.role === 'string' ? message.role : 'user',
+    content:
+        typeof message?.content === 'string' ? message.content : String(message?.content || ''),
+});
+
+export const sanitizeTokenPlaceMessages = (messages = []) =>
+    (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
 
 const sanitizeMetadataValue = (value) => {
     if (typeof value === 'string') return value.slice(0, 200);
@@ -113,7 +137,7 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         : [];
     const requestBody = {
         model: getTokenPlaceChatModel(options),
-        messages: promptPayload.combinedMessages || [],
+        messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
         metadata: buildTokenPlaceMetadata(options.metadata),
     };
 
@@ -128,6 +152,7 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestBody),
             signal: options.signal,
+            credentials: 'omit',
         });
     } catch (error) {
         throw createTokenPlaceNetworkError(error);

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,110 +1,164 @@
 import { loadGameState, ready } from './gameState/common.js';
+import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import {
+    createMalformedTokenPlaceResponseError,
+    createTokenPlaceHttpError,
+    createTokenPlaceNetworkError,
+} from './tokenPlaceErrors.js';
 
-const DEFAULT_URL = 'https://token.place/api';
+const DEFAULT_ORIGIN = 'https://token.place';
+const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
+const DEFAULT_CHAT_MODEL = 'gpt-5-chat-latest';
+const METADATA_DENY_PATTERN =
+    /(?:key|token|secret|credential|password|authorization|auth|inventory|save|state|player)/i;
 
-const parseBoolean = (value) => {
-    if (value === undefined || value === null) return undefined;
-
-    if (typeof value === 'boolean') return value;
-
-    const normalized = String(value).trim().toLowerCase();
-
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-
+const readEnvValue = (key) => {
+    if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
+        return import.meta.env[key];
+    }
+    if (typeof process !== 'undefined' && process.env?.[key]) {
+        return process.env[key];
+    }
     return undefined;
 };
 
-const getEnvUrl = () => {
-    // Prefer Vite-style environment variables but fall back to Node env for tests
-    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TOKEN_PLACE_URL) {
-        return import.meta.env.VITE_TOKEN_PLACE_URL;
-    }
-    if (typeof process !== 'undefined' && process.env?.VITE_TOKEN_PLACE_URL) {
-        return process.env.VITE_TOKEN_PLACE_URL;
-    }
-    return null;
+const stripTrailingSlashes = (value) =>
+    String(value || '')
+        .trim()
+        .replace(/\/+$/g, '');
+
+const isPlainObject = (value) =>
+    Boolean(value) &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype;
+
+export const resolveTokenPlaceBaseUrl = (options = {}) => {
+    const state = options.state || loadGameState();
+    const candidate =
+        options.url ||
+        state?.tokenPlace?.url ||
+        readEnvValue('VITE_TOKEN_PLACE_URL') ||
+        DEFAULT_ORIGIN;
+    let baseUrl = stripTrailingSlashes(candidate) || DEFAULT_ORIGIN;
+
+    baseUrl = baseUrl.replace(/\/api\/v1\/chat\/completions$/i, '');
+    baseUrl = baseUrl.replace(/\/api\/v1$/i, '');
+    baseUrl = baseUrl.replace(/\/api$/i, '');
+
+    return stripTrailingSlashes(baseUrl) || DEFAULT_ORIGIN;
 };
 
-const getEnabledOverride = () => {
-    const envValue =
-        (typeof import.meta !== 'undefined' &&
-        import.meta.env?.VITE_TOKEN_PLACE_ENABLED !== undefined
-            ? import.meta.env.VITE_TOKEN_PLACE_ENABLED
-            : undefined) ??
-        (typeof process !== 'undefined' ? process.env?.VITE_TOKEN_PLACE_ENABLED : undefined);
+export const buildTokenPlaceChatCompletionsUrl = (baseUrl) =>
+    `${resolveTokenPlaceBaseUrl({ url: baseUrl })}${CHAT_COMPLETIONS_PATH}`;
 
-    return parseBoolean(envValue);
+export const getTokenPlaceChatModel = (options = {}) =>
+    String(
+        options.model || readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL') || DEFAULT_CHAT_MODEL
+    ).trim() || DEFAULT_CHAT_MODEL;
+
+export const isTokenPlaceEnabled = () => true;
+
+const sanitizeMetadataValue = (value) => {
+    if (typeof value === 'string') return value.slice(0, 200);
+    if (typeof value === 'number' || typeof value === 'boolean') return value;
+    return undefined;
 };
 
-export const isTokenPlaceEnabled = (options = {}) => {
-    const { state = loadGameState() } = options;
-    const enabledOverride = getEnabledOverride();
+export const buildTokenPlaceMetadata = (metadata = {}) => {
+    const safeMetadata = {
+        client: 'dspace',
+        provider: 'token.place',
+    };
 
-    if (enabledOverride !== undefined) {
-        // Explicit env flag takes precedence over any configured URLs or saved state
-        return enabledOverride;
+    if (isPlainObject(metadata)) {
+        Object.entries(metadata).forEach(([key, value]) => {
+            if (!key || METADATA_DENY_PATTERN.test(key)) return;
+            const safeValue = sanitizeMetadataValue(value);
+            if (safeValue !== undefined) {
+                safeMetadata[key] = safeValue;
+            }
+        });
     }
 
-    const stateEnabled = parseBoolean(state?.tokenPlace?.enabled);
-
-    return stateEnabled === true;
+    return safeMetadata;
 };
 
-export const tokenPlaceChat = async (messages, { signal } = {}) => {
+export const extractTokenPlaceAssistantText = (response) => {
+    const content = response?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: missing assistant content.'
+        );
+    }
+    return content;
+};
+
+const parseErrorPayload = async (response) => {
+    try {
+        return await response.json();
+    } catch {
+        try {
+            return { message: await response.text() };
+        } catch {
+            return { message: response.statusText };
+        }
+    }
+};
+
+export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
-    const envUrl = getEnvUrl();
-    const state = loadGameState();
-    const enabled = isTokenPlaceEnabled({ state });
+    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const contextSources = Array.isArray(promptPayload.contextSources)
+        ? promptPayload.contextSources
+        : [];
+    const requestBody = {
+        model: getTokenPlaceChatModel(options),
+        messages: promptPayload.combinedMessages || [],
+        metadata: buildTokenPlaceMetadata(options.metadata),
+    };
 
-    if (!enabled) {
-        throw new Error(
-            'token.place is disabled. Set VITE_TOKEN_PLACE_ENABLED=true or set tokenPlace.enabled=true in game settings.'
+    const url = buildTokenPlaceChatCompletionsUrl(
+        options.url || resolveTokenPlaceBaseUrl({ state: promptPayload.gameState })
+    );
+
+    let response;
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+            signal: options.signal,
+        });
+    } catch (error) {
+        throw createTokenPlaceNetworkError(error);
+    }
+
+    if (!response.ok) {
+        const errorPayload = await parseErrorPayload(response);
+        throw createTokenPlaceHttpError(response.status, errorPayload, response.statusText);
+    }
+
+    let data;
+    try {
+        data = await response.json();
+    } catch (error) {
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: invalid JSON.'
         );
     }
 
-    const baseUrl = state.tokenPlace?.url || envUrl || DEFAULT_URL;
+    const outputText = extractTokenPlaceAssistantText(data);
+    const { text } = validateChatResponseText(outputText, { contextSources });
 
-    const systemMessage = {
-        role: 'system',
-        content:
-            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. If you're unsure about something, suggest checking the docs or joining the Discord server. Have fun!",
+    return {
+        text,
+        contextSources,
+        usage: data?.usage,
+        metadata: data?.metadata,
     };
+};
 
-    const openingMessage = {
-        role: 'assistant',
-        content: 'Welcome! How can I assist you today?',
-    };
-
-    let combinedMessages = [...messages];
-    if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage, openingMessage];
-    } else {
-        combinedMessages = [systemMessage, ...combinedMessages];
-    }
-
-    const response = await fetch(`${baseUrl}/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: combinedMessages }),
-        signal,
-    });
-
-    if (!response.ok) {
-        let details;
-        try {
-            const err = await response.json();
-            details = err.error || err.message || response.statusText;
-        } catch {
-            try {
-                details = await response.text();
-            } catch {
-                details = response.statusText;
-            }
-        }
-        throw new Error(`token.place API request failed: ${details}`);
-    }
-
-    const data = await response.json();
-    return data.reply;
+export const tokenPlaceChat = async (messages, options = {}) => {
+    const result = await TokenPlaceChatV2(messages, options);
+    return result.text;
 };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -56,22 +56,7 @@ export const getTokenPlaceChatModel = (options = {}) =>
         options.model || readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL') || DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-const parseEnabledOverride = (value) => {
-    if (value === true || value === false) return value;
-    if (typeof value !== 'string') return undefined;
-    const normalized = value.trim().toLowerCase();
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-    return undefined;
-};
-
-export const isTokenPlaceEnabled = (options = {}) => {
-    const envOverride = parseEnabledOverride(readEnvValue('VITE_TOKEN_PLACE_ENABLED'));
-    if (envOverride !== undefined) return envOverride;
-
-    const state = options.state || loadGameState();
-    return parseEnabledOverride(state?.tokenPlace?.enabled) !== false;
-};
+export const isTokenPlaceEnabled = () => true;
 
 const sanitizeChatMessage = (message) => ({
     role: typeof message?.role === 'string' ? message.role : 'user',

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -70,7 +70,7 @@ export const isTokenPlaceEnabled = (options = {}) => {
     if (envOverride !== undefined) return envOverride;
 
     const state = options.state || loadGameState();
-    return parseEnabledOverride(state?.tokenPlace?.enabled) === true;
+    return parseEnabledOverride(state?.tokenPlace?.enabled) !== false;
 };
 
 const sanitizeChatMessage = (message) => ({

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -1,20 +1,81 @@
-export const getTokenPlaceErrorSummary = (error) => {
-    const message = error?.message || '';
-    const normalizedMessage = message.toLowerCase();
+export class TokenPlaceError extends Error {
+    constructor(message, options = {}) {
+        super(message);
+        this.name = 'TokenPlaceError';
+        this.type = options.type || 'provider';
+        this.status = options.status;
+        this.code = options.code;
+        this.param = options.param;
+        this.providerMessage = options.providerMessage;
+        this.cause = options.cause;
+    }
+}
 
-    if (normalizedMessage.includes('disabled')) {
+const isAbortError = (error) =>
+    error?.name === 'AbortError' ||
+    String(error?.message || '')
+        .toLowerCase()
+        .includes('abort');
+
+export const createTokenPlaceHttpError = (status, errorPayload = {}, fallbackMessage = '') => {
+    const providerError =
+        errorPayload?.error && typeof errorPayload.error === 'object' ? errorPayload.error : {};
+    const message =
+        providerError.message || errorPayload?.message || fallbackMessage || 'Provider error';
+    let type = providerError.type || 'provider';
+
+    if (providerError.param === 'stream') {
+        type = 'validation';
+    } else if (
+        providerError.type === 'content_policy_violation' ||
+        providerError.code === 'content_blocked'
+    ) {
+        type = 'content_policy';
+    } else if (status === 429) {
+        type = 'rate_limit';
+    } else if (status >= 500) {
+        type = 'server';
+    }
+
+    return new TokenPlaceError(`token.place API v1 request failed: ${message}`, {
+        type,
+        status,
+        code: providerError.code,
+        param: providerError.param,
+        providerMessage: message,
+    });
+};
+
+export const createTokenPlaceNetworkError = (error) =>
+    new TokenPlaceError('Could not reach token.place.', {
+        type: isAbortError(error) ? 'abort' : 'network',
+        providerMessage: error?.message,
+        cause: error,
+    });
+
+export const createMalformedTokenPlaceResponseError = (
+    message = 'Malformed token.place response.'
+) => new TokenPlaceError(message, { type: 'malformed' });
+
+export const getTokenPlaceErrorSummary = (error) => {
+    const type = error?.type;
+    const status = error?.status;
+    const code = error?.code;
+    const param = error?.param;
+    const message = String(error?.message || '').toLowerCase();
+
+    if (type === 'abort' || error?.name === 'AbortError') {
         return {
-            type: 'disabled',
-            message:
-                'token.place chat is disabled. Enable it in Settings or set the token.place ' +
-                'flag for this environment.',
+            type: 'abort',
+            message: 'The token.place request was canceled. Please try again.',
         };
     }
 
     if (
-        normalizedMessage.includes('failed to fetch') ||
-        normalizedMessage.includes('network') ||
-        normalizedMessage.includes('fetch')
+        type === 'network' ||
+        message.includes('failed to fetch') ||
+        message.includes('network') ||
+        message.includes('fetch')
     ) {
         return {
             type: 'network',
@@ -22,7 +83,42 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
-    if (normalizedMessage.includes('api request failed')) {
+    if (type === 'content_policy' || code === 'content_blocked') {
+        return {
+            type: 'content_policy',
+            message: 'token.place blocked that request by policy. Try rephrasing your message.',
+        };
+    }
+
+    if (type === 'rate_limit' || status === 429) {
+        return {
+            type: 'rate_limit',
+            message: 'token.place is rate limited or out of daily quota. Please try again later.',
+        };
+    }
+
+    if (type === 'server' || status >= 500) {
+        return {
+            type: 'server',
+            message: 'token.place is temporarily unavailable. Please try again in a moment.',
+        };
+    }
+
+    if (type === 'validation' && param === 'stream') {
+        return {
+            type: 'validation',
+            message: 'token.place rejected an unsupported chat option. Please try again.',
+        };
+    }
+
+    if (type === 'malformed' || message.includes('malformed')) {
+        return {
+            type: 'malformed',
+            message: 'token.place returned an unexpected response. Please try again shortly.',
+        };
+    }
+
+    if (type === 'provider' || status >= 400) {
         return {
             type: 'provider',
             message: 'token.place returned an error. Please try again in a moment.',

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -71,6 +71,13 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
+    if (message.includes('token.place is disabled')) {
+        return {
+            type: 'disabled',
+            message: 'token.place is disabled. Enable it in settings or configure the integration.',
+        };
+    }
+
     if (
         type === 'network' ||
         message.includes('failed to fetch') ||
@@ -118,7 +125,12 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
-    if (type === 'provider' || status >= 400) {
+    if (
+        type === 'provider' ||
+        status >= 400 ||
+        message.includes('token.place api request failed') ||
+        message.includes('token.place api v1 request failed')
+    ) {
         return {
             type: 'provider',
             message: 'token.place returned an error. Please try again in a moment.',

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -17,6 +17,18 @@ const isAbortError = (error) =>
         .toLowerCase()
         .includes('abort');
 
+const isNetworkError = (error) => {
+    const name = String(error?.name || '').toLowerCase();
+    const message = String(error?.message || '').toLowerCase();
+    return (
+        name.includes('typeerror') ||
+        name.includes('network') ||
+        message.includes('failed to fetch') ||
+        message.includes('network') ||
+        message.includes('load failed')
+    );
+};
+
 export const createTokenPlaceHttpError = (status, errorPayload = {}, fallbackMessage = '') => {
     const providerError =
         errorPayload?.error && typeof errorPayload.error === 'object' ? errorPayload.error : {};
@@ -48,7 +60,7 @@ export const createTokenPlaceHttpError = (status, errorPayload = {}, fallbackMes
 
 export const createTokenPlaceNetworkError = (error) =>
     new TokenPlaceError('Could not reach token.place.', {
-        type: isAbortError(error) ? 'abort' : 'network',
+        type: isAbortError(error) ? 'abort' : isNetworkError(error) ? 'network' : 'unknown',
         providerMessage: error?.message,
         cause: error,
     });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -92,6 +92,7 @@ export default defineConfig({
     ],
   },
   test: {
+    root: __dirname,
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
@@ -111,8 +112,8 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
-      '__tests__/tokenPlace.test.js',
-      '__tests__/tokenPlaceErrors.test.js',
+      'frontend/__tests__/tokenPlace.test.js',
+      'frontend/__tests__/tokenPlaceErrors.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,8 +111,6 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
-      'frontend/__tests__/tokenPlace.test.js',
-      'frontend/__tests__/tokenPlaceErrors.test.js',
       '__tests__/tokenPlace.test.js',
       '__tests__/tokenPlaceErrors.test.js',
     ],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,7 +111,10 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
+      'frontend/__tests__/tokenPlace.test.js',
+      'frontend/__tests__/tokenPlaceErrors.test.js',
       '__tests__/tokenPlace.test.js',
+      '__tests__/tokenPlaceErrors.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,6 +111,7 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
+      '__tests__/tokenPlace.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {


### PR DESCRIPTION
### Motivation
- Replace the legacy token.place `/chat` client with a direct, zero-auth fetch-based token.place API v1 client so v3.1 defaults to token.place and follows the design doc contract. 
- Ensure requests are OpenAI-compatible (messages + model), non-streaming, and avoid sending any credentials or `Authorization` headers. 
- Provide safe metadata handling, clear error classification for UI consumption, and reuse the existing DSPACE prompt/RAG pipeline so token.place and OpenAI receive consistent prompts.

### Description
- Added a new fetch-based client `TokenPlaceChatV2(messages, options)` and compatibility helper `tokenPlaceChat(messages, options)` in `frontend/src/utils/tokenPlace.js`, plus pure helpers: `resolveTokenPlaceBaseUrl`, `buildTokenPlaceChatCompletionsUrl`, `getTokenPlaceChatModel`, `buildTokenPlaceMetadata`, and `extractTokenPlaceAssistantText`.
- Implemented URL normalization to produce `POST https://token.place/api/v1/chat/completions` by default and honor `VITE_TOKEN_PLACE_URL` and `state.tokenPlace.url` (normalized, trailing slashes stripped, no `/api/api` duplication); default model is `gpt-5-chat-latest` and `VITE_TOKEN_PLACE_CHAT_MODEL` overrides it.
- Enforced zero-auth request shape with OpenAI-compatible `messages`, `model`, and safe `metadata` (client/provider + caller plain-object keys filtered to remove secrets); `stream` is never set to `true`.
- Added robust error classification in `frontend/src/utils/tokenPlaceErrors.js` with `TokenPlaceError` and creators for network/abort, structured API v1 errors (validation/`stream`, content policy, rate limit 429, server 5xx), and malformed responses, plus a UI-safe `getTokenPlaceErrorSummary`.
- Reused `buildChatPrompt()` from `frontend/src/utils/openAI.js` and updated `providerRealityLine` to remove stale v3.0 OpenAI-default wording so token.place debug/system payloads do not contain "token.place is deferred" or similar language.
- Reworked and expanded unit tests in `frontend/__tests__/tokenPlace.test.js` to cover URL normalization, env/state overrides, request shape, zero-auth, metadata filtering, default/override model, response parsing, richer return `{ text, contextSources, usage, metadata }`, abort signal pass-through, malformed responses, and structured API error cases; added the test file to Vitest includes so the focused test command runs.

### Testing
- Ran the focused unit tests: `cd frontend && npm test -- tokenPlace.test.js` and the suite passed (`__tests__/tokenPlace.test.js` — 16 tests passed).
- Verified code search and guards with: `rg -n "VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|api/v1/chat/completions|/api/chat|\${baseUrl}/chat|Authorization|stream|providerRealityLine|deferred" frontend/src/utils frontend/__tests__` to confirm requests target `/api/v1/chat/completions`, no `Authorization` header is added, and stale provider-language was updated.
- Ran repository checks: `cd frontend && npm run check` (lint + format check) and it succeeded.

If you want, I can follow up with the settings/UI integration (provider choice persistence and chat UI refactor) in the next PR as scoped in the design doc.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309e21fc74832fbfcd55cd34cbd914)