### PR TITLE
Implement token.place API v1 chat client

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1,108 +1,239 @@
-const { vi } = require('vitest');
-const jest = vi;
+import { describe, expect, test, vi } from 'vitest';
 
-jest.mock('../src/utils/gameState/common.js', () => ({
-    loadGameState: jest.fn(),
+vi.mock('../src/utils/gameState/common.js', () => ({
+    loadGameState: vi.fn(),
     ready: Promise.resolve(),
 }));
 
-const { tokenPlaceChat, isTokenPlaceEnabled } = require('../src/utils/tokenPlace.js');
-const { loadGameState } = require('../src/utils/gameState/common.js');
+vi.mock('../src/utils/openAI.js', () => ({
+    buildChatPrompt: vi.fn(),
+    validateChatResponseText: vi.fn((text) => ({ text, wasSanitized: false })),
+}));
 
-describe('tokenPlaceChat', () => {
-    beforeEach(() => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ reply: 'mocked reply' }),
-            })
-        );
+import {
+    DEFAULT_TOKEN_PLACE_CHAT_MODEL,
+    TokenPlaceChatV2,
+    buildTokenPlaceChatCompletionsUrl,
+    buildTokenPlaceMetadata,
+    extractTokenPlaceAssistantText,
+    getTokenPlaceChatModel,
+    isTokenPlaceEnabled,
+    resolveTokenPlaceBaseUrl,
+    tokenPlaceChat,
+} from '../src/utils/tokenPlace.js';
+import { getTokenPlaceErrorSummary } from '../src/utils/tokenPlaceErrors.js';
+import { loadGameState } from '../src/utils/gameState/common.js';
+import { buildChatPrompt } from '../src/utils/openAI.js';
+
+const providerResponse = (overrides = {}) => ({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [{ message: { role: 'assistant', content: 'mocked reply' } }],
+    usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+    metadata: { client: 'dspace', conversation_id: 'conv-42' },
+    ...overrides,
+});
+
+const fetchOk = (json = providerResponse()) =>
+    Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(json),
     });
 
+const promptPayload = {
+    combinedMessages: [
+        {
+            role: 'system',
+            content: 'DSPACE v3.1 provider-neutral system prompt with token.place default support.',
+        },
+        { role: 'user', content: 'hello' },
+    ],
+    contextSources: [{ title: 'Docs', url: '/docs/about' }],
+};
+
+describe('token.place API v1 URL and model helpers', () => {
     afterEach(() => {
-        jest.resetAllMocks();
+        vi.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
     });
 
-    test('uses game state url when configured', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
-    });
-
-    test('falls back to env url when game state missing', async () => {
+    test('defaults to token.place origin and chat completions endpoint', () => {
         loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('http://env.token/chat', expect.any(Object));
-    });
-
-    test('prepends system message and returns response', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const result = await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const body = JSON.parse(fetch.mock.calls[0][1].body);
-        expect(body.messages[0].role).toBe('system');
-        expect(result).toBe('mocked reply');
-    });
-
-    test('passes abort signal to fetch', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const controller = new AbortController();
-        await tokenPlaceChat([], { signal: controller.signal });
-        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
-    });
-
-    test('throws helpful error when request fails', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        fetch.mockResolvedValueOnce({
-            ok: false,
-            json: () => Promise.resolve({ error: 'bad request' }),
-        });
-        await expect(tokenPlaceChat([])).rejects.toThrow(
-            'token.place API request failed: bad request'
+        expect(resolveTokenPlaceBaseUrl()).toBe('https://token.place');
+        expect(buildTokenPlaceChatCompletionsUrl(resolveTokenPlaceBaseUrl())).toBe(
+            'https://token.place/api/v1/chat/completions'
         );
     });
 
-    test('throws when disabled by default', async () => {
+    test('uses VITE_TOKEN_PLACE_URL override', () => {
         loadGameState.mockReturnValue({});
-        await expect(tokenPlaceChat([])).rejects.toThrow('token.place is disabled');
+        process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
+        expect(resolveTokenPlaceBaseUrl()).toBe('https://staging.token.place');
     });
 
-    test('uses default url when explicitly enabled without overrides', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('https://token.place/api/chat', expect.any(Object));
+    test('uses state.tokenPlace.url compatibility override when present', () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'https://local.token.place/' } });
+        process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
+        expect(resolveTokenPlaceBaseUrl()).toBe('https://local.token.place');
+    });
+
+    test('normalizes legacy /api base URLs without creating /api/api', () => {
+        expect(buildTokenPlaceChatCompletionsUrl('https://token.place/api')).toBe(
+            'https://token.place/api/v1/chat/completions'
+        );
+        expect(buildTokenPlaceChatCompletionsUrl('https://token.place/api')).not.toContain(
+            '/api/api/v1/chat/completions'
+        );
+    });
+
+    test('uses default and override chat model env var names', () => {
+        expect(getTokenPlaceChatModel()).toBe(DEFAULT_TOKEN_PLACE_CHAT_MODEL);
+        process.env.VITE_TOKEN_PLACE_CHAT_MODEL = 'gpt-test-alias';
+        expect(getTokenPlaceChatModel()).toBe('gpt-test-alias');
+    });
+
+    test('is enabled by default for v3.1 compatibility', () => {
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
     });
 });
 
