### PR TITLE
Harden token.place chat release audit

### DIFF
--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -19,30 +19,30 @@ Tracking / release gate:
 - [ ] Release owner:
 - [ ] QA owner:
 - [ ] Stop-ship criteria agreed before execution. Treat any of these triggers as a release blocker:
-    1. Fresh users cannot send a default token.place Chat message.
-    2. `/chat` prompts fresh users for an OpenAI key.
-    3. token.place requests include an `Authorization` header, OpenAI key, token.place credentials,
-       raw save data, or player inventory details in metadata.
-    4. Settings cannot switch providers or persist the selected provider.
-    5. Staging has not passed before production deploy.
+  1. Fresh users cannot send a default token.place Chat message.
+  2. `/chat` prompts fresh users for an OpenAI key.
+  3. token.place requests include an `Authorization` header, OpenAI key, token.place credentials,
+     raw save data, or player inventory details in metadata.
+  4. Settings cannot switch providers or persist the selected provider.
+  5. Staging has not passed before production deploy.
 
 ## 2) token.place API v1 contract
 
 - [ ] DSPACE calls `POST /api/v1/chat/completions` on the configured token.place origin.
 - [ ] API v1 is treated as non-streaming.
-    - [ ] Request JSON omits `stream` or sends `stream: false`.
-    - [ ] Request JSON never sends `stream: true`.
-    - [ ] UI copy and spinners tolerate waiting until the full completion is ready.
+  - [ ] Request JSON omits `stream` or sends `stream: false`.
+  - [ ] Request JSON never sends `stream: true`.
+  - [ ] UI copy and spinners tolerate waiting until the full completion is ready.
 - [ ] No token.place auth or API key is requested, stored, or sent.
 - [ ] token.place request headers contain no `Authorization` header.
 - [ ] Response parsing reads assistant text from `choices[0].message.content`.
 - [ ] `usage` counters are displayed, logged, or preserved only when token.place returns them.
 - [ ] Optional `metadata` is safe and minimal.
-    - [ ] Request metadata contains no secrets.
-    - [ ] Request metadata contains no raw save data.
-    - [ ] Request metadata contains no player inventory details.
-    - [ ] Response metadata is treated as optional and only expected when non-empty request metadata
-          is echoed.
+  - [ ] Request metadata contains no secrets.
+  - [ ] Request metadata contains no raw save data.
+  - [ ] Request metadata contains no player inventory details.
+  - [ ] Response metadata is treated as optional and only expected when non-empty request metadata
+        is echoed.
 - [ ] The v3.1 integration uses direct HTTPS API v1 requests.
 - [ ] No token.place API v2, SSE, streaming, legacy `/api/chat`, legacy `/chat`, relay, sink,
       source, faucet, retrieve, or `next_server` path is used.
@@ -68,7 +68,7 @@ Tracking / release gate:
       relevant, and service worker state if needed).
 - [ ] Visit `/chat` as a fresh user.
 - [ ] Confirm the active Chat panel uses token.place by default.
-    - [ ] UI marker is visible, or DOM/test marker such as `data-provider="token-place"` is present.
+  - [ ] UI marker is visible, or DOM/test marker such as `data-provider="token-place"` is present.
 - [ ] Select an NPC/persona if the UI does not already default to one.
 - [ ] Send a simple game-related message.
 - [ ] Verify the assistant response renders in Chat.
@@ -154,12 +154,21 @@ change provider when appropriate.
 
 ## 11) Observability and manual checks
 
+Deployment configuration expectations:
+
+- [ ] Staging builds set `VITE_TOKEN_PLACE_URL=https://staging.token.place`.
+- [ ] Production builds omit `VITE_TOKEN_PLACE_URL` or set
+      `VITE_TOKEN_PLACE_URL=https://token.place`.
+- [ ] Optional model overrides use `VITE_TOKEN_PLACE_CHAT_MODEL`.
+- [ ] OpenAI rollback/opt-in remains available through `/settings`; do not make OpenAI the
+      default again without an explicit product decision.
+
 Browser Network expected request:
 
 - [ ] Production: `POST https://token.place/api/v1/chat/completions`.
 - [ ] Staging: `POST https://staging.token.place/api/v1/chat/completions`.
 - [ ] No `Authorization` header.
-- [ ] JSON body includes `model`, `messages`, and optional safe `metadata`.
+- [ ] JSON body includes `model`, `messages`, and a safe `metadata` object.
 - [ ] `stream` is absent or false, never true.
 
 Expected response shape:
