### PR TITLE
Implement token.place API v1 chat client

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1,108 +1,282 @@
-const { vi } = require('vitest');
+import { vi } from 'vitest';
 const jest = vi;
 
+const mockedState = {
+    quests: {},
+    processes: {},
+    inventory: {},
+    openAI: { apiKey: 'sk-openai-secret' }, // scan-secrets: ignore
+    tokenPlace: {},
+};
+
+jest.mock('openai', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
 jest.mock('../src/utils/gameState/common.js', () => ({
-    loadGameState: jest.fn(),
+    loadGameState: jest.fn(() => mockedState),
     ready: Promise.resolve(),
 }));
 
-const { tokenPlaceChat, isTokenPlaceEnabled } = require('../src/utils/tokenPlace.js');
-const { loadGameState } = require('../src/utils/gameState/common.js');
+jest.mock('../src/utils/docsRag.js', () => ({
+    searchDocsRag: jest.fn(async () => ({
+        excerptsText: 'Docs excerpt for DSPACE chat testing.',
+        sources: [{ title: 'Docs', url: '/docs/about' }],
+    })),
+}));
 
-describe('tokenPlaceChat', () => {
+const { loadGameState } = await import('../src/utils/gameState/common.js');
+const {
+    TokenPlaceChatV2,
+    buildTokenPlaceChatCompletionsUrl,
+    buildTokenPlaceMetadata,
+    extractTokenPlaceAssistantText,
+    getTokenPlaceChatModel,
+    isTokenPlaceEnabled,
+    resolveTokenPlaceBaseUrl,
+    tokenPlaceChat,
+} = await import('../src/utils/tokenPlace.js');
+const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
+const { buildChatPrompt } = await import('../src/utils/openAI.js');
+
+const successResponse = (data = {}) => ({
+    ok: true,
+    status: 200,
+    json: () =>
+        Promise.resolve({
+            choices: [{ message: { content: 'mocked token.place reply' } }],
+            usage: { total_tokens: 42 },
+            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+            ...data,
+        }),
+});
+
+const latestFetchBody = () => JSON.parse(fetch.mock.calls.at(-1)[1].body);
+
+const expectNoLegacyEndpoint = (url) => {
+    expect(url).toContain('/api/v1/chat/completions');
+    expect(url).not.toContain('/api/api/v1/chat/completions');
+    expect(url).not.toMatch(/\/api\/chat$/);
+    expect(url).not.toMatch(/(?<!completions)\/chat$/);
+};
+
+describe('token.place API v1 client', () => {
     beforeEach(() => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ reply: 'mocked reply' }),
-            })
-        );
+        loadGameState.mockReturnValue(mockedState);
+        global.fetch = jest.fn(() => Promise.resolve(successResponse()));
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
         delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
-    test('uses game state url when configured', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
+    test('is enabled by default and legacy disabled state does not block v3.1 chat', async () => {
+        loadGameState.mockReturnValue({ ...mockedState, tokenPlace: { enabled: false } });
+        expect(isTokenPlaceEnabled()).toBe(true);
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
+        expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    test('falls back to env url when game state missing', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('http://env.token/chat', expect.any(Object));
+    test('fresh/default state posts to the API v1 chat completions endpoint', async () => {
+        loadGameState.mockReturnValue({ ...mockedState, tokenPlace: {} });
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        expect(fetch.mock.calls[0][0]).toBe('https://token.place/api/v1/chat/completions');
+        expectNoLegacyEndpoint(fetch.mock.calls[0][0]);
     });
 
-    test('prepends system message and returns response', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const result = await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const body = JSON.parse(fetch.mock.calls[0][1].body);
-        expect(body.messages[0].role).toBe('system');
-        expect(result).toBe('mocked reply');
-    });
-
-    test('passes abort signal to fetch', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const controller = new AbortController();
-        await tokenPlaceChat([], { signal: controller.signal });
-        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
-    });
-
-    test('throws helpful error when request fails', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        fetch.mockResolvedValueOnce({
-            ok: false,
-            json: () => Promise.resolve({ error: 'bad request' }),
-        });
-        await expect(tokenPlaceChat([])).rejects.toThrow(
-            'token.place API request failed: bad request'
+    test('VITE_TOKEN_PLACE_URL override works and strips trailing slashes', async () => {
+        process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place///';
+        expect(resolveTokenPlaceBaseUrl({ state: { tokenPlace: {} } })).toBe(
+            'https://staging.token.place'
+        );
+        expect(buildTokenPlaceChatCompletionsUrl({ state: { tokenPlace: {} } })).toBe(
+            'https://staging.token.place/api/v1/chat/completions'
         );
     });
 
-    test('throws when disabled by default', async () => {
-        loadGameState.mockReturnValue({});
-        await expect(tokenPlaceChat([])).rejects.toThrow('token.place is disabled');
+    test('state tokenPlace.url compatibility override wins when present', () => {
+        process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
+        expect(
+            buildTokenPlaceChatCompletionsUrl({
+                state: { tokenPlace: { url: 'https://state.token.place' } },
+            })
+        ).toBe('https://state.token.place/api/v1/chat/completions');
     });
 
-    test('uses default url when explicitly enabled without overrides', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('https://token.place/api/chat', expect.any(Object));
-    });
-});
-
-describe('isTokenPlaceEnabled', () => {
-    afterEach(() => {
-        delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
+    test('legacy /api URL normalizes without producing duplicate api segments', () => {
+        const url = buildTokenPlaceChatCompletionsUrl({
+            state: { tokenPlace: { url: 'https://token.place/api' } },
+        });
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(url).not.toContain('/api/api/v1/chat/completions');
     });
 
-    test('is false when no overrides are set', () => {
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
+    test('default and env override models are used', () => {
+        expect(getTokenPlaceChatModel()).toBe('gpt-5-chat-latest');
+        process.env.VITE_TOKEN_PLACE_CHAT_MODEL = 'custom-chat-model';
+        expect(getTokenPlaceChatModel()).toBe('custom-chat-model');
     });
 
-    test('is false when tokenPlace url exists in state without opt-in', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { url: 'http://tp' } } })).toBe(false);
+    test('request shape is OpenAI-compatible, zero-auth, non-streaming, and safe', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
+            metadata: {
+                conversation_id: 'conv-42',
+                apiKey: 'tp-secret',
+                inventory: { rocket: 1 },
+                saveData: 'raw save',
+            },
+            stream: true,
+        });
+        const options = fetch.mock.calls[0][1];
+        const body = latestFetchBody();
+        const serializedBody = JSON.stringify(body);
+
+        expect(options.method).toBe('POST');
+        expect(options.headers).toEqual({ 'Content-Type': 'application/json' });
+        expect(options.headers.Authorization).toBeUndefined();
+        expect(body.model).toBe('gpt-5-chat-latest');
+        expect(Array.isArray(body.messages)).toBe(true);
+        expect(body.messages.some((message) => message.role === 'user')).toBe(true);
+        expect(body.stream).toBe(false);
+        expect(body.metadata).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+        });
+        expect(serializedBody).not.toContain('sk-openai-secret');
+        expect(serializedBody).not.toContain('tp-secret');
+        expect(serializedBody).not.toContain('raw save');
+        expect(JSON.stringify(body.metadata)).not.toContain('rocket');
     });
 
-    test('is true when tokenPlace is explicitly enabled in state', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
+    test('stream is absent when not requested', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        expect(latestFetchBody().stream).toBeUndefined();
     });
 
-    test('respects explicit env disable', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
+    test('safe metadata helper keeps only safe scalar values', () => {
+        expect(
+            buildTokenPlaceMetadata({
+                conversation_id: 'conv-42',
+                requestId: 7,
+                token: 'secret',
+                player_inventory: 'nope',
+                nested: { unsafe: true },
+            })
+        ).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+            requestId: 7,
+        });
     });
 
-    test('is true when env override enables it', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+    test('response parser and rich helper return text, DSPACE contextSources, usage, and metadata', async () => {
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'where are docs?' }]);
+        expect(result.text).toBe('mocked token.place reply');
+        expect(result.usage).toEqual({ total_tokens: 42 });
+        expect(result.metadata).toEqual({ client: 'dspace', conversation_id: 'conv-42' });
+        expect(result.contextSources.length).toBeGreaterThan(0);
+        expect(result.contextSources[0]).toEqual(
+            expect.objectContaining({ type: expect.any(String), url: expect.any(String) })
+        );
+        expect(result.contextSources).not.toEqual(result.metadata);
+        expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
+            'hi'
+        );
+    });
+
+    test('compatibility tokenPlaceChat export returns only assistant text', async () => {
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked token.place reply'
+        );
+    });
+
+    test('abort signal is passed through', async () => {
+        const controller = new AbortController();
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], { signal: controller.signal });
+        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
+    });
+
+    test('malformed responses classify as safe malformed provider responses', async () => {
+        fetch.mockResolvedValueOnce(successResponse({ choices: [{ message: { content: '' } }] }));
+        let caughtError;
+        try {
+            await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        } catch (error) {
+            caughtError = error;
+        }
+
+        expect(caughtError).toMatchObject({ type: 'malformed' });
+        expect(getTokenPlaceErrorSummary(caughtError)).toEqual({
+            type: 'malformed',
+            message: 'token.place returned a response DSPACE could not read. Please try again.',
+        });
+    });
+
+    test.each([
+        [
+            'content policy',
+            400,
+            { message: 'blocked', type: 'content_policy_violation', code: 'content_blocked' },
+            'content_policy',
+        ],
+        ['rate limit', 429, { message: 'too many requests', type: 'rate_limit' }, 'rate_limit'],
+        ['server unavailable', 503, { message: 'unavailable', type: 'server_error' }, 'server'],
+        [
+            'generic provider',
+            400,
+            { message: 'invalid request', type: 'invalid_request_error' },
+            'provider',
+        ],
+        [
+            'stream true validation',
+            400,
+            { message: 'stream unsupported', param: 'stream' },
+            'validation',
+        ],
+    ])('structured API error summary: %s', async (_name, status, error, expectedType) => {
+        fetch.mockResolvedValueOnce({
+            ok: false,
+            status,
+            json: () => Promise.resolve({ error }),
+        });
+
+        try {
+            await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+            throw new Error('expected rejection');
+        } catch (caught) {
+            expect(getTokenPlaceErrorSummary(caught).type).toBe(expectedType);
+            expect(getTokenPlaceErrorSummary(caught).message).not.toMatch(/OpenAI/i);
+        }
+    });
+
+    test('network and abort errors are classified safely', async () => {
+        fetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'network',
+        });
+
+        fetch.mockRejectedValueOnce(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'abort',
+        });
+    });
+
+    test('token.place request and debug/system payloads do not include stale v3.0 guidance', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        const serializedRequest = JSON.stringify(latestFetchBody());
+        const { debugMessages } = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
+        const serializedDebug = JSON.stringify(debugMessages);
+
+        expect(serializedRequest).not.toMatch(/token\.place is deferred/i);
+        expect(serializedRequest).not.toMatch(/chat uses OpenAI/i);
+        expect(serializedDebug).not.toMatch(/token\.place is deferred/i);
+        expect(serializedDebug).not.toMatch(/chat uses OpenAI/i);
+        expect(serializedRequest).toMatch(/token\.place is the default provider/i);
     });
 });

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -44,7 +44,8 @@ const fallbackModels = ['gpt-5-mini'];
 export const CHAT_PROMPT_VERSION = getPromptVersionLabel();
 export const SYSTEM_POLICY_VERSION_LINE = 'SYSTEM_POLICY_VERSION=v3.0 never-invent-game-facts';
 export const safeFallbackMessage = "I don't know; please check /docs for the latest details.";
