### PR TITLE
docs: v3.1 token.place Chat changelog, docs, and QA checklist

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -17,37 +17,37 @@ page and uses the exact UI labels from `frontend/src/config/menu.json`.
 
 ### Top navigation (pinned)
 
-| UI label | Route | Notes |
-| --- | --- | --- |
-| Home | / | Homepage |
-| Quests | /quests | Quest list |
-| Inventory | /inventory | Inventory list |
-| Energy | /energy | Energy management |
-| Wallet | /wallet | Wallet overview |
-| Profile | /profile | Player profile |
-| Docs | /docs | Documentation index |
-| Chat | /chat | Chat interface |
-| Changelog | /changelog | Release notes |
+| UI label  | Route      | Notes                                                    |
+| --------- | ---------- | -------------------------------------------------------- |
+| Home      | /          | Homepage                                                 |
+| Quests    | /quests    | Quest list                                               |
+| Inventory | /inventory | Inventory list                                           |
+| Energy    | /energy    | Energy management                                        |
+| Wallet    | /wallet    | Wallet overview                                          |
+| Profile   | /profile   | Player profile                                           |
+| Docs      | /docs      | Documentation index                                      |
+| Chat      | /chat      | Chat interface; token.place is the v3.1 default provider |
+| Changelog | /changelog | Release notes                                            |
 
 ### More menu (unpinned)
 
-| UI label | Route | Notes |
-| --- | --- | --- |
-| Processes | /processes | Process list |
-| Import/export gamesaves | /gamesaves | Save import/export |
-| Cloud Sync | /cloudsync | Cloud sync setup |
-| Custom Content Backup | /contentbackup | Backup management |
-| Guilds | /guilds | Coming soon |
-| Stats | /stats | Player statistics |
-| Achievements | /achievements | Achievement list |
-| Leaderboard | /leaderboard | Global leaderboard |
-| Locations | /locations | Coming soon |
-| Titles | /titles | Player titles |
-| Toolbox | /toolbox | Utilities & QA tools |
-| Settings | /settings | User settings |
-| Discord | https://discord.gg/A3UAfYvnxM | External link |
-| Twitter | https://twitter.com/dspacegame | External link |
-| Github | https://github.com/democratizedspace/dspace | External link |
+| UI label                | Route                                       | Notes                                                                            |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- |
+| Processes               | /processes                                  | Process list                                                                     |
+| Import/export gamesaves | /gamesaves                                  | Save import/export                                                               |
+| Cloud Sync              | /cloudsync                                  | Cloud sync setup                                                                 |
+| Custom Content Backup   | /contentbackup                              | Backup management                                                                |
+| Guilds                  | /guilds                                     | Coming soon                                                                      |
+| Stats                   | /stats                                      | Player statistics                                                                |
+| Achievements            | /achievements                               | Achievement list                                                                 |
+| Leaderboard             | /leaderboard                                | Global leaderboard                                                               |
+| Locations               | /locations                                  | Coming soon                                                                      |
+| Titles                  | /titles                                     | Player titles                                                                    |
+| Toolbox                 | /toolbox                                    | Utilities & QA tools                                                             |
+| Settings                | /settings                                   | User settings, including Chat provider selection and optional OpenAI key storage |
+| Discord                 | https://discord.gg/A3UAfYvnxM               | External link                                                                    |
+| Twitter                 | https://twitter.com/dspacegame              | External link                                                                    |
+| Github                  | https://github.com/democratizedspace/dspace | External link                                                                    |
 
 ## Navigation click-paths (canonical)
 
@@ -74,6 +74,7 @@ answer "how do I get there?" with citeable pathing.
 
 ### Settings page click-paths
 
+- Settings → Chat Provider controls whether `/chat` uses the default token.place provider or optional OpenAI bring-your-own-key provider.
 - Settings → Debug opens /chat#prompt-debug.
 
 ### Editor/manage entrypoints (CTA labels)
@@ -94,17 +95,17 @@ This section is the citeable route catalog and anchors the canonical routes unde
 
 ### Custom content authoring
 
-| Route | Description |
-| --- | --- |
-| /quests/create | Create a custom quest |
-| /quests/manage | Manage custom quests |
-| /quests/:id/edit | Edit a custom quest |
-| /inventory/create | Create a custom item |
-| /inventory/manage | Manage custom inventory |
+| Route                        | Description                  |
+| ---------------------------- | ---------------------------- |
+| /quests/create               | Create a custom quest        |
+| /quests/manage               | Manage custom quests         |
+| /quests/:id/edit             | Edit a custom quest          |
+| /inventory/create            | Create a custom item         |
+| /inventory/manage            | Manage custom inventory      |
 | /inventory/item/:itemId/edit | Edit a custom inventory item |
-| /processes/create | Create a custom process |
-| /processes/manage | Manage custom processes |
-| /processes/:processId/edit | Edit a custom process |
+| /processes/create            | Create a custom process      |
+| /processes/manage            | Manage custom processes      |
+| /processes/:processId/edit   | Edit a custom process        |
 
 ## Static routes
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,16 +13,18 @@ across `dev`, `int`, and `prod` clusters.
 
 ## Environment Variables
 
