### PR TITLE
Add Chat provider settings panel and persist provider selection

### DIFF
--- a/frontend/__tests__/gameState/common.test.js
+++ b/frontend/__tests__/gameState/common.test.js
@@ -32,7 +32,11 @@ describe('gameState - common utilities', () => {
             quests: {},
             inventory: {},
             processes: {},
-            settings: { showChatDebugPayload: false, showQuestGraphVisualizer: false },
+            settings: {
+                chatProvider: 'token-place',
+                showChatDebugPayload: false,
+                showQuestGraphVisualizer: false,
+            },
             versionNumberString: '3',
         });
         expect(typeof fresh._meta?.lastUpdated).toBe('number');
@@ -144,9 +148,25 @@ describe('gameState - common utilities', () => {
             quests: {},
             inventory: {},
             processes: {},
-            settings: { showChatDebugPayload: false, showQuestGraphVisualizer: false },
+            settings: {
+                chatProvider: 'token-place',
+                showChatDebugPayload: false,
+                showQuestGraphVisualizer: false,
+            },
         });
         expect(typeof validated._meta?.lastUpdated).toBe('number');
+    });
+
+    test('validateGameState ignores legacy tokenPlace.enabled when defaulting chat provider', () => {
+        const validated = validateGameState({
+            quests: {},
+            inventory: {},
+            processes: {},
+            tokenPlace: { enabled: false },
+            settings: {},
+        });
+
+        expect(validated.settings.chatProvider).toBe('token-place');
     });
 
     test('rollbackGameState should restore previous state', async () => {

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -14,6 +14,20 @@ const SETTINGS_VIEWPORTS: SettingsViewport[] = [
     { name: 'desktop', width: 1280, height: 900, expectedColumns: 'multiple' },
 ];
 
+async function readGameState(page: Page) {
+    return page.evaluate(async () => {
+        const gameStateModule = await import('/src/utils/gameState/common.js');
+        await gameStateModule.ready;
+        return gameStateModule.loadGameState();
+    });
+}
+
+async function expectNoTokenPlaceKeyInput(page: Page) {
+    await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
+    await expect(page.getByPlaceholder(/token\.place/i)).toHaveCount(0);
+    await expect(page.locator('input[name*="tokenPlace"], input[id*="tokenPlace"]')).toHaveCount(0);
+}
+
 async function openSettingsAtViewport(page: Page, viewport: SettingsViewport) {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await page.goto('/settings');
@@ -24,6 +38,58 @@ async function openSettingsAtViewport(page: Page, viewport: SettingsViewport) {
 test.describe('Settings route', () => {
     test.beforeEach(async ({ page }) => {
         await clearUserData(page);
+    });
+
+    test('manages Chat provider and OpenAI key on settings page', async ({ page }) => {
+        await page.goto('/settings');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        await expect(page.getByRole('heading', { level: 3, name: 'Chat provider' })).toBeVisible();
+        await expect(
+            page.getByText('token.place is the default DSPACE Chat provider')
+        ).toBeVisible();
+        await expect(page.getByTestId('chat-provider-token-place')).toBeChecked();
+        await expect(page.getByTestId('token-place-no-key-note')).toContainText(
+            'does not need any credential field'
+        );
+        await expectNoTokenPlaceKeyInput(page);
+
+        let state = await readGameState(page);
+        expect(state.settings.chatProvider).toBe('token-place');
+        expect(state.tokenPlace?.apiKey).toBeUndefined();
+
+        await page.getByTestId('chat-provider-openai').check();
+        await expect(page.getByTestId('openai-key-panel')).toBeVisible();
+        await expect(page.getByTestId('chat-provider-status')).toContainText('OpenAI selected');
+        state = await readGameState(page);
+        expect(state.settings.chatProvider).toBe('openai');
+
+        await page.getByTestId('openai-api-key-input').fill('sk-e2e-settings-key');
+        await page.getByRole('button', { name: 'Save OpenAI key' }).click();
+        await expect(page.getByTestId('openai-key-configured')).toContainText(
+            'OpenAI API key configured'
+        );
+        state = await readGameState(page);
+        expect(state.openAI.apiKey).toBe('sk-e2e-settings-key');
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByTestId('chat-provider-openai')).toBeChecked();
+        await expect(page.getByTestId('openai-key-configured')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Clear key' }).click();
+        await expect(page.getByTestId('openai-api-key-input')).toBeVisible();
+        state = await readGameState(page);
+        expect(state.openAI.apiKey).toBe('');
+
+        await page.getByTestId('chat-provider-token-place').check();
+        await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expectNoTokenPlaceKeyInput(page);
+        state = await readGameState(page);
+        expect(state.settings.chatProvider).toBe('token-place');
+        expect(state.tokenPlace?.apiKey).toBeUndefined();
     });
 
     test('loads settings page', async ({ page }) => {

--- a/frontend/src/components/svelte/ChatProviderSettings.svelte
+++ b/frontend/src/components/svelte/ChatProviderSettings.svelte
@@ -1,0 +1,349 @@
+<script>
+    import { onDestroy, onMount } from 'svelte';
+    import {
+        loadGameState,
+        ready,
+        saveGameState,
+        state as gameStateStore,
+    } from '../../utils/gameState/common.js';
+    import { normalizeSettings } from '../../utils/settingsDefaults.js';
+
+    const TOKEN_PLACE = 'token-place';
+    const OPENAI = 'openai';
+
+    let hydrated = false;
+    let loading = true;
+    let savingProvider = false;
+    let savingKey = false;
+    let chatProvider = TOKEN_PLACE;
+    let savedApiKey = '';
+    let draftApiKey = '';
+    let editingApiKey = false;
+    let statusMessage = '';
+    let errorMessage = '';
+    let unsubscribe;
+
+    const syncFromState = (value) => {
+        const normalized = normalizeSettings(value?.settings);
+        chatProvider = normalized.chatProvider;
+        savedApiKey = value?.openAI?.apiKey || '';
+        if (!editingApiKey) {
+            draftApiKey = '';
+        }
+    };
+
+    onMount(async () => {
+        await ready;
+        syncFromState(loadGameState());
+        unsubscribe = gameStateStore.subscribe((value) => syncFromState(value));
+        editingApiKey = !savedApiKey;
+        hydrated = true;
+        loading = false;
+    });
+
+    onDestroy(() => {
+        unsubscribe?.();
+    });
+
+    const persistProvider = async (provider) => {
+        await ready;
+        savingProvider = true;
+        statusMessage = '';
+        errorMessage = '';
+
+        try {
+            const current = loadGameState();
+            const nextSettings = {
+                ...normalizeSettings(current.settings),
+                chatProvider: provider,
+            };
+
+            await saveGameState({
+                ...current,
+                settings: nextSettings,
+            });
+
+            chatProvider = provider;
+            statusMessage =
+                provider === OPENAI
+                    ? 'OpenAI selected. Save your API key below to use it in Chat.'
+                    : 'token.place selected. No API key is required.';
+        } catch (error) {
+            console.error('Failed to save chat provider setting', error);
+            errorMessage = 'Unable to save Chat provider. Please try again.';
+        } finally {
+            savingProvider = false;
+        }
+    };
+
+    const handleProviderChange = async (event) => {
+        const nextProvider = event.currentTarget.value;
+        if (nextProvider === chatProvider || savingProvider) {
+            return;
+        }
+        chatProvider = nextProvider;
+        await persistProvider(nextProvider);
+    };
+
+    const saveApiKey = async () => {
+        await ready;
+        savingKey = true;
+        statusMessage = '';
+        errorMessage = '';
+
+        try {
+            const current = loadGameState();
+            await saveGameState({
+                ...current,
+                openAI: {
+                    ...(current.openAI || {}),
+                    apiKey: draftApiKey.trim(),
+                },
+            });
+            savedApiKey = draftApiKey.trim();
+            draftApiKey = '';
+            editingApiKey = !savedApiKey;
+            statusMessage = savedApiKey
+                ? 'OpenAI API key saved on this device.'
+                : 'OpenAI API key cleared.';
+        } catch (error) {
+            console.error('Failed to save OpenAI API key', error);
+            errorMessage = 'Unable to save OpenAI API key. Please try again.';
+        } finally {
+            savingKey = false;
+        }
+    };
+
+    const clearApiKey = async () => {
+        draftApiKey = '';
+        await saveApiKey();
+    };
+
+    const editApiKey = () => {
+        draftApiKey = '';
+        editingApiKey = true;
+        statusMessage = '';
+        errorMessage = '';
+    };
+</script>
+
+<section class="panel chat-provider-settings" data-hydrated={hydrated ? 'true' : 'false'}>
+    <div class="heading">
+        <h3>Chat provider</h3>
+        <p>
+            token.place is the default DSPACE Chat provider. It works without authentication or a
+            user-managed API key. Select OpenAI only if you want to use your own API key.
+        </p>
+    </div>
+
+    {#if hydrated}
+        <fieldset class="provider-options" disabled={loading || savingProvider}>
+            <legend>Choose the provider for NPC Chat</legend>
+            <label class="provider-option">
+                <input
+                    type="radio"
+                    name="chat-provider"
+                    value={TOKEN_PLACE}
+                    checked={chatProvider === TOKEN_PLACE}
+                    on:change={handleProviderChange}
+                    data-testid="chat-provider-token-place"
+                />
+                <span>
+                    <strong>token.place</strong>
+                    <small>Default. No auth or API key required.</small>
+                </span>
+            </label>
+            <label class="provider-option">
+                <input
+                    type="radio"
+                    name="chat-provider"
+                    value={OPENAI}
+                    checked={chatProvider === OPENAI}
+                    on:change={handleProviderChange}
+                    data-testid="chat-provider-openai"
+                />
+                <span>
+                    <strong>OpenAI</strong>
+                    <small>Opt in with an API key saved locally in this browser.</small>
+                </span>
+            </label>
+        </fieldset>
+
+        {#if chatProvider === OPENAI}
+            <div class="openai-key-panel" data-testid="openai-key-panel">
+                <h4>OpenAI API key</h4>
+                <p>
+                    OpenAI keys stay in your existing local save at <code>openAI.apiKey</code> for backwards
+                    compatibility. Saved keys are hidden here after configuration.
+                </p>
+
+                {#if savedApiKey && !editingApiKey}
+                    <p class="configured" data-testid="openai-key-configured">
+                        OpenAI API key configured on this device.
+                    </p>
+                    <div class="actions">
+                        <button type="button" on:click={editApiKey}>Edit key</button>
+                        <button
+                            class="danger"
+                            type="button"
+                            on:click={clearApiKey}
+                            disabled={savingKey}
+                        >
+                            {savingKey ? 'Clearing…' : 'Clear key'}
+                        </button>
+                    </div>
+                {:else}
+                    <form on:submit|preventDefault={saveApiKey}>
+                        <label for="openai-api-key">OpenAI API key</label>
+                        <input
+                            id="openai-api-key"
+                            type="password"
+                            autocomplete="off"
+                            bind:value={draftApiKey}
+                            placeholder="sk-..."
+                            data-testid="openai-api-key-input"
+                        />
+                        <div class="actions">
+                            <button type="submit" disabled={savingKey}>
+                                {savingKey ? 'Saving…' : 'Save OpenAI key'}
+                            </button>
+                            <button
+                                class="danger"
+                                type="button"
+                                on:click={clearApiKey}
+                                disabled={savingKey && !savedApiKey}
+                            >
+                                Clear key
+                            </button>
+                        </div>
+                    </form>
+                {/if}
+            </div>
+        {:else}
+            <p class="token-place-note" data-testid="token-place-no-key-note">
+                token.place is ready for Chat and does not need any credential field.
+            </p>
+        {/if}
+
+        {#if statusMessage}
+            <p class="status" role="status" data-testid="chat-provider-status">{statusMessage}</p>
+        {/if}
+        {#if errorMessage}
+            <p class="error" role="alert">{errorMessage}</p>
+        {/if}
+    {:else}
+        <p class="status">Loading Chat provider settings…</p>
+    {/if}
+</section>
+
+<style>
+    .panel {
+        border: 1px solid #334155;
+        border-radius: 12px;
+        padding: 1.25rem;
+        display: grid;
+        gap: 1rem;
+        max-width: 640px;
+        background: linear-gradient(135deg, #0b1221, #0d1828);
+        color: #e2e8f0;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+    }
+
+    h3,
+    h4,
+    p {
+        margin: 0;
+    }
+
+    p,
+    small,
+    legend,
+    label {
+        color: #cbd5e1;
+        line-height: 1.5;
+    }
+
+    .heading {
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    .provider-options,
+    .openai-key-panel {
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        border-radius: 10px;
+        padding: 1rem;
+        display: grid;
+        gap: 0.75rem;
+        background: rgba(15, 23, 42, 0.65);
+    }
+
+    .provider-option {
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
+        cursor: pointer;
+    }
+
+    .provider-option span,
+    form {
+        display: grid;
+        gap: 0.25rem;
+    }
+
+    input[type='radio'] {
+        margin-top: 0.3rem;
+    }
+
+    input[type='password'] {
+        border: 1px solid #475569;
+        border-radius: 8px;
+        padding: 0.65rem;
+        font-size: 1rem;
+        background: #020617;
+        color: #e2e8f0;
+    }
+
+    .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 0.5rem;
+    }
+
+    button {
+        background: #15803d;
+        border: 1px solid #22c55e;
+        border-radius: 8px;
+        color: #fff;
+        cursor: pointer;
+        font-size: 1rem;
+        padding: 10px 18px;
+    }
+
+    button.danger {
+        background: #8a2c2c;
+        border-color: #fca5a5;
+    }
+
+    button[disabled],
+    fieldset[disabled] {
+        opacity: 0.7;
+        cursor: progress;
+    }
+
+    .configured,
+    .status {
+        color: #86efac;
+    }
+
+    .error {
+        color: #fecaca;
+    }
+
+    .token-place-note {
+        border-left: 4px solid #22c55e;
+        padding-left: 0.75rem;
+        color: #bbf7d0;
+    }
+</style>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -5,6 +5,7 @@ import DataReset from '../components/svelte/DataReset.svelte';
 import QaCheatsToggle from '../components/svelte/QaCheatsToggle.svelte';
 import LegacySaveUpgrade from '../components/svelte/LegacySaveUpgrade.svelte';
 import QuestGraphToggle from '../components/svelte/QuestGraphToggle.svelte';
+import ChatProviderSettings from '../components/svelte/ChatProviderSettings.svelte';
 import { getCheatsAvailabilityFlag, isStagingEnvironment } from '../utils/cheatsAvailability';
 import { getCookieItemsFromStore, getCookieKeysFromStore } from '../utils/migrationCookies.js';
 
@@ -26,6 +27,7 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
                 />
             ) : null
         }
+        <ChatProviderSettings client:idle />
         <QuestGraphToggle client:idle />
         <LegacySaveUpgrade
             legacyV1Items={legacyV1Items}

--- a/frontend/src/utils/settingsDefaults.js
+++ b/frontend/src/utils/settingsDefaults.js
@@ -1,7 +1,13 @@
 export const DEFAULT_SETTINGS = {
+    chatProvider: 'token-place',
     showChatDebugPayload: false,
     showQuestGraphVisualizer: false,
 };
+
+const ALLOWED_CHAT_PROVIDERS = new Set(['token-place', 'openai']);
+
+export const normalizeChatProvider = (provider) =>
+    ALLOWED_CHAT_PROVIDERS.has(provider) ? provider : DEFAULT_SETTINGS.chatProvider;
 
 export const normalizeSettings = (settings = {}) => {
     const base =
@@ -11,6 +17,7 @@ export const normalizeSettings = (settings = {}) => {
 
     return {
         ...base,
+        chatProvider: normalizeChatProvider(base.chatProvider),
         showChatDebugPayload: Boolean(base.showChatDebugPayload),
         showQuestGraphVisualizer: Boolean(base.showQuestGraphVisualizer),
     };

--- a/frontend/tests/settingsDefaults.test.ts
+++ b/frontend/tests/settingsDefaults.test.ts
@@ -1,0 +1,34 @@
+import { normalizeSettings } from '../src/utils/settingsDefaults.js';
+
+describe('settings defaults normalization', () => {
+    test.each([
+        ['missing chatProvider', {}, 'token-place'],
+        ['null chatProvider', { chatProvider: null }, 'token-place'],
+        ['invalid chatProvider', { chatProvider: 'legacy-token-place' }, 'token-place'],
+        ['token-place chatProvider', { chatProvider: 'token-place' }, 'token-place'],
+        ['openai chatProvider', { chatProvider: 'openai' }, 'openai'],
+    ])('%s normalizes to %s', (_label, input, expected) => {
+        expect(normalizeSettings(input).chatProvider).toBe(expected);
+    });
+
+    test('preserves existing boolean normalization behavior', () => {
+        expect(
+            normalizeSettings({
+                showChatDebugPayload: 1,
+                showQuestGraphVisualizer: '',
+            })
+        ).toMatchObject({
+            chatProvider: 'token-place',
+            showChatDebugPayload: true,
+            showQuestGraphVisualizer: false,
+        });
+    });
+
+    test('legacy tokenPlace.enabled does not affect chatProvider default', () => {
+        expect(
+            normalizeSettings({
+                tokenPlace: { enabled: false },
+            }).chatProvider
+        ).toBe('token-place');
+    });
+});


### PR DESCRIPTION
### Motivation

- Provide a central `/settings` UI to choose the Chat provider and move OpenAI key management out of `/chat`.  
- Default Chat provider must be `token-place` (no user credential); OpenAI is opt-in and uses the existing `openAI.apiKey` storage.  
- Ensure persisted normalized game state includes `settings.chatProvider` and that legacy `tokenPlace.enabled` does not override the new default.  

### Description

- Add `settings.chatProvider` default and normalization: `DEFAULT_SETTINGS.chatProvider = 'token-place'` and `normalizeSettings()` coerces missing/null/invalid values to `token-place` while preserving `openai` and `token-place`. (edited: `frontend/src/utils/settingsDefaults.js`)  
- New reusable settings panel `ChatProviderSettings.svelte` that renders on `/settings`, lets users pick `token.place` or `OpenAI`, persists the choice to `gameState.settings.chatProvider`, and manages `openAI.apiKey` (save/clear/edit) without page reloads and without ever asking for a token.place key. (new file: `frontend/src/components/svelte/ChatProviderSettings.svelte`)  
- Render the new panel from `frontend/src/pages/settings.astro` so the Settings page owns provider selection and OpenAI key management.  
- Tests and state updates: add normalization/unit tests and extend E2E coverage to verify default, selection persistence, OpenAI key save/clear, reload persistence, and absence of token.place credential inputs; also update game state test expectations to include the new default. (tests: `frontend/tests/settingsDefaults.test.ts`, modified: `frontend/__tests__/gameState/common.test.js`, modified: `frontend/e2e/settings-page.spec.ts`)  

### Testing

- Searched code references to confirm no accidental token.place credential fields or forbidden envs with `rg -n "chatProvider|Chat provider|openAI|apiKey|token-place|tokenPlace\.apiKey|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL" frontend/src/utils frontend/src/components frontend/src/pages/settings.astro frontend/e2e frontend/__tests__` and validated matches (local search completed).  
- Ran unit tests for settings normalization with `cd frontend && npm test -- settingsDefaults common.test.js`, and they passed (`✓ frontend/tests/settingsDefaults.test.ts (7 tests)` and `✓ frontend/__tests__/gameState/common.test.js (16 tests)`).  
- Ran formatting/lint checks with `cd frontend && npm run check`, which completed successfully (`All matched files use Prettier code style` and `lint` completed).  
- Attempted E2E run `cd frontend && npm run test:e2e -- settings-page.spec.ts`, but the environment could not download Playwright browsers/system dependencies (network errors like `ENETUNREACH` and apt repository failures), so Playwright E2E could not complete in this environment; the new E2E test was added and should pass when browsers are available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d4eaf8a8832f908f0388e53c694e)