### PR TITLE
Implement token.place API v1 client (fetch-based) with helpers, metadata safety, and tests

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1,4 +1,4 @@
-const { vi } = require('vitest');
+import { vi } from 'vitest';
 const jest = vi;
 
 jest.mock('../src/utils/gameState/common.js', () => ({
@@ -6,103 +6,317 @@ jest.mock('../src/utils/gameState/common.js', () => ({
     ready: Promise.resolve(),
 }));
 
-const { tokenPlaceChat, isTokenPlaceEnabled } = require('../src/utils/tokenPlace.js');
-const { loadGameState } = require('../src/utils/gameState/common.js');
+jest.mock('../src/utils/docsRag.js', () => ({
+    searchDocsRag: jest.fn(() => Promise.resolve({ excerptsText: '', sources: [] })),
+}));
 
-describe('tokenPlaceChat', () => {
-    beforeEach(() => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ reply: 'mocked reply' }),
-            })
+jest.mock('../src/utils/dchatKnowledge.js', () => ({
+    buildDchatKnowledgePack: jest.fn(() => ({ summary: '', sources: [] })),
+}));
+
+const {
+    TokenPlaceChatV2,
+    buildTokenPlaceChatCompletionsUrl,
+    buildTokenPlaceMetadata,
+    extractTokenPlaceAssistantText,
+    getTokenPlaceChatModel,
+    isTokenPlaceEnabled,
+    resolveTokenPlaceBaseUrl,
+    tokenPlaceChat,
+} = await import('../src/utils/tokenPlace.js');
+const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
+const { buildChatPrompt, providerRealityLine } = await import('../src/utils/openAI.js');
+const { loadGameState } = await import('../src/utils/gameState/common.js');
+
+const openAIKey = 'sk-openai-test-secret'; // scan-secrets: ignore
+const tokenPlaceCredential = 'token-place-secret'; // scan-secrets: ignore
+
+const mockChatCompletion = (overrides = {}) => ({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+        {
+            index: 0,
+            message: { role: 'assistant', content: 'mocked token.place reply' },
+            finish_reason: 'stop',
+        },
+    ],
+    usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
+    metadata: { client: 'dspace', conversation_id: 'conv-42' },
+    ...overrides,
+});
+
+const mockFetchOk = (body = mockChatCompletion()) => {
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: () => Promise.resolve(body),
+        })
+    );
+};
+
+const getFetchRequest = () => {
+    const [url, init] = fetch.mock.calls[0];
+    return { url, init, body: JSON.parse(init.body) };
+};
+
+describe('token.place API v1 URL/model helpers', () => {
+    afterEach(() => {
+        delete process.env.VITE_TOKEN_PLACE_URL;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
+        delete process.env.VITE_TOKEN_PLACE_BASE_URL;
+        delete process.env.VITE_TOKEN_PLACE_MODEL;
+        jest.resetAllMocks();
+    });
+
+    test('defaults to the token.place API v1 chat-completions endpoint', () => {
+        loadGameState.mockReturnValue({});
+        expect(resolveTokenPlaceBaseUrl()).toBe('https://token.place');
+        expect(buildTokenPlaceChatCompletionsUrl()).toBe(
+            'https://token.place/api/v1/chat/completions'
         );
+    });
+
+    test('uses VITE_TOKEN_PLACE_URL override', () => {
+        loadGameState.mockReturnValue({});
+        process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
+        expect(buildTokenPlaceChatCompletionsUrl()).toBe(
+            'https://staging.token.place/api/v1/chat/completions'
+        );
+    });
+
+    test('uses state tokenPlace.url as compatibility override', () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
+        process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
+        expect(buildTokenPlaceChatCompletionsUrl()).toBe(
+            'https://state.token.place/api/v1/chat/completions'
+        );
+    });
+
+    test('normalizes legacy /api values without producing duplicate /api paths', () => {
+        loadGameState.mockReturnValue({ tokenPlace: { url: 'https://token.place/api' } });
+        const url = buildTokenPlaceChatCompletionsUrl();
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(url).not.toContain('/api/api/v1/chat/completions');
+        expect(url).not.toMatch(/\/api\/chat$/);
+        expect(url).not.toMatch(/[^i]\/chat$/);
+    });
+
+    test('defaults and overrides the chat model with the v3.1 env var only', () => {
+        expect(getTokenPlaceChatModel()).toBe('gpt-5-chat-latest');
+        process.env.VITE_TOKEN_PLACE_CHAT_MODEL = 'custom-token-place-model';
+        process.env.VITE_TOKEN_PLACE_MODEL = 'wrong-model-name';
+        expect(getTokenPlaceChatModel()).toBe('custom-token-place-model');
+    });
+
+    test('is enabled by default for v3.1 compatibility', () => {
+        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: false } } })).toBe(true);
+    });
+});
+
+describe('TokenPlaceChatV2', () => {
+    beforeEach(() => {
+        loadGameState.mockReturnValue({
+            tokenPlace: { enabled: false },
+            openAI: { apiKey: openAIKey },
+        });
+        mockFetchOk();
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
+        delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
     });
 
-    test('uses game state url when configured', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(fetch).toHaveBeenCalledWith('http://token.place/chat', expect.any(Object));
+    test('posts OpenAI-compatible non-streaming request to API v1 without auth', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
+            metadata: {
+                conversation_id: 'conv-42',
+                apiKey: tokenPlaceCredential,
+                openAIKey,
+                inventory: ['secret item'],
+            },
+        });
+
+        const { url, init, body } = getFetchRequest();
+        const serializedBody = init.body;
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(init.method).toBe('POST');
+        expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+        expect(init.headers.Authorization).toBeUndefined();
+        expect(body.model).toBe('gpt-5-chat-latest');
+        expect(Array.isArray(body.messages)).toBe(true);
+        expect(body.messages.some((message) => message.role === 'user')).toBe(true);
+        expect(body.stream).not.toBe(true);
+        expect(body.metadata).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+        });
+        expect(serializedBody).not.toContain(openAIKey);
+        expect(serializedBody).not.toContain(tokenPlaceCredential);
     });
 