-export const providerRealityLine = 'In v3, chat uses OpenAI. token.place is deferred to v3.1.';
+export const providerRealityLine =
+    'In v3.1, DSPACE chat supports provider-aware responses. token.place is the default provider, and OpenAI remains available only when explicitly selected.';
 export const fallbackSystemPrompt =
     defaultPersona?.systemPrompt ||
     "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-5, Stable Diffusion, and DALL-E 2. You have curated knowledge about quests, items, processes, and how inventory and progression systems work in general. Use the PlayerState block when provided; if it is missing, ask for a /gamesaves export. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!";

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,110 +1,144 @@
 import { loadGameState, ready } from './gameState/common.js';
+import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { createTokenPlaceError } from './tokenPlaceErrors.js';
 
-const DEFAULT_URL = 'https://token.place/api';
+const DEFAULT_URL = 'https://token.place';
+const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
+const DEFAULT_MODEL = 'gpt-5-chat-latest';
+const SAFE_METADATA_KEY_PATTERN =
+    /^(client|provider|conversation_id|conversationId|request_id|requestId|source)$/;
+const SECRET_METADATA_KEY_PATTERN =
+    /key|token|secret|password|credential|authorization|auth|save|inventory|player/i;
 
-const parseBoolean = (value) => {
-    if (value === undefined || value === null) return undefined;
-
-    if (typeof value === 'boolean') return value;
-
-    const normalized = String(value).trim().toLowerCase();
-
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-
+const readEnvValue = (key) => {
+    if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
+        return import.meta.env[key];
+    }
+    if (typeof process !== 'undefined' && process.env?.[key]) {
+        return process.env[key];
+    }
     return undefined;
 };
 