@@ -174,11 +183,11 @@ Build/debug evidence:
 - [ ] Build metadata/debug panel identifies the expected candidate SHA or image digest.
 - [ ] Console has no uncaught SSR, hydration, provider-selection, or storage errors.
 - [ ] Relevant Playwright specs pass or have release-owner-approved environment exceptions:
-    - [ ] token.place default Chat spec.
-    - [ ] OpenAI opt-in/provider persistence spec.
-    - [ ] token.place error handling spec.
-    - [ ] persona switching spec.
-    - [ ] docs RAG/context spec.
+  - [ ] token.place default Chat spec.
+  - [ ] OpenAI opt-in/provider persistence spec.
+  - [ ] token.place error handling spec.
+  - [ ] persona switching spec.
+  - [ ] docs RAG/context spec.
 
 ## 12) Automation evidence
 
@@ -214,16 +223,16 @@ cd frontend && npm run build
 
 - [ ] Search results are reviewed and any stale user-facing wording is removed or explicitly
       justified as historical QA/design context.
-    - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
-          planning-only design notes, literal test assertions that prevent stale text from
-          returning, compatibility coverage in `frontend/__tests__/tokenPlace.test.js` (excluded
-          from the command above), non-token.place GitHub/metrics `Authorization` checks, and the
-          audit command itself.
-    - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
-          `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
-          legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths such as
-          `/api/v2/chat/completions` or `/v2/chat/completions`, or token.place `Authorization`
-          header logic.
+  - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
+        planning-only design notes, literal test assertions that prevent stale text from
+        returning, compatibility coverage in `frontend/__tests__/tokenPlace.test.js` (excluded
+        from the command above), non-token.place GitHub/metrics `Authorization` checks, and the
+        audit command itself.
+  - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
+        `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
+        legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths such as
+        `/api/v2/chat/completions` or `/v2/chat/completions`, or token.place `Authorization`
+        header logic.
 - [ ] Prettier check passes.
 - [ ] Frontend build passes.
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -214,6 +214,14 @@ cd frontend && npm run build
 
 - [ ] Search results are reviewed and any stale user-facing wording is removed or explicitly
       justified as historical QA/design context.
+    - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
+          planning-only design notes, literal test assertions that prevent stale text from
+          returning, non-token.place GitHub/metrics `Authorization` checks, and the audit command
+          itself.
+    - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
+          `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
+          legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths, or
+          token.place `Authorization` header logic.
 - [ ] Prettier check passes.
 - [ ] Frontend build passes.
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -185,7 +185,7 @@ Build/debug evidence:
 Run from repo root unless noted and attach output to release evidence:
 
 ```bash
-rg -n "VITE_TOKEN_PLACE_ENABLED|tokenPlace\.enabled|state\.tokenPlace\.enabled|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|/api/chat|token\.place is disabled|deferred to v3.1|coming in v3.1|In v3, chat uses OpenAI|OpenAIAPIKeySettings|TokenPlaceChat|api/v2/chat/completions|stream:\s*true|Authorization|tokenPlace\.apiKey|token\.place API key" frontend/src frontend/__tests__ frontend/e2e docs
+rg -n -g '!frontend/__tests__/tokenPlace.test.js' "VITE_TOKEN_PLACE_ENABLED|tokenPlace\.enabled|state\.tokenPlace\.enabled|VITE_TOKEN_PLACE_BASE_URL|VITE_TOKEN_PLACE_MODEL|/api/chat|token\.place is disabled|deferred to v3.1|coming in v3.1|In v3, chat uses OpenAI|OpenAIAPIKeySettings|TokenPlaceChat|api/v2/chat/completions|/v2/chat/completions|stream:\s*true|Authorization|tokenPlace\.apiKey|token\.place API key" frontend/src frontend/__tests__ frontend/e2e docs
 ```
 
 ```bash
@@ -216,12 +216,14 @@ cd frontend && npm run build
       justified as historical QA/design context.
     - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
           planning-only design notes, literal test assertions that prevent stale text from
