### PR TITLE
Harden token.place release QA: strip sensitive metadata and add staging/prod smoke steps

### DIFF
--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -180,6 +180,23 @@ Build/debug evidence:
     - [ ] persona switching spec.
     - [ ] docs RAG/context spec.
 
+Manual smoke steps for staging and production:
+
+1. Open a fresh/private browser profile for the deployed DSPACE URL.
+2. Clear site storage, then visit `/settings` and confirm Chat provider is `token.place`.
+3. Visit `/chat`, send a short game-related message, and confirm the active panel has
+   `data-provider="token-place"` or equivalent token.place provider copy.
+4. In the Browser Network tab, inspect the chat completion request:
+    - Staging should call `POST https://staging.token.place/api/v1/chat/completions`.
+    - Production should call `POST https://token.place/api/v1/chat/completions`.
+    - The request must not include an `Authorization` header.
+    - The JSON body must include `model`, `messages`, and optional safe `metadata`.
+    - `stream` must be absent or `false`; it must never be `true`.
+5. Confirm the response renders assistant text from `choices[0].message.content`; usage counters
+   and response metadata may be absent, but must be accepted when returned.
+6. Return to `/settings`, switch to OpenAI only with a fake/test key in non-production QA, and
+   confirm token.place requests still do not include any OpenAI key or token.place credential.
+
 ## 12) Automation evidence
 
 Run from repo root unless noted and attach output to release evidence:

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -107,6 +107,11 @@ describe('token.place API v1 client', () => {
             metadata: {
                 conversation_id: 'conv-42',
                 apiKey: 'token-place-secret',
+                credential: 'token-place-credential',
+                authorization: 'Bearer token-place-auth',
+                playerInventory: ['secret item'],
+                rawSaveData: { inventory: ['hidden'] },
+                secret: 'hidden-secret',
                 playerSave: { raw: true },
                 token: 'hidden',
             },
@@ -117,6 +122,10 @@ describe('token.place API v1 client', () => {
         const serialized = JSON.stringify({ headers: init.headers, body });
         expect(serialized).not.toContain('sk-secret-openai-key');
         expect(serialized).not.toContain('token-place-secret');
+        expect(serialized).not.toContain('token-place-credential');
+        expect(serialized).not.toContain('token-place-auth');
+        expect(serialized).not.toContain('secret item');
+        expect(serialized).not.toContain('hidden-secret');
         expect(serialized).not.toContain('hidden');
         expect(body.metadata).toEqual({
             conversation_id: 'conv-42',


### PR DESCRIPTION
### Motivation

- Final release hardening for the v3.1 token.place Chat integration to ensure no secrets/credentials or player state leak to token.place and to tighten QA guidance for staging/production promotion. 
- Provide clear manual smoke steps operators/QA can follow and cover additional metadata edge-cases in unit tests to reduce regression risk.

### Description

- Expanded unit coverage in `frontend/__tests__/tokenPlace.test.js` to assert that credential-like fields, authorization values, player-inventory/raw-save/secret fields are stripped from request headers/body/metadata and that token.place requests remain zero-auth. 
- Added explicit manual smoke steps to `docs/qa/v3.1.md` documenting staging/production token.place endpoints, expected browser Network request shape (no `Authorization`, `model`/`messages` present, no `stream: true`), response shape, and OpenAI opt-in verification steps. 
- No runtime token.place client changes were introduced in this PR; changes are focused on tests and release QA documentation. 

### Testing

- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — passed (all token.place unit tests succeeded). 
- Ran E2E suite attempt: `cd frontend && npm run test:e2e -- chat-provider-routing.spec.ts token-place-chat-banners.spec.ts settings-page.spec.ts chat-message-flow.spec.ts chat-persona-switching.spec.ts chat-debug-stamp.spec.ts chat-debug-navigation.spec.ts chat-rag-context.spec.ts` — blocked by environment network/browser install failures (Playwright attempted to install Chromium/system deps and failed with `ENETUNREACH`), so E2E could not be executed here. 
- Formatting/lint checks: `cd frontend && npm run check` — passed (Prettier check succeeded). 
- Build: `cd frontend && npm run build` — passed (Astro/Vite build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34baef2d44832fb067b5df1d2f3185)