-describe('isTokenPlaceEnabled', () => {
+describe('token.place metadata and response helpers', () => {
+    test('builds safe metadata and filters secrets/player save details', () => {
+        expect(
+            buildTokenPlaceMetadata({
+                conversation_id: 'conv-42',
+                apiKey: 'sk-nope',
+                tokenPlaceToken: 'tp-nope',
+                inventory: { rocket: 1 },
+                playerSave: 'raw-save',
+            })
+        ).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+        });
+    });
+
+    test('extracts OpenAI-compatible assistant text and rejects malformed content', () => {
+        expect(extractTokenPlaceAssistantText(providerResponse())).toBe('mocked reply');
+        expect(() =>
+            extractTokenPlaceAssistantText({ choices: [{ message: { content: '' } }] })
+        ).toThrow('malformed response');
+    });
+});
+
+describe('TokenPlaceChatV2', () => {
+    beforeEach(() => {
+        loadGameState.mockReturnValue({ openAI: { apiKey: 'sk-secret' }, tokenPlace: {} });
+        buildChatPrompt.mockResolvedValue(promptPayload);
+        global.fetch = vi.fn(() => fetchOk());
+    });
+
     afterEach(() => {
+        vi.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
     });
 
-    test('is false when no overrides are set', () => {
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
+    test('posts fresh state to token.place API v1 and not legacy chat endpoints', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        const [url, request] = fetch.mock.calls[0];
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(url).not.toMatch(/\/api\/chat$|\/chat$/);
+        expect(request.method).toBe('POST');
     });
 
-    test('is false when tokenPlace url exists in state without opt-in', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { url: 'http://tp' } } })).toBe(false);
+    test('sends OpenAI-compatible non-streaming body with no Authorization header or secrets', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
+            metadata: { conversation_id: 'conv-42', credential: 'secret', openAIKey: 'sk-secret' },
+        });
+        const request = fetch.mock.calls[0][1];
+        const body = JSON.parse(request.body);
+        const serializedBody = JSON.stringify(body);
+        expect(request.headers).toEqual({ 'Content-Type': 'application/json' });
+        expect(request.headers.Authorization).toBeUndefined();
+        expect(body.model).toBe('gpt-5-chat-latest');
+        expect(body.messages).toEqual(promptPayload.combinedMessages);
+        expect(body.stream).not.toBe(true);
+        expect(body.metadata).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+        });
+        expect(serializedBody).not.toContain('sk-secret');
+        expect(serializedBody).not.toContain('credential');
     });
 