-const getEnvUrl = () => {
-    // Prefer Vite-style environment variables but fall back to Node env for tests
-    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TOKEN_PLACE_URL) {
-        return import.meta.env.VITE_TOKEN_PLACE_URL;
-    }
-    if (typeof process !== 'undefined' && process.env?.VITE_TOKEN_PLACE_URL) {
-        return process.env.VITE_TOKEN_PLACE_URL;
-    }
-    return null;
+const isPlainObject = (value) =>
+    Boolean(value) &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype;
+
+export const isTokenPlaceEnabled = () => true;
+
+export const resolveTokenPlaceBaseUrl = (options = {}) => {
+    const state = options.state || loadGameState();
+    const configuredUrl =
+        state?.tokenPlace?.url || readEnvValue('VITE_TOKEN_PLACE_URL') || DEFAULT_URL;
+    let baseUrl = String(configuredUrl).trim() || DEFAULT_URL;
+    baseUrl = baseUrl.replace(/\/+$/, '');
+    baseUrl = baseUrl.replace(/\/api(?:\/v\d+)?(?:\/chat\/completions)?$/i, '');
+    return baseUrl || DEFAULT_URL;
 };
 
-const getEnabledOverride = () => {
-    const envValue =
-        (typeof import.meta !== 'undefined' &&
-        import.meta.env?.VITE_TOKEN_PLACE_ENABLED !== undefined
-            ? import.meta.env.VITE_TOKEN_PLACE_ENABLED
-            : undefined) ??
-        (typeof process !== 'undefined' ? process.env?.VITE_TOKEN_PLACE_ENABLED : undefined);
+export const buildTokenPlaceChatCompletionsUrl = (options = {}) =>
+    `${resolveTokenPlaceBaseUrl(options)}${CHAT_COMPLETIONS_PATH}`;
 
-    return parseBoolean(envValue);
-};
+export const getTokenPlaceChatModel = () =>
+    readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL')?.trim() || DEFAULT_MODEL;
 