-    test('falls back to env url when game state missing', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_URL = 'http://env.token';
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('http://env.token/chat', expect.any(Object));
-    });
-
-    test('prepends system message and returns response', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        const result = await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const body = JSON.parse(fetch.mock.calls[0][1].body);
-        expect(body.messages[0].role).toBe('system');
-        expect(result).toBe('mocked reply');
-    });
-
-    test('passes abort signal to fetch', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
+    test('passes abort signal through to fetch', async () => {
         const controller = new AbortController();
-        await tokenPlaceChat([], { signal: controller.signal });
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], { signal: controller.signal });
         expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
     });
 
-    test('throws helpful error when request fails', async () => {
-        loadGameState.mockReturnValue({ tokenPlace: { url: 'http://token.place', enabled: true } });
-        fetch.mockResolvedValueOnce({
-            ok: false,
-            json: () => Promise.resolve({ error: 'bad request' }),
+    test('parses assistant text and preserves context sources, usage, and metadata', async () => {
+        const contextSources = [{ title: 'Docs', url: '/docs/about' }];
+        const result = await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [{ role: 'user', content: 'hello' }],
+                gameState: {},
+                contextSources,
+            },
         });
-        await expect(tokenPlaceChat([])).rejects.toThrow(
-            'token.place API request failed: bad request'
+
+        expect(result).toEqual({
+            text: 'mocked token.place reply',
+            contextSources,
+            usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
+            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+        });
+    });
+
+    test('tokenPlaceChat remains a string-returning compatibility helper', async () => {
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked token.place reply'
         );
     });
 
-    test('throws when disabled by default', async () => {
-        loadGameState.mockReturnValue({});
-        await expect(tokenPlaceChat([])).rejects.toThrow('token.place is disabled');
+    test('throws and summarizes malformed 200 responses safely', async () => {
+        mockFetchOk({ choices: [{ message: { content: '' } }] });
+        await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            tokenPlaceType: 'malformed_response',
+        });
+        try {
+            await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        } catch (error) {
+            expect(getTokenPlaceErrorSummary(error)).toEqual({
+                type: 'malformed_response',
+                message: 'token.place returned a response DSPACE could not read. Please try again.',
+            });
+        }
     });
 
-    test('uses default url when explicitly enabled without overrides', async () => {
-        loadGameState.mockReturnValue({});
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        await tokenPlaceChat([]);
-        expect(fetch).toHaveBeenCalledWith('https://token.place/api/chat', expect.any(Object));
+    test('structured content policy errors produce safe summaries', async () => {
+        fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            statusText: 'Bad Request',
+            json: () =>
+                Promise.resolve({
+                    error: {
+                        message: 'blocked',
+                        type: 'content_policy_violation',
+                        code: 'content_blocked',
+                    },
+                }),
+        });
+        await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'content_policy_violation',
+            code: 'content_blocked',
+        });
+        try {
+            await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        } catch (error) {
+            expect(getTokenPlaceErrorSummary(error).type).toBe('content_policy');
+            expect(getTokenPlaceErrorSummary(error).message).not.toMatch(/OpenAI/i);
+        }
+    });
+
+    test('HTTP 429 and 5xx errors produce expected summaries', () => {
+        expect(getTokenPlaceErrorSummary({ status: 429 })).toMatchObject({ type: 'rate_limit' });
+        expect(getTokenPlaceErrorSummary({ status: 503 })).toMatchObject({ type: 'server' });
+    });
+
+    test('generic provider and stream validation errors produce safe summaries', () => {
+        expect(
+            getTokenPlaceErrorSummary({
+                status: 400,
+                type: 'invalid_request_error',
+                param: 'stream',
+            })
+        ).toMatchObject({ type: 'provider_validation' });
+        expect(
+            getTokenPlaceErrorSummary({ status: 400, type: 'invalid_request_error' })
+        ).toMatchObject({ type: 'provider' });
+    });
+
+    test('network and abort errors produce expected summaries', () => {
+        expect(getTokenPlaceErrorSummary(new TypeError('Failed to fetch'))).toMatchObject({
+            type: 'network',
+        });
+        const abortError = new Error('The operation was aborted');
+        abortError.name = 'AbortError';
+        expect(getTokenPlaceErrorSummary(abortError)).toMatchObject({ type: 'abort' });
     });
 });
 