-| Name | Required | Description | Example | Source |
-| --- | --- | --- | --- | --- |
-| `PORT` | No (default `8080`) | TCP port that the HTTP server binds to. The Helm chart maps this to the service port automatically. | `8080` | ConfigMap / values.yaml |
-| `HOST` | No (default `0.0.0.0`) | Interface for the listener. Leave at the default to accept traffic from the Service/Ingress. | `0.0.0.0` | ConfigMap / values.yaml |
-| `NODE_ENV` | No (default `production`) | Sets Node.js runtime mode. Keep `production` for optimized builds. | `production` | ConfigMap / values.yaml |
-| `DSPACE_FEATURE_FLAGS` | No | Comma-separated feature flag identifiers surfaced in readiness probes and startup logs. Supports `key=value` overrides consumed by `/config.json` (for example `offlineWorker.enabled=false`). | `beta-chat,balance-panel` | ConfigMap / values.yaml |
-| `DSPACE_TELEMETRY_ENABLED` | No (default `false`) | Opt-in switch for telemetry; `/config.json` mirrors it. The feature flag override `telemetry.enabled=true` also enables telemetry. | `true` | ConfigMap / values.yaml |
-| `METRICS_TOKEN` | Recommended | Bearer token that protects the `/metrics` endpoint. When set, Prometheus or other collectors must send `Authorization: Bearer <token>`. | *(generated)* | Kubernetes Secret (`dspace-secrets`, key `metricsToken` managed via SOPS) |
-| `SERVER_CERT_PATH` | Optional | Path to a TLS certificate inside the container. Provide along with `SERVER_KEY_PATH` to terminate TLS in-process instead of via Traefik. | `/app/tls/tls.crt` | Kubernetes Secret (mounted volume) |
-| `SERVER_KEY_PATH` | Optional | Private key paired with `SERVER_CERT_PATH`. | `/app/tls/tls.key` | Kubernetes Secret (mounted volume) |
+| Name                          | Required                  | Description                                                                                                                                                                                    | Example                       | Source                                                                    |
+| ----------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------- |
+| `PORT`                        | No (default `8080`)       | TCP port that the HTTP server binds to. The Helm chart maps this to the service port automatically.                                                                                            | `8080`                        | ConfigMap / values.yaml                                                   |
+| `HOST`                        | No (default `0.0.0.0`)    | Interface for the listener. Leave at the default to accept traffic from the Service/Ingress.                                                                                                   | `0.0.0.0`                     | ConfigMap / values.yaml                                                   |
+| `NODE_ENV`                    | No (default `production`) | Sets Node.js runtime mode. Keep `production` for optimized builds.                                                                                                                             | `production`                  | ConfigMap / values.yaml                                                   |
+| `DSPACE_FEATURE_FLAGS`        | No                        | Comma-separated feature flag identifiers surfaced in readiness probes and startup logs. Supports `key=value` overrides consumed by `/config.json` (for example `offlineWorker.enabled=false`). | `beta-chat,balance-panel`     | ConfigMap / values.yaml                                                   |
+| `DSPACE_TELEMETRY_ENABLED`    | No (default `false`)      | Opt-in switch for telemetry; `/config.json` mirrors it. The feature flag override `telemetry.enabled=true` also enables telemetry.                                                             | `true`                        | ConfigMap / values.yaml                                                   |
+| `METRICS_TOKEN`               | Recommended               | Bearer token that protects the `/metrics` endpoint. When set, Prometheus or other collectors must send `Authorization: Bearer <token>`.                                                        | _(generated)_                 | Kubernetes Secret (`dspace-secrets`, key `metricsToken` managed via SOPS) |
+| `VITE_TOKEN_PLACE_URL`        | Optional                  | token.place origin for the default v3.1 Chat provider. Production defaults to `https://token.place`; staging should set `https://staging.token.place`.                                         | `https://staging.token.place` | ConfigMap / values.yaml                                                   |
+| `VITE_TOKEN_PLACE_CHAT_MODEL` | Optional                  | Model override for token.place API v1 Chat completions. Leave unset unless a deployment needs a known-good model alias.                                                                        | `gpt-5-chat-latest`           | ConfigMap / values.yaml                                                   |
+| `SERVER_CERT_PATH`            | Optional                  | Path to a TLS certificate inside the container. Provide along with `SERVER_KEY_PATH` to terminate TLS in-process instead of via Traefik.                                                       | `/app/tls/tls.crt`            | Kubernetes Secret (mounted volume)                                        |
+| `SERVER_KEY_PATH`             | Optional                  | Private key paired with `SERVER_CERT_PATH`.                                                                                                                                                    | `/app/tls/tls.key`            | Kubernetes Secret (mounted volume)                                        |
 
 > **Secrets**: `METRICS_TOKEN`, TLS material, and any future API keys should live in a SOPS-managed
 > secret named `dspace-secrets` (see Helm values below). Flux/SOPS will render them into the
@@ -35,11 +37,11 @@ into a deterministic ConfigMap that the corresponding `HelmRelease` consumes. Th
 summarises the runtime differences so operators can confirm hostnames, scaling choices, and
 feature toggles without opening each values file.
 