-    test('is true when tokenPlace is explicitly enabled in state', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
+    test('uses VITE_TOKEN_PLACE_CHAT_MODEL in request body', async () => {
+        process.env.VITE_TOKEN_PLACE_CHAT_MODEL = 'gpt-custom';
+        await TokenPlaceChatV2([]);
+        expect(JSON.parse(fetch.mock.calls[0][1].body).model).toBe('gpt-custom');
     });
 
-    test('respects explicit env disable', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
+    test('returns text, DSPACE contextSources, usage, and token.place metadata', async () => {
+        const result = await TokenPlaceChatV2([]);
+        expect(result).toEqual({
+            text: 'mocked reply',
+            contextSources: promptPayload.contextSources,
+            usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+        });
     });
 
-    test('is true when env override enables it', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+    test('compatibility tokenPlaceChat returns assistant text only', async () => {
+        await expect(tokenPlaceChat([])).resolves.toBe('mocked reply');
+    });
+
+    test('passes abort signal through to fetch', async () => {
+        const controller = new AbortController();
+        await TokenPlaceChatV2([], { signal: controller.signal });
+        expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
+    });
+
+    test('token.place payloads do not include stale v3.0 provider guidance', async () => {
+        await TokenPlaceChatV2([]);
+        const body = JSON.parse(fetch.mock.calls[0][1].body);
+        const payload = JSON.stringify(body.messages).toLowerCase();
+        expect(payload).not.toContain('token.place is deferred');
+        expect(payload).not.toContain('chat uses openai');
+    });
+
+    test('malformed 200 response throws and summarizes safely', async () => {
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ choices: [{ message: { content: '' } }] }),
+        });
+        await expect(TokenPlaceChatV2([])).rejects.toMatchObject({ type: 'malformed' });
+    });
+});
+
+describe('token.place error summaries', () => {
+    test('summarizes content policy, 429, 5xx, stream, generic provider, network, and malformed', () => {
+        expect(
+            getTokenPlaceErrorSummary({
+                status: 400,
+                providerError: { type: 'content_policy_violation', code: 'content_blocked' },
+            }).type
+        ).toBe('content_policy');
+        expect(getTokenPlaceErrorSummary({ status: 429, providerError: {} }).type).toBe(
+            'rate_limit'
+        );
+        expect(getTokenPlaceErrorSummary({ status: 503, providerError: {} }).type).toBe(
+            'unavailable'
+        );
+        expect(
+            getTokenPlaceErrorSummary({
+                status: 400,
+                providerError: { type: 'invalid_request_error', param: 'stream' },
+            }).type
+        ).toBe('stream_unsupported');
+        expect(
+            getTokenPlaceErrorSummary({ status: 400, providerError: { message: 'bad' } }).type
+        ).toBe('provider');
+        expect(getTokenPlaceErrorSummary(new TypeError('Failed to fetch')).type).toBe('network');
+        expect(getTokenPlaceErrorSummary({ type: 'malformed' }).message).not.toContain('OpenAI');
     });
 });

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -44,7 +44,8 @@ const fallbackModels = ['gpt-5-mini'];
 export const CHAT_PROMPT_VERSION = getPromptVersionLabel();
 export const SYSTEM_POLICY_VERSION_LINE = 'SYSTEM_POLICY_VERSION=v3.0 never-invent-game-facts';
 export const safeFallbackMessage = "I don't know; please check /docs for the latest details.";
-export const providerRealityLine = 'In v3, chat uses OpenAI. token.place is deferred to v3.1.';
+export const providerRealityLine =
+    'In DSPACE v3.1, chat can use token.place by default or OpenAI when selected in Settings.';
 export const fallbackSystemPrompt =
     defaultPersona?.systemPrompt ||
     "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-5, Stable Diffusion, and DALL-E 2. You have curated knowledge about quests, items, processes, and how inventory and progression systems work in general. Use the PlayerState block when provided; if it is missing, ask for a /gamesaves export. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!";

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,110 +1,170 @@
 import { loadGameState, ready } from './gameState/common.js';
+import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { createTokenPlaceError } from './tokenPlaceErrors.js';
 
-const DEFAULT_URL = 'https://token.place/api';
+export const DEFAULT_TOKEN_PLACE_BASE_URL = 'https://token.place';
+export const TOKEN_PLACE_CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
+export const DEFAULT_TOKEN_PLACE_CHAT_MODEL = 'gpt-5-chat-latest';
 
-const parseBoolean = (value) => {
-    if (value === undefined || value === null) return undefined;
-
-    if (typeof value === 'boolean') return value;
-
-    const normalized = String(value).trim().toLowerCase();
-
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-
+const readEnvValue = (key) => {
+    if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
+        return import.meta.env[key];
+    }
+    if (typeof process !== 'undefined' && process.env?.[key]) {
+        return process.env[key];
+    }
     return undefined;
 };
 
