### PR TITLE
Mirror token.place relay RSA wrapping

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -286,6 +286,7 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(decodeBase64Text(body.client_public_key)).toMatch(/-----BEGIN PUBLIC KEY-----/);
         expect(Uint8Array.from(atob(body.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
@@ -330,6 +331,26 @@ describe('token.place API v1 client', () => {
         );
 
         expect(decrypted).toEqual({ ok: true, source: 'chat_history' });
+    });
+
+    test('decryption accepts token.place static chat compatible CBC/PKCS1 fixture shape', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            { ok: true, source: 'token-place-static-chat-compatible' },
+            relayServerKeys[0].publicKeyPem
+        );
+
+        const decrypted = await decryptTokenPlaceEnvelope(
+            {
+                chat_history: encrypted.ciphertext,
+                ciphertext: encrypted.ciphertext,
+                cipherkey: encrypted.cipherkey,
+                iv: encrypted.iv,
+            },
+            relayServerKeys[0].privateKey
+        );
+
+        expect(Uint8Array.from(atob(encrypted.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
+        expect(decrypted).toEqual({ ok: true, source: 'token-place-static-chat-compatible' });
     });
 
     test('decryption accepts ciphertext when chat_history is absent', async () => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
         "marked": "^4.3.0",
         "minisearch": "^7.2.0",
         "node-fetch": "^3.3.1",
+        "node-forge": "^1.4.0",
         "openai": "^5.16.0",
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,3 +1,4 @@
+import forge from 'node-forge';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
 import {
@@ -175,6 +176,17 @@ const base64ToBytes = (value) => {
     }
     return Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
 };
+const bytesToBinary = (bytes) => {
+    const array = toUint8Array(bytes);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < array.length; i += chunkSize) {
+        const chunk = array.subarray(i, i + chunkSize);
+        binary += String.fromCharCode.apply(null, chunk);
+    }
+    return binary;
+};
+const binaryToBytes = (value) => Uint8Array.from(String(value), (char) => char.charCodeAt(0));
 const pemToBase64 = (pem) =>
     String(pem).replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
 const base64ToPem = (base64, label = 'PUBLIC KEY') => {
@@ -210,11 +222,25 @@ const importRsaPublicKey = async (pem) =>
 const importRsaPrivateKey = async (base64Pkcs8) =>
     getCrypto().subtle.importKey(
         'pkcs8',
-        base64ToBytes(base64Pkcs8),
+        base64ToBytes(pemToBase64(base64Pkcs8)),
         { name: 'RSA-OAEP', hash: 'SHA-256' },
         true,
         ['decrypt']
     );
+
+const encryptRsaPkcs1v15 = (publicKeyPem, plaintext) => {
+    const publicKey = forge.pki.publicKeyFromPem(publicKeyPem);
+    return bytesToBase64(binaryToBytes(publicKey.encrypt(plaintext, 'RSAES-PKCS1-V1_5')));
+};
+
+const decryptRsaPkcs1v15 = (privateKeyPem, ciphertextBase64) => {
+    const privateKey = forge.pki.privateKeyFromPem(privateKeyPem);
+    const plaintext = privateKey.decrypt(
+        bytesToBinary(base64ToBytes(ciphertextBase64)),
+        'RSAES-PKCS1-V1_5'
+    );
+    return textEncoder.encode(plaintext);
+};
 
 export const generateTokenPlaceClientKeypair = async () => {
     const pair = await getCrypto().subtle.generateKey(
@@ -230,12 +256,13 @@ export const generateTokenPlaceClientKeypair = async () => {
     const spki = await getCrypto().subtle.exportKey('spki', pair.publicKey);
     const pkcs8 = await getCrypto().subtle.exportKey('pkcs8', pair.privateKey);
     const publicPem = base64ToPem(bytesToBase64(spki));
+    const privatePem = base64ToPem(bytesToBase64(pkcs8), 'PRIVATE KEY');
     return {
         publicKey: pair.publicKey,
-        privateKey: pair.privateKey,
+        privateKey: privatePem,
         publicKeyPem: publicPem,
         publicKeyBase64: bytesToBase64(textEncoder.encode(publicPem)),
-        privateKeyBase64: bytesToBase64(pkcs8),
+        privateKeyBase64: pemToBase64(privatePem),
     };
 };
 
@@ -245,18 +272,16 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const encodedAesKey = textEncoder.encode(bytesToBase64(rawAesKey));
+    const encodedAesKey = bytesToBase64(rawAesKey);
     const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
-    const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, encodedAesKey);
     return {
         ciphertext: bytesToBase64(ciphertext),
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey: encryptRsaPkcs1v15(serverPublicKeyPem, encodedAesKey),
         iv: bytesToBase64(iv),
     };
 };
@@ -301,18 +326,31 @@ const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
 };
 
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const wrappedAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
     const usesGcm = String(payload.mode || '')
         .toLowerCase()
         .includes('gcm');
+    let wrappedAesKey;
+    if (usesGcm) {
+        wrappedAesKey = await getCrypto().subtle.decrypt(
+            { name: 'RSA-OAEP' },
+            typeof clientPrivateKey === 'string'
+                ? await importRsaPrivateKey(clientPrivateKey)
+                : clientPrivateKey,
+            base64ToBytes(payload.cipherkey)
+        );
+    } else {
+        try {
+            wrappedAesKey = decryptRsaPkcs1v15(clientPrivateKey, payload.cipherkey);
+        } catch (error) {
+            wrappedAesKey = await getCrypto().subtle.decrypt(
+                { name: 'RSA-OAEP' },
+                typeof clientPrivateKey === 'string'
+                    ? await importRsaPrivateKey(clientPrivateKey)
+                    : clientPrivateKey,
+                base64ToBytes(payload.cipherkey)
+            );
+        }
+    }
     const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
     const encryptedText = payload.chat_history || payload.ciphertext;
     if (!encryptedText) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.2
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       openai:
         specifier: ^5.16.0
         version: 5.16.0(ws@8.18.3)(zod@3.25.76)
@@ -4177,6 +4180,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -10471,6 +10478,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-forge@1.4.0: {}
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
### Motivation
- Restore compatibility with token.place static/desktop clients by supporting JSEncrypt-compatible RSA PKCS#1 v1.5 wrapping for the `cipherkey` layer while preserving existing AES handling and GCM fallback behavior.
- Keep the relay outer envelope ciphertext-only invariant and continue to send `client_public_key` as base64-encoded PEM so the relay and browser implementations remain mutually compatible.

### Description
- Implement PKCS#1 v1.5 RSA wrap/unwrap helpers using `node-forge` and add small binary/encoding helpers to interoperate with WebCrypto-based AES operations in `frontend/src/utils/tokenPlace.js`.
- Change `encryptTokenPlaceEnvelope` to RSA-wrap the base64 AES key using PKCS#1 v1.5 (token.place/JSEncrypt-compatible) while continuing to use AES-CBC + PKCS7 and a 16-byte IV for payload encryption.
- Change `decryptTokenPlaceEnvelope` to attempt PKCS#1 v1.5 unwrap for the relay CBC path and preserve the WebCrypto OAEP/`RSA-OAEP` path when explicit AES-GCM is declared or as a fallback if PKCS#1 unwrap fails.
- Add unit tests and small assertions in `frontend/__tests__/tokenPlace.test.js` to cover base64 PEM client keys, 16-byte IVs, omitted `mode`/`tag`, and a token.place static-chat-compatible CBC/PKCS1 fixture; add `node-forge` to `frontend/package.json` and update `pnpm-lock.yaml`.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (41/41).
- Ran repo checks: `cd frontend && npm run check` — lint/format checks passed after formatting fix.
- Built the frontend: `cd frontend && npm run build` — build completed successfully.
- Notes: added `node-forge` to `frontend/package.json` and updated `pnpm-lock.yaml`; tests exercise the new PKCS#1 v1.5 path and existing GCM/OAEP compatibility code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378c816750832fa02d5b3e9e5b0f91)