### PR TITLE
Harden token.place metadata filtering, expand tests, and update v3.1 QA notes

### DIFF
--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -154,6 +154,15 @@ change provider when appropriate.
 
 ## 11) Observability and manual checks
 
+Staging/prod verification setup:
+
+- [ ] Staging DSPACE is built with `VITE_TOKEN_PLACE_URL=https://staging.token.place`.
+- [ ] Production DSPACE omits `VITE_TOKEN_PLACE_URL` or is built with
+      `VITE_TOKEN_PLACE_URL=https://token.place`.
+- [ ] Optional model rollback/compatibility overrides use `VITE_TOKEN_PLACE_CHAT_MODEL` only.
+- [ ] No deployment environment, ConfigMap, docs, or runbook introduces alternate token.place URL
+      or model env names, or any token.place credential.
+
 Browser Network expected request:
 
 - [ ] Production: `POST https://token.place/api/v1/chat/completions`.

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -106,7 +106,9 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             metadata: {
                 conversation_id: 'conv-42',
+                note: 'contains secret material',
                 apiKey: 'token-place-secret',
+                label: 'safe local correlation',
                 playerSave: { raw: true },
                 token: 'hidden',
             },
@@ -120,6 +122,7 @@ describe('token.place API v1 client', () => {
         expect(serialized).not.toContain('hidden');
         expect(body.metadata).toEqual({
             conversation_id: 'conv-42',
+            label: 'safe local correlation',
             client: 'dspace',
             provider: 'token.place',
         });

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -11,6 +11,8 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const DEFAULT_CHAT_MODEL = 'gpt-5-chat-latest';
 const METADATA_DENY_PATTERN =
     /(?:key|token|secret|credential|password|authorization|auth|inventory|save|state|player)/i;
+const METADATA_VALUE_DENY_PATTERN =
+    /(?:sk-[a-z0-9_-]+|token-place-secret|openai|api[_-]?key|secret|credential|password|authorization|bearer\s+)/i;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
 
 const readEnvValue = (key) => {
@@ -67,7 +69,10 @@ export const sanitizeTokenPlaceMessages = (messages = []) =>
     (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
 
 const sanitizeMetadataValue = (value) => {
-    if (typeof value === 'string') return value.slice(0, 200);
+    if (typeof value === 'string') {
+        const trimmedValue = value.slice(0, 200);
+        return METADATA_VALUE_DENY_PATTERN.test(trimmedValue) ? undefined : trimmedValue;
+    }
     if (typeof value === 'number' || typeof value === 'boolean') return value;
     return undefined;
 };


### PR DESCRIPTION
### Motivation
- Reduce risk of leaking secrets or API keys via token.place request metadata by filtering values as well as keys. 
- Ensure token.place client adheres to the v3.1 non-auth, API v1 contract and that unit tests assert the zero-auth / safe-metadata behavior. 
- Make staging/prod verification guidance explicit in the v3.1 QA checklist to avoid introducing alternate env names or credential fields.

### Description
- Tightened metadata sanitization in `frontend/src/utils/tokenPlace.js` to drop suspicious secret-like string values in addition to denied metadata keys by adding `METADATA_VALUE_DENY_PATTERN` and updating `sanitizeMetadataValue` to return `undefined` for matches. 
- Kept and exercised the richer `TokenPlaceChatV2` helper shape and zero-auth request semantics (no `Authorization` header, `credentials: 'omit'`, `model` + `messages`, no `stream: true`). 
- Adjusted `frontend/__tests__/tokenPlace.test.js` to include an assertion that secret-like metadata values are filtered while safe correlation fields remain in the final `metadata` object. 
- Updated `docs/qa/v3.1.md` to include explicit staging/production verification notes for `VITE_TOKEN_PLACE_URL`, `VITE_TOKEN_PLACE_CHAT_MODEL`, and to warn against introducing alternate env names or token.place credentials in deployments or docs.

### Testing
- Ran the focused unit suite: `cd frontend && npm test -- tokenPlace.test.js`, and `tokenPlace.test.js` passed (19 tests). 
- Ran formatting and lint checks with `cd frontend && npm run check` and `prettier` formatting on touched files, which passed. 
- Built the frontend bundle with `cd frontend && npm run build`, which completed successfully. 
- Attempted the Playwright E2E run `cd frontend && npm run test:e2e -- <chat specs>` but it was blocked by the environment failing to download Playwright browser/system dependencies (`ENETUNREACH`), so E2E verification could not complete here. 
- Attempted `cd frontend && npm run test:quick` but the run could not be completed in this environment due to missing local fixture paths (`ENOENT`) coupled with the Playwright/browser download issues; these are environment-specific and not related to the code changes above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34bafda040832f8e5d3ce04beabb2f)