### PR TITLE
Make token.place relay E2EE compatible with token.place CBC wire format

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -37,8 +37,8 @@ const okResponse = (body = {}) => ({
         }),
 });
 
-const decodeBase64Text = (value) =>
-    new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
+const base64ToBytes = (value) => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+const decodeBase64Text = (value) => new TextDecoder().decode(base64ToBytes(value));
 
 let relayServerKeys;
 let relayReply = {
@@ -49,6 +49,7 @@ const makeRelayFetch = ({
     retrieveStatuses = [200],
     serverFailureOnce = false,
     accepted = true,
+    responseCiphertextField = 'ciphertext',
 } = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
@@ -87,7 +88,15 @@ const makeRelayFetch = ({
                 },
                 clientPublicPem
             );
-            return { ok: true, status: 200, json: () => Promise.resolve(encrypted) };
+            const response =
+                responseCiphertextField === 'chat_history'
+                    ? { ...encrypted, chat_history: encrypted.ciphertext }
+                    : encrypted;
+            if (responseCiphertextField === 'chat_history_only') {
+                response.chat_history = response.ciphertext;
+                delete response.ciphertext;
+            }
+            return { ok: true, status: 200, json: () => Promise.resolve(response) };
         }
         if (url.endsWith('/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
@@ -280,6 +289,9 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(base64ToBytes(body.iv)).toHaveLength(16);
+        expect(body).not.toHaveProperty('mode');
+        expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
     });
 
@@ -304,6 +316,22 @@ describe('token.place API v1 client', () => {
             })
         );
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+    });
+
+    test('decrypt accepts chat_history ciphertext when ciphertext is absent', async () => {
+        global.fetch = makeRelayFetch({ responseCiphertextField: 'chat_history_only' });
+
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked reply'
+        );
+    });
+
+    test('decrypt accepts ciphertext when chat_history is absent', async () => {
+        global.fetch = makeRelayFetch({ responseCiphertextField: 'ciphertext' });
+
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked reply'
+        );
     });
 
     test('large encrypted envelopes do not overflow base64 conversion', async () => {

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -43,13 +43,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -61,9 +61,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const ciphertextBase64 = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: ciphertextBase64,
+        ciphertext: ciphertextBase64,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -37,13 +37,13 @@ async function generateRelayKeypair() {
 }
 
 async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem: string) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -54,9 +54,15 @@ async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const ciphertextBase64 = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: ciphertextBase64,
+        ciphertext: ciphertextBase64,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -73,13 +73,13 @@ async function encryptRelayEnvelope(
     envelope: Record<string, unknown>,
     clientPublicKeyBase64: string
 ) {
-    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await webcrypto.subtle.exportKey('raw', aesKey);
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await webcrypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
@@ -91,9 +91,15 @@ async function encryptRelayEnvelope(
         true,
         ['encrypt']
     );
-    const cipherkey = await webcrypto.subtle.encrypt({ name: 'RSA-OAEP' }, publicKey, rawAesKey);
+    const cipherkey = await webcrypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        publicKey,
+        encoder.encode(bytesToBase64(rawAesKey))
+    );
+    const ciphertextBase64 = bytesToBase64(ciphertext);
     return {
-        ciphertext: bytesToBase64(ciphertext),
+        chat_history: ciphertextBase64,
+        ciphertext: ciphertextBase64,
         cipherkey: bytesToBase64(cipherkey),
         iv: bytesToBase64(iv),
     };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -241,18 +241,22 @@ export const generateTokenPlaceClientKeypair = async () => {
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
-    const aesKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    const aesKey = await crypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
     const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, rawAesKey);
+    const cipherkey = await crypto.subtle.encrypt(
+        { name: 'RSA-OAEP' },
+        serverKey,
+        textEncoder.encode(bytesToBase64(rawAesKey))
+    );
     return {
         ciphertext: bytesToBase64(ciphertext),
         cipherkey: bytesToBase64(cipherkey),
@@ -260,16 +264,7 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
     };
 };
 
