### PR TITLE
Mirror token.place RSA wrapping (JSEncrypt) for relay E2EE compatibility

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1054,33 +1054,33 @@ Local-mode validation status (March 20, 2026):
 - [x] Chat page loads and persona picker works
       ([<chat-persona-switching.spec.ts:shows persona-specific summaries and welcome prompts>](../../frontend/e2e/chat-persona-switching.spec.ts#L33))
 - [x] Sending a message:
-      ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
+      ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L193-L199))
   - [x] Shows loading state
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L193-L199))
   - [x] Returns a reply
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L193-L199))
   - [x] Handles long replies (scroll, wrap, etc.)
-        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L196-L202))
+        ([<chat-message-flow.spec.ts:shows loading state and renders assistant replies>](../../frontend/e2e/chat-message-flow.spec.ts#L193-L199))
 - [x] Error handling:
-      ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L204-L218),
-      [<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L220-L231),
-      [<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L246-L257),
-      [<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L259-L270),
-      [<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L272-L283),
-      [<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L285-L296))
+      ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L201-L215),
+      [<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L217-L228),
+      [<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L243-L254),
+      [<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L256-L267),
+      [<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L269-L280),
+      [<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L282-L293))
   - [x] Network failure shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L204-L218))
+        ([<chat-message-flow.spec.ts:shows user-facing error when network requests fail>](../../frontend/e2e/chat-message-flow.spec.ts#L201-L215))
   - [x] Invalid API key shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L246-L257))
+        ([<chat-message-flow.spec.ts:surfaces API key errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L243-L254))
   - [x] Rate limit / quota shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L220-L231),
-        [<chat-message-flow.spec.ts:surfaces quota errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L233-L244))
+        ([<chat-message-flow.spec.ts:surfaces rate limit errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L217-L228),
+        [<chat-message-flow.spec.ts:surfaces quota errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L230-L241))
   - [x] Model access / permissions error shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L259-L270))
+        ([<chat-message-flow.spec.ts:surfaces model access errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L256-L267))
   - [x] Provider 5xx outage shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L272-L283))
+        ([<chat-message-flow.spec.ts:surfaces provider outages without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L269-L280))
   - [x] Unknown error shows a dedicated banner message above the chat UI
-        ([<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L285-L296))
+        ([<chat-message-flow.spec.ts:surfaces unknown errors without getting stuck>](../../frontend/e2e/chat-message-flow.spec.ts#L282-L293))
 
 ### 9.2 Provider verification (v3 ships OpenAI; token.place postponed)
 
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L848-L862))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L921-L935))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -24,6 +24,7 @@ const {
     resolveTokenPlaceBaseUrl,
     tokenPlaceChat,
 } = await import('../src/utils/tokenPlace.js');
+const { JSEncrypt } = await import('jsencrypt');
 const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
 const { buildChatPrompt } = await import('../src/utils/openAI.js');
 
