### PR TITLE
Implement token.place relay E2EE chat flow

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1054,33 +1054,33 @@ Local-mode validation status (March 20, 2026):
 - [x] Chat page loads and persona picker works
       ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33))
 - [x] Sending a message:
-      ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L138-L143))
+      ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
   - [x] Shows loading state
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L138-L143))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
   - [x] Returns a reply
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L138-L143))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
   - [x] Handles long replies (scroll, wrap, etc.)
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L138-L143))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
 - [x] Error handling:
-      ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L146-L159),
-      [<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L162-L173),
-      [<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L188-L199),
-      [<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L201-L212),
-      [<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L214-L225),
-      [<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L227-L238))
+      ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L204-L218),
+      [<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L220-L231),
+      [<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L246-L257),
+      [<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L259-L270),
+      [<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L272-L283),
+      [<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L285-L296))
   - [x] Network failure shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L146-L159))
+        ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L204-L218))
   - [x] Invalid API key shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L188-L199))
+        ([<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L246-L257))
   - [x] Rate limit / quota shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L162-L173),
-        [<chat-message-flow.spec.ts:surfaces quota errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L175-L186))
+        ([<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L220-L231),
+        [<chat-message-flow.spec.ts:surfaces quota errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L233-L244))
   - [x] Model access / permissions error shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L201-L212))
+        ([<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L259-L270))
   - [x] Provider 5xx outage shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L214-L225))
+        ([<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L272-L283))
   - [x] Unknown error shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L227-L238))
+        ([<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L285-L296))
 
 ### 9.2 Provider verification (v3 ships OpenAI; token.place postponed)
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L359-L373))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L700-L714))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -433,6 +433,72 @@ describe('token.place API v1 client', () => {
         }
     });
 
+    test('decrypted content policy errors surface as structured provider errors', async () => {
+        relayReply = {
+            error: {
+                message: 'blocked by policy',
+                type: 'content_policy_violation',
+                code: 'content_blocked',
+                param: 'messages',
+            },
+        };
+
+        let thrownError;
+        try {
+            await tokenPlaceChat([{ role: 'user', content: 'blocked prompt' }]);
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toMatchObject({
+            type: 'content_policy',
+            status: 400,
+            code: 'content_blocked',
+            param: 'messages',
+            providerMessage: 'blocked by policy',
+        });
+        expect(thrownError.message).toBe('token.place API v1 request failed: blocked by policy');
+        expect(thrownError.message).not.toMatch(/missing assistant content/i);
+        expect(getTokenPlaceErrorSummary(thrownError).type).toBe('content_policy');
+    });
+
+    test('decrypted status-bearing API errors preserve status, code, and message', async () => {
+        relayReply = {
+            status_code: 429,
+            error: {
+                message: 'too many requests',
+                type: 'rate_limit',
+                code: 'rate_limit_exceeded',
+            },
+        };
+
+        let thrownError;
+        try {
+            await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toMatchObject({
+            type: 'rate_limit',
+            status: 429,
+            code: 'rate_limit_exceeded',
+            providerMessage: 'too many requests',
+        });
+        expect(thrownError.message).toBe('token.place API v1 request failed: too many requests');
+        expect(thrownError.message).not.toMatch(/missing assistant content/i);
+        expect(getTokenPlaceErrorSummary(thrownError).type).toBe('rate_limit');
+    });
+
+    test('decrypted responses missing choices and error remain malformed', async () => {
+        relayReply = { usage: { prompt_tokens: 1 } };
+
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'malformed',
+            message: 'Malformed token.place response: missing assistant content.',
+        });
+    });
+
     test('network errors classify safely', async () => {
         fetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'network' });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -13,6 +13,7 @@ jest.mock('../src/utils/docsRag.js', () => ({
 const { loadGameState } = await import('../src/utils/gameState/common.js');
 const {
     TokenPlaceChatV2,
+    decryptTokenPlaceEnvelope,
     encryptTokenPlaceEnvelope,
     generateTokenPlaceClientKeypair,
     validateTokenPlaceResponseEnvelope,
@@ -44,7 +45,11 @@ let relayReply = {
     choices: [{ message: { content: 'mocked reply' } }],
 };
 
-const makeRelayFetch = ({ retrieveStatuses = [200], serverFailureOnce = false } = {}) => {
+const makeRelayFetch = ({
+    retrieveStatuses = [200],
+    serverFailureOnce = false,
+    accepted = true,
+} = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
         if (url.endsWith('/api/v1/relay/servers/next')) {
@@ -62,7 +67,7 @@ const makeRelayFetch = ({ retrieveStatuses = [200], serverFailureOnce = false } 
             };
         }
         if (url.endsWith('/api/v1/relay/requests')) {
-            return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
+            return { ok: true, status: 200, json: () => Promise.resolve({ accepted }) };
         }
         if (url.endsWith('/api/v1/relay/responses/retrieve')) {
             const status = retrieveStatuses[Math.min(retrieveCount, retrieveStatuses.length - 1)];
@@ -276,6 +281,41 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('decrypted API v1 request nests metadata under options', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
+            metadata: { conversation_id: 'conv-42' },
+        });
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+
+        expect(decrypted.api_v1_request).toEqual(
+            expect.objectContaining({
+                model: 'llama-3.1-8b-instruct',
+                messages: expect.any(Array),
+                options: {
+                    metadata: {
+                        conversation_id: 'conv-42',
+                        client: 'dspace',
+                        provider: 'token.place',
+                    },
+                },
+            })
+        );
+        expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+    });
+
+    test('large encrypted envelopes do not overflow base64 conversion', async () => {
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [{ role: 'system', content: 'x'.repeat(100_000) }],
+                    contextSources: [],
+                    gameState: {},
+                },
+            })
+        ).resolves.toMatchObject({ text: 'mocked reply' });
     });
 
     test('safe metadata preserves trusted client and provider fields', () => {
@@ -499,6 +539,18 @@ describe('token.place API v1 client', () => {
         ).toBe(true);
     });
 
+    test('relay accepted false fast-fails before polling', async () => {
+        global.fetch = makeRelayFetch({ accepted: false });
+
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'malformed',
+            message: 'token.place relay rejected the request.',
+        });
+        expect(
+            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/responses/retrieve'))
+        ).toBe(false);
+    });
+
     test('decrypted envelope validation rejects unsafe/mismatched shapes', () => {
         const base = {
             protocol: 'tokenplace_api_v1_relay_e2ee',
@@ -575,6 +627,7 @@ describe('token.place API v1 client', () => {
         global.fetch = makeRelayFetch({ retrieveStatuses: [404, 404] });
         await expect(tokenPlaceChat([], { pollIntervalMs: 1 })).rejects.toMatchObject({
             type: 'malformed',
+            message: 'No token.place compute node is available.',
         });
     });
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -13,6 +13,9 @@ jest.mock('../src/utils/docsRag.js', () => ({
 const { loadGameState } = await import('../src/utils/gameState/common.js');
 const {
     TokenPlaceChatV2,
+    encryptTokenPlaceEnvelope,
+    generateTokenPlaceClientKeypair,
+    validateTokenPlaceResponseEnvelope,
     buildTokenPlaceChatCompletionsUrl,
     buildTokenPlaceMetadata,
     extractTokenPlaceAssistantText,
@@ -33,14 +36,82 @@ const okResponse = (body = {}) => ({
         }),
 });
 
+const decodeBase64Text = (value) =>
+    new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
+
+let relayServerKeys;
+let relayReply = {
+    choices: [{ message: { content: 'mocked reply' } }],
+};
+
+const makeRelayFetch = ({ retrieveStatuses = [200], serverFailureOnce = false } = {}) => {
+    let retrieveCount = 0;
+    return jest.fn(async (url, init = {}) => {
+        if (url.endsWith('/api/v1/relay/servers/next')) {
+            const key =
+                serverFailureOnce &&
+                fetch.mock.calls.filter(([calledUrl]) =>
+                    calledUrl.endsWith('/api/v1/relay/servers/next')
+                ).length === 1
+                    ? relayServerKeys[1]
+                    : relayServerKeys[0];
+            return {
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ server_public_key: key.publicKeyBase64 }),
+            };
+        }
+        if (url.endsWith('/api/v1/relay/requests')) {
+            return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
+        }
+        if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+            const status = retrieveStatuses[Math.min(retrieveCount, retrieveStatuses.length - 1)];
+            retrieveCount += 1;
+            if (status === 202) return { ok: false, status: 202, json: () => Promise.resolve({}) };
+            if (status === 404 || status === 410)
+                return { ok: false, status, json: () => Promise.resolve({ message: 'gone' }) };
+            const body = JSON.parse(init.body);
+            const clientPublicPem = decodeBase64Text(body.client_public_key);
+            const encrypted = await encryptTokenPlaceEnvelope(
+                {
+                    protocol: 'tokenplace_api_v1_relay_e2ee',
+                    version: 1,
+                    request_id: body.request_id,
+                    client_public_key: body.client_public_key,
+                    api_v1_response: relayReply,
+                },
+                clientPublicPem
+            );
+            return { ok: true, status: 200, json: () => Promise.resolve(encrypted) };
+        }
+        if (url.endsWith('/api/v1/relay/requests/cancel')) {
+            return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
+        }
+        throw new Error(`Unexpected fetch URL ${url}`);
+    });
+};
+
+const getFetchCalls = () =>
+    fetch.mock.calls.map(([url, init = {}]) => ({
+        url,
+        init,
+        body: init.body ? JSON.parse(init.body) : undefined,
+    }));
+const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
-    return { url, init, body: JSON.parse(init.body) };
+    return { url, init, body: init.body ? JSON.parse(init.body) : undefined };
 };
 
 describe('token.place API v1 client', () => {
-    beforeEach(() => {
-        global.fetch = jest.fn(() => Promise.resolve(okResponse()));
+    beforeEach(async () => {
+        relayServerKeys = [
+            await generateTokenPlaceClientKeypair(),
+            await generateTokenPlaceClientKeypair(),
+        ];
+        relayReply = { choices: [{ message: { content: 'mocked reply' } }] };
+        global.fetch = makeRelayFetch();
         loadGameState.mockReturnValue({});
     });
 
@@ -51,11 +122,14 @@ describe('token.place API v1 client', () => {
         delete process.env.VITE_TOKEN_PLACE_ENABLED;
     });
 
-    test('fresh/default state posts to token.place API v1 chat completions', async () => {
+    test('fresh/default state uses token.place relay E2EE routes', async () => {
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        const { url, init } = getFetchCall();
-        expect(url).toBe('https://token.place/api/v1/chat/completions');
-        expect(init.method).toBe('POST');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next')?.init.method).toBe('GET');
+        expect(getFetchCallByPath('/api/v1/relay/requests')?.init.method).toBe('POST');
+        expect(getFetchCallByPath('/api/v1/relay/responses/retrieve')?.init.method).toBe('POST');
+        expect(fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/chat/completions'))).toBe(
+            false
+        );
     });
 
     test('legacy enabled flags do not disable default token.place chat', async () => {
@@ -64,25 +138,27 @@ describe('token.place API v1 client', () => {
 
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
-        const { url, init, body } = getFetchCall();
-        expect(url).toBe('https://token.place/api/v1/chat/completions');
-        expect(init.method).toBe('POST');
-        expect(init.credentials).toBe('omit');
-        expect(init.headers?.Authorization).toBeUndefined();
-        expect(body.messages).toContainEqual({ role: 'user', content: 'hello' });
+        const relayRequest = getFetchCallByPath('/api/v1/relay/requests');
+        expect(relayRequest.init.method).toBe('POST');
+        expect(relayRequest.init.credentials).toBe('omit');
+        expect(relayRequest.init.headers?.Authorization).toBeUndefined();
+        expect(JSON.stringify(relayRequest.body)).not.toContain('hello');
     });
 
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCall().url).toBe('https://staging.token.place/api/v1/chat/completions');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
+            'https://staging.token.place/api/v1/relay/servers/next'
+        );
     });
 
     test('VITE_TOKEN_PLACE_URL production override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCall().url).toBe('https://token.place/api/v1/chat/completions');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
+            'https://token.place/api/v1/relay/servers/next'
+        );
     });
 
     test('explicit url overrides state and runtime compatibility values', async () => {
@@ -92,14 +168,18 @@ describe('token.place API v1 client', () => {
             url: 'https://explicit.token.place/api/v1',
             runtimeUrl: 'https://runtime.token.place',
         });
-        expect(getFetchCall().url).toBe('https://explicit.token.place/api/v1/chat/completions');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
+            'https://explicit.token.place/api/v1/relay/servers/next'
+        );
     });
 
     test('state tokenPlace url compatibility override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
         loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCall().url).toBe('https://state.token.place/api/v1/chat/completions');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
+            'https://state.token.place/api/v1/relay/servers/next'
+        );
     });
 
     test('runtime url is used before saved state and VITE fallback', async () => {
@@ -108,7 +188,9 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             runtimeUrl: 'https://staging.token.place/api',
         });