-export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const rawAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
+const decryptAesGcmTokenPlaceEnvelope = async (payload, rawAesKey) => {
     const aesKey = await getCrypto().subtle.importKey(
         'raw',
         rawAesKey,
@@ -277,11 +272,47 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         false,
         ['decrypt']
     );
-    const plaintext = await getCrypto().subtle.decrypt(
+    const ciphertext = payload.tag
+        ? new Uint8Array([...base64ToBytes(payload.ciphertext), ...base64ToBytes(payload.tag)])
+        : base64ToBytes(payload.ciphertext);
+    return getCrypto().subtle.decrypt(
         { name: 'AES-GCM', iv: base64ToBytes(payload.iv) },
         aesKey,
-        base64ToBytes(payload.ciphertext)
+        ciphertext
     );
+};
+
+const decryptAesCbcTokenPlaceEnvelope = async (payload, rawAesKey) => {
+    const aesKey = await getCrypto().subtle.importKey(
+        'raw',
+        rawAesKey,
+        { name: 'AES-CBC' },
+        false,
+        ['decrypt']
+    );
+    return getCrypto().subtle.decrypt(
+        { name: 'AES-CBC', iv: base64ToBytes(payload.iv) },
+        aesKey,
+        base64ToBytes(payload.chat_history || payload.ciphertext)
+    );
+};
+
+export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
+    const privateKey =
+        typeof clientPrivateKey === 'string'
+            ? await importRsaPrivateKey(clientPrivateKey)
+            : clientPrivateKey;
+    const wrappedAesKey = await getCrypto().subtle.decrypt(
+        { name: 'RSA-OAEP' },
+        privateKey,
+        base64ToBytes(payload.cipherkey)
+    );
+    const rawAesKey = /gcm/i.test(String(payload.mode || ''))
+        ? wrappedAesKey
+        : base64ToBytes(textDecoder.decode(wrappedAesKey));
+    const plaintext = /gcm/i.test(String(payload.mode || ''))
+        ? await decryptAesGcmTokenPlaceEnvelope(payload, rawAesKey)
+        : await decryptAesCbcTokenPlaceEnvelope(payload, rawAesKey);
     return JSON.parse(textDecoder.decode(plaintext));
 };
 


### PR DESCRIPTION
### Motivation
- The relay responses from token.place use AES-CBC with PKCS7 padding, a 16-byte IV, and RSA-OAEP-SHA256 wrapping of the base64-encoded AES key bytes, so DSPACE must match that wire format to decrypt compute-node replies.
- DSPACE previously used AES-GCM with a 12-byte IV and wrapped raw AES key bytes, causing "Malformed encrypted token.place response." errors when reading current token.place relay responses.

### Description
- Switched envelope encryption to AES-CBC with a 16-byte IV and RSA-OAEP wrapping of the base64-encoded AES key bytes in `frontend/src/utils/tokenPlace.js` and made decryption accept both CBC (default) and explicit GCM payloads when `mode`/`tag` are present. 
- Updated decryption to accept `payload.chat_history || payload.ciphertext` as the ciphertext source and preserved existing envelope validation and structured `api_v1_response` error handling. 
- Kept the outer relay request ciphertext-only invariant and unchanged protocol/version/field checks. 
- Updated unit tests and Playwright E2E stubs to emit/consume token.place’s existing CBC-shaped relay format and added assertions for 16-byte IVs and absence of `mode`/`tag` by default. Files changed: `frontend/src/utils/tokenPlace.js`, `frontend/__tests__/tokenPlace.test.js`, and the three E2E stubs under `frontend/e2e/` listed in scope.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — PASS (36 tests, all green). 
- Ran lint/format checks: `cd frontend && npm run check` — PASS (prettier/ESLint checks OK). 
- Built the frontend: `cd frontend && npm run build` — PASS (Astro build completed). 
- Attempted targeted E2E: `cd frontend && npx playwright test e2e/chat-provider-routing.spec.ts e2e/chat-message-flow.spec.ts e2e/token-place-chat-banners.spec.ts` — WARN (blocked in this environment because Playwright attempted to download browsers and failed with network `ENETUNREACH`; stubs were updated to CBC format but full Playwright run could not complete here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376c3a0434832f97226b9cf74206c2)