@@ -379,6 +380,52 @@ describe('token.place API v1 client', () => {
         await expect(
             decryptTokenPlaceEnvelope(payload, relayServerKeys[0].privateKey)
         ).rejects.toThrow('Malformed encrypted token.place response: missing ciphertext field.');
+    });
+
+    test('decryption rejects JSEncrypt-wrapped AES keys with invalid decoded length', async () => {
+        const rsa = new JSEncrypt();
+        rsa.setPublicKey(relayServerKeys[0].publicKeyPem);
+        const cipherkey = rsa.encrypt(bytesToBase64(new Uint8Array(8)));
+
+        await expect(
+            decryptTokenPlaceEnvelope(
+                {
+                    ciphertext: bytesToBase64(new Uint8Array(16)),
+                    cipherkey,
+                    iv: bytesToBase64(new Uint8Array(16)),
+                },
+                relayServerKeys[0].privateKey
+            )
+        ).rejects.toThrow('Malformed encrypted token.place response.');
+    });
+
+    test('decryption accepts explicit GCM payloads with JSEncrypt-wrapped raw text keys', async () => {
+        const crypto = globalThis.crypto;
+        const rawAesKey = new TextEncoder().encode('12345678901234567890123456789012');
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
+            'encrypt',
+        ]);
+        const ciphertext = await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv },
+            aesKey,
+            new TextEncoder().encode(JSON.stringify({ ok: true, mode: 'jsencrypt-gcm' }))
+        );
+        const rsa = new JSEncrypt();
+        rsa.setPublicKey(relayServerKeys[0].publicKeyPem);
+        const cipherkey = rsa.encrypt(new TextDecoder().decode(rawAesKey));
+
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                mode: 'AES-GCM',
+                ciphertext: bytesToBase64(ciphertext),
+                cipherkey,
+                iv: bytesToBase64(iv),
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(decrypted).toEqual({ ok: true, mode: 'jsencrypt-gcm' });
     });
 
     test('decryption accepts explicit GCM payloads with embedded WebCrypto tags', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -286,6 +286,7 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(decodeBase64Text(body.client_public_key)).toMatch(/^-----BEGIN PUBLIC KEY-----/);
         expect(Uint8Array.from(atob(body.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
@@ -332,6 +333,29 @@ describe('token.place API v1 client', () => {
         expect(decrypted).toEqual({ ok: true, source: 'chat_history' });
     });
 
+    test('decryption accepts token.place static-chat compatible CBC relay response shape', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            { ok: true, source: 'static-chat-compatible' },
+            relayServerKeys[0].publicKeyPem
+        );
+        const fixture = {
+            chat_history: encrypted.ciphertext,
+            ciphertext: encrypted.ciphertext,
+            cipherkey: encrypted.cipherkey,
+            iv: encrypted.iv,
+        };
+
+        expect(Uint8Array.from(atob(fixture.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
+        expect(fixture).not.toHaveProperty('mode');
+        expect(fixture).not.toHaveProperty('tag');
+        await expect(
+            decryptTokenPlaceEnvelope(fixture, relayServerKeys[0].privateKey)
+        ).resolves.toEqual({
+            ok: true,
+            source: 'static-chat-compatible',
+        });
+    });
+
     test('decryption accepts ciphertext when chat_history is absent', async () => {
         const encrypted = await encryptTokenPlaceEnvelope(
             { ok: true, source: 'ciphertext' },
@@ -371,7 +395,7 @@ describe('token.place API v1 client', () => {
         );
         const cipherkey = await crypto.subtle.encrypt(
             { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
+            relayServerKeys[0].publicKeyCrypto,
             rawAesKey
         );
 
@@ -382,7 +406,7 @@ describe('token.place API v1 client', () => {
                 cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
-            relayServerKeys[0].privateKey
+            relayServerKeys[0].privateKeyCrypto
         );
 
         expect(decrypted).toEqual({ ok: true, mode: 'embedded-gcm-tag' });
@@ -406,7 +430,7 @@ describe('token.place API v1 client', () => {
         const tag = encrypted.slice(-16);
         const cipherkey = await crypto.subtle.encrypt(
             { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
+            relayServerKeys[0].publicKeyCrypto,
             rawAesKey
         );
 
@@ -418,7 +442,7 @@ describe('token.place API v1 client', () => {
                 cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
-            relayServerKeys[0].privateKey
+            relayServerKeys[0].privateKeyCrypto
         );
 
         expect(decrypted).toEqual({ ok: true, mode: 'separate-gcm-tag' });
@@ -438,7 +462,7 @@ describe('token.place API v1 client', () => {
         );
         const cipherkey = await crypto.subtle.encrypt(
             { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
+            relayServerKeys[0].publicKeyCrypto,
             rawAesKey
         );
 
@@ -448,7 +472,7 @@ describe('token.place API v1 client', () => {
                 cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
-            relayServerKeys[0].privateKey
+            relayServerKeys[0].privateKeyCrypto
         );
 
         expect(decrypted).toEqual({ ok: true, key: 'raw' });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -399,9 +399,9 @@ describe('token.place API v1 client', () => {
         ).rejects.toThrow('Malformed encrypted token.place response.');
     });
 
-    test('decryption accepts explicit GCM payloads with JSEncrypt-wrapped raw text keys', async () => {
+    test('decryption accepts explicit GCM payloads with PEM private keys', async () => {
         const crypto = globalThis.crypto;
-        const rawAesKey = new TextEncoder().encode('12345678901234567890123456789012');
+        const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
             'encrypt',
@@ -409,23 +409,25 @@ describe('token.place API v1 client', () => {
         const ciphertext = await crypto.subtle.encrypt(
             { name: 'AES-GCM', iv },
             aesKey,
-            new TextEncoder().encode(JSON.stringify({ ok: true, mode: 'jsencrypt-gcm' }))
+            new TextEncoder().encode(JSON.stringify({ ok: true, mode: 'pem-gcm' }))
         );
-        const rsa = new JSEncrypt();
-        rsa.setPublicKey(relayServerKeys[0].publicKeyPem);
-        const cipherkey = rsa.encrypt(new TextDecoder().decode(rawAesKey));
+        const cipherkey = await crypto.subtle.encrypt(
+            { name: 'RSA-OAEP' },
+            relayServerKeys[0].publicKeyCrypto,
+            rawAesKey
+        );
 
         const decrypted = await decryptTokenPlaceEnvelope(
             {
                 mode: 'AES-GCM',
                 ciphertext: bytesToBase64(ciphertext),
-                cipherkey,
+                cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
             relayServerKeys[0].privateKey
         );
 
-        expect(decrypted).toEqual({ ok: true, mode: 'jsencrypt-gcm' });
+        expect(decrypted).toEqual({ ok: true, mode: 'pem-gcm' });
     });
 
     test('decryption accepts explicit GCM payloads with embedded WebCrypto tags', async () => {

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from 'node:crypto';
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -17,11 +17,8 @@ const SERVER_MESSAGE = /unavailable right now/i;
 const encoder = new TextEncoder();
 const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
     Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
-const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
 const base64ToPem = (base64: string) =>
     `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
-const pemToBase64 = (pem: string) =>
-    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
 
 async function generateRelayKeypair() {
     const pair = await webcrypto.subtle.generateKey(
@@ -54,23 +51,17 @@ async function encryptRelayEnvelope(
         encoder.encode(JSON.stringify(envelope))
     );
     const clientPublicPem = Buffer.from(clientPublicKeyBase64, 'base64').toString('utf8');
-    const publicKey = await webcrypto.subtle.importKey(
-        'spki',
-        base64ToBytes(pemToBase64(clientPublicPem)),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['encrypt']
-    );
-    const cipherkey = await webcrypto.subtle.encrypt(
-        { name: 'RSA-OAEP' },
-        publicKey,
-        encoder.encode(bytesToBase64(rawAesKey))
+    const cipherkey = bytesToBase64(
+        publicEncrypt(
+            { key: clientPublicPem, padding: constants.RSA_PKCS1_PADDING },
+            Buffer.from(bytesToBase64(rawAesKey), 'utf8')
+        )
     );
     const encodedCiphertext = bytesToBase64(ciphertext);
     return {
         chat_history: encodedCiphertext,
         ciphertext: encodedCiphertext,
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey,
         iv: bytesToBase64(iv),
     };
 }

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from 'node:crypto';
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -14,11 +14,8 @@ type CapturedRequest = {
 const encoder = new TextEncoder();
 const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
     Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
-const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
 const base64ToPem = (base64: string) =>
     `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
-const pemToBase64 = (pem: string) =>
-    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
 
 async function generateRelayKeypair() {
     const pair = await webcrypto.subtle.generateKey(
@@ -47,23 +44,17 @@ async function encryptRelayEnvelope(envelope: Record<string, unknown>, publicPem
         aesKey,
         encoder.encode(JSON.stringify(envelope))
     );
-    const publicKey = await webcrypto.subtle.importKey(
-        'spki',
-        base64ToBytes(pemToBase64(publicPem)),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['encrypt']
-    );
-    const cipherkey = await webcrypto.subtle.encrypt(
-        { name: 'RSA-OAEP' },
-        publicKey,
-        encoder.encode(bytesToBase64(rawAesKey))
+    const cipherkey = bytesToBase64(
+        publicEncrypt(
+            { key: publicPem, padding: constants.RSA_PKCS1_PADDING },
+            Buffer.from(bytesToBase64(rawAesKey), 'utf8')
+        )
     );
     const encodedCiphertext = bytesToBase64(ciphertext);
     return {
         chat_history: encodedCiphertext,
         ciphertext: encodedCiphertext,
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey,
         iv: bytesToBase64(iv),
     };
 }

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from 'node:crypto';
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -16,11 +16,8 @@ type TokenPlaceStubMode =
 const encoder = new TextEncoder();
 const bytesToBase64 = (bytes: ArrayBuffer | Uint8Array) =>
     Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
-const base64ToBytes = (value: string) => Uint8Array.from(Buffer.from(value, 'base64'));
 const base64ToPem = (base64: string) =>
     `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
-const pemToBase64 = (pem: string) =>
-    pem.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
 
 const relayErrorResponse = (mode: TokenPlaceStubMode) => {
     if (mode === 'content-policy') {
@@ -84,23 +81,17 @@ async function encryptRelayEnvelope(
         encoder.encode(JSON.stringify(envelope))
     );
     const clientPublicPem = Buffer.from(clientPublicKeyBase64, 'base64').toString('utf8');
-    const publicKey = await webcrypto.subtle.importKey(
-        'spki',
-        base64ToBytes(pemToBase64(clientPublicPem)),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['encrypt']
-    );
-    const cipherkey = await webcrypto.subtle.encrypt(
-        { name: 'RSA-OAEP' },
-        publicKey,
-        encoder.encode(bytesToBase64(rawAesKey))
+    const cipherkey = bytesToBase64(
+        publicEncrypt(
+            { key: clientPublicPem, padding: constants.RSA_PKCS1_PADDING },
+            Buffer.from(bytesToBase64(rawAesKey), 'utf8')
+        )
     );
     const encodedCiphertext = bytesToBase64(ciphertext);
     return {
         chat_history: encodedCiphertext,
         ciphertext: encodedCiphertext,
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey,
         iv: bytesToBase64(iv),
     };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,6 +105,7 @@
         "fake-indexeddb": "^6.1.0",
         "highlight.js": "^11.8.0",
         "jsdom": "^21.1.1",
+        "jsencrypt": "^3.5.4",
         "markdown-it": "^13.0.1",
         "marked": "^4.3.0",
         "minisearch": "^7.2.0",

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -234,12 +234,37 @@ const encryptTokenPlaceCipherkey = (aesKeyBase64, publicKeyPem) => {
     return cipherkey;
 };
 
-const decryptTokenPlaceCipherkey = (cipherkey, privateKeyPem) => {
+const isValidAesKeySize = (bytes) => [16, 24, 32].includes(bytes.byteLength);
+
+const decodeBase64AesKey = (value) => {
+    const normalized = String(value || '').trim();
+    if (!normalized) throw new Error('Malformed encrypted token.place response.');
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized) || normalized.length % 4 !== 0) {
+        throw new Error('Malformed encrypted token.place response.');
+    }
+    const decodedKey = base64ToBytes(normalized);
+    if (!isValidAesKeySize(decodedKey)) {
+        throw new Error('Malformed encrypted token.place response.');
+    }
+    return decodedKey;
+};
+
+const decryptTokenPlaceCipherkey = (cipherkey, privateKeyPem, { usesGcm = false } = {}) => {
     const rsa = new JSEncrypt();
     rsa.setPrivateKey(privateKeyPem);
-    const aesKeyBase64 = rsa.decrypt(cipherkey);
-    if (!aesKeyBase64) throw new Error('Malformed encrypted token.place response.');
-    return base64ToBytes(aesKeyBase64);
+    const decryptedKey = rsa.decrypt(cipherkey);
+    if (!decryptedKey) throw new Error('Malformed encrypted token.place response.');
+    if (usesGcm) {
+        const rawKey = textEncoder.encode(decryptedKey);
+        if (isValidAesKeySize(rawKey)) return rawKey;
+    }
+    try {
+        return decodeBase64AesKey(decryptedKey);
+    } catch (error) {
+        const rawKey = textEncoder.encode(decryptedKey);
+        if (!usesGcm && rawKey.byteLength === 32) return rawKey;
+        throw error;
+    }
 };
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
@@ -291,7 +316,7 @@ const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
     const decodedKeyText = textDecoder.decode(wrappedAesKey);
     try {
         const decodedKey = base64ToBytes(decodedKeyText);
-        if ([16, 24, 32].includes(decodedKey.byteLength)) return decodedKey;
+        if (isValidAesKeySize(decodedKey)) return decodedKey;
     } catch {
         // Fall through to the raw-key compatibility check below.
     }
@@ -307,7 +332,7 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         .includes('gcm');
     let rawAesKey;
     if (typeof clientPrivateKey === 'string') {
-        rawAesKey = decryptTokenPlaceCipherkey(payload.cipherkey, clientPrivateKey);
+        rawAesKey = decryptTokenPlaceCipherkey(payload.cipherkey, clientPrivateKey, { usesGcm });
     } else {
         const wrappedAesKey = await getCrypto().subtle.decrypt(
             { name: 'RSA-OAEP' },

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -249,23 +249,28 @@ const decodeBase64AesKey = (value) => {
     return decodedKey;
 };
 
-const decryptTokenPlaceCipherkey = (cipherkey, privateKeyPem, { usesGcm = false } = {}) => {
+const decryptTokenPlaceCipherkey = (cipherkey, privateKeyPem) => {
     const rsa = new JSEncrypt();
     rsa.setPrivateKey(privateKeyPem);
     const decryptedKey = rsa.decrypt(cipherkey);
     if (!decryptedKey) throw new Error('Malformed encrypted token.place response.');
-    if (usesGcm) {
-        const rawKey = textEncoder.encode(decryptedKey);
-        if (isValidAesKeySize(rawKey)) return rawKey;
-    }
     try {
         return decodeBase64AesKey(decryptedKey);
     } catch (error) {
         const rawKey = textEncoder.encode(decryptedKey);
-        if (!usesGcm && rawKey.byteLength === 32) return rawKey;
+        if (rawKey.byteLength === 32) return rawKey;
         throw error;
     }
 };
+
+const importTokenPlacePrivateKey = async (privateKeyPem) =>
+    getCrypto().subtle.importKey(
+        'pkcs8',
+        base64ToBytes(pemToBase64(privateKeyPem)),
+        { name: 'RSA-OAEP', hash: 'SHA-256' },
+        false,
+        ['decrypt']
+    );
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
@@ -331,15 +336,25 @@ export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
         .toLowerCase()
         .includes('gcm');
     let rawAesKey;
-    if (typeof clientPrivateKey === 'string') {
-        rawAesKey = decryptTokenPlaceCipherkey(payload.cipherkey, clientPrivateKey, { usesGcm });
+    if (usesGcm) {
+        const privateKey =
+            typeof clientPrivateKey === 'string'
+                ? await importTokenPlacePrivateKey(clientPrivateKey)
+                : clientPrivateKey;
+        rawAesKey = await getCrypto().subtle.decrypt(
+            { name: 'RSA-OAEP' },
+            privateKey,
+            base64ToBytes(payload.cipherkey)
+        );
+    } else if (typeof clientPrivateKey === 'string') {
+        rawAesKey = decryptTokenPlaceCipherkey(payload.cipherkey, clientPrivateKey);
     } else {
         const wrappedAesKey = await getCrypto().subtle.decrypt(
             { name: 'RSA-OAEP' },
             clientPrivateKey,
             base64ToBytes(payload.cipherkey)
         );
-        rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
+        rawAesKey = decodeTokenPlaceCbcAesKey(wrappedAesKey);
     }
     const encryptedText = payload.chat_history || payload.ciphertext;
     if (!encryptedText) {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,3 +1,4 @@
+import { JSEncrypt } from 'jsencrypt';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
 import {
@@ -198,24 +199,6 @@ export const normalizeTokenPlacePublicKey = (value) => {
     return { pem: base64ToPem(raw), base64: bytesToBase64(textEncoder.encode(base64ToPem(raw))) };
 };
 
-const importRsaPublicKey = async (pem) =>
-    getCrypto().subtle.importKey(
-        'spki',
-        base64ToBytes(pemToBase64(pem)),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['encrypt']
-    );
-
-const importRsaPrivateKey = async (base64Pkcs8) =>
-    getCrypto().subtle.importKey(
-        'pkcs8',
-        base64ToBytes(base64Pkcs8),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['decrypt']
-    );
-
 export const generateTokenPlaceClientKeypair = async () => {
     const pair = await getCrypto().subtle.generateKey(
         {
@@ -230,13 +213,33 @@ export const generateTokenPlaceClientKeypair = async () => {
     const spki = await getCrypto().subtle.exportKey('spki', pair.publicKey);
     const pkcs8 = await getCrypto().subtle.exportKey('pkcs8', pair.privateKey);
     const publicPem = base64ToPem(bytesToBase64(spki));
+    const privatePem = base64ToPem(bytesToBase64(pkcs8), 'PRIVATE KEY');
     return {
-        publicKey: pair.publicKey,
-        privateKey: pair.privateKey,
+        publicKey: publicPem,
+        privateKey: privatePem,
+        publicKeyCrypto: pair.publicKey,
+        privateKeyCrypto: pair.privateKey,
         publicKeyPem: publicPem,
         publicKeyBase64: bytesToBase64(textEncoder.encode(publicPem)),
-        privateKeyBase64: bytesToBase64(pkcs8),
+        privateKeyPem: privatePem,
+        privateKeyBase64: bytesToBase64(textEncoder.encode(privatePem)),
     };
+};
+
+const encryptTokenPlaceCipherkey = (aesKeyBase64, publicKeyPem) => {
+    const rsa = new JSEncrypt();
+    rsa.setPublicKey(publicKeyPem);
+    const cipherkey = rsa.encrypt(aesKeyBase64);
+    if (!cipherkey) throw new Error('Unable to encrypt token.place cipher key.');
+    return cipherkey;
+};
+
+const decryptTokenPlaceCipherkey = (cipherkey, privateKeyPem) => {
+    const rsa = new JSEncrypt();
+    rsa.setPrivateKey(privateKeyPem);
+    const aesKeyBase64 = rsa.decrypt(cipherkey);
+    if (!aesKeyBase64) throw new Error('Malformed encrypted token.place response.');
+    return base64ToBytes(aesKeyBase64);
 };
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
@@ -245,18 +248,16 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const encodedAesKey = textEncoder.encode(bytesToBase64(rawAesKey));
+    const encodedAesKey = bytesToBase64(rawAesKey);
     const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
-    const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, encodedAesKey);
     return {
         ciphertext: bytesToBase64(ciphertext),
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey: encryptTokenPlaceCipherkey(encodedAesKey, serverPublicKeyPem),
         iv: bytesToBase64(iv),
     };
 };
@@ -301,19 +302,20 @@ const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
 };
 
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const wrappedAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
     const usesGcm = String(payload.mode || '')
         .toLowerCase()
         .includes('gcm');
-    const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
+    let rawAesKey;
+    if (typeof clientPrivateKey === 'string') {
+        rawAesKey = decryptTokenPlaceCipherkey(payload.cipherkey, clientPrivateKey);
+    } else {
+        const wrappedAesKey = await getCrypto().subtle.decrypt(
+            { name: 'RSA-OAEP' },
+            clientPrivateKey,
+            base64ToBytes(payload.cipherkey)
+        );
+        rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
+    }
     const encryptedText = payload.chat_history || payload.ciphertext;
     if (!encryptedText) {
         throw new Error('Malformed encrypted token.place response: missing ciphertext field.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       jsdom:
         specifier: ^21.1.1
         version: 21.1.2(canvas@3.1.2)
+      jsencrypt:
+        specifier: ^3.5.4
+        version: 3.5.4
       markdown-it:
         specifier: ^13.0.1
         version: 13.0.2
@@ -3749,6 +3752,9 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsencrypt@3.5.4:
+    resolution: {integrity: sha512-kNjfYEMNASxrDGsmcSQh/rUTmcoRfSUkxnAz+MMywM8jtGu+fFEZ3nJjHM58zscVnwR0fYmG9sGkTDjqUdpiwA==}
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -9903,6 +9909,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  jsencrypt@3.5.4: {}
 
   jsesc@3.0.2: {}
 


### PR DESCRIPTION
### Motivation

- Staging was failing with malformed encrypted responses because token.place uses a JSEncrypt/PKCS#1 v1.5-compatible RSA wrapping for the base64 AES key while DSPACE previously assumed WebCrypto RSA-OAEP unwrap. 
- The change preserves the relay ciphertext-only invariant and keeps AES-CBC/PKCS7 + 16-byte IV envelope compatibility with token.place static chat clients.

### Description

- Added `jsencrypt` to the frontend to perform JSEncrypt-compatible RSA wrap/unwrap for the base64-encoded AES key while preserving explicit AES-GCM handling when declared by the relay. 
- Updated `frontend/src/utils/tokenPlace.js` to emit base64 PEM `client_public_key`, export PEM/private PEM for the generated client keypair, wrap outgoing AES key with JSEncrypt RSA, and unwrap incoming CBC responses via JSEncrypt when the client private key is a PEM string while retaining WebCrypto OAEP for CryptoKey paths. 
- Removed the WebCrypto-only RSA import helpers for the PKCS#1 v1.5 path and added small helpers `encryptTokenPlaceCipherkey` and `decryptTokenPlaceCipherkey` for JSEncrypt usage. 
- Extended unit tests in `frontend/__tests__/tokenPlace.test.js` to assert base64 PEM client key shape, add a token.place static-chat-compatible CBC response fixture, and switch WebCrypto encrypt/decrypt test cases to use exported CryptoKey fields; updated `frontend/package.json` and lockfile to include `jsencrypt`.

### Testing

- Ran the focused unit suite: `cd frontend && npm test -- tokenPlace.test.js`, and all token.place tests passed (41/41). 
- Ran repo checks: `cd frontend && npm run check`, and lint/format checks passed. 
- Built the frontend: `cd frontend && npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378c7af2e0832f806a191acd6ccba7)