-        expect(getFetchCall().url).toBe('https://staging.token.place/api/v1/chat/completions');
+        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
+            'https://staging.token.place/api/v1/relay/servers/next'
+        );
     });
 
     test('legacy /api base normalizes without /api/api duplication', () => {
@@ -136,8 +218,6 @@ describe('token.place API v1 client', () => {
         expect(
             getTokenPlaceChatModel({ model: 'explicit-model', runtimeModel: 'runtime-model' })
         ).toBe('explicit-model');
-        await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCall().body.model).toBe('custom-model');
     });
 
     test('request is zero-auth and excludes secrets from headers/body/metadata', async () => {
@@ -152,7 +232,7 @@ describe('token.place API v1 client', () => {
                 secret: 'secret-canary-echo',
             },
         });
-        const { init, body } = getFetchCall();
+        const { init, body } = getFetchCallByPath('/api/v1/relay/requests');
         expect(init.headers.Authorization).toBeUndefined();
         expect(Object.keys(init.headers ?? {}).some((key) => /^authorization$/i.test(key))).toBe(
             false
@@ -165,11 +245,7 @@ describe('token.place API v1 client', () => {
         expect(serialized).not.toContain('player-inventory-canary-charlie');
         expect(serialized).not.toContain('raw-save-data-canary-delta');
         expect(serialized).not.toContain('secret-canary-echo');
-        expect(body.metadata).toEqual({
-            conversation_id: 'conv-42',
-            client: 'dspace',
-            provider: 'token.place',
-        });
+        expect(body).not.toHaveProperty('metadata');
     });
 
     test('request body includes model, schema-safe messages, safe metadata, and no true stream', async () => {
@@ -183,15 +259,22 @@ describe('token.place API v1 client', () => {
                 avatar: 'pilot.png',
             },
         ]);
-        const { body } = getFetchCall();
-        expect(body.model).toBe('llama-3.1-8b-instruct');
-        expect(body.messages[0].role).toBe('system');
-        expect(body.messages.at(-1)).toEqual({ role: 'user', content: 'hello' });
-        expect(body.messages.at(-1)).not.toHaveProperty('id');
-        expect(body.messages.at(-1)).not.toHaveProperty('timestamp');
-        expect(body.messages.at(-1)).not.toHaveProperty('tokens');
-        expect(body.messages.at(-1)).not.toHaveProperty('avatar');
-        expect(body.metadata).toEqual({ client: 'dspace', provider: 'token.place' });
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        expect(body).toEqual(
+            expect.objectContaining({
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                request_id: expect.any(String),
+                client_public_key: expect.any(String),
+                server_public_key: expect.any(String),
+                ciphertext: expect.any(String),
+                cipherkey: expect.any(String),
+                iv: expect.any(String),
+                cancel_token: expect.any(String),
+            })
+        );
+        expect(JSON.stringify(body)).not.toContain('hello');
+        expect(JSON.stringify(body)).not.toContain('model');
         expect(body.stream).not.toBe(true);
     });
 
@@ -219,13 +302,12 @@ describe('token.place API v1 client', () => {
     });
 
     test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {
-        fetch.mockResolvedValueOnce(
-            okResponse({
-                usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
-                metadata: { client: 'dspace', conversation_id: 'conv-42' },
-                contextSources: [{ title: 'provider field should not be used' }],
-            })
-        );
+        relayReply = {
+            choices: [{ message: { content: 'mocked reply' } }],
+            usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+            contextSources: [{ title: 'provider field should not be used' }],
+        };
         const dspaceSources = [{ title: 'DSPACE docs', url: '/docs/about' }];
         const result = await TokenPlaceChatV2([], {
             promptPayload: {
@@ -356,6 +438,146 @@ describe('token.place API v1 client', () => {
         expect(summary.message).not.toMatch(/OpenAI/i);
     });
 
+    test('relay request body is ciphertext-only for prompt and game-state sentinels', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'PLAYERSTATE_SECRET_SENTINEL' }], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: 'DOCS_GROUNDING_SECRET_SENTINEL' },
+                    {
+                        role: 'user',
+                        content: 'PLAYERSTATE_SECRET_SENTINEL INVENTORY_SAVE_SECRET_SENTINEL',
+                    },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const serialized = JSON.stringify(getFetchCallByPath('/api/v1/relay/requests').body);
+        expect(serialized).not.toContain('PLAYERSTATE_SECRET_SENTINEL');
+        expect(serialized).not.toContain('DOCS_GROUNDING_SECRET_SENTINEL');
+        expect(serialized).not.toContain('INVENTORY_SAVE_SECRET_SENTINEL');
+        expect(serialized).not.toContain('messages');
+    });
+
+    test('HTTP 202 retrieve polling continues until final response', async () => {
+        global.fetch = makeRelayFetch({ retrieveStatuses: [202, 202, 200] });
+        await expect(
+            tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
+        ).resolves.toBe('mocked reply');
+        const retrieveCalls = fetch.mock.calls.filter(([url]) =>
+            url.endsWith('/api/v1/relay/responses/retrieve')
+        );
+        expect(retrieveCalls).toHaveLength(3);
+    });
+
+    test('terminal selected-server failure clears selected server and can reselect', async () => {
+        global.fetch = makeRelayFetch({ retrieveStatuses: [410, 200], serverFailureOnce: true });
+        await expect(
+            tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
+        ).resolves.toBe('mocked reply');
+        const serverSelections = fetch.mock.calls.filter(([url]) =>
+            url.endsWith('/api/v1/relay/servers/next')
+        );
+        const dispatches = fetch.mock.calls.filter(([url]) =>
+            url.endsWith('/api/v1/relay/requests')
+        );
+        expect(serverSelections).toHaveLength(2);
+        expect(dispatches).toHaveLength(2);
+    });
+
+    test('timeout calls cancel when possible and returns helpful error', async () => {
+        global.fetch = makeRelayFetch({ retrieveStatuses: [202] });
+        await expect(
+            tokenPlaceChat([{ role: 'user', content: 'hello' }], {
+                timeoutMs: 1,
+                pollIntervalMs: 1,
+            })
+        ).rejects.toMatchObject({ status: 408 });
+        expect(
+            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/requests/cancel'))
+        ).toBe(true);
+    });
+
+    test('decrypted envelope validation rejects unsafe/mismatched shapes', () => {
+        const base = {
+            protocol: 'tokenplace_api_v1_relay_e2ee',
+            version: 1,
+            request_id: 'request-1',
+            client_public_key: 'client-key',
+            api_v1_response: { choices: [{ message: { content: 'ok' } }] },
+        };
+        const expected = { requestId: 'request-1', clientPublicKey: 'client-key' };
+        expect(validateTokenPlaceResponseEnvelope(base, expected)).toBe(base.api_v1_response);
+        expect(() =>
+            validateTokenPlaceResponseEnvelope({ ...base, request_id: 'other' }, expected)
+        ).toThrow(/mismatched request id/i);
+        expect(() =>
+            validateTokenPlaceResponseEnvelope({ ...base, client_public_key: 'other' }, expected)
+        ).toThrow(/mismatched client key/i);
+        expect(() =>
+            validateTokenPlaceResponseEnvelope({ ...base, protocol: 'wrong' }, expected)
+        ).toThrow(/wrong protocol/i);
+        expect(() => validateTokenPlaceResponseEnvelope({ ...base, version: 2 }, expected)).toThrow(
+            /wrong version/i
+        );
+        const { api_v1_response: _apiV1Response, ...missingResponse } = base;
+        expect(() => validateTokenPlaceResponseEnvelope(missingResponse, expected)).toThrow(
+            /missing API response/i
+        );
+    });
+
+    test('no available compute node, relay unavailable, malformed encrypted response, and disconnected server classify safely', async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (url.endsWith('/api/v1/relay/servers/next')) {
+                return { ok: true, status: 200, json: () => Promise.resolve({}) };
+            }
+            throw new Error(`Unexpected URL ${url}`);
+        });
+        await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
+
+        global.fetch = jest.fn(async (url) => {
+            if (url.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: false,
+                    status: 503,
+                    statusText: 'Unavailable',
+                    json: () => Promise.resolve({ message: 'down' }),
+                };
+            }
+            throw new Error(`Unexpected URL ${url}`);
+        });
+        await expect(tokenPlaceChat([])).rejects.toMatchObject({ status: 503 });
+
+        global.fetch = jest.fn(async (url, init = {}) => {
+            if (url.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({ server_public_key: relayServerKeys[0].publicKeyBase64 }),
+                };
+            }
+            if (url.endsWith('/api/v1/relay/requests')) {
+                return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
+            }
+            if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ ciphertext: 'bad', cipherkey: 'bad', iv: 'bad' }),
+                };
+            }
+            throw new Error(`Unexpected URL ${url} ${init.method}`);
+        });
+        await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
+
+        global.fetch = makeRelayFetch({ retrieveStatuses: [404, 404] });
+        await expect(tokenPlaceChat([], { pollIntervalMs: 1 })).rejects.toMatchObject({
+            type: 'malformed',
+        });
+    });
+
     test('shared prompt and token.place payload omit stale provider guidance', async () => {
         const promptPayload = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
         const serializedPrompt = JSON.stringify({
@@ -367,7 +589,7 @@ describe('token.place API v1 client', () => {
         expect(serializedPrompt).not.toMatch(/chat uses OpenAI/i);
 
         await tokenPlaceChat([{ role: 'user', content: 'hello' }], { promptPayload });
-        const serializedRequest = JSON.stringify(getFetchCall().body.messages);
+        const serializedRequest = JSON.stringify(getFetchCallByPath('/api/v1/relay/requests').body);
         expect(serializedRequest).not.toMatch(/token\.place is deferred/i);
         expect(serializedRequest).not.toMatch(/chat uses OpenAI/i);
     });

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -1,3 +1,5 @@
+import { webcrypto } from 'node:crypto';
+
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, seedOpenAIChatState, waitForHydration } from './test-helpers';
@@ -11,6 +13,61 @@ const QUOTA_MESSAGE = /out of credits/i;
 const AUTH_MESSAGE = /api key/i;
 const PERMISSION_MESSAGE = /denied access/i;
 const SERVER_MESSAGE = /unavailable right now/i;
+
+const encoder = new TextEncoder();
+const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
+    Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
+const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
+const base64ToPem = (base64: string) =>
+    `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
+const pemToBase64 = (pem: string) =>
+    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
+
+async function generateRelayKeypair() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = await webcrypto.subtle.exportKey('spki', pair.publicKey);
+    const publicPem = base64ToPem(bytesToBase64(spki));
+    return { publicKeyBase64: bytesToBase64(encoder.encode(publicPem)) };
+}
+
+async function encryptRelayEnvelope(
+    envelope: Record<string, unknown>,
+    clientPublicKeyBase64: string
+) {
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
+    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await webcrypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        aesKey,
+        encoder.encode(JSON.stringify(envelope))
+    );
+    const clientPublicPem = Buffer.from(clientPublicKeyBase64, 'base64').toString('utf8');
+    const publicKey = await webcrypto.subtle.importKey(
+        'spki',
+        base64ToBytes(pemToBase64(clientPublicPem)),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        true,
+        ['encrypt']
+    );
+    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    return {
+        ciphertext: bytesToBase64(ciphertext),
+        cipherkey: bytesToBase64(cipherkey),
+        iv: bytesToBase64(iv),
+    };
+}
 
 type StubMode =
     | 'success'
@@ -303,7 +360,22 @@ test.describe('Chat provider routing', () => {
             body: Record<string, unknown>;
             headers: Record<string, string>;
         }> = [];
-        await page.route('https://token.place/api/v1/chat/completions', async (route) => {
+        const legacyRequests: string[] = [];
+        const serverKey = await generateRelayKeypair();
+        await page.route('https://token.place/api/v1/relay/servers/next', async (route) => {
+            const request = route.request();
+            tokenPlaceRequests.push({
+                url: request.url(),
+                body: {},
+                headers: request.headers(),
+            });
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+            });
+        });
+        await page.route('https://token.place/api/v1/relay/requests', async (route) => {
             const request = route.request();
             tokenPlaceRequests.push({
                 url: request.url(),
@@ -313,17 +385,44 @@ test.describe('Chat provider routing', () => {
             await route.fulfill({
                 status: 200,
                 contentType: 'application/json',
-                body: JSON.stringify({
-                    choices: [{ message: { content: 'token.place grounded reply' } }],
-                    contextSources: [
-                        { type: 'provider', label: 'provider source should not show' },
-                    ],
-                    usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
-                    metadata: { request_id: 'tp-123', provider: 'token.place' },
-                }),
+                body: JSON.stringify({ accepted: true }),
             });
         });
-        const legacyRequests: string[] = [];
+        await page.route('https://token.place/api/v1/relay/responses/retrieve', async (route) => {
+            const request = route.request();
+            const body = JSON.parse(request.postData() || '{}');
+            tokenPlaceRequests.push({
+                url: request.url(),
+                body,
+                headers: request.headers(),
+            });
+            const encrypted = await encryptRelayEnvelope(
+                {
+                    protocol: 'tokenplace_api_v1_relay_e2ee',
+                    version: 1,
+                    request_id: body.request_id,
+                    client_public_key: body.client_public_key,
+                    api_v1_response: {
+                        choices: [{ message: { content: 'token.place grounded reply' } }],
+                        contextSources: [
+                            { type: 'provider', label: 'provider source should not show' },
+                        ],
+                        usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
+                        metadata: { request_id: 'tp-123', provider: 'token.place' },
+                    },
+                },
+                String(body.client_public_key)
+            );
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(encrypted),
+            });
+        });
+        await page.route('https://token.place/api/v1/chat/completions', async (route) => {
+            legacyRequests.push(route.request().url());
+            await route.abort();
+        });
         await page.route(/\/api\/chat$|\/chat$/, async (route) => {
             const request = route.request();
             if (request.isNavigationRequest()) {
@@ -343,19 +442,29 @@ test.describe('Chat provider routing', () => {
         await chatPanel.getByRole('button', { name: 'Send' }).click();
 
         await expect(chatPanel.getByText('token.place grounded reply')).toBeVisible();
-        expect(tokenPlaceRequests).toHaveLength(1);
+        expect(tokenPlaceRequests.map((request) => request.url)).toEqual([
+            'https://token.place/api/v1/relay/servers/next',
+            'https://token.place/api/v1/relay/requests',
+            'https://token.place/api/v1/relay/responses/retrieve',
+        ]);
         expect(legacyRequests).toEqual([]);
-        const [{ url, body, headers }] = tokenPlaceRequests;
-        expect(url).toBe('https://token.place/api/v1/chat/completions');
+        const { body, headers } = tokenPlaceRequests[1];
         expect(headers.authorization).toBeUndefined();
-        expect(JSON.stringify(body)).not.toContain('apiKey');
-        expect(JSON.stringify(body)).not.toContain('openAI');
-        expect(body.messages.some((message) => message.role === 'system')).toBe(true);
-        expect(body.messages.at(-1)).toMatchObject({
-            role: 'user',
-            content: 'How do DSPACE routes work?',
-        });
-        expect(body.metadata).toEqual({ client: 'dspace', provider: 'token.place' });
+        expect(body).toEqual(
+            expect.objectContaining({
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                client_public_key: expect.any(String),
+                ciphertext: expect.any(String),
+                cipherkey: expect.any(String),
+                iv: expect.any(String),
+                cancel_token: expect.any(String),
+            })
+        );
+        const serializedBody = JSON.stringify(body);
+        expect(serializedBody).not.toContain('apiKey');
+        expect(serializedBody).not.toContain('openAI');
+        expect(serializedBody).not.toContain('How do DSPACE routes work?');
 
         const sources = chatPanel.getByTestId('sources-used');
         await expect(sources).toBeVisible();

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -1,3 +1,5 @@
+import { webcrypto } from 'node:crypto';
+
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
@@ -8,6 +10,59 @@ type CapturedRequest = {
     headers: Record<string, string>;
     body: Record<string, unknown>;
 };
+
+const encoder = new TextEncoder();
+const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
+    Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
+const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
+const base64ToPem = (base64: string) =>
+    `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
+const pemToBase64 = (pem: string) =>
+    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
+
+async function generateRelayKeypair() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = await webcrypto.subtle.exportKey('spki', pair.publicKey);
+    const publicPem = base64ToPem(bytesToBase64(spki));
+    return { publicPem, publicKeyBase64: bytesToBase64(encoder.encode(publicPem)) };
+}
+
+async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem: string) {
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
+    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await webcrypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        aesKey,
+        encoder.encode(JSON.stringify(envelope))
+    );
+    const publicKey = await webcrypto.subtle.importKey(
+        'spki',
+        base64ToBytes(pemToBase64(publicPem)),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        true,
+        ['encrypt']
+    );
+    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    return {
+        ciphertext: bytesToBase64(ciphertext),
+        cipherkey: bytesToBase64(cipherkey),
+        iv: bytesToBase64(iv),
+    };
+}
+
+const decodeClientPublicPem = (value: string) => Buffer.from(value, 'base64').toString('utf8');
 
 const tokenPlacePayload = (content = 'token.place assistant reply') => ({
     id: 'chatcmpl-e2e-token-place',
@@ -21,7 +76,21 @@ const tokenPlacePayload = (content = 'token.place assistant reply') => ({
 
 async function routeTokenPlaceSuccess(page: Page, origin = 'https://token.place') {
     const requests: CapturedRequest[] = [];
-    await page.route(`${origin}/api/v1/chat/completions`, async (route) => {
+    const serverKey = await generateRelayKeypair();
+    await page.route(`${origin}/api/v1/relay/servers/next`, async (route) => {
+        requests.push({
+            method: route.request().method(),
+            url: route.request().url(),
+            headers: route.request().headers(),
+            body: {},
+        });
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+        });
+    });
+    await page.route(`${origin}/api/v1/relay/requests`, async (route) => {
         const request = route.request();
         requests.push({
             method: request.method(),
@@ -32,7 +101,32 @@ async function routeTokenPlaceSuccess(page: Page, origin = 'https://token.place'
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify(tokenPlacePayload()),
+            body: JSON.stringify({ accepted: true }),
+        });
+    });
+    await page.route(`${origin}/api/v1/relay/responses/retrieve`, async (route) => {
+        const request = route.request();
+        const body = JSON.parse(request.postData() || '{}');
+        requests.push({
+            method: request.method(),
+            url: request.url(),
+            headers: request.headers(),
+            body,
+        });
+        const encrypted = await encryptRelayEnvelope(
+            {
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                request_id: body.request_id,
+                client_public_key: body.client_public_key,
+                api_v1_response: tokenPlacePayload(),
+            },
+            decodeClientPublicPem(String(body.client_public_key))
+        );
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(encrypted),
         });
     });
     return requests;
@@ -80,7 +174,7 @@ test.describe('Chat provider routing', () => {
         page,
     }) => {
         const requests = await routeTokenPlaceSuccess(page);
-        await blockLiveChatProviders(page, ['https://token.place/api/v1/chat/completions']);
+        await blockLiveChatProviders(page, ['https://token.place/api/v1/relay/']);
 
         const chatPanel = await openChat(page, 'token-place');
         await expect(page.locator('[data-testid="chat-panel"]')).toHaveCount(1);
@@ -90,17 +184,26 @@ test.describe('Chat provider routing', () => {
         await sendFromPanel(chatPanel, 'Route my fresh profile through token.place');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
 
-        expect(requests).toHaveLength(1);
-        const request = requests[0];
+        expect(requests.map((request) => request.url)).toEqual([
+            'https://token.place/api/v1/relay/servers/next',
+            'https://token.place/api/v1/relay/requests',
+            'https://token.place/api/v1/relay/responses/retrieve',
+        ]);
+        const request = requests[1];
         expect(request.method).toBe('POST');
-        expect(request.url).toBe('https://token.place/api/v1/chat/completions');
-        expect(request.url).toMatch(/\/api\/v1\/chat\/completions$/);
         expect(request.headers.authorization).toBeUndefined();
-        expect(request.body.model).toBeTruthy();
-        expect(Array.isArray(request.body.messages)).toBe(true);
-        expect(request.body.stream).not.toBe(true);
-        expect(request.body.metadata).toEqual({ client: 'dspace', provider: 'token.place' });
+        expect(request.body).toEqual(
+            expect.objectContaining({
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                ciphertext: expect.any(String),
+                cipherkey: expect.any(String),
+                iv: expect.any(String),
+                cancel_token: expect.any(String),
+            })
+        );
         const serializedBody = JSON.stringify(request.body);
+        expect(serializedBody).not.toContain('Route my fresh profile through token.place');
         expect(serializedBody).not.toMatch(/apiKey|sk-/i);
         expect(serializedBody).not.toMatch(/raw save|inventory details/i);
         expect(JSON.stringify(request.headers)).not.toMatch(/authorization|apiKey|sk-/i);
@@ -114,15 +217,14 @@ test.describe('Chat provider routing', () => {
             tokenPlace: { url: 'https://staging.token.place/api' },
         });
         const requests = await routeTokenPlaceSuccess(page);
-        await blockLiveChatProviders(page, ['https://token.place/api/v1/chat/completions']);
+        await blockLiveChatProviders(page, ['https://token.place/api/v1/relay/']);
 
         const chatPanel = await openChat(page, 'token-place');
         await sendFromPanel(chatPanel, 'Use runtime token.place');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
 
-        expect(requests).toHaveLength(1);
-        expect(requests[0].url).toBe('https://token.place/api/v1/chat/completions');
-        expect(requests[0].url).not.toContain('/api/api/v1/chat/completions');
+        expect(requests[0].url).toBe('https://token.place/api/v1/relay/servers/next');
+        expect(requests[0].url).not.toContain('/api/api/v1/relay');
     });
 
     test('provider preference persists after selecting OpenAI and saving a fake key', async ({
@@ -148,7 +250,7 @@ test.describe('Chat provider routing', () => {
     test('OpenAI is optional and gated when selected without a key', async ({ page }) => {
         let tokenPlaceCalls = 0;
         let openAiCalls = 0;
-        await page.route('https://token.place/api/v1/chat/completions', async (route) => {
+        await page.route('https://token.place/api/v1/relay/**', async (route) => {
             tokenPlaceCalls += 1;
             await route.abort();
         });
@@ -197,7 +299,7 @@ test.describe('Chat provider routing', () => {
             openAI: { apiKey: 'sk-fake-e2e-openai-key' },
         });
         const requests = await routeTokenPlaceSuccess(page);
-        await blockLiveChatProviders(page, ['https://token.place/api/v1/chat/completions']);
+        await blockLiveChatProviders(page, ['https://token.place/api/v1/relay/']);
 
         await page.goto('/settings');
         await waitForHydration(page);
@@ -216,14 +318,16 @@ test.describe('Chat provider routing', () => {
         const chatPanel = await openChat(page, 'token-place');
         await sendFromPanel(chatPanel, 'Back to default provider');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
-        expect(requests).toHaveLength(1);
+        expect(requests.some((request) => request.url.endsWith('/api/v1/relay/requests'))).toBe(
+            true
+        );
     });
 
     test('default token.place flow supports persona switching and debug/RAG payload ordering', async ({
         page,
     }) => {
         const requests = await routeTokenPlaceSuccess(page);
-        await blockLiveChatProviders(page, ['https://token.place/api/v1/chat/completions']);
+        await blockLiveChatProviders(page, ['https://token.place/api/v1/relay/']);
         await seedState(page, {
             settings: { chatProvider: 'token-place', showChatDebugPayload: true },
         });
@@ -242,7 +346,9 @@ test.describe('Chat provider routing', () => {
 
         await sendFromPanel(chatPanel, 'Show the debug payload with RAG context');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
-        expect(requests).toHaveLength(1);
+        expect(requests.some((request) => request.url.endsWith('/api/v1/relay/requests'))).toBe(
+            true
+        );
         await expect(page.getByTestId('debug-provider-row')).toContainText('token-place');
         await page.getByRole('button', { name: 'Show prompt' }).click();
         await expect(page.getByRole('button', { name: 'Hide prompt' })).toBeVisible();
@@ -255,8 +361,12 @@ test.describe('Chat provider routing', () => {
         expect(debugText.join('\n')).not.toMatch(
             /token\.place is deferred|chat uses OpenAI|OpenAI-only/i
         );
-        expect(JSON.stringify(requests[0].body)).not.toMatch(
-            /token\.place is deferred|chat uses OpenAI|OpenAI-only/i
+        expect(
+            JSON.stringify(
+                requests.find((request) => request.url.endsWith('/api/v1/relay/requests'))?.body
+            )
+        ).not.toMatch(
+            /token\.place is deferred|chat uses OpenAI|OpenAI-only|Show the debug payload/i
         );
     });
 });

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -1,3 +1,5 @@
+import { webcrypto } from 'node:crypto';
+
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
@@ -11,73 +13,137 @@ type TokenPlaceStubMode =
     | 'provider-error'
     | 'unexpected-http-error';
 
+const encoder = new TextEncoder();
+const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
+    Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
+const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
+const base64ToPem = (base64: string) =>
+    `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
+const pemToBase64 = (pem: string) =>
+    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
+
+const relayErrorResponse = (mode: TokenPlaceStubMode) => {
+    if (mode === 'content-policy') {
+        return {
+            status: 400,
+            error: {
+                message: 'Content blocked',
+                type: 'content_policy_violation',
+                code: 'content_blocked',
+            },
+        };
+    }
+
+    if (mode === 'rate-limit') {
+        return { status: 429, error: { message: 'Slow down', type: 'rate_limit' } };
+    }
+
+    if (mode === 'server-error') {
+        return { status: 503, error: { message: 'Unavailable', type: 'server_error' } };
+    }
+
+    if (mode === 'provider-error') {
+        return { status: 400, error: { message: 'Provider down' } };
+    }
+
+    if (mode === 'unexpected-http-error') {
+        return { status: 418, error: { message: 'Unexpected token.place failure' } };
+    }
+
+    return { choices: [{ message: { role: 'assistant', content: '' } }] };
+};
+
+async function generateRelayKeypair() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = await webcrypto.subtle.exportKey('spki', pair.publicKey);
+    const publicPem = base64ToPem(bytesToBase64(spki));
+    return { publicKeyBase64: bytesToBase64(encoder.encode(publicPem)) };
+}
+
+async function encryptRelayEnvelope(
+    envelope: Record<string, unknown>,
+    clientPublicKeyBase64: string
+) {
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
+    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await webcrypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        aesKey,
+        encoder.encode(JSON.stringify(envelope))
+    );
+    const clientPublicPem = Buffer.from(clientPublicKeyBase64, 'base64').toString('utf8');
+    const publicKey = await webcrypto.subtle.importKey(
+        'spki',
+        base64ToBytes(pemToBase64(clientPublicPem)),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        true,
+        ['encrypt']
+    );
+    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    return {
+        ciphertext: bytesToBase64(ciphertext),
+        cipherkey: bytesToBase64(cipherkey),
+        iv: bytesToBase64(iv),
+    };
+}
+
 const installTokenPlaceStub = async (page: Page, mode: TokenPlaceStubMode) => {
-    await page.route('https://token.place/api/v1/chat/completions', async (route) => {
+    const serverKey = await generateRelayKeypair();
+
+    await page.route('https://token.place/api/v1/relay/servers/next', async (route) => {
         if (mode === 'network-error') {
             await route.abort('failed');
             return;
         }
 
-        if (mode === 'content-policy') {
-            await route.fulfill({
-                status: 400,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    error: {
-                        message: 'Content blocked',
-                        type: 'content_policy_violation',
-                        code: 'content_blocked',
-                    },
-                }),
-            });
-            return;
-        }
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+        });
+    });
 
-        if (mode === 'rate-limit') {
-            await route.fulfill({
-                status: 429,
-                contentType: 'application/json',
-                body: JSON.stringify({ error: { message: 'Slow down', type: 'rate_limit' } }),
-            });
-            return;
-        }
+    await page.route('https://token.place/api/v1/relay/requests', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ accepted: true }),
+        });
+    });
 
-        if (mode === 'server-error') {
-            await route.fulfill({
-                status: 503,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    error: { message: 'Unavailable', type: 'server_error' },
-                }),
-            });
-            return;
-        }
+    await page.route('https://token.place/api/v1/relay/responses/retrieve', async (route) => {
+        const body = JSON.parse(route.request().postData() || '{}');
+        const encrypted = await encryptRelayEnvelope(
+            {
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                request_id: body.request_id,
+                client_public_key: body.client_public_key,
+                api_v1_response: relayErrorResponse(mode),
+            },
+            body.client_public_key
+        );
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(encrypted),
+        });
+    });
 
-        if (mode === 'malformed') {
-            await route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify({ choices: [{ message: { content: '' } }] }),
-            });
-            return;
-        }
-
-        if (mode === 'provider-error') {
-            await route.fulfill({
-                status: 400,
-                contentType: 'application/json',
-                body: JSON.stringify({ error: { message: 'Provider down' } }),
-            });
-            return;
-        }
-
-        if (mode === 'unexpected-http-error') {
-            await route.fulfill({
-                status: 418,
-                contentType: 'application/json',
-                body: JSON.stringify({ error: { message: 'Unexpected token.place failure' } }),
-            });
-        }
+    await page.route('https://token.place/api/v1/chat/completions', async (route) => {
+        throw new Error(`Unexpected legacy token.place request: ${route.request().url()}`);
     });
 };
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -126,8 +126,35 @@ const parseErrorPayload = async (response) => {
     }
 };
 
-const bytesToBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
-const base64ToBytes = (value) => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+const toUint8Array = (bytes) => {
+    if (bytes instanceof Uint8Array) return bytes;
+    if (bytes instanceof ArrayBuffer) return new Uint8Array(bytes);
+    if (ArrayBuffer.isView(bytes)) {
+        return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    }
+    return new Uint8Array(bytes);
+};
+
+const bytesToBase64 = (bytes) => {
+    const array = toUint8Array(bytes);
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(array).toString('base64');
+    }
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < array.length; i += chunkSize) {
+        const chunk = array.subarray(i, i + chunkSize);
+        binary += String.fromCharCode.apply(null, chunk);
+    }
+    return btoa(binary);
+};
+
+const base64ToBytes = (value) => {
+    if (typeof Buffer !== 'undefined') {
+        return new Uint8Array(Buffer.from(String(value), 'base64'));
+    }
+    return Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+};
 const pemToBase64 = (pem) =>
     String(pem).replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
 const base64ToPem = (base64, label = 'PUBLIC KEY') => {
@@ -389,8 +416,9 @@ export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
     messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {},
-    metadata: buildTokenPlaceMetadata(options.metadata),
+    options: {
+        metadata: buildTokenPlaceMetadata(options.metadata),
+    },
 });
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
@@ -406,7 +434,7 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         api_v1_request: buildApiV1Request(promptPayload, options),
     };
     const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
-    await dispatchTokenPlaceRelayRequest(
+    const dispatched = await dispatchTokenPlaceRelayRequest(
         baseUrl,
         {
             server_public_key: server.server_public_key,
@@ -419,6 +447,9 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         },
         options
     );
+    if (dispatched?.accepted === false) {
+        throw createMalformedTokenPlaceResponseError('token.place relay rejected the request.');
+    }
     const encryptedResponse = await pollTokenPlaceRelayResponse(
         baseUrl,
         { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
@@ -459,6 +490,11 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
             requestId: undefined,
             cancelToken: undefined,
         });
+        if (data?.terminalSelectedServerFailure) {
+            throw createMalformedTokenPlaceResponseError(
+                'No token.place compute node is available.'
+            );
+        }
     }
 
     const outputText = extractTokenPlaceAssistantText(data);

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -8,10 +8,18 @@ import {
 
 const DEFAULT_ORIGIN = 'https://token.place';
 const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
+const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
+const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
+const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const METADATA_DENY_PATTERN =
     /(?:key|token|secret|credential|password|authorization|auth|inventory|save|state|player)/i;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+
+const getCrypto = () => globalThis.crypto;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 const readEnvValue = (key) => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
@@ -118,50 +126,339 @@ const parseErrorPayload = async (response) => {
     }
 };
 
-export const TokenPlaceChatV2 = async (messages, options = {}) => {
-    await ready;
-    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
-    const contextSources = Array.isArray(promptPayload.contextSources)
-        ? promptPayload.contextSources
-        : [];
-    const requestBody = {
-        model: getTokenPlaceChatModel(options),
-        messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-        metadata: buildTokenPlaceMetadata(options.metadata),
+const bytesToBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+const base64ToBytes = (value) => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+const pemToBase64 = (pem) =>
+    String(pem).replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
+const base64ToPem = (base64, label = 'PUBLIC KEY') => {
+    const lines = String(base64).match(/.{1,64}/g) || [];
+    return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----`;
+};
+
+export const normalizeTokenPlacePublicKey = (value) => {
+    const raw = String(value || '').trim();
+    if (!raw)
+        throw createMalformedTokenPlaceResponseError(
+            'token.place relay server is missing a public key.'
+        );
+    if (/-----BEGIN [^-]+-----/.test(raw)) {
+        return { pem: raw, base64: bytesToBase64(textEncoder.encode(raw)) };
+    }
+    const decoded = textDecoder.decode(base64ToBytes(raw));
+    if (/-----BEGIN [^-]+-----/.test(decoded)) {
+        return { pem: decoded, base64: raw };
+    }
+    return { pem: base64ToPem(raw), base64: bytesToBase64(textEncoder.encode(base64ToPem(raw))) };
+};
+
+const importRsaPublicKey = async (pem) =>
+    getCrypto().subtle.importKey(
+        'spki',
+        base64ToBytes(pemToBase64(pem)),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        true,
+        ['encrypt']
+    );
+
+const importRsaPrivateKey = async (base64Pkcs8) =>
+    getCrypto().subtle.importKey(
+        'pkcs8',
+        base64ToBytes(base64Pkcs8),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        true,
+        ['decrypt']
+    );
+
+export const generateTokenPlaceClientKeypair = async () => {
+    const pair = await getCrypto().subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = await getCrypto().subtle.exportKey('spki', pair.publicKey);
+    const pkcs8 = await getCrypto().subtle.exportKey('pkcs8', pair.privateKey);
+    const publicPem = base64ToPem(bytesToBase64(spki));
+    return {
+        publicKey: pair.publicKey,
+        privateKey: pair.privateKey,
+        publicKeyPem: publicPem,
+        publicKeyBase64: bytesToBase64(textEncoder.encode(publicPem)),
+        privateKeyBase64: bytesToBase64(pkcs8),
     };
+};
 
-    const baseUrl = resolveTokenPlaceBaseUrl({
-        url: options.url,
-        state: promptPayload.gameState,
-        runtimeUrl: options.runtimeUrl,
-    });
-    const url = `${baseUrl}${CHAT_COMPLETIONS_PATH}`;
+export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
+    const crypto = getCrypto();
+    const aesKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        aesKey,
+        textEncoder.encode(JSON.stringify(envelope))
+    );
+    const serverKey = await importRsaPublicKey(serverPublicKeyPem);
+    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, rawAesKey);
+    return {
+        ciphertext: bytesToBase64(ciphertext),
+        cipherkey: bytesToBase64(cipherkey),
+        iv: bytesToBase64(iv),
+    };
+};
 
+export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
+    const privateKey =
+        typeof clientPrivateKey === 'string'
+            ? await importRsaPrivateKey(clientPrivateKey)
+            : clientPrivateKey;
+    const rawAesKey = await getCrypto().subtle.decrypt(
+        { name: 'RSA-OAEP' },
+        privateKey,
+        base64ToBytes(payload.cipherkey)
+    );
+    const aesKey = await getCrypto().subtle.importKey(
+        'raw',
+        rawAesKey,
+        { name: 'AES-GCM' },
+        false,
+        ['decrypt']
+    );
+    const plaintext = await getCrypto().subtle.decrypt(
+        { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
+        aesKey,
+        base64ToBytes(payload.ciphertext)
+    );
+    return JSON.parse(textDecoder.decode(plaintext));
+};
+
+const randomBase64Url = (bytes = 18) =>
+    bytesToBase64(getCrypto().getRandomValues(new Uint8Array(bytes)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
+
+const fetchJson = async (url, init, unavailableMessage) => {
     let response;
     try {
-        response = await fetch(url, {
+        response = await fetch(url, { ...init, credentials: 'omit' });
+    } catch (error) {
+        throw createTokenPlaceNetworkError(error);
+    }
+    if (!response.ok) {
+        const payload = await parseErrorPayload(response);
+        const err = createTokenPlaceHttpError(
+            response.status,
+            payload,
+            response.statusText || unavailableMessage
+        );
+        if (response.status >= 500) err.message = unavailableMessage;
+        throw err;
+    }
+    try {
+        return await response.json();
+    } catch {
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place relay response: invalid JSON.'
+        );
+    }
+};
+
+export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
+    const data = await fetchJson(
+        `${baseUrl}/api/v1/relay/servers/next`,
+        { method: 'GET', signal: options.signal },
+        'token.place relay is unavailable.'
+    );
+    const rawKey = data?.server_public_key || data?.serverPublicKey || data?.public_key;
+    if (!rawKey)
+        throw createMalformedTokenPlaceResponseError('No token.place compute node is available.');
+    const normalized = normalizeTokenPlacePublicKey(rawKey);
+    return { ...data, server_public_key: normalized.base64, serverPublicKeyPem: normalized.pem };
+};
+
+export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
+    fetchJson(
+        `${baseUrl}/api/v1/relay/requests`,
+        {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(requestBody),
+            body: JSON.stringify(body),
+            signal: options.signal,
+        },
+        'token.place relay is unavailable.'
+    );
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const retrieveRelayResponse = async (baseUrl, body, options = {}) => {
+    let response;
+    try {
+        response = await fetch(`${baseUrl}/api/v1/relay/responses/retrieve`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
             signal: options.signal,
             credentials: 'omit',
         });
     } catch (error) {
         throw createTokenPlaceNetworkError(error);
     }
-
+    if (response.status === 202) return { ready: false };
+    if ([404, 410].includes(response.status)) return { terminalSelectedServerFailure: true };
     if (!response.ok) {
-        const errorPayload = await parseErrorPayload(response);
-        throw createTokenPlaceHttpError(response.status, errorPayload, response.statusText);
+        const payload = await parseErrorPayload(response);
+        if (response.status >= 500)
+            throw createTokenPlaceHttpError(
+                response.status,
+                payload,
+                'token.place relay is unavailable.'
+            );
+        throw createTokenPlaceHttpError(response.status, payload, response.statusText);
     }
-
-    let data;
     try {
-        data = await response.json();
-    } catch (error) {
+        return { ready: true, data: await response.json() };
+    } catch {
+        throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
+    }
+};
+
+const cancelRelayRequest = async (baseUrl, cancelToken, options = {}) => {
+    if (!cancelToken) return;
+    try {
+        await fetch(`${baseUrl}/api/v1/relay/requests/cancel`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cancel_token: cancelToken }),
+            signal: options.signal,
+            credentials: 'omit',
+        });
+    } catch {
+        // Best-effort timeout cleanup only; preserve the user-facing timeout error.
+    }
+};
+
+export const pollTokenPlaceRelayResponse = async (baseUrl, body, options = {}) => {
+    const startedAt = Date.now();
+    const timeoutMs = options.timeoutMs ?? DEFAULT_RELAY_TIMEOUT_MS;
+    const intervalMs = options.pollIntervalMs ?? DEFAULT_RELAY_POLL_INTERVAL_MS;
+    while (Date.now() - startedAt < timeoutMs) {
+        const result = await retrieveRelayResponse(baseUrl, body, options);
+        if (result.ready) return result.data;
+        if (result.terminalSelectedServerFailure) return result;
+        await sleep(intervalMs);
+    }
+    await cancelRelayRequest(baseUrl, options.cancelToken, options);
+    throw createTokenPlaceHttpError(
+        408,
+        { message: 'Timed out waiting for token.place compute response.' },
+        'Timeout'
+    );
+};
+
+export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
+    if (envelope?.protocol !== RELAY_PROTOCOL)
         throw createMalformedTokenPlaceResponseError(
-            'Malformed token.place response: invalid JSON.'
+            'Malformed token.place response: wrong protocol.'
         );
+    if (envelope?.version !== RELAY_VERSION)
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: wrong version.'
+        );
+    if (envelope?.request_id !== expected.requestId)
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: mismatched request id.'
+        );
+    if (envelope?.client_public_key !== expected.clientPublicKey)
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: mismatched client key.'
+        );
+    if (!envelope?.api_v1_response)
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: missing API response.'
+        );
+    return envelope.api_v1_response;
+};
+
+const buildApiV1Request = (promptPayload, options = {}) => ({
+    model: getTokenPlaceChatModel(options),
+    messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
+    options: {},
+    metadata: buildTokenPlaceMetadata(options.metadata),
+});
+
+const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
+    const server = await selectTokenPlaceRelayServer(baseUrl, options);
+    const clientKeys = options.clientKeys || (await generateTokenPlaceClientKeypair());
+    const requestId = options.requestId || randomBase64Url();
+    const cancelToken = options.cancelToken || randomBase64Url();
+    const envelope = {
+        protocol: RELAY_PROTOCOL,
+        version: RELAY_VERSION,
+        request_id: requestId,
+        client_public_key: clientKeys.publicKeyBase64,
+        api_v1_request: buildApiV1Request(promptPayload, options),
+    };
+    const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
+    await dispatchTokenPlaceRelayRequest(
+        baseUrl,
+        {
+            server_public_key: server.server_public_key,
+            client_public_key: clientKeys.publicKeyBase64,
+            request_id: requestId,
+            protocol: RELAY_PROTOCOL,
+            version: RELAY_VERSION,
+            ...encrypted,
+            cancel_token: cancelToken,
+        },
+        options
+    );
+    const encryptedResponse = await pollTokenPlaceRelayResponse(
+        baseUrl,
+        { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
+        { ...options, cancelToken }
+    );
+    if (encryptedResponse?.terminalSelectedServerFailure) return encryptedResponse;
+    let responseEnvelope;
+    try {
+        responseEnvelope = await decryptTokenPlaceEnvelope(
+            encryptedResponse,
+            clientKeys.privateKey
+        );
+    } catch (error) {
+        throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
+    }
+    return validateTokenPlaceResponseEnvelope(responseEnvelope, {
+        requestId,
+        clientPublicKey: clientKeys.publicKeyBase64,
+    });
+};
+
+export const TokenPlaceChatV2 = async (messages, options = {}) => {
+    await ready;
+    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const contextSources = Array.isArray(promptPayload.contextSources)
+        ? promptPayload.contextSources
+        : [];
+    const baseUrl = resolveTokenPlaceBaseUrl({
+        url: options.url,
+        state: promptPayload.gameState,
+        runtimeUrl: options.runtimeUrl,
+    });
+
+    let data = await runRelayAttempt(baseUrl, promptPayload, options);
+    if (data?.terminalSelectedServerFailure) {
+        data = await runRelayAttempt(baseUrl, promptPayload, {
+            ...options,
+            requestId: undefined,
+            cancelToken: undefined,
+        });
     }
 
     const outputText = extractTokenPlaceAssistantText(data);

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -114,6 +114,26 @@ export const extractTokenPlaceAssistantText = (response) => {
     return content;
 };
 
+const getStructuredApiErrorStatus = (apiResponse) => {
+    const candidates = [
+        apiResponse?.error?.status,
+        apiResponse?.error?.status_code,
+        apiResponse?.status,
+        apiResponse?.status_code,
+    ];
+    const status = candidates
+        .map((candidate) => Number(candidate))
+        .find((candidate) => Number.isInteger(candidate) && candidate >= 400 && candidate <= 599);
+    return status ?? 400;
+};
+
+const throwStructuredTokenPlaceApiError = (apiResponse) => {
+    if (!apiResponse?.error || typeof apiResponse.error !== 'object') return;
+    throw createTokenPlaceHttpError(getStructuredApiErrorStatus(apiResponse), {
+        error: apiResponse.error,
+    });
+};
+
 const parseErrorPayload = async (response) => {
     try {
         return await response.json();
@@ -497,6 +517,7 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         }
     }
 
+    throwStructuredTokenPlaceApiError(data);
     const outputText = extractTokenPlaceAssistantText(data);
     const { text } = validateChatResponseText(outputText, { contextSources });
 


### PR DESCRIPTION
### Motivation
- Replace the legacy plaintext POST to `/api/v1/chat/completions` so DSPACE `/chat` uses the token.place API v1 relay-blind E2EE desktop-compute flow described in P8a and avoid sending PlayerState/docs grounding plaintext to the relay.
- Ensure the browser generates and retains a client keypair, selects a compute node, dispatches a ciphertext-only relay request, polls for the encrypted response, decrypts and validates it client-side, and preserves zero-auth `credentials: 'omit'` behavior.

### Description
- Implemented the relay E2EE flow in `frontend/src/utils/tokenPlace.js`: added Web Crypto helpers and end-to-end pieces for key generation (`generateTokenPlaceClientKeypair`), public-key normalization (`normalizeTokenPlacePublicKey`), envelope encryption/decryption (`encryptTokenPlaceEnvelope`, `decryptTokenPlaceEnvelope`), compute-node selection (`selectTokenPlaceRelayServer`), request dispatch (`dispatchTokenPlaceRelayRequest`), response polling (`pollTokenPlaceRelayResponse` and helpers), timeout/cancel support, and decrypted-envelope validation (`validateTokenPlaceResponseEnvelope`).
- Preserved existing URL/model resolution helpers (`resolveTokenPlaceBaseUrl`, `getTokenPlaceChatModel`) and kept `tokenPlaceChat(messages, options)` as a string-returning compatibility wrapper.
- Kept all token.place requests `credentials: 'omit'` and ensured no `Authorization` header or plaintext PlayerState/docs appears in outer relay requests (outer body is ciphertext + safe routing metadata only).
- Reworked unit tests in `frontend/__tests__/tokenPlace.test.js` to mock the relay endpoints and cover: server selection, `/api/v1/relay/requests` payload shape (ciphertext/cipherkey/iv/cancel_token), absence of plaintext sentinels, 202 polling behavior, terminal compute-node failure + reselection, timeout + cancel, and envelope validation failures.
- Updated E2E provider-routing stub `frontend/e2e/chat-provider-routing.spec.ts` to emulate the relay endpoints (`/api/v1/relay/servers/next`, `/api/v1/relay/requests`, `/api/v1/relay/responses/retrieve`) and assert the relay E2EE route sequence and ciphertext-only outer payloads while blocking plaintext `/api/v1/chat/completions` calls.

### Testing
- Unit tests: ran `cd frontend && npm test -- tokenPlace.test.js` and all token.place unit tests passed (28/28). ✅
- Formatting/lint/build: ran `cd frontend && npm run check` and `cd frontend && npm run build`; both succeeded. ✅
- E2E Playwright run: attempted `cd frontend && npx playwright test e2e/chat-provider-routing.spec.ts e2e/chat-message-flow.spec.ts`, but the environment could not install Playwright browsers (Chromium) due to external network/DNS failures (multiple `ENETUNREACH` errors), so Playwright E2E could not be executed in this environment; the modified E2E stubs are present and should pass in CI or a machine with browsers installed. ⚠️
- Additional verification: ran repository search for relevant tokens/paths to confirm no accidental plaintext paths remain (`/api/v1/chat/completions`, `relay/servers/next`, `relay/requests`, `responses/retrieve`, `ciphertext`, `cipherkey`, `iv`, `PLAYERSTATE_SECRET_SENTINEL`) and updated tests assert those invariants. ✅

Notes and follow-ups
- The implementation uses browser Web Crypto (RSA-OAEP + AES-GCM) and normalizes PEM/Base64 formats to interoperate with token.place relay public keys; comments/tests explain choices and compatibility handling.
- Playwright E2E must be run in CI or locally where `npx playwright install` and system deps succeed; the PR includes adjusted E2E stubs that validate the relay sequence and ciphertext-only invariant when Playwright can run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37327a4bdc832f809c55b64ed49284)