-const getEnvUrl = () => {
-    // Prefer Vite-style environment variables but fall back to Node env for tests
-    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TOKEN_PLACE_URL) {
-        return import.meta.env.VITE_TOKEN_PLACE_URL;
+const isPlainObject = (value) =>
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+
+const normalizeMetadataValue = (value) => {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed ? trimmed.slice(0, 200) : undefined;
     }
-    if (typeof process !== 'undefined' && process.env?.VITE_TOKEN_PLACE_URL) {
-        return process.env.VITE_TOKEN_PLACE_URL;
-    }
-    return null;
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'boolean') return value;
+    return undefined;
 };
 
-const getEnabledOverride = () => {
-    const envValue =
-        (typeof import.meta !== 'undefined' &&
-        import.meta.env?.VITE_TOKEN_PLACE_ENABLED !== undefined
-            ? import.meta.env.VITE_TOKEN_PLACE_ENABLED
-            : undefined) ??
-        (typeof process !== 'undefined' ? process.env?.VITE_TOKEN_PLACE_ENABLED : undefined);
+const metadataKeyLooksSecret = (key) =>
+    /(?:api[_-]?key|openai|authorization|bearer|credential|inventory|password|player|save|secret|token)/i.test(
+        key
+    );
 
-    return parseBoolean(envValue);
+export const resolveTokenPlaceBaseUrl = (options = {}) => {
+    const state = options.state || loadGameState();
+    const configuredUrl = state?.tokenPlace?.url || readEnvValue('VITE_TOKEN_PLACE_URL');
+    const rawUrl = String(configuredUrl || DEFAULT_TOKEN_PLACE_BASE_URL).trim();
+    const withoutTrailingSlashes = rawUrl.replace(/\/+$/g, '');
+    const withoutLegacyApiSuffix = withoutTrailingSlashes.replace(/\/api$/i, '');
+    return withoutLegacyApiSuffix || DEFAULT_TOKEN_PLACE_BASE_URL;
 };
 
-export const isTokenPlaceEnabled = (options = {}) => {
-    const { state = loadGameState() } = options;
-    const enabledOverride = getEnabledOverride();
+export const buildTokenPlaceChatCompletionsUrl = (baseUrl) =>
+    `${String(baseUrl || DEFAULT_TOKEN_PLACE_BASE_URL)
+        .replace(/\/+$/g, '')
+        .replace(/\/api$/i, '')}${TOKEN_PLACE_CHAT_COMPLETIONS_PATH}`;
 
-    if (enabledOverride !== undefined) {
-        // Explicit env flag takes precedence over any configured URLs or saved state
-        return enabledOverride;
+export const getTokenPlaceChatModel = () =>
+    readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL')?.trim() || DEFAULT_TOKEN_PLACE_CHAT_MODEL;
+
+export const buildTokenPlaceMetadata = (metadata = {}) => {
+    const safeMetadata = {
+        client: 'dspace',
+        provider: 'token.place',
+    };
+
+    if (!isPlainObject(metadata)) {
+        return safeMetadata;
     }
 
-    const stateEnabled = parseBoolean(state?.tokenPlace?.enabled);
+    for (const [key, value] of Object.entries(metadata)) {
+        if (!key || metadataKeyLooksSecret(key)) continue;
+        const safeValue = normalizeMetadataValue(value);
+        if (safeValue !== undefined) {
+            safeMetadata[key] = safeValue;
+        }
+    }
 
-    return stateEnabled === true;
+    safeMetadata.client = 'dspace';
+    safeMetadata.provider = 'token.place';
+    return safeMetadata;
 };
 
-export const tokenPlaceChat = async (messages, { signal } = {}) => {
+export const extractTokenPlaceAssistantText = (responseJson) => {
+    const content = responseJson?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+        throw createTokenPlaceError('malformed', 'token.place returned a malformed response.');
+    }
+    return content;
+};
+
+export const isTokenPlaceEnabled = () => true;
+
+const readResponseJson = async (response) => {
+    try {
+        return await response.json();
+    } catch {
+        return null;
+    }
+};
+
+const assertNonStreaming = (requestBody) => {
+    if (requestBody.stream === true) {
+        throw createTokenPlaceError('provider', 'token.place API v1 does not support streaming.', {
+            status: 400,
+            providerError: {
+                message: 'token.place API v1 does not support streaming.',
+                type: 'invalid_request_error',
+                param: 'stream',
+                code: 'unsupported_stream',
+            },
+        });
+    }
+};
+
+export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
-    const envUrl = getEnvUrl();
-    const state = loadGameState();
-    const enabled = isTokenPlaceEnabled({ state });
-
-    if (!enabled) {
-        throw new Error(
-            'token.place is disabled. Set VITE_TOKEN_PLACE_ENABLED=true or set tokenPlace.enabled=true in game settings.'
-        );
-    }
-
-    const baseUrl = state.tokenPlace?.url || envUrl || DEFAULT_URL;
-
-    const systemMessage = {
-        role: 'system',
-        content:
-            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. If you're unsure about something, suggest checking the docs or joining the Discord server. Have fun!",
+    const state = options.state || loadGameState();
+    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const contextSources = Array.isArray(promptPayload.contextSources)
+        ? promptPayload.contextSources
+        : [];
+    const requestBody = {
+        model: getTokenPlaceChatModel(),
+        messages: promptPayload.combinedMessages,
+        metadata: buildTokenPlaceMetadata(options.metadata),
     };
 
-    const openingMessage = {
-        role: 'assistant',
-        content: 'Welcome! How can I assist you today?',
-    };
+    assertNonStreaming(requestBody);
 
-    let combinedMessages = [...messages];
-    if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage, openingMessage];
-    } else {
-        combinedMessages = [systemMessage, ...combinedMessages];
+    const url = buildTokenPlaceChatCompletionsUrl(resolveTokenPlaceBaseUrl({ state }));
+    let response;
+
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+            signal: options.signal,
+        });
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            throw createTokenPlaceError('abort', 'The token.place request was canceled.', {
+                cause: error,
+            });
+        }
+        throw createTokenPlaceError('network', 'Unable to reach token.place.', { cause: error });
     }
 