-describe('isTokenPlaceEnabled', () => {
+describe('token.place metadata and response helpers', () => {
+    test('buildTokenPlaceMetadata keeps only safe plain-object scalar metadata', () => {
+        expect(
+            buildTokenPlaceMetadata({
+                conversation_id: 'conv-42',
+                attempt: 2,
+                debug: true,
+                nested: { unsafe: true },
+                api_key: 'secret',
+                tokenPlaceCredential: 'secret',
+                playerState: 'secret',
+            })
+        ).toEqual({
+            client: 'dspace',
+            provider: 'token.place',
+            conversation_id: 'conv-42',
+            attempt: 2,
+            debug: true,
+        });
+    });
+
+    test('extractTokenPlaceAssistantText reads choices[0].message.content', () => {
+        expect(extractTokenPlaceAssistantText(mockChatCompletion())).toBe(
+            'mocked token.place reply'
+        );
+        expect(() => extractTokenPlaceAssistantText({ choices: [] })).toThrow(
+            'token.place returned a malformed chat response.'
+        );
+    });
+});
+
+describe('shared prompt guidance for token.place', () => {
+    beforeEach(() => {
+        loadGameState.mockReturnValue({});
+    });
+
     afterEach(() => {
-        delete process.env.VITE_TOKEN_PLACE_URL;
-        delete process.env.VITE_TOKEN_PLACE_ENABLED;
+        jest.resetAllMocks();
     });
 
-    test('is false when no overrides are set', () => {
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(false);
+    test('provider reality line is v3.1 accurate', () => {
+        expect(providerRealityLine).toMatch(/v3\.1/i);
+        expect(providerRealityLine).not.toMatch(/deferred/i);
+        expect(providerRealityLine).not.toMatch(/chat uses OpenAI/i);
     });
 
-    test('is false when tokenPlace url exists in state without opt-in', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { url: 'http://tp' } } })).toBe(false);
+    test('token.place request payloads do not include stale v3.0 provider guidance', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+        const { body } = getFetchRequest();
+        const payload = JSON.stringify(body.messages);
+        expect(payload).not.toMatch(/token\.place is deferred/i);
+        expect(payload).not.toMatch(/chat uses OpenAI/i);
     });
 
-    test('is true when tokenPlace is explicitly enabled in state', () => {
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(true);
-    });
-
-    test('respects explicit env disable', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
-        expect(isTokenPlaceEnabled({ state: { tokenPlace: { enabled: true } } })).toBe(false);
-    });
-
-    test('is true when env override enables it', () => {
-        process.env.VITE_TOKEN_PLACE_ENABLED = 'true';
-        expect(isTokenPlaceEnabled({ state: {} })).toBe(true);
+    test('debug/system prompt construction does not include stale v3.0 provider guidance', async () => {
+        const prompt = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
+        const payload = JSON.stringify(prompt.debugMessages);
+        expect(payload).not.toMatch(/token\.place is deferred/i);
+        expect(payload).not.toMatch(/chat uses OpenAI/i);
     });
 });

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -44,7 +44,8 @@ const fallbackModels = ['gpt-5-mini'];
 export const CHAT_PROMPT_VERSION = getPromptVersionLabel();
 export const SYSTEM_POLICY_VERSION_LINE = 'SYSTEM_POLICY_VERSION=v3.0 never-invent-game-facts';
 export const safeFallbackMessage = "I don't know; please check /docs for the latest details.";
-export const providerRealityLine = 'In v3, chat uses OpenAI. token.place is deferred to v3.1.';
+export const providerRealityLine =
+    'DSPACE v3.1 chat supports token.place by default and OpenAI as an explicit opt-in provider.';
 export const fallbackSystemPrompt =
     defaultPersona?.systemPrompt ||
     "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. DSPACE is made from a combination of the founder, Esp, and a variety of generative models, including GPT-5, Stable Diffusion, and DALL-E 2. You have curated knowledge about quests, items, processes, and how inventory and progression systems work in general. Use the PlayerState block when provided; if it is missing, ask for a /gamesaves export. If you encounter anything you're not sure about, tell the user you don't know and suggest checking out the docs or joining the Discord server. If someone talks about something off-topic, humor them and help out with whatever they need, but don't output anything harmful or offensive. Have fun!";

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,110 +1,150 @@
 import { loadGameState, ready } from './gameState/common.js';
+import { buildChatPrompt, validateChatResponseText } from './openAI.js';
 
-const DEFAULT_URL = 'https://token.place/api';
+const DEFAULT_TOKEN_PLACE_ORIGIN = 'https://token.place';
+const TOKEN_PLACE_CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
+const DEFAULT_TOKEN_PLACE_CHAT_MODEL = 'gpt-5-chat-latest';
+const SENSITIVE_METADATA_KEY_PATTERN =
+    /(api[_-]?key|authorization|auth|bearer|credential|secret|token|password|openai|save|inventory|playerstate|game[_-]?state)/i;
 
-const parseBoolean = (value) => {
-    if (value === undefined || value === null) return undefined;
+const isPlainObject = (value) =>
+    value !== null &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype;
 
-    if (typeof value === 'boolean') return value;
-
-    const normalized = String(value).trim().toLowerCase();
-
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-
+const readEnvValue = (key) => {
+    if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
+        return import.meta.env[key];
+    }
+    if (typeof process !== 'undefined' && process.env?.[key]) {
+        return process.env[key];
+    }
     return undefined;
 };
 
-const getEnvUrl = () => {
-    // Prefer Vite-style environment variables but fall back to Node env for tests
-    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TOKEN_PLACE_URL) {
-        return import.meta.env.VITE_TOKEN_PLACE_URL;
-    }
-    if (typeof process !== 'undefined' && process.env?.VITE_TOKEN_PLACE_URL) {
-        return process.env.VITE_TOKEN_PLACE_URL;
-    }
-    return null;
+const normalizeTokenPlaceUrl = (value) => {
+    const rawValue = typeof value === 'string' ? value.trim() : '';
+    if (!rawValue) return DEFAULT_TOKEN_PLACE_ORIGIN;
+
+    const withoutTrailingSlashes = rawValue.replace(/\/+$/g, '');
+    const withoutChatPath = withoutTrailingSlashes
+        .replace(/\/api\/v1\/chat\/completions$/i, '')
+        .replace(/\/api\/chat$/i, '')
+        .replace(/\/chat$/i, '')
+        .replace(/\/api$/i, '');
+
+    return withoutChatPath || DEFAULT_TOKEN_PLACE_ORIGIN;
 };
 
-const getEnabledOverride = () => {
-    const envValue =
-        (typeof import.meta !== 'undefined' &&
-        import.meta.env?.VITE_TOKEN_PLACE_ENABLED !== undefined
-            ? import.meta.env.VITE_TOKEN_PLACE_ENABLED
-            : undefined) ??
-        (typeof process !== 'undefined' ? process.env?.VITE_TOKEN_PLACE_ENABLED : undefined);
-
-    return parseBoolean(envValue);
+export const resolveTokenPlaceBaseUrl = (options = {}) => {
+    const state = options.state ?? loadGameState();
+    const stateUrl = state?.tokenPlace?.url;
+    const envUrl = readEnvValue('VITE_TOKEN_PLACE_URL');
+    return normalizeTokenPlaceUrl(stateUrl || envUrl || DEFAULT_TOKEN_PLACE_ORIGIN);
 };
 
-export const isTokenPlaceEnabled = (options = {}) => {
-    const { state = loadGameState() } = options;
-    const enabledOverride = getEnabledOverride();
+export const buildTokenPlaceChatCompletionsUrl = (options = {}) =>
+    `${resolveTokenPlaceBaseUrl(options)}${TOKEN_PLACE_CHAT_COMPLETIONS_PATH}`;
 
-    if (enabledOverride !== undefined) {
-        // Explicit env flag takes precedence over any configured URLs or saved state
-        return enabledOverride;
-    }
+export const getTokenPlaceChatModel = () =>
+    readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL')?.trim() || DEFAULT_TOKEN_PLACE_CHAT_MODEL;
 
-    const stateEnabled = parseBoolean(state?.tokenPlace?.enabled);
+export const isTokenPlaceEnabled = () => true;
 
-    return stateEnabled === true;
-};
-
-export const tokenPlaceChat = async (messages, { signal } = {}) => {
-    await ready;
-    const envUrl = getEnvUrl();
-    const state = loadGameState();
-    const enabled = isTokenPlaceEnabled({ state });
-
-    if (!enabled) {
-        throw new Error(
-            'token.place is disabled. Set VITE_TOKEN_PLACE_ENABLED=true or set tokenPlace.enabled=true in game settings.'
-        );
-    }
-
-    const baseUrl = state.tokenPlace?.url || envUrl || DEFAULT_URL;
-
-    const systemMessage = {
-        role: 'system',
-        content:
-            "You are dChat, a helpful assistant in the game DSPACE. Your purpose is to assist players by providing information, guidance, and support related to the game. DSPACE is a web-based space exploration idle game where you can 3D print things, grow plants hydroponically, and create and launch model rockets. The game is fully open source, and development is ongoing. If you're unsure about something, suggest checking the docs or joining the Discord server. Have fun!",
+export const buildTokenPlaceMetadata = (metadata = {}) => {
+    const safeMetadata = {
+        client: 'dspace',
+        provider: 'token.place',
     };
 
-    const openingMessage = {
-        role: 'assistant',
-        content: 'Welcome! How can I assist you today?',
-    };
+    if (!isPlainObject(metadata)) return safeMetadata;
 
-    let combinedMessages = [...messages];
-    if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage, openingMessage];
-    } else {
-        combinedMessages = [systemMessage, ...combinedMessages];
-    }
-
-    const response = await fetch(`${baseUrl}/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: combinedMessages }),
-        signal,
+    Object.entries(metadata).forEach(([key, value]) => {
+        if (!key || SENSITIVE_METADATA_KEY_PATTERN.test(key)) return;
+        if (value === null || value === undefined) return;
+        if (['string', 'number', 'boolean'].includes(typeof value)) {
+            safeMetadata[key] = value;
+        }
     });
 
-    if (!response.ok) {
-        let details;
-        try {
-            const err = await response.json();
-            details = err.error || err.message || response.statusText;
-        } catch {
-            try {
-                details = await response.text();
-            } catch {
-                details = response.statusText;
-            }
+    return safeMetadata;
+};
+
+export const extractTokenPlaceAssistantText = (responseBody) => {
+    const content = responseBody?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+        const error = new Error('token.place returned a malformed chat response.');
+        error.name = 'TokenPlaceMalformedResponseError';
+        error.tokenPlaceType = 'malformed_response';
+        throw error;
+    }
+    return content;
+};
+
+const buildTokenPlaceProviderError = (response, errorBody) => {
+    const providerError = errorBody?.error && isPlainObject(errorBody.error) ? errorBody.error : {};
+    const message =
+        typeof providerError.message === 'string' && providerError.message.trim()
+            ? providerError.message
+            : `token.place API v1 request failed with status ${response.status}.`;
+    const error = new Error(message);
+    error.name = 'TokenPlaceProviderError';
+    error.status = response.status;
+    error.statusText = response.statusText;
+    error.type = providerError.type;
+    error.code = providerError.code;
+    error.param = providerError.param;
+    error.providerError = providerError;
+    return error;
+};
+
+const parseTokenPlaceResponseBody = async (response) => {
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+};
+
+export const TokenPlaceChatV2 = async (messages, options = {}) => {
+    await ready;
+    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const { combinedMessages, contextSources } = promptPayload;
+    const metadata = buildTokenPlaceMetadata(options.metadata);
+    const body = {
+        model: getTokenPlaceChatModel(),
+        messages: combinedMessages,
+        metadata,
+    };
+
+    const response = await fetch(
+        buildTokenPlaceChatCompletionsUrl({ state: promptPayload.gameState }),
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            signal: options.signal,
         }
-        throw new Error(`token.place API request failed: ${details}`);
+    );
+
+    const responseBody = await parseTokenPlaceResponseBody(response);
+
+    if (!response.ok) {
+        throw buildTokenPlaceProviderError(response, responseBody);
     }
 
-    const data = await response.json();
-    return data.reply;
+    const outputText = extractTokenPlaceAssistantText(responseBody);
+    const { text } = validateChatResponseText(outputText, { contextSources });
+
+    return {
+        text,
+        contextSources: Array.isArray(contextSources) ? contextSources : [],
+        usage: responseBody?.usage,
+        metadata: responseBody?.metadata,
+    };
+};
+
+export const tokenPlaceChat = async (messages, options = {}) => {
+    const response = await TokenPlaceChatV2(messages, options);
+    return response.text;
 };

--- a/frontend/src/utils/tokenPlaceErrors.js
+++ b/frontend/src/utils/tokenPlaceErrors.js
@@ -1,20 +1,38 @@
-export const getTokenPlaceErrorSummary = (error) => {
-    const message = error?.message || '';
-    const normalizedMessage = message.toLowerCase();
+const toNumericStatus = (status) => {
+    if (typeof status === 'string') return Number(status);
+    return status;
+};
 
-    if (normalizedMessage.includes('disabled')) {
+const extractDetails = (error) => {
+    const providerError = error?.providerError || error?.error || {};
+    return {
+        status: toNumericStatus(error?.status ?? error?.response?.status),
+        type: error?.type ?? providerError.type,
+        code: error?.code ?? providerError.code,
+        param: error?.param ?? providerError.param,
+        message: providerError.message ?? error?.message ?? '',
+        name: error?.name ?? '',
+    };
+};
+
+export const getTokenPlaceErrorSummary = (error) => {
+    const { status, type, code, param, message, name } = extractDetails(error);
+    const normalizedMessage = String(message || '').toLowerCase();
+    const normalizedName = String(name || '').toLowerCase();
+
+    if (normalizedName.includes('abort') || normalizedMessage.includes('abort')) {
         return {
-            type: 'disabled',
-            message:
-                'token.place chat is disabled. Enable it in Settings or set the token.place ' +
-                'flag for this environment.',
+            type: 'abort',
+            message: 'The token.place request was canceled. Try again when you are ready.',
         };
     }
 
     if (
+        normalizedName === 'typeerror' ||
         normalizedMessage.includes('failed to fetch') ||
         normalizedMessage.includes('network') ||
-        normalizedMessage.includes('fetch')
+        normalizedMessage.includes('fetch') ||
+        normalizedMessage.includes('connection')
     ) {
         return {
             type: 'network',
@@ -22,7 +40,42 @@ export const getTokenPlaceErrorSummary = (error) => {
         };
     }
 
-    if (normalizedMessage.includes('api request failed')) {
+    if (type === 'content_policy_violation' || code === 'content_blocked') {
+        return {
+            type: 'content_policy',
+            message: 'token.place blocked this request by policy. Try rephrasing your message.',
+        };
+    }
+
+    if (status === 429) {
+        return {
+            type: 'rate_limit',
+            message: 'token.place is rate limiting chat right now. Please wait and try again.',
+        };
+    }
+
+    if (typeof status === 'number' && status >= 500) {
+        return {
+            type: 'server',
+            message: 'token.place is unavailable right now. Please try again in a moment.',
+        };
+    }
+
+    if (param === 'stream') {
+        return {
+            type: 'provider_validation',
+            message: 'token.place rejected an unsupported chat option. Please try again.',
+        };
+    }
+
+    if (error?.tokenPlaceType === 'malformed_response' || normalizedName.includes('malformed')) {
+        return {
+            type: 'malformed_response',
+            message: 'token.place returned a response DSPACE could not read. Please try again.',
+        };
+    }
+
+    if (type || code || status) {
         return {
             type: 'provider',
             message: 'token.place returned an error. Please try again in a moment.',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -111,6 +111,8 @@ export default defineConfig({
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
+      'frontend/__tests__/tokenPlace.test.js',
+      '__tests__/tokenPlace.test.js',
     ],
     exclude: ['frontend/e2e/**'],
     coverage: {


### PR DESCRIPTION
### Motivation
- Replace the legacy token.place `/chat`/relay logic with a direct, zero-auth token.place API v1 client that uses `POST /api/v1/chat/completions` per the v3.1 design. 
- Ensure requests are OpenAI-compatible (messages + model), non-streaming, and do not send any token.place Authorization or OpenAI credentials. 
- Provide safe, minimal request metadata and robust provider error classification so the UI can show safe summaries. 

### Description
- Added a fetch-based token.place client and tests in `frontend/src/utils/tokenPlace.js` that POSTs to `/api/v1/chat/completions` and returns a richer `TokenPlaceChatV2()` shape `{ text, contextSources, usage, metadata }` while keeping `tokenPlaceChat()` as a string-returning compatibility wrapper. 
- Implemented pure helpers: `resolveTokenPlaceBaseUrl`, `buildTokenPlaceChatCompletionsUrl`, `getTokenPlaceChatModel`, `buildTokenPlaceMetadata`, and `extractTokenPlaceAssistantText`, plus safe URL normalization (handles origin-style and legacy `/api` values, strips trailing slashes) and model env override `VITE_TOKEN_PLACE_CHAT_MODEL`. 
- Metadata merging filters to plain-object scalar values and excludes sensitive keys (patterns like `api_key`, `authorization`, `openai`, `save`, `inventory`, etc.), and always includes `{ client: 'dspace', provider: 'token.place' }` by default. 
- Request building reuses the shared `buildChatPrompt()` path from `openAI.js` for persona/RAG/contextSources, avoids circular imports, and forces non-streaming body (no `stream: true`). 
- Added defensive response parsing and error construction: `choices[0].message.content` extraction, preservation of `usage` and provider `metadata`, and `TokenPlaceProviderError` creation for structured provider errors. 
- Expanded `frontend/src/utils/tokenPlaceErrors.js` to classify network/abort, content policy, 429 rate limits, 5xx server errors, stream-validation errors, malformed responses, and generic provider errors with safe, UI-friendly summaries. 
- Removed the disabled-by-default behavior: `isTokenPlaceEnabled()` now returns `true` by default for v3.1 compatibility and legacy `state.tokenPlace.enabled` no longer blocks default client usage. 
- Updated `providerRealityLine` in `frontend/src/utils/openAI.js` to a v3.1-accurate, provider-neutral phrase so token.place prompt payloads do not include stale v3.0 wording. 
- Reworked and added unit tests in `frontend/__tests__/tokenPlace.test.js` to cover URL normalization, env overrides, state URL compatibility, model defaults/override, request shape (no `Authorization`, no secret leakage), metadata behavior, response parsing, richer return shape, contextSources preservation, abort signal passthrough, malformed responses, structured provider errors, and stale-provider-guidance checks. 
- Included the new focused test file in the Vitest config so the frontend-focused test command runs it. 

### Testing
- Ran the repository verification grep to confirm presence/absence of target strings: `rg -n "VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|api/v1/chat/completions|/api/chat|\$\{baseUrl\}/chat|Authorization|stream|providerRealityLine|deferred" frontend/src/utils frontend/__tests__` (completed; findings used to validate changes). 
- Ran the focused frontend test: `cd frontend && npm test -- tokenPlace.test.js` which executed the tokenPlace test file (Vitest) and passed: "__tests__/tokenPlace.test.js (20 tests)" — all tests passed. 
- Ran repository frontend checks: `cd frontend && npm run check` which runs lint and format-check; the command completed with no formatting failures (Prettier check passed) and no lint errors surfaced in the run. 
- Ran `git diff --check` (whitespace/trailing checks) as part of validation; no issues reported. 

If reviewers want, follow-ups: add Playwright/e2e tests for token.place default flow and /settings provider wiring (planned in later prompts) and a human review for any telemetry/metadata fields to add beyond the minimal `{ client, provider }` pattern.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309e3e5700832f96500b3068860550)