### PR TITLE
Move Chat provider configuration to /settings and persist selection

### DIFF
--- a/frontend/__tests__/OpenAIAPIKeySettings.test.js
+++ b/frontend/__tests__/OpenAIAPIKeySettings.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/svelte';
-import OpenAIAPIKeySettings from '../src/pages/chat/svelte/OpenAIAPIKeySettings.svelte';
+import OpenAIAPIKeySettings from '../src/components/svelte/OpenAIAPIKeySettings.svelte';
 
 vi.mock('../src/utils/gameState/common.js', () => ({
     loadGameState: vi.fn(() => ({

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -39,6 +39,81 @@ test.describe('Settings route', () => {
         await expect(page.getByTestId('logout-state')).toHaveText('No saved credentials detected.');
     });
 
+    test('manages Chat provider and OpenAI key settings', async ({ page }) => {
+        await page.goto('/settings');
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+
+        await expect(page.getByRole('heading', { level: 2, name: 'Chat provider' })).toBeVisible();
+        await expect(page.getByTestId('chat-provider-token-place')).toBeChecked();
+        await expect(page.getByLabel(/token\.place.*api key/i)).toHaveCount(0);
+        await expect(page.getByTestId('openai-key-panel')).toHaveCount(0);
+
+        await page.getByTestId('chat-provider-openai').check();
+        await expect(page.getByTestId('chat-provider-openai')).toBeChecked();
+        await expect(page.getByTestId('openai-key-panel')).toBeVisible();
+
+        await expect
+            .poll(() =>
+                page.evaluate(() => {
+                    const raw = localStorage.getItem('gameState');
+                    return raw ? JSON.parse(raw).settings?.chatProvider : undefined;
+                })
+            )
+            .toBe('openai');
+
+        await page.getByTestId('openai-api-key-input').fill('sk-settings-e2e');
+        await page.getByTestId('openai-api-key-save').click();
+        await expect(page.getByTestId('openai-api-key-configured')).toBeVisible();
+        await expect
+            .poll(() =>
+                page.evaluate(() => {
+                    const raw = localStorage.getItem('gameState');
+                    return raw ? JSON.parse(raw).openAI?.apiKey : undefined;
+                })
+            )
+            .toBe('sk-settings-e2e');
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByTestId('chat-provider-openai')).toBeChecked();
+        await expect(page.getByTestId('openai-api-key-configured')).toBeVisible();
+
+        await page.getByTestId('openai-api-key-clear').click();
+        await expect(page.getByTestId('openai-api-key-input')).toBeVisible();
+        await expect
+            .poll(() =>
+                page.evaluate(() => {
+                    const raw = localStorage.getItem('gameState');
+                    return raw ? JSON.parse(raw).openAI?.apiKey : undefined;
+                })
+            )
+            .toBe('');
+
+        await page.getByTestId('chat-provider-token-place').check();
+        await expect(page.getByTestId('chat-provider-token-place')).toBeChecked();
+        await expect(page.getByTestId('openai-key-panel')).toHaveCount(0);
+        await expect
+            .poll(() =>
+                page.evaluate(() => {
+                    const raw = localStorage.getItem('gameState');
+                    return raw ? JSON.parse(raw).settings?.chatProvider : undefined;
+                })
+            )
+            .toBe('token-place');
+
+        const tokenPlaceCredentialInputs = page.locator(
+            'input[aria-label*="token.place" i], input[name*="tokenPlace" i], input[name*="token-place" i], input[id*="tokenPlace" i], input[id*="token-place" i]'
+        );
+        await expect(tokenPlaceCredentialInputs).toHaveCount(0);
+        const savedState = await page.evaluate(() => {
+            const raw = localStorage.getItem('gameState');
+            return raw ? JSON.parse(raw) : {};
+        });
+        expect(savedState.tokenPlace?.apiKey).toBeUndefined();
+    });
+
     for (const viewport of SETTINGS_VIEWPORTS) {
         test(`keeps settings cards spaced without overlap at ${viewport.name} width`, async ({
             page,

--- a/frontend/src/components/svelte/ChatProviderSettings.svelte
+++ b/frontend/src/components/svelte/ChatProviderSettings.svelte
@@ -1,0 +1,196 @@
+<script>
+    import { onDestroy, onMount } from 'svelte';
+    import OpenAIAPIKeySettings from './OpenAIAPIKeySettings.svelte';
+    import {
+        loadGameState,
+        ready,
+        saveGameState,
+        state as gameStateStore,
+    } from '../../utils/gameState/common.js';
+    import { normalizeSettings } from '../../utils/settingsDefaults.js';
+
+    const CHAT_PROVIDER_OPTIONS = ['token-place', 'openai'];
+
+    let hydrated = false;
+    let loading = true;
+    let chatProvider = 'token-place';
+    let status = 'token.place is selected by default.';
+    let unsubscribe;
+
+    const syncFromState = (value) => {
+        chatProvider = normalizeSettings(value?.settings).chatProvider;
+    };
+
+    onMount(async () => {
+        await ready;
+        const current = loadGameState();
+        syncFromState(current);
+        status =
+            chatProvider === 'openai'
+                ? 'OpenAI is selected for Chat.'
+                : 'token.place is selected for Chat.';
+        unsubscribe = gameStateStore.subscribe((value) => syncFromState(value));
+        hydrated = true;
+        loading = false;
+    });
+
+    onDestroy(() => {
+        unsubscribe?.();
+    });
+
+    const persistProvider = async (nextProvider) => {
+        if (!CHAT_PROVIDER_OPTIONS.includes(nextProvider) || nextProvider === chatProvider) {
+            return;
+        }
+
+        chatProvider = nextProvider;
+        loading = true;
+        status = 'Saving Chat provider…';
+
+        await ready;
+        const current = loadGameState();
+        const settings = normalizeSettings(current.settings);
+
+        await saveGameState({
+            ...current,
+            settings: {
+                ...settings,
+                chatProvider: nextProvider,
+            },
+        });
+
+        status =
+            nextProvider === 'openai'
+                ? 'OpenAI selected. Add your OpenAI API key below to use it in Chat.'
+                : 'token.place selected. No API key or credential is required.';
+        loading = false;
+    };
+</script>
+
+<section class="panel chat-provider-settings" data-hydrated={hydrated ? 'true' : 'false'}>
+    <div class="heading">
+        <h2>Chat provider</h2>
+        <p>
+            Choose the provider used by the DSPACE Chat NPCs. token.place is the default and works
+            without authentication or an API key.
+        </p>
+    </div>
+
+    <fieldset disabled={loading} aria-describedby="chat-provider-help chat-provider-status">
+        <legend>Provider</legend>
+        <label class="provider-option">
+            <input
+                type="radio"
+                name="chat-provider"
+                value="token-place"
+                checked={chatProvider === 'token-place'}
+                on:change={() => persistProvider('token-place')}
+                data-testid="chat-provider-token-place"
+            />
+            <span>
+                <strong>token.place</strong>
+                <small
+                    >Default Chat provider. No auth, no OpenAI key, and no credential field.</small
+                >
+            </span>
+        </label>
+        <label class="provider-option">
+            <input
+                type="radio"
+                name="chat-provider"
+                value="openai"
+                checked={chatProvider === 'openai'}
+                on:change={() => persistProvider('openai')}
+                data-testid="chat-provider-openai"
+            />
+            <span>
+                <strong>OpenAI</strong>
+                <small>Use your own OpenAI API key stored locally in this browser.</small>
+            </span>
+        </label>
+    </fieldset>
+
+    <p id="chat-provider-help" class="help-text">
+        DSPACE does not ask for or store a token.place API key. OpenAI keys stay in the existing
+        local OpenAI settings slot for backwards compatibility.
+    </p>
+    <p id="chat-provider-status" class="status" role="status" data-testid="chat-provider-status">
+        {status}
+    </p>
+
+    {#if hydrated && chatProvider === 'openai'}
+        <div class="openai-key-panel" data-testid="openai-key-panel">
+            <OpenAIAPIKeySettings reloadOnSave={false} />
+        </div>
+    {/if}
+</section>
+
+<style>
+    .panel {
+        border: 1px solid #334155;
+        border-radius: 12px;
+        padding: 1.25rem;
+        display: grid;
+        gap: 0.85rem;
+        max-width: 640px;
+        background: linear-gradient(135deg, #0b1221, #0d1828);
+        color: #e2e8f0;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+    }
+
+    .heading {
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    h2,
+    p {
+        margin: 0;
+    }
+
+    fieldset {
+        border: 1px solid #475569;
+        border-radius: 10px;
+        display: grid;
+        gap: 0.75rem;
+        margin: 0;
+        padding: 1rem;
+    }
+
+    legend {
+        padding: 0 0.35rem;
+        font-weight: 700;
+    }
+
+    .provider-option {
+        align-items: flex-start;
+        cursor: pointer;
+        display: grid;
+        gap: 0.65rem;
+        grid-template-columns: auto 1fr;
+    }
+
+    .provider-option input {
+        margin-top: 0.2rem;
+    }
+
+    .provider-option span {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    small,
+    .help-text {
+        color: #cbd5e1;
+    }
+
+    .status {
+        color: #93c5fd;
+        font-weight: 700;
+    }
+
+    .openai-key-panel {
+        border-top: 1px solid #334155;
+        padding-top: 0.85rem;
+    }
+</style>

--- a/frontend/src/components/svelte/OpenAIAPIKeySettings.svelte
+++ b/frontend/src/components/svelte/OpenAIAPIKeySettings.svelte
@@ -1,9 +1,12 @@
 <script>
     import { onMount } from 'svelte';
     import { writable } from 'svelte/store';
-    import { loadGameState, saveGameState, ready } from '../../../utils/gameState/common.js';
+    import { loadGameState, saveGameState, ready } from '../../utils/gameState/common.js';
 
     export let apiKey = writable('');
+    export let reloadOnSave = true;
+
+    let status = '';
 
     const isMounted = writable(false);
     const isEditing = writable(true);
@@ -23,6 +26,7 @@
         gameState.openAI = gameState.openAI || {};
         gameState.openAI.apiKey = $apiKey;
         await saveGameState(gameState);
+        status = 'OpenAI API key saved.';
         isEditing.set(false);
     }
 
@@ -33,13 +37,15 @@
         gameState.openAI.apiKey = '';
         await saveGameState(gameState);
         apiKey.set('');
+        status = 'OpenAI API key cleared.';
         isEditing.set(true);
     }
 
     async function handleSubmit() {
         await saveAPIKey();
-        // reload the page
-        window.location.reload();
+        if (reloadOnSave) {
+            window.location.reload();
+        }
     }
 
     function editAPIKey() {
@@ -61,23 +67,47 @@
                     <a href="https://platform.openai.com/account/usage">here.</a>
                 </p>
                 <form on:submit|preventDefault={handleSubmit}>
-                    <input type="text" bind:value={$apiKey} />
+                    <label for="openai-api-key">OpenAI API key</label>
+                    <input
+                        id="openai-api-key"
+                        type="password"
+                        autocomplete="off"
+                        bind:value={$apiKey}
+                        data-testid="openai-api-key-input"
+                    />
                     <div class="horizontal">
-                        <button type="submit">Submit</button>
+                        <button type="submit" data-testid="openai-api-key-save"
+                            >Save OpenAI API key</button
+                        >
                         <button class="red" type="button" on:click={() => deleteAPIKey()}
                             >Clear</button
                         >
                     </div>
                 </form>
             {:else}
-                <button type="button" on:click={() => editAPIKey()}>Edit API Key</button>
+                <p class="configured" data-testid="openai-api-key-configured">
+                    OpenAI API key configured.
+                </p>
+                <div class="horizontal">
+                    <button type="button" on:click={() => editAPIKey()}>Edit API Key</button>
+                    <button
+                        class="red"
+                        type="button"
+                        on:click={() => deleteAPIKey()}
+                        data-testid="openai-api-key-clear">Clear</button
+                    >
+                </div>
             {/if}
         </div>
 
+        {#if status}
+            <p class="status" role="status" data-testid="openai-api-key-status">{status}</p>
+        {/if}
+
         <p>
-            When you connect your API key, the chat can tap a curated knowledge base of quest lore,
-            items, and highlights from your local inventory so NPCs can answer gameplay questions
-            and show their unique personalities right away.
+            When you connect your API key, the chat can tap a curated knowledge base covering quest
+            lore, items, and highlights from your local inventory so NPCs can answer gameplay
+            questions and show their unique personalities right away.
         </p>
     </div>
 {/if}
@@ -104,6 +134,15 @@
     .red {
         background-color: #8a2c2c;
         color: white;
+    }
+
+    label {
+        font-weight: 700;
+    }
+
+    .configured,
+    .status {
+        font-weight: 700;
     }
 
     input {

--- a/frontend/src/pages/chat/svelte/Integrations.svelte
+++ b/frontend/src/pages/chat/svelte/Integrations.svelte
@@ -1,5 +1,5 @@
 <script>
-    import OpenAIAPIKeySettings from './OpenAIAPIKeySettings.svelte';
+    import OpenAIAPIKeySettings from '../../../components/svelte/OpenAIAPIKeySettings.svelte';
     import { onMount } from 'svelte';
     import { derived, writable } from 'svelte/store';
     import { loadGameState, ready, state as gameState } from '../../../utils/gameState/common.js';

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -5,6 +5,7 @@ import DataReset from '../components/svelte/DataReset.svelte';
 import QaCheatsToggle from '../components/svelte/QaCheatsToggle.svelte';
 import LegacySaveUpgrade from '../components/svelte/LegacySaveUpgrade.svelte';
 import QuestGraphToggle from '../components/svelte/QuestGraphToggle.svelte';
+import ChatProviderSettings from '../components/svelte/ChatProviderSettings.svelte';
 import { getCheatsAvailabilityFlag, isStagingEnvironment } from '../utils/cheatsAvailability';
 import { getCookieItemsFromStore, getCookieKeysFromStore } from '../utils/migrationCookies.js';
 
@@ -26,6 +27,7 @@ const legacyCookieKeys = getCookieKeysFromStore(Astro.cookies);
                 />
             ) : null
         }
+        <ChatProviderSettings client:idle />
         <QuestGraphToggle client:idle />
         <LegacySaveUpgrade
             legacyV1Items={legacyV1Items}

--- a/frontend/src/utils/settingsDefaults.js
+++ b/frontend/src/utils/settingsDefaults.js
@@ -1,4 +1,10 @@
+export const CHAT_PROVIDER_TOKEN_PLACE = 'token-place';
+export const CHAT_PROVIDER_OPENAI = 'openai';
+
+const CHAT_PROVIDER_VALUES = new Set([CHAT_PROVIDER_TOKEN_PLACE, CHAT_PROVIDER_OPENAI]);
+
 export const DEFAULT_SETTINGS = {
+    chatProvider: CHAT_PROVIDER_TOKEN_PLACE,
     showChatDebugPayload: false,
     showQuestGraphVisualizer: false,
 };
@@ -11,6 +17,9 @@ export const normalizeSettings = (settings = {}) => {
 
     return {
         ...base,
+        chatProvider: CHAT_PROVIDER_VALUES.has(base.chatProvider)
+            ? base.chatProvider
+            : CHAT_PROVIDER_TOKEN_PLACE,
         showChatDebugPayload: Boolean(base.showChatDebugPayload),
         showQuestGraphVisualizer: Boolean(base.showQuestGraphVisualizer),
     };

--- a/frontend/tests/settingsDefaults.test.ts
+++ b/frontend/tests/settingsDefaults.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeSettings } from '../src/utils/settingsDefaults.js';
+import { validateGameState } from '../src/utils/gameState/common.js';
+
+describe('settings defaults', () => {
+    test.each([
+        ['missing chatProvider', {}, 'token-place'],
+        ['null chatProvider', { chatProvider: null }, 'token-place'],
+        ['invalid chatProvider', { chatProvider: 'token.place' }, 'token-place'],
+        ['token-place chatProvider', { chatProvider: 'token-place' }, 'token-place'],
+        ['openai chatProvider', { chatProvider: 'openai' }, 'openai'],
+    ])('normalizes %s', (_label, settings, expected) => {
+        expect(normalizeSettings(settings).chatProvider).toBe(expected);
+    });
+
+    test('preserves existing boolean settings normalization', () => {
+        expect(
+            normalizeSettings({
+                showChatDebugPayload: 1,
+                showQuestGraphVisualizer: '',
+            })
+        ).toMatchObject({
+            chatProvider: 'token-place',
+            showChatDebugPayload: true,
+            showQuestGraphVisualizer: false,
+        });
+    });
+
+    test('legacy tokenPlace.enabled does not affect chatProvider default', () => {
+        const state = validateGameState({
+            quests: {},
+            inventory: {},
+            processes: {},
+            tokenPlace: { enabled: false },
+            settings: {},
+        });
+
+        expect(state.settings.chatProvider).toBe('token-place');
+        expect(state.tokenPlace.enabled).toBe(false);
+    });
+});


### PR DESCRIPTION
### Motivation

- Provide a user-facing place to select the Chat provider and make token.place the default without requiring any token.place credentials.
- Keep OpenAI API key management backwards-compatible while making `/chat` provider-agnostic for future provider routing.

### Description

- Add `settings.chatProvider` with allowed values `token-place` and `openai` and default `token-place`, and update `normalizeSettings()` to coerce missing/null/invalid values to `token-place` while preserving existing boolean settings behavior (`showChatDebugPayload`, `showQuestGraphVisualizer`). (edited: `frontend/src/utils/settingsDefaults.js`).
- New reusable settings panel component `ChatProviderSettings.svelte` that renders on `/settings` and persists the selection to `gameState.settings.chatProvider` using existing `saveGameState`, explains token.place default behavior, shows OpenAI key management only when `openai` is selected, and never shows any token.place credential field. (added: `frontend/src/components/svelte/ChatProviderSettings.svelte`; updated: `frontend/src/pages/settings.astro`).
- Move/OpenAI key management into a shared component and make it settings-friendly by moving `OpenAIAPIKeySettings.svelte` into `frontend/src/components/svelte`, adding optional `reloadOnSave` and status text, and preserving storage at `gameState.openAI.apiKey` (no migration or renaming). (`frontend/src/components/svelte/OpenAIAPIKeySettings.svelte`, updated imports in `frontend/src/pages/chat/svelte/Integrations.svelte`).
- Minimal wiring changes so `/chat` remains functional (imports updated only); no provider-specific UI refactor of the chat message UI was performed in this PR.
- Tests added: unit tests for normalization (`frontend/tests/settingsDefaults.test.ts`) and an E2E spec added/extended (`frontend/e2e/settings-page.spec.ts`) to exercise provider selection, OpenAI key save/clear, persistence, and absence of token.place credential inputs.

### Testing

- Ran `cd frontend && npm test -- settingsDefaults` and `cd frontend && npm test -- settingsDefaults OpenAIAPIKeySettings` (Vitest): both test runs passed (unit tests for `normalizeSettings` and `OpenAIAPIKeySettings` succeeded).
- Ran `cd frontend && npm run check` (lint + format check): completed successfully with Prettier and lint checks passing.
- Verified code occurrences with `rg -n "chatProvider|Chat provider|openAI|apiKey|token-place|tokenPlace\.apiKey|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL"` to confirm no unintended keys or new token.place credentials were introduced; the results show the new `chatProvider` usage only where intended.
- Attempted E2E run `cd frontend && npm run test:e2e -- settings-page.spec.ts` but it could not complete in this environment because Playwright attempted to install browsers/system packages and network access to apt/Playwright CDNs failed (repeated `ENETUNREACH` errors during Chromium download), so the E2E run was blocked by the environment and not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d4fe02e4832f8c7e1eca9fe4bf7f)