-| Environment | Hostname | Image strategy | Metrics | Feature flags | Notes |
-| --- | --- | --- | --- | --- | --- |
-| dev | `dev.dspace.example.com` | Follows tag `main` for rapid iteration | Disabled (`serviceMonitor.enabled=false`) | `beta-chat` | Single replica, metrics exporter left off to minimize noise. |
-| int | `int.dspace.example.com` | Pins an immutable digest for release verification | Enabled (`serviceMonitor` scrapes namespace `dspace`) | `beta-chat,balance-panel` | Autoscaling between two and four replicas with 60% CPU target. |
-| prod | `dspace.example.com` | Pins an immutable digest for production rollouts | Enabled (`serviceMonitor` scrapes namespace `dspace`) | `beta-chat,balance-panel,observability` | Alerts enabled and resources raised (500m/768Mi requests). |
+| Environment | Hostname                 | Image strategy                                    | Metrics                                               | Feature flags                           | Notes                                                          |
+| ----------- | ------------------------ | ------------------------------------------------- | ----------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------- |
+| dev         | `dev.dspace.example.com` | Follows tag `main` for rapid iteration            | Disabled (`serviceMonitor.enabled=false`)             | `beta-chat`                             | Single replica, metrics exporter left off to minimize noise.   |
+| int         | `int.dspace.example.com` | Pins an immutable digest for release verification | Enabled (`serviceMonitor` scrapes namespace `dspace`) | `beta-chat,balance-panel`               | Autoscaling between two and four replicas with 60% CPU target. |
+| prod        | `dspace.example.com`     | Pins an immutable digest for production rollouts  | Enabled (`serviceMonitor` scrapes namespace `dspace`) | `beta-chat,balance-panel,observability` | Alerts enabled and resources raised (500m/768Mi requests).     |
 
 Flux consumption details:
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -1,55 +1,234 @@
-# DSPACE v3.1 QA Checklist (token.place integration + v3 rerun)
+# DSPACE v3.1 QA Checklist (token.place Chat default)
 
-> Focus: validate token.place integration deferred from v3, then repeat the full v3 QA suite.
+> Focus: validate DSPACE v3.1.0 Chat behavior, token.place API v1 integration, OpenAI opt-in
+> settings, and staging-to-production promotion readiness.
 
 Tracking / release gate:
-- [ ] Issue #3420: https://github.com/democratizedspace/dspace/issues/3420 (Enable token.place chat provider + add E2E coverage and release gates)
 
-## A) token.place onboarding (infra gates)
+- [ ] Issue #3420: https://github.com/democratizedspace/dspace/issues/3420 (Enable token.place
+      chat provider + add E2E coverage and release gates)
 
-- [ ] token.place deployed to staging
-- [ ] token.place deployed to production
-- [ ] Health checks and monitoring dashboards exist
-- [ ] Rate limiting / abuse controls reviewed
-- [ ] CORS configuration correct for dspace origins
-- [ ] Secrets management + rotation plan defined
+## 0) Release scope and build under test
 
-## B) dspace integration gates
+- [ ] Target version: `v3.1.0`
+- [ ] Candidate tag/commit:
+- [ ] Release branch:
+- [ ] Staging URL:
+- [ ] Production URL:
+- [ ] Build metadata checked in UI/debug output:
+- [ ] Scope confirmed: token.place is the default `/chat` provider; OpenAI is optional via
+      `/settings`; no core runtime changes are being added during QA.
+- [ ] Stop-ship criteria agreed: broken default Chat, leaked keys/credentials, wrong token.place
+      origin, OpenAI becoming default again without product approval, or malformed provider payloads.
 
