### PR TITLE
Align token.place relay crypto wire format

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -39,6 +39,7 @@ const okResponse = (body = {}) => ({
 
 const decodeBase64Text = (value) =>
     new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
+const decodeBase64Bytes = (value) => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
 
 let relayServerKeys;
 let relayReply = {
@@ -87,6 +88,7 @@ const makeRelayFetch = ({
                 },
                 clientPublicPem
             );
+            encrypted.chat_history = encrypted.ciphertext;
             return { ok: true, status: 200, json: () => Promise.resolve(encrypted) };
         }
         if (url.endsWith('/api/v1/relay/requests/cancel')) {
@@ -278,9 +280,41 @@ describe('token.place API v1 client', () => {
                 cancel_token: expect.any(String),
             })
         );
+        expect(decodeBase64Bytes(body.iv)).toHaveLength(16);
+        expect(body).not.toHaveProperty('mode');
+        expect(body).not.toHaveProperty('tag');
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('decrypt accepts token.place CBC response ciphertext from chat_history or ciphertext', async () => {
+        const envelope = {
+            protocol: 'tokenplace_api_v1_relay_e2ee',
+            version: 1,
+            request_id: 'request-cbc',
+            client_public_key: relayServerKeys[0].publicKeyBase64,
+            api_v1_response: { choices: [{ message: { content: 'cbc reply' } }] },
+        };
+        const encrypted = await encryptTokenPlaceEnvelope(
+            envelope,
+            relayServerKeys[0].publicKeyPem
+        );
+
+        await expect(
+            decryptTokenPlaceEnvelope(
+                { ...encrypted, chat_history: encrypted.ciphertext },
+                relayServerKeys[0].privateKey
+            )
+        ).resolves.toEqual(envelope);
+
+        const { chat_history: _chatHistory, ...ciphertextOnly } = {
+            ...encrypted,
+            chat_history: encrypted.ciphertext,
+        };
+        await expect(
+            decryptTokenPlaceEnvelope(ciphertextOnly, relayServerKeys[0].privateKey)
+        ).resolves.toEqual(envelope);
     });
 
     test('decrypted API v1 request nests metadata under options', async () => {

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -43,13 +43,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -61,8 +61,13 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
     return {
+        chat_history: bytesToBase64(ciphertext),
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -37,13 +37,13 @@ async function generateRelayKeypair() {
 }
 
 async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem: string) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -54,8 +54,13 @@ async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
     return {
+        chat_history: bytesToBase64(ciphertext),
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -73,13 +73,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -91,8 +91,13 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
     return {
+        chat_history: bytesToBase64(ciphertext),
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -239,20 +239,27 @@ export const generateTokenPlaceClientKeypair = async () => {
     };
 };
 
+const isGcmRelayPayload = (payload) =>
+    String(payload?.mode || '').toLowerCase() === 'gcm' && typeof payload?.tag === 'string';
+
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
-    const aesKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
     const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, rawAesKey);
+    const cipherkey = await crypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        serverKey,
+        textEncoder.encode(bytesToBase64(rawAesKey))
+    );
     return {
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
@@ -265,22 +272,29 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         typeof clientPrivateKey === 'string'
             ? await importRsaPrivateKey(clientPrivateKey)
             : clientPrivateKey;
-    const rawAesKey = await getCrypto().subtle.decrypt(
+    const wrappedAesKey = await getCrypto().subtle.decrypt(
         { name: 'RSA-OAEP' },
         privateKey,
         base64ToBytes(payload.cipherkey)
     );
+    const rawAesKey = isGcmRelayPayload(payload)
+        ? wrappedAesKey
+        : base64ToBytes(textDecoder.decode(wrappedAesKey));
+    const algorithmName = isGcmRelayPayload(payload) ? 'AES-GCM' : 'AES-CBC';
     const aesKey = await getCrypto().subtle.importKey(
         'raw',
         rawAesKey,
-        { name: 'AES-GCM' },
+        { name: algorithmName },
         false,
         ['decrypt']
     );
+    const ciphertext = isGcmRelayPayload(payload)
+        ? new Uint8Array([...base64ToBytes(payload.ciphertext), ...base64ToBytes(payload.tag)])
+        : base64ToBytes(payload.chat_history || payload.ciphertext);
     const plaintext = await getCrypto().subtle.decrypt(
-        { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
+        { name: algorithmName, iv: base64ToBytes(payload.iv) },
         aesKey,
-        base64ToBytes(payload.ciphertext)
+        ciphertext
     );
     return JSON.parse(textDecoder.decode(plaintext));
 };


### PR DESCRIPTION
### Motivation
- Make DSPACE relay E2EE compatible with token.place’s current wire format (desktop/relay) which uses AES-CBC with PKCS7 padding, 16-byte IV, and RSA-OAEP-SHA256 wrapping of the base64 AES key bytes.

### Description
- Switch relay envelope encryption to AES-CBC with a 16-byte IV and RSA-OAEP wrapping of `bytesToBase64(rawAesKey)` instead of raw key bytes, preserving ciphertext-only outer relay request shape.
- Change response decryption to prefer `payload.chat_history || payload.ciphertext`, default to CBC when no `mode`/`tag` are present, and keep explicit AES-GCM support when `mode`/`tag` indicate GCM.
- Update unit tests and Playwright relay stubs to emit CBC-shaped responses (include `chat_history`, `ciphertext`, `cipherkey`, and 16-byte `iv`) and add assertions for `iv` length and absence of default `mode`/`tag`.
- Files modified: `frontend/src/utils/tokenPlace.js`, `frontend/__tests__/tokenPlace.test.js`, and the three E2E stubs under `frontend/e2e/` touched to produce CBC fixtures.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — passed (35 tests, all green).
- Ran e2e Playwright targets: `cd frontend && npx playwright test e2e/chat-provider-routing.spec.ts e2e/chat-message-flow.spec.ts e2e/token-place-chat-banners.spec.ts` — blocked by environment/browser setup failures (Playwright failed to install Chromium and system deps due to `ENETUNREACH` network errors), so E2E was not executed to completion.
- Formatting/lint/build checks: `cd frontend && npm run check` — passed; `cd frontend && npm run build` — passed.

Residual risks & follow-ups: verify staging manually after deployment following the acceptance steps (ensure GET `/api/v1/relay/servers/next`, POST `/api/v1/relay/requests`, and POST `/api/v1/relay/responses/retrieve` return expected shapes and DSPACE decrypts responses), and re-run Playwright E2E in CI (networked environment) to confirm end-to-end behavior once browsers can be installed. Optional future work: keep AES-GCM handling for payloads that explicitly include `mode`/`tag` (already implemented).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376c253be4832f87fd8551fab2f1b1)