### PR TITLE
Align token.place relay E2EE wire format

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -37,8 +37,8 @@ const okResponse = (body = {}) => ({
         }),
 });
 
-const decodeBase64Text = (value) =>
-    new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
+const decodeBase64Bytes = (value) => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+const decodeBase64Text = (value) => new TextDecoder().decode(decodeBase64Bytes(value));
 
 let relayServerKeys;
 let relayReply = {
@@ -49,6 +49,7 @@ const makeRelayFetch = ({
     retrieveStatuses = [200],
     serverFailureOnce = false,
     accepted = true,
+    responseCiphertextField = 'chat_history',
 } = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
@@ -87,7 +88,15 @@ const makeRelayFetch = ({
                 },
                 clientPublicPem
             );
-            return { ok: true, status: 200, json: () => Promise.resolve(encrypted) };
+            const responseBody =
+                responseCiphertextField === 'chat_history'
+                    ? {
+                          ...encrypted,
+                          chat_history: encrypted.ciphertext,
+                          ciphertext: encrypted.ciphertext,
+                      }
+                    : encrypted;
+            return { ok: true, status: 200, json: () => Promise.resolve(responseBody) };
         }
         if (url.endsWith('/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
@@ -280,7 +289,22 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(decodeBase64Bytes(body.iv)).toHaveLength(16);
+        expect(body).not.toHaveProperty('mode');
+        expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('decrypt accepts chat_history ciphertext fallback and ciphertext without chat_history', async () => {
+        global.fetch = makeRelayFetch({ responseCiphertextField: 'chat_history' });
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked reply'
+        );
+
+        global.fetch = makeRelayFetch({ responseCiphertextField: 'ciphertext' });
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked reply'
+        );
     });
 
     test('decrypted API v1 request nests metadata under options', async () => {
@@ -563,6 +587,9 @@ describe('token.place API v1 client', () => {
         expect(serialized).not.toContain('PLAYERSTATE_SECRET_SENTINEL');
         expect(serialized).not.toContain('DOCS_GROUNDING_SECRET_SENTINEL');
         expect(serialized).not.toContain('INVENTORY_SAVE_SECRET_SENTINEL');
+        expect(serialized).not.toContain('PlayerState');
+        expect(serialized).not.toContain('inventory');
+        expect(serialized).not.toContain('save');
         expect(serialized).not.toContain('messages');
     });
 

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -43,13 +43,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -61,9 +61,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -37,13 +37,13 @@ async function generateRelayKeypair() {
 }
 
 async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem: string) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -54,9 +54,15 @@ async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -73,13 +73,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -91,9 +91,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const encodedCiphertext = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: encodedCiphertext,
+        ciphertext: encodedCiphertext,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -20,6 +20,8 @@ const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const AES_CBC_IV_BYTES = 16;
+const AES_GCM_IV_BYTES = 12;
 
 const readEnvValue = (key) => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
@@ -241,18 +243,19 @@ export const generateTokenPlaceClientKeypair = async () => {
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
-    const aesKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iv = crypto.getRandomValues(new Uint8Array(AES_CBC_IV_BYTES));
     const ciphertext = await crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
     const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, rawAesKey);
+    const wrappedKeyBytes = textEncoder.encode(bytesToBase64(rawAesKey));
+    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, wrappedKeyBytes);
     return {
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
@@ -260,27 +263,51 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
     };
 };
 
+const unwrapTokenPlaceAesKey = async (payload, privateKey) => {
+    const unwrapped = await getCrypto().subtle.decrypt(
+        { name: 'RSA-OAEP' },
+        privateKey,
+        base64ToBytes(payload.cipherkey)
+    );
+    const unwrappedText = textDecoder.decode(unwrapped);
+    return /^[A-Za-z0-9+/]+={0,2}$/.test(unwrappedText.trim())
+        ? base64ToBytes(unwrappedText)
+        : unwrapped;
+};
+
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
     const privateKey =
         typeof clientPrivateKey === 'string'
             ? await importRsaPrivateKey(clientPrivateKey)
             : clientPrivateKey;
-    const rawAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
+    const ciphertext = payload.chat_history || payload.ciphertext;
+    const rawAesKey = await unwrapTokenPlaceAesKey(payload, privateKey);
+    const explicitGcm =
+        String(payload.mode || '')
+            .toLowerCase()
+            .includes('gcm') && payload.tag;
+    const algorithm = explicitGcm ? 'AES-GCM' : 'AES-CBC';
     const aesKey = await getCrypto().subtle.importKey(
         'raw',
         rawAesKey,
-        { name: 'AES-GCM' },
+        { name: algorithm },
         false,
         ['decrypt']
     );
+    const iv = base64ToBytes(payload.iv);
+    const encryptedBytes = base64ToBytes(ciphertext);
     const plaintext = await getCrypto().subtle.decrypt(
-        { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
+        explicitGcm
+            ? {
+                  name: 'AES-GCM',
+                  iv: iv.length ? iv : new Uint8Array(AES_GCM_IV_BYTES),
+                  tagLength: 128,
+              }
+            : { name: 'AES-CBC', iv: iv.length ? iv : new Uint8Array(AES_CBC_IV_BYTES) },
         aesKey,
-        base64ToBytes(payload.ciphertext)
+        explicitGcm
+            ? new Uint8Array([...encryptedBytes, ...base64ToBytes(payload.tag)])
+            : encryptedBytes
     );
     return JSON.parse(textDecoder.decode(plaintext));
 };


### PR DESCRIPTION
### Motivation
- DSPACE was using AES-GCM and raw-key wrapping for token.place relay envelopes, which is incompatible with token.place’s existing desktop/relay wire format (AES-CBC, 16-byte IV, RSA-OAEP wrapping of base64 AES key), causing "Malformed encrypted token.place response.".
- The change must be minimal, preserve the ciphertext-only outer relay request invariant, and keep the existing response envelope validation and structured provider error handling.

### Description
- Switch relay envelope encryption/decryption to AES-CBC with a 16-byte IV and RSA-OAEP wrapping of the base64-encoded AES key bytes, while retaining AES-GCM only when a payload explicitly includes `mode`/`tag` indicating GCM.
- Accept `payload.chat_history || payload.ciphertext` when decrypting responses and continue to use `cipherkey` and `iv` as base64-encoded RSA ciphertext and 16-byte IV respectively.
- Update the unit test fixtures and assertions in `frontend/__tests__/tokenPlace.test.js` to produce and validate CBC-shaped responses, including explicit assertions that outbound `iv` decodes to 16 bytes and that no default `mode`/`tag` are present.
- Update E2E test stubs in `frontend/e2e/*` to emit CBC-compatible relay responses (`chat_history`/`ciphertext`, `cipherkey`, 16-byte `iv`) so the test harness matches token.place’s current wire format.

### Testing
- Ran `cd frontend && npm test -- tokenPlace.test.js`, and the unit test file passed (35 tests) without failures.
- Attempted `cd frontend && npx playwright test e2e/chat-provider-routing.spec.ts e2e/chat-message-flow.spec.ts e2e/token-place-chat-banners.spec.ts`, but Playwright browser installation failed due to environment network errors (`ENETUNREACH`), so E2E tests could not be executed in this environment.
- Ran `cd frontend && npm run check`, and lint/format checks passed.
- Ran `cd frontend && npm run build`, and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376c31f37c832fb4ebcbcf6e92be1d)