### PR TITLE
Align token.place relay crypto wire format

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L700-L714))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L848-L862))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -37,6 +37,8 @@ const okResponse = (body = {}) => ({
         }),
 });
 
+const bytesToBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+
 const decodeBase64Text = (value) =>
     new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
 
@@ -338,6 +340,103 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(encrypted, relayServerKeys[0].privateKey);
 
         expect(decrypted).toEqual({ ok: true, source: 'ciphertext' });
+    });
+
+    test('decryption accepts explicit GCM payloads with embedded WebCrypto tags', async () => {
+        const crypto = globalThis.crypto;
+        const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
+            'encrypt',
+        ]);
+        const ciphertext = await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv },
+            aesKey,
+            new TextEncoder().encode(JSON.stringify({ ok: true, mode: 'embedded-gcm-tag' }))
+        );
+        const cipherkey = await crypto.subtle.encrypt(
+            { name: 'RSA-OAEP' },
+            relayServerKeys[0].publicKey,
+            rawAesKey
+        );
+
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                mode: 'AES-GCM',
+                ciphertext: bytesToBase64(ciphertext),
+                cipherkey: bytesToBase64(cipherkey),
+                iv: bytesToBase64(iv),
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(decrypted).toEqual({ ok: true, mode: 'embedded-gcm-tag' });
+    });
+
+    test('decryption accepts explicit GCM payloads with separate tags', async () => {
+        const crypto = globalThis.crypto;
+        const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
+            'encrypt',
+        ]);
+        const encrypted = new Uint8Array(
+            await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv },
+                aesKey,
+                new TextEncoder().encode(JSON.stringify({ ok: true, mode: 'separate-gcm-tag' }))
+            )
+        );
+        const ciphertext = encrypted.slice(0, -16);
+        const tag = encrypted.slice(-16);
+        const cipherkey = await crypto.subtle.encrypt(
+            { name: 'RSA-OAEP' },
+            relayServerKeys[0].publicKey,
+            rawAesKey
+        );
+
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                mode: 'aes-256-gcm',
+                ciphertext: bytesToBase64(ciphertext),
+                tag: bytesToBase64(tag),
+                cipherkey: bytesToBase64(cipherkey),
+                iv: bytesToBase64(iv),
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(decrypted).toEqual({ ok: true, mode: 'separate-gcm-tag' });
+    });
+
+    test('decryption accepts CBC payloads with raw wrapped AES keys', async () => {
+        const crypto = globalThis.crypto;
+        const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
+        const iv = crypto.getRandomValues(new Uint8Array(16));
+        const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-CBC' }, false, [
+            'encrypt',
+        ]);
+        const ciphertext = await crypto.subtle.encrypt(
+            { name: 'AES-CBC', iv },
+            aesKey,
+            new TextEncoder().encode(JSON.stringify({ ok: true, key: 'raw' }))
+        );
+        const cipherkey = await crypto.subtle.encrypt(
+            { name: 'RSA-OAEP' },
+            relayServerKeys[0].publicKey,
+            rawAesKey
+        );
+
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                ciphertext: bytesToBase64(ciphertext),
+                cipherkey: bytesToBase64(cipherkey),
+                iv: bytesToBase64(iv),
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(decrypted).toEqual({ ok: true, key: 'raw' });
     });
 
     test('large encrypted envelopes do not overflow base64 conversion', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -342,6 +342,21 @@ describe('token.place API v1 client', () => {
         expect(decrypted).toEqual({ ok: true, source: 'ciphertext' });
     });
 
+    test('decryption rejects responses missing chat_history and ciphertext fields', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            { ok: true, source: 'missing-ciphertext-field' },
+            relayServerKeys[0].publicKeyPem
+        );
+        const payload = {
+            cipherkey: encrypted.cipherkey,
+            iv: encrypted.iv,
+        };
+
+        await expect(
+            decryptTokenPlaceEnvelope(payload, relayServerKeys[0].privateKey)
+        ).rejects.toThrow('Malformed encrypted token.place response: missing ciphertext field.');
+    });
+
     test('decryption accepts explicit GCM payloads with embedded WebCrypto tags', async () => {
         const crypto = globalThis.crypto;
         const rawAesKey = crypto.getRandomValues(new Uint8Array(32));

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -87,7 +87,11 @@ const makeRelayFetch = ({
                 },
                 clientPublicPem
             );
-            return { ok: true, status: 200, json: () => Promise.resolve(encrypted) };
+            return {
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
+            };
         }
         if (url.endsWith('/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
@@ -280,6 +284,9 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(Uint8Array.from(atob(body.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
+        expect(body).not.toHaveProperty('mode');
+        expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
     });
 
@@ -304,6 +311,33 @@ describe('token.place API v1 client', () => {
             })
         );
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+    });
+
+    test('decryption accepts chat_history as the response ciphertext', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            { ok: true, source: 'chat_history' },
+            relayServerKeys[0].publicKeyPem
+        );
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                chat_history: encrypted.ciphertext,
+                cipherkey: encrypted.cipherkey,
+                iv: encrypted.iv,
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(decrypted).toEqual({ ok: true, source: 'chat_history' });
+    });
+
+    test('decryption accepts ciphertext when chat_history is absent', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            { ok: true, source: 'ciphertext' },
+            relayServerKeys[0].publicKeyPem
+        );
+        const decrypted = await decryptTokenPlaceEnvelope(encrypted, relayServerKeys[0].privateKey);
+
+        expect(decrypted).toEqual({ ok: true, source: 'ciphertext' });
     });
 
     test('large encrypted envelopes do not overflow base64 conversion', async () => {

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -43,13 +43,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -61,9 +61,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };
@@ -461,6 +467,9 @@ test.describe('Chat provider routing', () => {
                 cancel_token: expect.any(String),
             })
         );