-          returning, non-token.place GitHub/metrics `Authorization` checks, and the audit command
-          itself.
+          returning, compatibility coverage in `frontend/__tests__/tokenPlace.test.js` (excluded
+          from the command above), non-token.place GitHub/metrics `Authorization` checks, and the
+          audit command itself.
     - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
           `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
-          legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths, or
-          token.place `Authorization` header logic.
+          legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths such as
+          `/api/v2/chat/completions` or `/v2/chat/completions`, or token.place `Authorization`
+          header logic.
 - [ ] Prettier check passes.
 - [ ] Frontend build passes.
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:matches default endpoint and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L90))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L312-L326))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L336-L350))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -122,18 +122,26 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             metadata: {
                 conversation_id: 'conv-42',
-                apiKey: 'token-place-secret',
-                playerSave: { raw: true },
-                token: 'hidden',
+                credential: 'credential-canary-alpha',
+                authorization: 'authorization-canary-bravo',
+                playerInventory: 'player-inventory-canary-charlie',
+                rawSaveData: 'raw-save-data-canary-delta',
+                secret: 'secret-canary-echo',
             },
         });
         const { init, body } = getFetchCall();
         expect(init.headers.Authorization).toBeUndefined();
+        expect(Object.keys(init.headers ?? {}).some((key) => /^authorization$/i.test(key))).toBe(
+            false
+        );
         expect(init.credentials).toBe('omit');
         const serialized = JSON.stringify({ headers: init.headers, body });
         expect(serialized).not.toContain('sk-secret-openai-key');
-        expect(serialized).not.toContain('token-place-secret');
-        expect(serialized).not.toContain('hidden');
+        expect(serialized).not.toContain('credential-canary-alpha');
+        expect(serialized).not.toContain('authorization-canary-bravo');
+        expect(serialized).not.toContain('player-inventory-canary-charlie');
+        expect(serialized).not.toContain('raw-save-data-canary-delta');
+        expect(serialized).not.toContain('secret-canary-echo');
         expect(body.metadata).toEqual({
             conversation_id: 'conv-42',
             client: 'dspace',

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -65,7 +65,12 @@ describe('token.place API v1 client', () => {
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
 
         expect(fetch).toHaveBeenCalledTimes(1);
-        expect(getFetchCall().url).toBe('https://token.place/api/v1/chat/completions');
+        const { url, init, body } = getFetchCall();
+        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        expect(init.method).toBe('POST');
+        expect(init.credentials).toBe('omit');
+        expect(init.headers?.Authorization).toBeUndefined();
+        expect(body.messages).toContainEqual({ role: 'user', content: 'hello' });
     });
 
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -48,6 +48,7 @@ describe('token.place API v1 client', () => {
         jest.resetAllMocks();
         delete process.env.VITE_TOKEN_PLACE_URL;
         delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
+        delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
     test('fresh/default state posts to token.place API v1 chat completions', async () => {
@@ -55,6 +56,16 @@ describe('token.place API v1 client', () => {
         const { url, init } = getFetchCall();
         expect(url).toBe('https://token.place/api/v1/chat/completions');
         expect(init.method).toBe('POST');
+    });
+
+    test('legacy enabled flags do not disable default token.place chat', async () => {
+        process.env.VITE_TOKEN_PLACE_ENABLED = 'false';
+        loadGameState.mockReturnValue({ tokenPlace: { enabled: false } });
+
+        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(getFetchCall().url).toBe('https://token.place/api/v1/chat/completions');
     });
 
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {


### PR DESCRIPTION
### Motivation
- Ensure the v3.1 token.place Chat default path cannot be disabled by legacy flags or saved legacy state and tighten the QA audit guidance to prevent accidental reintroduction of legacy token.place paths/keys.

### Description
- Add a unit test in `frontend/__tests__/tokenPlace.test.js` that asserts legacy `VITE_TOKEN_PLACE_ENABLED=false` and persisted `tokenPlace.enabled=false` do not disable the default token.place chat path and that requests still post to `/api/v1/chat/completions`.
- Clean up test teardown to remove the legacy `VITE_TOKEN_PLACE_ENABLED` env var after tests.
- Expand `docs/qa/v3.1.md` with explicit acceptable residuals and an explicit exclusion list preventing active runtime/docs/E2E usage of legacy env names (`VITE_TOKEN_PLACE_ENABLED`, `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`), legacy API paths (`/api/chat`, `/chat`, API v2 paths), token.place API-key wording, and any `Authorization` header logic for token.place.

### Testing
- Ran `cd frontend && npm test -- tokenPlace.test.js` and it passed (token.place unit suite green).
- Attempted `cd frontend && npm run test:e2e -- <chat specs>` but Playwright/browser install failed due to network `ENETUNREACH` while downloading Chromium/system deps, so E2E could not be exercised here.
- Attempted `cd frontend && npm run test:quick` but it surfaced unrelated path-resolution failures when run from `frontend/` (token.place unit coverage within that run passed before unrelated failures occurred).
- Ran `cd frontend && npm run check` which passed, and `cd frontend && npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34baf5f974832f9b1a425c7f9c068d)