-- [ ] dspace uses token.place endpoint correctly in staging
-- [ ] token.place endpoint config matches env vars and runtime settings
-      ([<tokenPlace.test.js:state tokenPlace url compatibility override works>](../../frontend/__tests__/tokenPlace.test.js#L72-L77),
-      [<tokenPlace.test.js:VITE_TOKEN_PLACE_URL staging override works>](../../frontend/__tests__/tokenPlace.test.js#L60-L64))
-- [ ] token.place chat completes when enabled
-      ([<tokenPlace.test.js:parses assistant text and compatibility helper returns string>](../../frontend/__tests__/tokenPlace.test.js#L145-L153))
-- [ ] OpenAI fallback remains functional while token.place rollout toggles are off
-      ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33),
-      [<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L96))
-- [ ] Provider selection UX is clear (and defaults are sane)
-- [ ] Failover behavior is defined and tested
-- [ ] Docs updated to reflect the *actual* shipped behavior
-- [ ] Changelog includes integration notes + any behavior changes
+## 1) token.place API v1 contract
 
-## C) Repeat v3 checklist
+- [ ] DSPACE sends token.place Chat requests to `POST /api/v1/chat/completions`.
+- [ ] Production request origin is `https://token.place` unless explicitly overridden to the same
+      origin.
+- [ ] Staging request origin is `https://staging.token.place` with
+      `VITE_TOKEN_PLACE_URL=https://staging.token.place`.
+- [ ] Request body includes `model` and OpenAI-compatible `messages`.
+- [ ] `stream` is absent or `false`; it is never `true`.
+- [ ] API v1 is treated as non-streaming; UI waits for the completed response.
+- [ ] No token.place auth/API key is requested, displayed, stored, or sent.
+- [ ] token.place requests do not include an `Authorization` header.
+- [ ] Responses are parsed from `choices[0].message.content`.
+- [ ] `usage` counters are surfaced/handled when returned.
+- [ ] Optional `metadata` is safe and non-secret; response metadata is accepted only as optional
+      echoed metadata.
+- [ ] No API v2, SSE, streaming, token.place npm package path, legacy `/api/chat`, or bare `/chat`
+      token.place backend endpoint is used for v3.1.
 
-- [ ] Re-run all sections from the v3 checklist (Automation → Smoke → Core → Custom → Docs/Changelog
-  → Deploy)
+## 2) Environment matrix
 
-## D) Custom content PR submission (GitHub workflow)
+| Environment       | Expected token.place configuration                                                       | Required checks                                                       | Result / evidence |
+| ----------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| Local             | Default `https://token.place`, or local explicit `VITE_TOKEN_PLACE_URL` for test doubles | Unit tests, build, provider UI smoke                                  |                   |
+| Staging DSPACE    | `VITE_TOKEN_PLACE_URL=https://staging.token.place`                                       | Browser Network request to staging token.place API v1; no auth header |                   |
+| Production DSPACE | Default `https://token.place`, or explicit `VITE_TOKEN_PLACE_URL=https://token.place`    | Production smoke after deploy; no staging origin                      |                   |
 
-- [ ] Submit bundles of custom quests, items, and processes that can reference each other. See
-      [custom content bundles](../design/custom-content-bundles.md).
-- [ ] Open `/quests/submit`
-      ([<quest-pr-form.spec.ts:quest PR form is accessible>](../../frontend/e2e/quest-pr-form.spec.ts#L17-L22))
-- [ ] With a GitHub token, create a PR successfully
-      ([<quest-pr-form.spec.ts:quest PR form submits and shows link>](../../frontend/e2e/quest-pr-form.spec.ts#L76-L104))
-- [ ] Failure modes are safe + clear:
-      ([<quest-pr-form.spec.ts:shows validation guidance when token or quest JSON are missing>](../../frontend/e2e/quest-pr-form.spec.ts#L24-L33))
-  - [ ] Missing token → blocked with instructions
-        ([<quest-pr-form.spec.ts:shows validation guidance when token or quest JSON are missing>](../../frontend/e2e/quest-pr-form.spec.ts#L24-L33))
-  - [ ] Bad scopes → clear error
-        ([<quest-pr-form.spec.ts:surfaces GitHub scope errors when the API rejects the token>](../../frontend/e2e/quest-pr-form.spec.ts#L35-L53))
-  - [ ] Network/API failure → clear error, no data loss
-        ([<quest-pr-form.spec.ts:keeps form state when network errors occur>](../../frontend/e2e/quest-pr-form.spec.ts#L55-L74))
-- [ ] Confirm secrets are not logged or embedded in exported data
-      ([<githubGists.test.ts:removes secret tokens from saves>](../../frontend/__tests__/cloudsync/githubGists.test.ts#L10-L24))
+- [ ] If model override is used, document `VITE_TOKEN_PLACE_CHAT_MODEL` value and reason:
+- [ ] Confirm no deployment uses `VITE_TOKEN_PLACE_BASE_URL` or `VITE_TOKEN_PLACE_MODEL`.
+
+## 3) Fresh-user happy path
+
+- [ ] Clear IndexedDB, localStorage, sessionStorage, and cookies for the DSPACE origin.
+- [ ] Visit `/chat` directly.
+- [ ] Confirm the active panel defaults to token.place, using visible copy or DOM marker such as
+      `data-provider="token-place"` when only visible to tests.
+- [ ] Select an NPC/persona if the UI does not already choose one.
+- [ ] Send a simple gameplay question.
+- [ ] Verify a non-empty assistant response appears.
+- [ ] Verify no OpenAI key prompt blocks the default Chat flow.
+- [ ] Verify no token.place credential or API-key prompt appears anywhere in the flow.
+- [ ] Reload `/chat` and verify the default remains token.place for the fresh-user state.
+
+## 4) Settings provider flow
+
+- [ ] Open `/settings` from the More menu or direct URL.
+- [ ] Confirm Chat provider settings are present.
+- [ ] Confirm the default provider is token.place.
+- [ ] Switch provider to OpenAI.
+- [ ] In local/non-production QA only, save a fake or test OpenAI key and verify it is accepted by
+      the settings form without making production OpenAI calls.
+- [ ] Verify `/chat` shows OpenAI selected after saving provider preference.
+- [ ] Clear the OpenAI key.
+- [ ] Verify OpenAI-selected Chat with no key shows helpful guidance and does not make a broken
+      empty-key request.
+- [ ] Switch back to token.place.
+- [ ] Reload and verify provider preference persists.
+- [ ] Confirm `/chat` no longer hosts the primary OpenAI API key form.
+
+## 5) Persistence, import/export, and fallback storage
+
+- [ ] IndexedDB primary path stores `settings.chatProvider` and the existing `openAI.apiKey` field
+      when OpenAI is used.
+- [ ] Missing, null, or invalid `settings.chatProvider` normalizes to `token-place`.
+- [ ] localStorage fallback sanity: simulate IndexedDB unavailability where practical and verify the
+      selected provider still persists or fails safely.
+- [ ] Export a save from `/gamesaves`; confirm provider preference is included only as normal game
+      settings and no token.place credentials exist.
+- [ ] Import that save into a clean browser profile and verify provider preference restores.
+- [ ] If content backup/import is exercised, confirm it does not add Chat credentials or provider
+      secrets to custom content bundles.
+- [ ] Clearing local data removes the OpenAI key and returns Chat to token.place by default.
+
+## 6) Privacy and security
+
+- [ ] token.place request has no `Authorization` header.
+- [ ] token.place request sends no OpenAI key.
+- [ ] token.place request sends no token.place credentials.
+- [ ] token.place metadata contains no secrets, raw save data, raw player inventory details,
+      GitHub tokens, or API keys.
+- [ ] OpenAI key stays local in existing client storage and is sent only to OpenAI when OpenAI is
+      explicitly selected.
+- [ ] No token.place credentials are stored in IndexedDB, localStorage, exported saves, logs, debug
+      payloads, or screenshots.
+- [ ] Prompt debug output redacts/omits keys and credentials.
+- [ ] Browser console and server logs contain no provider secrets.
+
+## 7) Chat quality and regression checks
+
+- [ ] NPC persona switching still updates persona summaries, greetings, and system prompt content.
+- [ ] PlayerState prompt inclusion still summarizes quest progress, active processes, inventory
+      context, and other intended state safely.
+- [ ] Docs RAG/context sources still attach relevant docs, quest, item, and process context.
+- [ ] Source links render and remain sanitized.
+- [ ] Prompt debug panel shows the provider-appropriate messages payload.
+- [ ] Save snapshot hint still appears where expected.
+- [ ] Token.place and OpenAI paths share the same persona/docs/player-state quality baseline.
+- [ ] No prompt, debug payload, docs copy, or UI banner contains stale “token.place deferred,”
+      “coming in v3.1,” or OpenAI-default v3.0 guidance.
+- [ ] `/dchat`, if still exposed separately, does not contradict the `/chat` provider behavior.
+
+## 8) Error handling
+
+- [ ] token.place network failure shows a clear retryable error and preserves the drafted message.
+- [ ] token.place HTTP 400 content-policy response shows safe content guidance without exposing raw
+      provider internals.
+- [ ] token.place HTTP 429 rate limit/quota response shows a clear wait/try-later message.
+- [ ] token.place HTTP 5xx response shows provider-unavailable guidance.
+- [ ] Malformed token.place completion payload is handled without crashing; no blank assistant
+      message is appended as success.
+- [ ] OpenAI selected with missing key shows a Settings link/instruction and makes no empty-key API
+      call.
+- [ ] OpenAI auth/quota errors when selected remain clear and do not switch the default provider
+      silently.
+- [ ] Switching back to token.place after an OpenAI error clears provider-specific blocking state.
+
+## 9) Accessibility and mobile
+
+- [ ] Textarea has an accessible label or labelled-by relationship.
+- [ ] Keyboard send behavior works as designed, including Enter/Shift+Enter behavior.
+- [ ] Send button has an accessible name and disabled/in-flight state.
+- [ ] Focus moves predictably after sending and after errors.
+- [ ] Provider settings controls are reachable by keyboard and have visible focus states.
+- [ ] Mobile/touch send behavior works on narrow viewport.
+- [ ] Chat transcript remains readable on mobile and does not hide provider/error messages.
+- [ ] Screen-reader-only or DOM-only provider markers do not create confusing duplicate text.
+
+## 10) Observability and manual browser checks
+
+Browser Network expectations:
+
+- [ ] Production: `POST https://token.place/api/v1/chat/completions`.
+- [ ] Staging: `POST https://staging.token.place/api/v1/chat/completions`.
+- [ ] Request has `Content-Type: application/json`.
+- [ ] Request has no `Authorization` header.
+- [ ] JSON body includes `model`, `messages`, and optional safe `metadata`.
+- [ ] `stream` is absent or `false`, never `true`.
+
+Expected token.place response shape:
+
+- [ ] Assistant text is present at `choices[0].message.content`.
+- [ ] `usage` counters are handled when returned.
+- [ ] `metadata` appears only when echoed from non-empty safe request metadata.
+
+Build/debug evidence:
+
+- [ ] `/config.json` returns expected environment metadata and does not expose secrets.
+- [ ] `/healthz` and `/livez` pass for deployed environments.
+- [ ] Build metadata/debug panel identifies the candidate under test.
+- [ ] Relevant Playwright specs are run or linked as CI evidence, including default token.place
+      Chat, OpenAI opt-in, settings persistence, provider error handling, persona switching, and
+      docs RAG/context behavior.
+
+## 11) Automation checklist
+
+Run from repo root unless noted:
+
+```bash
+rg -n "deferred to v3.1|coming in v3.1|OpenAI API key.*chat|/api/chat|tokenPlace\.enabled|chatProvider|api/v1/chat/completions|20260801|VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|Authorization|stream" docs frontend/src/pages/docs frontend/src/utils/changelogNotes.ts
+```
+
+```bash
+cd frontend && npx prettier --check ../docs/qa/v3.1.md src/pages/docs/md/changelog/20260801.md src/pages/docs/md/token-place.md src/pages/docs/md/roadmap.md src/pages/docs/md/faq.md src/pages/docs/md/routes.md
+```
+
+```bash
+cd frontend && npm run build
+```
+
+- [ ] `npm run lint`
+- [ ] `npm run link-check`
+- [ ] token.place unit tests pass.
+- [ ] Cross-provider Playwright specs pass in an environment with browsers installed.
+- [ ] Any skipped browser checks have owner, environment reason, and CI/staging artifact follow-up.
+
+## 12) Promotion checklist
+
+- [ ] Staging deployment uses the candidate build and `VITE_TOKEN_PLACE_URL=https://staging.token.place`.
+- [ ] Staging fresh-user Chat happy path passes.
+- [ ] Staging Settings/OpenAI opt-in path passes with non-production test credentials only.
+- [ ] Staging Network inspection confirms no token.place `Authorization` header and no streaming.
+- [ ] Staging pass is signed off before production promotion.
+- [ ] Production deployment uses default `https://token.place` or explicit
+      `VITE_TOKEN_PLACE_URL=https://token.place`.
+- [ ] Production smoke after deploy confirms `/chat`, `/settings`, `/config.json`, `/healthz`, and
+      `/livez`.
+- [ ] Production Network inspection confirms no staging token.place origin.
+- [ ] Production monitoring/logs show no new Chat error spike.
+
+Rollback/mitigation plan:
+
+- [ ] Individual users can switch to OpenAI in `/settings` if they have an OpenAI key.
+- [ ] Deployment env override can temporarily point `VITE_TOKEN_PLACE_URL` and/or
+      `VITE_TOKEN_PLACE_CHAT_MODEL` to a known-good endpoint/model.
+- [ ] Do not make OpenAI the default provider again without an explicit product decision.
+- [ ] If token.place is degraded, publish a user-facing status note explaining optional OpenAI
+      opt-in rather than asking users for token.place credentials.
+
+## 13) Sign-off table
+
+| Area                   | Owner | Environment   | Evidence link / notes | Status | Timestamp |
+| ---------------------- | ----- | ------------- | --------------------- | ------ | --------- |
+| API v1 contract        |       | Local/Staging |                       |        |           |
+| Fresh-user Chat        |       | Staging       |                       |        |           |
+| Settings/OpenAI opt-in |       | Staging       |                       |        |           |
+| Privacy/security       |       | Staging/Prod  |                       |        |           |
+| Error handling         |       | Local/Staging |                       |        |           |
+| Accessibility/mobile   |       | Local/Staging |                       |        |           |
+| Automation             |       | CI/Local      |                       |        |           |
+| Production smoke       |       | Prod          |                       |        |           |
+| Final release approval |       | Prod          |                       |        |           |

--- a/frontend/src/pages/docs/md/changelog.md
+++ b/frontend/src/pages/docs/md/changelog.md
@@ -7,9 +7,8 @@ Stay up to date with the latest improvements to DSPACE. Every entry links to a
 full set of release notes so you can dive into gameplay updates, docs refreshes,
 and tooling changes as they land.
 
-For v3 launch readiness details (including Completionist Award III in the v3 launch lane and
-OpenAI-only v3 chat with token.place deferred to v3.1), see
-[v3 Release State](/docs/v3-release-state).
+For v3 launch readiness details, see [v3 Release State](/docs/v3-release-state). For the v3.1
+Chat provider update, see [August 1, 2026](/docs/changelog/20260801).
 
 ## Latest releases
 

--- a/frontend/src/pages/docs/md/changelog/20260801.md
+++ b/frontend/src/pages/docs/md/changelog/20260801.md
@@ -1,0 +1,45 @@
+---
+title: 'August 1, 2026'
+slug: '20260801'
+tagline: 'DSPACE v3.1.0 token.place Chat default'
+summary: >-
+    DSPACE v3.1.0 makes token.place API v1 the default Chat provider so /chat works for fresh
+    players without auth or API keys, while OpenAI remains available as an optional bring-your-own-key
+    provider from Settings.
+---
+
+DSPACE v3.1.0 makes Chat easier to try, safer to configure, and clearer to operate.
+
+## token.place is now the default Chat provider
+
+The `/chat` route now starts with token.place by default. Fresh players can open Chat, pick an NPC
+persona, and send a message without signing in, entering an API key, or setting up billing.
+
+DSPACE does not ask players for token.place credentials, does not store a token.place API key, and
+does not send a token.place `Authorization` header for the default Chat flow.
+
+## OpenAI remains optional in Settings
+
+Players who prefer OpenAI can still bring their own OpenAI API key. Choose OpenAI from
+[`/settings`](/settings), save the key locally, and Chat will use that selected provider until the
+setting changes again.
+
+This keeps the existing OpenAI path available without making it a requirement for new players.
+
+## API v1 integration notes
+
+The v3.1.0 token.place integration uses direct HTTPS API v1 requests to
+`POST https://token.place/api/v1/chat/completions`. The request and response shape is
+OpenAI-compatible, and DSPACE reads assistant text from `choices[0].message.content`.
+
+API v1 is non-streaming, so Chat responses may appear only after the full completion is ready. The
+UI keeps the normal waiting state during that request instead of adding streaming behavior.
+
+DSPACE is intentionally not using the token.place npm package yet. The runtime will move to the
+package only after that package path is ready for DSPACE's API v1 needs.
+
+## Deployment configuration
+
+Production uses `https://token.place` by default. Deployments that need a different origin can set
+`VITE_TOKEN_PLACE_URL`; staging should use `VITE_TOKEN_PLACE_URL=https://staging.token.place`.
+Operators can override the default Chat model with `VITE_TOKEN_PLACE_CHAT_MODEL` when needed.

--- a/frontend/src/pages/docs/md/faq.md
+++ b/frontend/src/pages/docs/md/faq.md
@@ -74,6 +74,12 @@ quest-only submissions or `/bundles/submit` when your quest depends on custom it
 Only for GitHub-connected features (bundle submission and cloud sync). See
 [Authentication](/docs/authentication) for scope requirements and storage behavior.
 
+## Does Chat require an API key?
+
+No. In v3.1, `/chat` defaults to token.place and works without auth, billing setup, or an
+API key. If you prefer OpenAI, choose it in `/settings` and bring your own OpenAI API key. DSPACE
+never asks users to create a token.place API key.
+
 ## Where is data stored?
 
 Primary v3 storage is IndexedDB. Legacy localStorage/cookies are treated as migration sources.

--- a/frontend/src/pages/docs/md/npcs.md
+++ b/frontend/src/pages/docs/md/npcs.md
@@ -9,9 +9,8 @@ DSPACE's chat console now lets you pick an NPC persona before starting a
 conversation. Choose dChat for general knowledge, or switch to Sydney,
 Nova, or Hydro to receive guidance steeped in their specialties. Each
 persona keeps its existing lore and draws from the shared quest, item, and
-process knowledge base once you connect an OpenAI API key in the chat
-settings. The chat payload now also includes your live quest progress,
-active process timers, and current inventory so answers stay grounded.
+process knowledge base through the default token.place provider, or through OpenAI if you opt in
+from `/settings`. The chat payload now also includes your live quest progress, active process timers, and current inventory so answers stay grounded.
 Ask open-ended questions about quests, items, or processes and the
 personas will answer with that live context.
 
@@ -25,9 +24,9 @@ bios below describe intended roles rather than live multiplayer features.
 dChat is a compact, spherical smart assistant powered by large language models. Equipped with reasoning
 and information retrieval capabilities, it can answer questions and engage in conversation effortlessly.
 dChat now has a curated knowledge base covering the game's quests, achievements, items, processes, and the player's
-current inventory snapshot. Connect your OpenAI API key in the chat settings and dChat will
-automatically include this context when answering questions. dChat will be provided free of charge
-to Metaguild members once guilds launch, and it's fully open source and self-hosted.
+current inventory snapshot. In v3.1 this context is available through the default token.place Chat
+provider without an API key; OpenAI remains optional from `/settings`. dChat is fully open source
+and self-hosted.
 
 ### Sample Dialogue
 

--- a/frontend/src/pages/docs/md/roadmap.md
+++ b/frontend/src/pages/docs/md/roadmap.md
@@ -23,7 +23,8 @@ current shipped status where relevant.
 ## Shipped in v3 (April 2026)
 
 - [x] DSPACE v3 released
-- [x] OpenAI-backed NPC chat personas shipped in `/chat`
+- [x] token.place-backed NPC chat personas are the v3.1 `/chat` default, with OpenAI still
+      available as an opt-in provider in `/settings`
 - [x] Utility destinations shipped in the More menu (`/stats`, `/leaderboard`, `/titles`,
       `/toolbox`, `/settings`, `/gamesaves`, `/cloudsync`, `/contentbackup`)
 

--- a/frontend/src/pages/docs/md/routes.md
+++ b/frontend/src/pages/docs/md/routes.md
@@ -57,6 +57,7 @@ External links in the More menu:
 - Save portability: `/gamesaves`, `/cloudsync`, `/contentbackup`
 - Progress visibility: `/stats`, `/achievements`, `/titles`, `/leaderboard`
 - Configuration/tools: `/settings`, `/toolbox`
+- Chat: `/chat` uses token.place by default; `/settings` controls the optional OpenAI provider and local OpenAI key storage.
 - Debug: `/debug`
 
 ## Dynamic route patterns

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -3,33 +3,58 @@ title: 'token.place Integration'
 slug: 'token-place'
 ---
 
-DSPACE ships with a token.place integration for in-game chat. In v3.1, fresh chat defaults to
-the zero-auth token.place API v1 endpoint (`https://token.place/api/v1/chat/completions`), while
-users with an existing OpenAI API key continue to use
-the OpenAI-backed flow.
+DSPACE v3.1 uses token.place as the default provider for the in-game Chat experience. That means a
+fresh player can open `/chat`, choose an NPC persona, and send a message without signing in,
+creating an API key, or configuring billing.
 
-## How it works
+## What token.place does in DSPACE Chat
 
-- The chat client calls `tokenPlaceChat` (see `frontend/src/utils/tokenPlace.js`), which posts
-  OpenAI-compatible `messages` and `model` fields to `/api/v1/chat/completions` without sending
-  credentials or an `Authorization` header.
-- The default origin is `https://token.place`. Deployments can point to a custom token.place
-  origin with `VITE_TOKEN_PLACE_URL`, and legacy saved `tokenPlace.url` values are still honored
-  for compatibility.
-- Token.place is the default v3.1 chat provider and is not disabled by default. Legacy
-  `VITE_TOKEN_PLACE_ENABLED` and `state.tokenPlace.enabled` values are ignored by provider
-  enablement so old saved disabled flags cannot block fresh default token.place chat.
-- Users with an existing OpenAI API key still use the OpenAI-backed flow, and the OpenAI key
-  settings remain available separately (see
-  `frontend/src/pages/chat/svelte/ChatPanel.svelte`).
+- token.place powers the default NPC Chat path in `/chat`.
+- DSPACE sends OpenAI-compatible chat messages to token.place API v1 at
+  `https://token.place/api/v1/chat/completions`.
+- DSPACE reads the assistant reply from `choices[0].message.content` and displays it in the same
+  NPC Chat interface used by the other provider option.
+- The Chat payload can include DSPACE's normal persona, quest, item, process, docs context, and safe
+  non-secret request metadata so answers stay grounded in the game.
 
-## Local URL override
+DSPACE does not charge players for this default Chat path, does not ask players for token.place
+credentials, and does not store a token.place API key.
 
-Use `VITE_TOKEN_PLACE_URL` only to point local development at another token.place origin:
+## Default provider behavior
+
+For new or reset saves, Chat defaults to token.place. No token.place setup is required from the
+player.
+
+If you previously used OpenAI, you can keep using it by selecting OpenAI in `/settings`. The OpenAI
+path is optional and uses your own OpenAI key stored in DSPACE's existing local client storage.
+
+## OpenAI opt-in through Settings
+
+Use `/settings` when you want to change Chat providers:
+
+1. Keep **token.place** selected for the default no-key Chat experience.
+2. Select **OpenAI** only if you want to bring your own OpenAI API key.
+3. Clear the OpenAI key or switch back to token.place whenever you want to return to the default
+   provider.
+
+The `/chat` page itself should not require an OpenAI key for the default v3.1 experience.
+
+## Current limitations and implementation notes
+
+- token.place API v1 is non-streaming. Responses may appear after the full completion is ready
+  rather than token-by-token.
+- DSPACE uses direct HTTPS API v1 requests for now. It will move to the token.place npm package only
+  after that package path is ready for this integration.
+- DSPACE does not send a token.place `Authorization` header, OpenAI key, token.place credential, raw
+  save data, or detailed inventory payload in token.place metadata.
+
+## Deployment configuration
+
+Production uses `https://token.place` by default. Staging deployments should set:
 
 ```bash
-VITE_TOKEN_PLACE_URL=$TOKEN_PLACE_API_URL npm run dev
+VITE_TOKEN_PLACE_URL=https://staging.token.place
 ```
 
-The URL preference order is `tokenPlace.url` (legacy saved game state), then
-`VITE_TOKEN_PLACE_URL`, then `https://token.place`.
+Operators can also set `VITE_TOKEN_PLACE_URL=https://token.place` explicitly in production, or set
+`VITE_TOKEN_PLACE_CHAT_MODEL` to override the default chat model for a deployment.

--- a/frontend/src/pages/docs/md/v3-release-state.md
+++ b/frontend/src/pages/docs/md/v3-release-state.md
@@ -56,7 +56,8 @@ The More menu includes in-scope routes for:
 ### NPC chat and AI
 
 - v3 includes persona-style chat experiences (for example Sydney, Nova, Hydro).
-- OpenAI-only chat is the supported provider path in v3.
+- v3.1 updates `/chat` so token.place is the default provider, with OpenAI available as an
+  optional bring-your-own-key path from `/settings`.
 - Chat surfaces include `/chat` and `/dchat`.
 
 ## Deferred or intentionally limited in v3
@@ -72,8 +73,8 @@ The More menu includes in-scope routes for:
 
 ### token.place integration
 
-- token.place integration exists behind flags but remains disabled for the v3 launch release.
-- token.place activation is deferred to v3.1 in the follow-up track and is not a v3 launch gate.
+- token.place is the v3.1 default Chat provider.
+- `/chat` works without auth or API keys for the default provider.
 - Current status is tracked at [/docs/token-place](/docs/token-place).
 
 ## What changed from earlier versions


### PR DESCRIPTION
### Motivation
- Announce and document the v3.1 default Chat provider change so fresh users can use `/chat` without an API key and maintain the OpenAI opt-in path in Settings.
- Provide a discoverable dated changelog entry for the explicit human-requested `20260801.md` release note and update related user-facing docs and route/config references to match shipped behavior.
- Equip release engineers and QA with a full v3.1 QA checklist that codifies the token.place API v1 contract, environment matrix, privacy expectations, and promotion/rollback steps.

### Description
- Add `frontend/src/pages/docs/md/changelog/20260801.md` announcing DSPACE v3.1.0 token.place default Chat provider and API v1/non-streaming notes. 
- Replace and expand `frontend/src/pages/docs/md/token-place.md` to explain default provider behavior, OpenAI opt-in via `/settings`, non-streaming limitation, and deployment env vars `VITE_TOKEN_PLACE_URL` and `VITE_TOKEN_PLACE_CHAT_MODEL`.
- Update docs/route/config/FAQ/roadmap/v3-release-state content to reflect token.place as the v3.1 default and to document `/settings` as the provider-selection surface, and add the two requested env vars to `docs/config.md` using the exact names requested.
- Add a fleshed-out release QA plan at `docs/qa/v3.1.md` covering API contract, fresh-user happy path, settings/persistence, privacy/security, error handling, accessibility, observability, promotion, and rollback.

### Testing
- Ran the repository search for related tokens to validate no stale guidance remains: `rg -n "deferred to v3\.1|coming in v3\.1|OpenAI API key.*chat|/api/chat|tokenPlace\.enabled|chatProvider|api/v1/chat/completions|20260801|VITE_TOKEN_PLACE_URL|VITE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|Authorization|stream" docs frontend/src/pages/docs frontend/src/utils/changelogNotes.ts` — passed and returned updated hits consistent with v3.1 wording.
- Checked formatting: `cd frontend && npx prettier --check ../docs/qa/v3.1.md src/pages/docs/md/changelog/20260801.md src/pages/docs/md/token-place.md src/pages/docs/md/roadmap.md src/pages/docs/md/faq.md src/pages/docs/md/routes.md` — passed (all matched Prettier code style).
- Built docs artefacts: `npm run build:docs-rag` and `npm run build:meta` — both completed successfully and generated required `frontend/src/generated/rag` and `frontend/src/generated/build_meta.json` files.
- Built the frontend: `cd frontend && npm run build` — succeeded (Astro/Vite build complete). 
- Link checking and whitespace checks: `node scripts/link-check.mjs` and `git diff --check` — both passed (all local markdown links resolved and no diff-check issues).
- Not run here: Playwright E2E browser tests and cross-provider Playwright specs were not executed in this environment (browsers not installed here); CI must run the full E2E suite as part of promotion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a07e5164832f965d440ad86bf4d6)