+        expect(Buffer.from(body.iv, 'base64')).toHaveLength(16);
+        expect(body).not.toHaveProperty('mode');
+        expect(body).not.toHaveProperty('tag');
         const serializedBody = JSON.stringify(body);
         expect(serializedBody).not.toContain('apiKey');
         expect(serializedBody).not.toContain('openAI');

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -37,13 +37,13 @@ async function generateRelayKeypair() {
 }
 
 async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem: string) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -54,9 +54,15 @@ async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };
@@ -202,6 +208,9 @@ test.describe('Chat provider routing', () => {
                 cancel_token: expect.any(String),
             })
         );
+        expect(Buffer.from(request.body.iv, 'base64')).toHaveLength(16);
+        expect(request.body).not.toHaveProperty('mode');
+        expect(request.body).not.toHaveProperty('tag');
         const serializedBody = JSON.stringify(request.body);
         expect(serializedBody).not.toContain('Route my fresh profile through token.place');
         expect(serializedBody).not.toMatch(/apiKey|sk-/i);

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -73,13 +73,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -91,9 +91,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -315,6 +315,9 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         .includes('gcm');
     const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
     const encryptedText = payload.chat_history || payload.ciphertext;
+    if (!encryptedText) {
+        throw new Error('Malformed encrypted token.place response: missing ciphertext field.');
+    }
 
     const plaintext = usesGcm
         ? await decryptGcmTokenPlaceEnvelope({ ...payload, ciphertext: encryptedText }, rawAesKey)

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -271,12 +271,33 @@ const decryptGcmTokenPlaceEnvelope = async (payload, rawAesKey) => {
     );
     const ciphertext = base64ToBytes(payload.ciphertext);
     const tag = payload.tag ? base64ToBytes(payload.tag) : new Uint8Array();
-    const encrypted = tag.length ? new Uint8Array([...ciphertext, ...tag]) : ciphertext;
+    let encrypted;
+    if (tag.length) {
+        encrypted = new Uint8Array(ciphertext.length + tag.length);
+        encrypted.set(ciphertext);
+        encrypted.set(tag, ciphertext.length);
+    } else {
+        encrypted = ciphertext;
+    }
     return getCrypto().subtle.decrypt(
         { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
         aesKey,
         encrypted
     );
+};
+
+const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
+    const decodedKeyText = textDecoder.decode(wrappedAesKey);
+    try {
+        const decodedKey = base64ToBytes(decodedKeyText);
+        if ([16, 24, 32].includes(decodedKey.byteLength)) return decodedKey;
+    } catch {
+        // Fall through to the raw-key compatibility check below.
+    }
+    // Compatibility fallback: current token.place CBC payloads wrap the base64-encoded
+    // AES key, but early/internal payloads may have wrapped the raw 256-bit key bytes.
+    if (wrappedAesKey.byteLength === 32) return new Uint8Array(wrappedAesKey);
+    throw new Error('Malformed encrypted token.place response.');
 };
 
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
@@ -289,16 +310,17 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         privateKey,
         base64ToBytes(payload.cipherkey)
     );
-    const usesGcm =
-        String(payload.mode || '')
-            .toLowerCase()
-            .includes('gcm') && payload.tag;
-    const rawAesKey = usesGcm ? wrappedAesKey : base64ToBytes(textDecoder.decode(wrappedAesKey));
+    const usesGcm = String(payload.mode || '')
+        .toLowerCase()
+        .includes('gcm');
+    const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
     const encryptedText = payload.chat_history || payload.ciphertext;
 
     const plaintext = usesGcm
         ? await decryptGcmTokenPlaceEnvelope({ ...payload, ciphertext: encryptedText }, rawAesKey)