-    const response = await fetch(`${baseUrl}/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: combinedMessages }),
-        signal,
-    });
+    const responseJson = await readResponseJson(response);
 
     if (!response.ok) {
-        let details;
-        try {
-            const err = await response.json();
-            details = err.error || err.message || response.statusText;
-        } catch {
-            try {
-                details = await response.text();
-            } catch {
-                details = response.statusText;
-            }
-        }
-        throw new Error(`token.place API request failed: ${details}`);
+        const providerError = responseJson?.error;
+        throw createTokenPlaceError('provider', providerError?.message || response.statusText, {
+            status: response.status,
+            providerError,
+        });
     }
 
-    const data = await response.json();
-    return data.reply;
+    const outputText = extractTokenPlaceAssistantText(responseJson);
+    const { text } = validateChatResponseText(outputText, { contextSources });
+
+    return {
+        text,
+        contextSources,
+        usage: responseJson?.usage,
+        metadata: responseJson?.metadata,
+    };
+};
+
+export const tokenPlaceChat = async (messages, options = {}) => {
+    const result = await TokenPlaceChatV2(messages, options);
+    return result.text;
 };

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -1,20 +1,35 @@
+export const createTokenPlaceError = (type, message, details = {}) => {
+    const error = new Error(message || 'token.place returned an error.');
+    error.name = 'TokenPlaceError';
+    error.type = type;
+    if (details.status !== undefined) error.status = details.status;
+    if (details.providerError) error.providerError = details.providerError;
+    if (details.cause) error.cause = details.cause;
+    return error;
+};
+
 export const getTokenPlaceErrorSummary = (error) => {
-    const message = error?.message || '';
+    const providerError = error?.providerError || error?.error;
+    const providerType = String(providerError?.type || error?.type || '').toLowerCase();
+    const providerCode = String(providerError?.code || '').toLowerCase();
+    const providerParam = String(providerError?.param || '').toLowerCase();
+    const status = Number(error?.status || error?.response?.status);
+    const message = String(error?.message || providerError?.message || '');
     const normalizedMessage = message.toLowerCase();
 
-    if (normalizedMessage.includes('disabled')) {
+    if (error?.name === 'AbortError' || providerType === 'abort') {
         return {
-            type: 'disabled',
-            message:
-                'token.place chat is disabled. Enable it in Settings or set the token.place ' +
-                'flag for this environment.',
+            type: 'abort',
+            message: 'The token.place request was canceled. Please try again.',
         };
     }
 
     if (
+        providerType === 'network' ||
         normalizedMessage.includes('failed to fetch') ||
         normalizedMessage.includes('network') ||
-        normalizedMessage.includes('fetch')
+        normalizedMessage.includes('unable to reach') ||
+        normalizedMessage.includes('connection')
     ) {
         return {
             type: 'network',
@@ -22,7 +37,42 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
-    if (normalizedMessage.includes('api request failed')) {
+    if (providerType === 'malformed' || normalizedMessage.includes('malformed response')) {
+        return {
+            type: 'malformed',
+            message: 'token.place returned a response DSPACE could not read. Please try again.',
+        };
+    }
+
+    if (providerType === 'content_policy_violation' || providerCode === 'content_blocked') {
+        return {
+            type: 'content_policy',
+            message: 'token.place blocked that request for safety. Try rephrasing your message.',
+        };
+    }
+
+    if (status === 429) {
+        return {
+            type: 'rate_limit',
+            message: 'token.place is rate limited right now. Please wait a moment and try again.',
+        };
+    }
+
+    if (status >= 500) {
+        return {
+            type: 'unavailable',
+            message: 'token.place is temporarily unavailable. Please try again in a moment.',
+        };
+    }
+
+    if (providerParam === 'stream') {
+        return {
+            type: 'stream_unsupported',
+            message: 'token.place API v1 does not support streaming chat requests.',
+        };
+    }
+
+    if (providerError || providerType === 'provider' || status >= 400) {
         return {
             type: 'provider',
             message: 'token.place returned an error. Please try again in a moment.',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,6 +111,8 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
+      'frontend/__tests__/tokenPlace.test.js',
+      '__tests__/tokenPlace.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {


### PR DESCRIPTION
### Motivation
- Replace the legacy token.place `/chat` relay client with a direct, zero-auth, fetch-based token.place API v1 client for the v3.1 default chat provider behavior.
- Ensure token.place requests use OpenAI-compatible `messages` payloads, preserve DSPACE RAG `contextSources`, and avoid streaming or any Authorization headers.
- Provide safe, non-secret metadata echo behavior and robust provider-neutral prompt construction so token.place requests do not include stale v3.0 wording.

### Description
- Added a new fetch-based client and helpers in `frontend/src/utils/tokenPlace.js` including `TokenPlaceChatV2`, `tokenPlaceChat`, `resolveTokenPlaceBaseUrl`, `buildTokenPlaceChatCompletionsUrl`, `getTokenPlaceChatModel`, `buildTokenPlaceMetadata`, and `extractTokenPlaceAssistantText` and made `isTokenPlaceEnabled()` return true by default for v3.1 compatibility.
- Implemented safe metadata filtering (no keys that look like secrets or player saves), model/env overrides via `VITE_TOKEN_PLACE_CHAT_MODEL` and `VITE_TOKEN_PLACE_URL`, URL normalization (handles legacy `/api` base values and never emits `/api/api/...`), and enforced non-streaming requests to `POST /api/v1/chat/completions`.
- Added structured error construction and UI-friendly summaries in `frontend/src/utils/tokenPlaceErrors.js` covering network/abort, malformed responses, content policy, 429 rate limits, 5xx availability, `stream` param errors, and generic provider errors without mentioning OpenAI.
- Updated `frontend/src/utils/openAI.js` to remove the stale v3.0 provider claim by changing `providerRealityLine` to a v3.1-neutral line, and added comprehensive unit tests in `frontend/__tests__/tokenPlace.test.js` with the Vitest include updated in `vitest.config.mts`.

### Testing
- Ran the search verification `rg -n "VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|api/v1/chat/completions|/api/chat|Authorization|stream|providerRealityLine|deferred" frontend/src/utils frontend/__tests__` to validate key strings were updated (command executed successfully).
- Ran the focused unit suite `cd frontend && npm test -- tokenPlace.test.js` and the token.place tests passed: `17 passed, 0 failed`.
- Ran repository checks `cd frontend && npm run check` which executed lint and Prettier formatting checks and completed successfully with no formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309e3714f8832f80503a4c43e5f09b)