### PR TITLE
Mirror token.place relay RSA wrapping (PKCS#1 v1.5)

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, test, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 const jest = vi;
 
 jest.mock('../src/utils/gameState/common.js', () => ({
@@ -41,6 +41,18 @@ const bytesToBase64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(byte
 
 const decodeBase64Text = (value) =>
     new TextDecoder().decode(Uint8Array.from(atob(value), (char) => char.charCodeAt(0)));
+
+const generateOaepKeypair = () =>
+    globalThis.crypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
 
 let relayServerKeys;
 let relayReply = {
@@ -116,11 +128,14 @@ const getFetchCall = () => {
 };
 
 describe('token.place API v1 client', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
         relayServerKeys = [
             await generateTokenPlaceClientKeypair(),
             await generateTokenPlaceClientKeypair(),
         ];
+    });
+
+    beforeEach(() => {
         relayReply = { choices: [{ message: { content: 'mocked reply' } }] };
         global.fetch = makeRelayFetch();
         loadGameState.mockReturnValue({});
@@ -286,9 +301,15 @@ describe('token.place API v1 client', () => {
         );
         expect(JSON.stringify(body)).not.toContain('hello');
         expect(JSON.stringify(body)).not.toContain('model');
+        expect(JSON.stringify(body)).not.toContain('PlayerState');
+        expect(JSON.stringify(body)).not.toContain('inventory');
+        expect(JSON.stringify(body)).not.toContain('save');
+        expect(JSON.stringify(body)).not.toContain('messages');
+        expect(decodeBase64Text(body.client_public_key)).toMatch(/-----BEGIN PUBLIC KEY-----/);
         expect(Uint8Array.from(atob(body.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
+        expect(body).not.toHaveProperty('model');
         expect(body.stream).not.toBe(true);
     });
 
@@ -332,6 +353,37 @@ describe('token.place API v1 client', () => {
         expect(decrypted).toEqual({ ok: true, source: 'chat_history' });
     });
 
+    test('decryption accepts token.place static chat compatible CBC and PKCS#1 response shape', async () => {
+        const encrypted = await encryptTokenPlaceEnvelope(
+            {
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                request_id: 'fixture-request',
+                client_public_key: relayServerKeys[0].publicKeyBase64,
+                api_v1_response: {
+                    choices: [{ message: { content: 'desktop-compatible response' } }],
+                },
+            },
+            relayServerKeys[0].publicKeyPem
+        );
+        const payload = {
+            chat_history: encrypted.ciphertext,
+            ciphertext: encrypted.ciphertext,
+            cipherkey: encrypted.cipherkey,
+            iv: encrypted.iv,
+        };
+
+        expect(Uint8Array.from(atob(payload.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
+        await expect(
+            decryptTokenPlaceEnvelope(payload, relayServerKeys[0].privateKey)
+        ).resolves.toMatchObject({
+            protocol: 'tokenplace_api_v1_relay_e2ee',
+            api_v1_response: {
+                choices: [{ message: { content: 'desktop-compatible response' } }],
+            },
+        });
+    });
+
     test('decryption accepts ciphertext when chat_history is absent', async () => {
         const encrypted = await encryptTokenPlaceEnvelope(
             { ok: true, source: 'ciphertext' },
@@ -359,6 +411,7 @@ describe('token.place API v1 client', () => {
 
     test('decryption accepts explicit GCM payloads with embedded WebCrypto tags', async () => {
         const crypto = globalThis.crypto;
+        const oaepKeys = await generateOaepKeypair();
         const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
@@ -371,7 +424,7 @@ describe('token.place API v1 client', () => {
         );
         const cipherkey = await crypto.subtle.encrypt(
             { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
+            oaepKeys.publicKey,
             rawAesKey
         );
 
@@ -382,7 +435,7 @@ describe('token.place API v1 client', () => {
                 cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
-            relayServerKeys[0].privateKey
+            oaepKeys.privateKey
         );
 
         expect(decrypted).toEqual({ ok: true, mode: 'embedded-gcm-tag' });
@@ -390,6 +443,7 @@ describe('token.place API v1 client', () => {
 
     test('decryption accepts explicit GCM payloads with separate tags', async () => {
         const crypto = globalThis.crypto;
+        const oaepKeys = await generateOaepKeypair();
         const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-GCM' }, false, [
@@ -406,7 +460,7 @@ describe('token.place API v1 client', () => {
         const tag = encrypted.slice(-16);
         const cipherkey = await crypto.subtle.encrypt(
             { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
+            oaepKeys.publicKey,
             rawAesKey
         );
 
@@ -418,7 +472,7 @@ describe('token.place API v1 client', () => {
                 cipherkey: bytesToBase64(cipherkey),
                 iv: bytesToBase64(iv),
             },
-            relayServerKeys[0].privateKey
+            oaepKeys.privateKey
         );
 
         expect(decrypted).toEqual({ ok: true, mode: 'separate-gcm-tag' });
@@ -436,16 +490,15 @@ describe('token.place API v1 client', () => {
             aesKey,
             new TextEncoder().encode(JSON.stringify({ ok: true, key: 'raw' }))
         );
-        const cipherkey = await crypto.subtle.encrypt(
-            { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
-            rawAesKey
+        const cipherkey = relayServerKeys[0].publicKey.encrypt(
+            String.fromCharCode(...rawAesKey),
+            'RSAES-PKCS1-V1_5'
         );
 
         const decrypted = await decryptTokenPlaceEnvelope(
             {
                 ciphertext: bytesToBase64(ciphertext),
-                cipherkey: bytesToBase64(cipherkey),
+                cipherkey: btoa(cipherkey),
                 iv: bytesToBase64(iv),
             },
             relayServerKeys[0].privateKey

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
         "marked": "^4.3.0",
         "minisearch": "^7.2.0",
         "node-fetch": "^3.3.1",
+        "node-forge": "^1.4.0",
         "openai": "^5.16.0",
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,5 +1,6 @@
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import forge from 'node-forge';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -198,15 +199,6 @@ export const normalizeTokenPlacePublicKey = (value) => {
     return { pem: base64ToPem(raw), base64: bytesToBase64(textEncoder.encode(base64ToPem(raw))) };
 };
 
-const importRsaPublicKey = async (pem) =>
-    getCrypto().subtle.importKey(
-        'spki',
-        base64ToBytes(pemToBase64(pem)),
-        { name: 'RSA-OAEP', hash: 'SHA-256' },
-        true,
-        ['encrypt']
-    );
-
 const importRsaPrivateKey = async (base64Pkcs8) =>
     getCrypto().subtle.importKey(
         'pkcs8',
@@ -217,27 +209,29 @@ const importRsaPrivateKey = async (base64Pkcs8) =>
     );
 
 export const generateTokenPlaceClientKeypair = async () => {
-    const pair = await getCrypto().subtle.generateKey(
-        {
-            name: 'RSA-OAEP',
-            modulusLength: 2048,
-            publicExponent: new Uint8Array([1, 0, 1]),
-            hash: 'SHA-256',
-        },
-        true,
-        ['encrypt', 'decrypt']
-    );
-    const spki = await getCrypto().subtle.exportKey('spki', pair.publicKey);
-    const pkcs8 = await getCrypto().subtle.exportKey('pkcs8', pair.privateKey);
-    const publicPem = base64ToPem(bytesToBase64(spki));
+    const pair = forge.pki.rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
+    const publicPem = forge.pki.publicKeyToPem(pair.publicKey);
+    const privatePem = forge.pki.privateKeyToPem(pair.privateKey);
     return {
         publicKey: pair.publicKey,
         privateKey: pair.privateKey,
         publicKeyPem: publicPem,
         publicKeyBase64: bytesToBase64(textEncoder.encode(publicPem)),
-        privateKeyBase64: bytesToBase64(pkcs8),
+        privateKeyBase64: bytesToBase64(textEncoder.encode(privatePem)),
     };
 };
+
+const getForgePublicKey = (keyOrPem) =>
+    typeof keyOrPem === 'string' ? forge.pki.publicKeyFromPem(keyOrPem) : keyOrPem;
+
+const getForgePrivateKey = (keyOrPem) => {
+    if (typeof keyOrPem !== 'string') return keyOrPem;
+    const decoded = textDecoder.decode(base64ToBytes(keyOrPem));
+    if (/-----BEGIN [^-]+-----/.test(decoded)) return forge.pki.privateKeyFromPem(decoded);
+    return forge.pki.privateKeyFromPem(keyOrPem);
+};
+
+const binaryStringToBytes = (value) => Uint8Array.from(value, (char) => char.charCodeAt(0) & 0xff);
 
 export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) => {
     const crypto = getCrypto();
@@ -245,18 +239,20 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const encodedAesKey = textEncoder.encode(bytesToBase64(rawAesKey));
+    const encodedAesKey = bytesToBase64(rawAesKey);
     const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
-    const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, encodedAesKey);
+    const cipherkey = getForgePublicKey(serverPublicKeyPem).encrypt(
+        encodedAesKey,
+        'RSAES-PKCS1-V1_5'
+    );
     return {
         ciphertext: bytesToBase64(ciphertext),
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey: bytesToBase64(binaryStringToBytes(cipherkey)),
         iv: bytesToBase64(iv),
     };
 };
@@ -301,18 +297,27 @@ const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
 };
 
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const wrappedAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
     const usesGcm = String(payload.mode || '')
         .toLowerCase()
         .includes('gcm');
+    let wrappedAesKey;
+    if (usesGcm) {
+        const privateKey =
+            typeof clientPrivateKey === 'string'
+                ? await importRsaPrivateKey(clientPrivateKey)
+                : clientPrivateKey;
+        wrappedAesKey = await getCrypto().subtle.decrypt(
+            { name: 'RSA-OAEP' },
+            privateKey,
+            base64ToBytes(payload.cipherkey)
+        );
+    } else {
+        const unwrapped = getForgePrivateKey(clientPrivateKey).decrypt(
+            forge.util.createBuffer(base64ToBytes(payload.cipherkey)).getBytes(),
+            'RSAES-PKCS1-V1_5'
+        );
+        wrappedAesKey = binaryStringToBytes(unwrapped);
+    }
     const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
     const encryptedText = payload.chat_history || payload.ciphertext;
     if (!encryptedText) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.2
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       openai:
         specifier: ^5.16.0
         version: 5.16.0(ws@8.18.3)(zod@3.25.76)
@@ -4177,6 +4180,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -10471,6 +10478,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-forge@1.4.0: {}
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
### Motivation
- Staging was failing with `Malformed encrypted token.place response.` due to an RSA wrapping mismatch with token.place's static chat (JSEncrypt / PKCS#1 v1.5) expectations. 
- The relay AES/CBC envelope shape is correct from prior changes, but the RSA layer must be PKCS#1 v1.5-compatible for desktop/relay responses and for compatibility with the static chat implementation.

### Description
- Add `node-forge` and switch client RSA keypair generation to PEM keys so `client_public_key` is sent as base64-encoded PEM. (edited `frontend/package.json`, `pnpm-lock.yaml`).
- Use node-forge RSA `RSAES-PKCS1-V1_5` wrapping/unwrapping for the AES key on the CBC path so responses encrypted by token.place desktop/relay (JSEncrypt-compatible) decrypt correctly; keep Web Crypto OAEP for explicit GCM responses. (edited `frontend/src/utils/tokenPlace.js`).
- Preserve AES-CBC + PKCS7 envelope rules: 16-byte IV, AES-256, ciphertext in `chat_history || ciphertext`, and `cipherkey` contains a PKCS#1 v1.5-wrapped base64 AES key for CBC responses. (edited `frontend/src/utils/tokenPlace.js`).
- Add/fix unit tests to cover the token.place static chat-compatible response shape and to assert ciphertext-only relay request invariants; update tests that exercise OAEP/GCM to keep both code paths covered. (edited `frontend/__tests__/tokenPlace.test.js`).

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (41 passed).
- Ran formatting/lint checks: `cd frontend && npm run check` — passed (Prettier check and lint run completed).
- Built the frontend: `cd frontend && npm run build` — build completed successfully.

Modified files included in this change: `frontend/src/utils/tokenPlace.js`, `frontend/__tests__/tokenPlace.test.js`, `frontend/package.json`, and lockfile updates in `pnpm-lock.yaml`.

Notes and follow-ups: the change is intentionally minimal and targeted at RSA wrapping compatibility; a human reviewer should verify the runtime bundle and browser polyfills for `node-forge` in target browsers and confirm E2E Playwright runs in CI/staging as a follow-up if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378c7566d0832fb792f6e5351b1fd3)