-        : await getCrypto().subtle.decrypt(
+        : // token.place's current relay wire format is AES-CBC without a MAC. Keep this
+          // compatibility path narrow and prefer/restore AEAD (AES-GCM) when the relay declares it.
+          await getCrypto().subtle.decrypt(
               { name: 'AES-CBC', iv: base64ToBytes(payload.iv) },
               await getCrypto().subtle.importKey('raw', rawAesKey, { name: 'AES-CBC' }, false, [
                   'decrypt',

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -241,18 +241,19 @@ export const generateTokenPlaceClientKeypair = async () => {
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
-    const aesKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encodedAesKey = textEncoder.encode(bytesToBase64(rawAesKey));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
     const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, rawAesKey);
+    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, encodedAesKey);
     return {
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
@@ -260,16 +261,7 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
     };
 };
 
-export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const rawAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
+const decryptGcmTokenPlaceEnvelope = async (payload, rawAesKey) => {
     const aesKey = await getCrypto().subtle.importKey(
         'raw',
         rawAesKey,
@@ -277,11 +269,42 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         false,
         ['decrypt']
     );
-    const plaintext = await getCrypto().subtle.decrypt(
+    const ciphertext = base64ToBytes(payload.ciphertext);
+    const tag = payload.tag ? base64ToBytes(payload.tag) : new Uint8Array();
+    const encrypted = tag.length ? new Uint8Array([...ciphertext, ...tag]) : ciphertext;
+    return getCrypto().subtle.decrypt(
         { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
         aesKey,
-        base64ToBytes(payload.ciphertext)
+        encrypted
     );
+};
+
+export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
+    const privateKey =
+        typeof clientPrivateKey === 'string'
+            ? await importRsaPrivateKey(clientPrivateKey)
+            : clientPrivateKey;
+    const wrappedAesKey = await getCrypto().subtle.decrypt(
+        { name: 'RSA-OAEP' },
+        privateKey,
+        base64ToBytes(payload.cipherkey)
+    );
+    const usesGcm =
+        String(payload.mode || '')
+            .toLowerCase()
+            .includes('gcm') && payload.tag;
+    const rawAesKey = usesGcm ? wrappedAesKey : base64ToBytes(textDecoder.decode(wrappedAesKey));
+    const encryptedText = payload.chat_history || payload.ciphertext;
+
+    const plaintext = usesGcm
+        ? await decryptGcmTokenPlaceEnvelope({ ...payload, ciphertext: encryptedText }, rawAesKey)
+        : await getCrypto().subtle.decrypt(
+              { name: 'AES-CBC', iv: base64ToBytes(payload.iv) },
+              await getCrypto().subtle.importKey('raw', rawAesKey, { name: 'AES-CBC' }, false, [
+                  'decrypt',
+              ]),
+              base64ToBytes(encryptedText)
+          );
     return JSON.parse(textDecoder.decode(plaintext));
 };
 


### PR DESCRIPTION
### Motivation
- Token.place relay responses in staging used AES-CBC / PKCS7-style wire format (16-byte IV, base64 ciphertext, RSA-OAEP wrapping of base64 AES key) while DSPACE was encrypting/decrypting using AES-GCM and raw key bytes, causing "Malformed encrypted token.place response." errors.
- The change aims to minimally adapt DSPACE to token.place’s current relay wire format while preserving forward compatibility for explicit GCM-mode payloads.

### Description
- Switch relay envelope encryption to AES-CBC with a 16-byte IV and RSA-OAEP-SHA256 wrapping of the base64-encoded AES key bytes in `frontend/src/utils/tokenPlace.js` and decode responses from `payload.chat_history || payload.ciphertext` by default. 
- Add GCM compatibility: detect explicit `mode`/`tag` and use AES-GCM only when the payload declares it; otherwise treat payloads as CBC. 
- Update unit tests in `frontend/__tests__/tokenPlace.test.js` to return CBC-shaped fixtures (include `chat_history`) and add assertions that outgoing `iv` decodes to 16 bytes and that `mode`/`tag` are absent by default. 
- Update E2E Playwright stubs in `frontend/e2e/{chat-message-flow.spec.ts,chat-provider-routing.spec.ts,token-place-chat-banners.spec.ts}` to emit CBC-shaped encrypted responses with `chat_history`/`ciphertext`, `cipherkey`, and 16-byte `iv`, and add assertions for these invariants.
- Kept response envelope validation and structured `api_v1_response` error handling unchanged and preserved the ciphertext-only outer relay request invariant.

### Testing
- Ran unit tests focused on token.place: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (36 tests). ✅
- Attempted targeted Playwright E2E: `cd frontend && npx playwright test e2e/chat-provider-routing.spec.ts e2e/chat-message-flow.spec.ts e2e/token-place-chat-banners.spec.ts` — blocked by environment network limits while Playwright attempted to install Chromium/system dependencies (failed with `ENETUNREACH` / apt repository connection errors). ⚠️
- Formatting/lint checks: `cd frontend && npm run check` — passed. ✅
- Build: `cd frontend && npm run build` — passed. ✅

Residual risks / follow-ups: run full Playwright E2E in CI or a network-enabled environment to verify runtime behavior end-to-end on staging; if token.place updates to publish GCM-mode responses, current detection will use GCM only when `mode`/`tag` are present so no change is required but we should monitor for wire-format changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376c1edd18832fb95e4b1a42f516e2)