-export const isTokenPlaceEnabled = (options = {}) => {
-    const { state = loadGameState() } = options;
-    const enabledOverride = getEnabledOverride();
+export const buildTokenPlaceMetadata = (metadata = {}) => {
+    const safeMetadata = { client: 'dspace', provider: 'token.place' };
+    if (!isPlainObject(metadata)) return safeMetadata;
 
-    if (enabledOverride !== undefined) {
-        // Explicit env flag takes precedence over any configured URLs or saved state
-        return enabledOverride;
-    }
-
-    const stateEnabled = parseBoolean(state?.tokenPlace?.enabled);
-
-    return stateEnabled === true;
-};
-
-export const tokenPlaceChat = async (messages, { signal } = {}) => {
-    await ready;
-    const envUrl = getEnvUrl();
-    const state = loadGameState();
-    const enabled = isTokenPlaceEnabled({ state });
-
-    if (!enabled) {
-        throw new Error(
-            'token.place is disabled. Set VITE_TOKEN_PLACE_ENABLED=true or set tokenPlace.enabled=true in game settings.'
-        );
-    }
-
-    const baseUrl = state.tokenPlace?.url || envUrl || DEFAULT_URL;
-
-    const systemMessage = {
-        role: 'system',
-        content:
-            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. If you're unsure about something, suggest checking the docs or joining the Discord server. Have fun!",
-    };
-
-    const openingMessage = {
-        role: 'assistant',
-        content: 'Welcome! How can I assist you today?',
-    };
-
-    let combinedMessages = [...messages];
-    if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage, openingMessage];
-    } else {
-        combinedMessages = [systemMessage, ...combinedMessages];
-    }
-
-    const response = await fetch(`${baseUrl}/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: combinedMessages }),
-        signal,
+    Object.entries(metadata).forEach(([key, value]) => {
+        if (!SAFE_METADATA_KEY_PATTERN.test(key) || SECRET_METADATA_KEY_PATTERN.test(key)) return;
+        if (['string', 'number', 'boolean'].includes(typeof value) || value === null) {
+            safeMetadata[key] = value;
+        }
     });
 
-    if (!response.ok) {
-        let details;
-        try {
-            const err = await response.json();
-            details = err.error || err.message || response.statusText;
-        } catch {
-            try {
-                details = await response.text();
-            } catch {
-                details = response.statusText;
-            }
-        }
-        throw new Error(`token.place API request failed: ${details}`);
+    return safeMetadata;
+};
+
+export const extractTokenPlaceAssistantText = (responseData) => {
+    const content = responseData?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+        throw createTokenPlaceError(
+            'malformed',
+            'Malformed token.place response: missing assistant content.'
+        );
+    }
+    return content;
+};
+
+const parseResponseJson = async (response) => {
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+};
+
+const throwForResponseError = (response, data) => {
+    const structuredError = isPlainObject(data?.error) ? data.error : {};
+    throw createTokenPlaceError('provider', 'token.place API request failed.', {
+        status: response.status,
+        code: structuredError.code,
+        param: structuredError.param,
+        providerMessage: structuredError.message,
+        type: structuredError.type || 'provider',
+    });
+};
+
+export const TokenPlaceChatV2 = async (messages, options = {}) => {
+    await ready;
+    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const { combinedMessages, contextSources } = promptPayload;
+    const metadata = buildTokenPlaceMetadata(options.metadata);
+    const body = {
+        model: getTokenPlaceChatModel(),
+        messages: combinedMessages,
+        metadata,
+    };
+
+    if (options.stream === true) {
+        body.stream = false;
     }
 
-    const data = await response.json();
-    return data.reply;
+    let response;
+    try {
+        response = await fetch(
+            buildTokenPlaceChatCompletionsUrl({ state: promptPayload.gameState }),
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                signal: options.signal,
+            }
+        );
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            throw createTokenPlaceError('abort', 'token.place request was aborted.', {
+                cause: error,
+            });
+        }
+        throw createTokenPlaceError('network', 'Failed to reach token.place.', { cause: error });
+    }
+
+    const data = await parseResponseJson(response);
+    if (!response.ok) {
+        throwForResponseError(response, data);
+    }
+
+    const outputText = extractTokenPlaceAssistantText(data);
+    const { text } = validateChatResponseText(outputText, { contextSources });
+
+    return {
+        text,
+        contextSources: Array.isArray(contextSources) ? contextSources : [],
+        usage: data?.usage,
+        metadata: data?.metadata,
+    };
+};
+
+export const tokenPlaceChat = async (messages, options = {}) => {
+    const response = await TokenPlaceChatV2(messages, options);
+    return response.text;
 };

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -1,19 +1,49 @@
-export const getTokenPlaceErrorSummary = (error) => {
-    const message = error?.message || '';
-    const normalizedMessage = message.toLowerCase();
+export class TokenPlaceError extends Error {
+    constructor(message, options = {}) {
+        super(message);
+        this.name = 'TokenPlaceError';
+        this.type = options.type || 'provider';
+        this.status = options.status;
+        this.code = options.code;
+        this.param = options.param;
+        this.providerMessage = options.providerMessage;
+        this.cause = options.cause;
+    }
+}
 
-    if (normalizedMessage.includes('disabled')) {
+const toNumericStatus = (status) => {
+    if (typeof status === 'string') return Number(status);
+    return status;
+};
+
+export const createTokenPlaceError = (type, message, options = {}) =>
+    new TokenPlaceError(message, { ...options, type });
+
+export const getTokenPlaceErrorSummary = (error) => {
+    const status = toNumericStatus(error?.status ?? error?.response?.status);
+    const type = error?.type ?? error?.error?.type;
+    const code = error?.code ?? error?.error?.code;
+    const param = error?.param ?? error?.error?.param;
+    const message = error?.providerMessage || error?.error?.message || error?.message || '';
+    const normalizedMessage = String(message).toLowerCase();
+    const normalizedName = String(error?.name || '').toLowerCase();
+    const normalizedType = String(type || '').toLowerCase();
+    const normalizedCode = String(code || '').toLowerCase();
+
+    if (
+        normalizedName === 'aborterror' ||
+        type === 'abort' ||
+        normalizedMessage.includes('abort')
+    ) {
         return {
-            type: 'disabled',
-            message:
-                'token.place chat is disabled. Enable it in Settings or set the token.place ' +
-                'flag for this environment.',
+            type: 'abort',
+            message: 'The token.place request was cancelled. Please try again.',
         };
     }
 
     if (
-        normalizedMessage.includes('failed to fetch') ||
-        normalizedMessage.includes('network') ||
+        type === 'network' ||
+        normalizedName === 'typeerror' ||
         normalizedMessage.includes('fetch')
     ) {
         return {
@@ -22,7 +52,42 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
-    if (normalizedMessage.includes('api request failed')) {
+    if (normalizedType === 'content_policy_violation' || normalizedCode === 'content_blocked') {
+        return {
+            type: 'content_policy',
+            message: 'token.place blocked this request by policy. Try changing the message.',
+        };
+    }
+
+    if (status === 429) {
+        return {
+            type: 'rate_limit',
+            message: 'token.place is rate limiting requests right now. Please wait and try again.',
+        };
+    }
+
+    if (typeof status === 'number' && status >= 500) {
+        return {
+            type: 'server',
+            message: 'token.place is unavailable right now. Please try again in a moment.',
+        };
+    }
+
+    if (type === 'malformed') {
+        return {
+            type: 'malformed',
+            message: 'token.place returned a response DSPACE could not read. Please try again.',
+        };
+    }
+
+    if (param === 'stream' || normalizedMessage.includes('stream')) {
+        return {
+            type: 'validation',
+            message: 'token.place rejected an unsupported request option. Please try again.',
+        };
+    }
+
+    if (type === 'provider' || error?.error) {
         return {
             type: 'provider',
             message: 'token.place returned an error. Please try again in a moment.',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,6 +111,8 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
+      'frontend/__tests__/tokenPlace.test.js',
+      '__tests__/tokenPlace.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {


### PR DESCRIPTION
### Motivation
- Replace the legacy token.place `/chat` relay client with a direct, fetch-based token.place API v1 client so fresh users can use token.place zero-auth by default.
- Ensure requests are OpenAI-compatible (same prompt/messages pipeline), non-streaming, safe (no secrets), and support environment/state URL and model overrides.
- Add robust error classification and unit tests to catch malformed responses, policy/rate/server errors, and stale v3.0 prompt guidance.

### Description
- Implemented a fetch-based client in `frontend/src/utils/tokenPlace.js` exposing `TokenPlaceChatV2(messages, options)` (returns `{ text, contextSources, usage, metadata }`) and a compatibility `tokenPlaceChat(messages, options)` wrapper, plus helpers: `resolveTokenPlaceBaseUrl`, `buildTokenPlaceChatCompletionsUrl`, `getTokenPlaceChatModel`, `buildTokenPlaceMetadata`, and `extractTokenPlaceAssistantText`.
- Requests use `POST /api/v1/chat/completions` on a normalized base URL (default `https://token.place`), include `model` and `messages` from `buildChatPrompt()`, never send `Authorization`, and force `stream` to absent/false; caller-provided metadata is merged only for safe plain-object scalar keys.
- Added `TokenPlaceError` and richer error-summary mapping in `frontend/src/utils/tokenPlaceErrors.js` to classify network, abort, validation/stream, content policy, 429, 5xx, malformed, provider, and unknown errors with UI-safe messages (no OpenAI mentions).
- Updated `frontend/src/utils/openAI.js` `providerRealityLine` to v3.1-accurate wording to avoid stale v3.0 OpenAI-default claims leaking into token.place payloads.
- Reworked and expanded unit tests in `frontend/__tests__/tokenPlace.test.js` to cover URL normalization, env/state overrides, default model and model override, request shape/no-auth/non-streaming, safe metadata filtering, response parsing and richer return shape, abort passthrough, malformed and structured errors, and stale-provider-guidance checks; added test inclusion in `vitest.config.mts` so the focused test runs with the verification command.

### Testing
- Ran the verification search: `rg -n "VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|api/v1/chat/completions|/api/chat|\$\{baseUrl\}/chat|Authorization|stream|providerRealityLine|deferred" frontend/src/utils frontend/__tests__` (no forbidden strings introduced). (OK)
- Ran unit tests for the token.place client: `cd frontend && npm test -- tokenPlace.test.js`, which executed the updated suite and passed: `__tests__/tokenPlace.test.js` — 20 tests passed. (OK)
- Ran formatting and lint checks: `cd frontend && npm run check` which ran ESLint and Prettier format check and returned success (Prettier formatting verified). (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309e2eded8832fbb43da5fae69ad74)