### PR TITLE
Mirror token.place RSA PKCS#1 v1.5 wrapping for relay E2EE

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -297,7 +297,7 @@ describe('token.place API v1 client', () => {
             metadata: { conversation_id: 'conv-42' },
         });
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
-        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKeyPem);
 
         expect(decrypted.api_v1_request).toEqual(
             expect.objectContaining({
@@ -315,7 +315,7 @@ describe('token.place API v1 client', () => {
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
     });
 
-    test('decryption accepts chat_history as the response ciphertext', async () => {
+    test('decryption accepts token.place static chat-compatible CBC/PKCS1 relay responses', async () => {
         const encrypted = await encryptTokenPlaceEnvelope(
             { ok: true, source: 'chat_history' },
             relayServerKeys[0].publicKeyPem
@@ -323,12 +323,14 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(
             {
                 chat_history: encrypted.ciphertext,
+                ciphertext: 'fallback-ciphertext-should-not-be-used',
                 cipherkey: encrypted.cipherkey,
                 iv: encrypted.iv,
             },
-            relayServerKeys[0].privateKey
+            relayServerKeys[0].privateKeyPem
         );
 
+        expect(Uint8Array.from(atob(encrypted.iv), (char) => char.charCodeAt(0))).toHaveLength(16);
         expect(decrypted).toEqual({ ok: true, source: 'chat_history' });
     });
 
@@ -337,7 +339,10 @@ describe('token.place API v1 client', () => {
             { ok: true, source: 'ciphertext' },
             relayServerKeys[0].publicKeyPem
         );
-        const decrypted = await decryptTokenPlaceEnvelope(encrypted, relayServerKeys[0].privateKey);
+        const decrypted = await decryptTokenPlaceEnvelope(
+            encrypted,
+            relayServerKeys[0].privateKeyPem
+        );
 
         expect(decrypted).toEqual({ ok: true, source: 'ciphertext' });
     });
@@ -353,7 +358,7 @@ describe('token.place API v1 client', () => {
         };
 
         await expect(
-            decryptTokenPlaceEnvelope(payload, relayServerKeys[0].privateKey)
+            decryptTokenPlaceEnvelope(payload, relayServerKeys[0].privateKeyPem)
         ).rejects.toThrow('Malformed encrypted token.place response: missing ciphertext field.');
     });
 
@@ -422,36 +427,6 @@ describe('token.place API v1 client', () => {
         );
 
         expect(decrypted).toEqual({ ok: true, mode: 'separate-gcm-tag' });
-    });
-
-    test('decryption accepts CBC payloads with raw wrapped AES keys', async () => {
-        const crypto = globalThis.crypto;
-        const rawAesKey = crypto.getRandomValues(new Uint8Array(32));
-        const iv = crypto.getRandomValues(new Uint8Array(16));
-        const aesKey = await crypto.subtle.importKey('raw', rawAesKey, { name: 'AES-CBC' }, false, [
-            'encrypt',
-        ]);
-        const ciphertext = await crypto.subtle.encrypt(
-            { name: 'AES-CBC', iv },
-            aesKey,
-            new TextEncoder().encode(JSON.stringify({ ok: true, key: 'raw' }))
-        );
-        const cipherkey = await crypto.subtle.encrypt(
-            { name: 'RSA-OAEP' },
-            relayServerKeys[0].publicKey,
-            rawAesKey
-        );
-
-        const decrypted = await decryptTokenPlaceEnvelope(
-            {
-                ciphertext: bytesToBase64(ciphertext),
-                cipherkey: bytesToBase64(cipherkey),
-                iv: bytesToBase64(iv),
-            },
-            relayServerKeys[0].privateKey
-        );
-
-        expect(decrypted).toEqual({ ok: true, key: 'raw' });
     });
 
     test('large encrypted envelopes do not overflow base64 conversion', async () => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
         "marked": "^4.3.0",
         "minisearch": "^7.2.0",
         "node-fetch": "^3.3.1",
+        "node-forge": "^1.4.0",
         "openai": "^5.16.0",
         "postcss": "^8.4.23",
         "pretty-date": "^0.2.0",

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,3 +1,4 @@
+import forge from 'node-forge';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
 import {
@@ -198,6 +199,19 @@ export const normalizeTokenPlacePublicKey = (value) => {
     return { pem: base64ToPem(raw), base64: bytesToBase64(textEncoder.encode(base64ToPem(raw))) };
 };
 
+const wrapTokenPlaceAesKey = (base64AesKey, publicKeyPem) => {
+    const publicKey = forge.pki.publicKeyFromPem(publicKeyPem);
+    const encrypted = publicKey.encrypt(base64AesKey, 'RSAES-PKCS1-V1_5');
+    return forge.util.encode64(encrypted);
+};
+
+const unwrapTokenPlaceAesKey = (cipherkey, privateKeyPem) => {
+    const privateKey = forge.pki.privateKeyFromPem(privateKeyPem);
+    const decoded = privateKey.decrypt(forge.util.decode64(cipherkey), 'RSAES-PKCS1-V1_5');
+    if (!decoded) throw new Error('Malformed encrypted token.place response.');
+    return textEncoder.encode(decoded);
+};
+
 const importRsaPublicKey = async (pem) =>
     getCrypto().subtle.importKey(
         'spki',
@@ -217,25 +231,18 @@ const importRsaPrivateKey = async (base64Pkcs8) =>
     );
 
 export const generateTokenPlaceClientKeypair = async () => {
-    const pair = await getCrypto().subtle.generateKey(
-        {
-            name: 'RSA-OAEP',
-            modulusLength: 2048,
-            publicExponent: new Uint8Array([1, 0, 1]),
-            hash: 'SHA-256',
-        },
-        true,
-        ['encrypt', 'decrypt']
+    const pair = forge.pki.rsa.generateKeyPair({ bits: 2048, workers: 0 });
+    const publicKeyPem = forge.pki.publicKeyToPem(pair.publicKey);
+    const privateKeyPem = forge.pki.privateKeyInfoToPem(
+        forge.pki.wrapRsaPrivateKey(forge.pki.privateKeyToAsn1(pair.privateKey))
     );
-    const spki = await getCrypto().subtle.exportKey('spki', pair.publicKey);
-    const pkcs8 = await getCrypto().subtle.exportKey('pkcs8', pair.privateKey);
-    const publicPem = base64ToPem(bytesToBase64(spki));
     return {
-        publicKey: pair.publicKey,
-        privateKey: pair.privateKey,
-        publicKeyPem: publicPem,
-        publicKeyBase64: bytesToBase64(textEncoder.encode(publicPem)),
-        privateKeyBase64: bytesToBase64(pkcs8),
+        publicKey: await importRsaPublicKey(publicKeyPem),
+        privateKey: await importRsaPrivateKey(pemToBase64(privateKeyPem)),
+        publicKeyPem,
+        publicKeyBase64: bytesToBase64(textEncoder.encode(publicKeyPem)),
+        privateKeyBase64: pemToBase64(privateKeyPem),
+        privateKeyPem,
     };
 };
 
@@ -245,18 +252,16 @@ export const encryptTokenPlaceEnvelope = async (envelope, serverPublicKeyPem) =>
         'encrypt',
     ]);
     const rawAesKey = await crypto.subtle.exportKey('raw', aesKey);
-    const encodedAesKey = textEncoder.encode(bytesToBase64(rawAesKey));
+    const encodedAesKey = bytesToBase64(rawAesKey);
     const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-CBC', iv },
         aesKey,
         textEncoder.encode(JSON.stringify(envelope))
     );
-    const serverKey = await importRsaPublicKey(serverPublicKeyPem);
-    const cipherkey = await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, encodedAesKey);
     return {
         ciphertext: bytesToBase64(ciphertext),
-        cipherkey: bytesToBase64(cipherkey),
+        cipherkey: wrapTokenPlaceAesKey(encodedAesKey, serverPublicKeyPem),
         iv: bytesToBase64(iv),
     };
 };
@@ -301,18 +306,18 @@ const decodeTokenPlaceCbcAesKey = (wrappedAesKey) => {
 };
 
 export const decryptTokenPlaceEnvelope = async (payload, clientPrivateKey) => {
-    const privateKey =
-        typeof clientPrivateKey === 'string'
-            ? await importRsaPrivateKey(clientPrivateKey)
-            : clientPrivateKey;
-    const wrappedAesKey = await getCrypto().subtle.decrypt(
-        { name: 'RSA-OAEP' },
-        privateKey,
-        base64ToBytes(payload.cipherkey)
-    );
     const usesGcm = String(payload.mode || '')
         .toLowerCase()
         .includes('gcm');
+    const wrappedAesKey = usesGcm
+        ? await getCrypto().subtle.decrypt(
+              { name: 'RSA-OAEP' },
+              typeof clientPrivateKey === 'string'
+                  ? await importRsaPrivateKey(clientPrivateKey)
+                  : clientPrivateKey,
+              base64ToBytes(payload.cipherkey)
+          )
+        : unwrapTokenPlaceAesKey(payload.cipherkey, clientPrivateKey);
     const rawAesKey = usesGcm ? wrappedAesKey : decodeTokenPlaceCbcAesKey(wrappedAesKey);
     const encryptedText = payload.chat_history || payload.ciphertext;
     if (!encryptedText) {
@@ -528,7 +533,7 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     try {
         responseEnvelope = await decryptTokenPlaceEnvelope(
             encryptedResponse,
-            clientKeys.privateKey
+            clientKeys.privateKeyPem
         );
     } catch (error) {
         throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.2
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       openai:
         specifier: ^5.16.0
         version: 5.16.0(ws@8.18.3)(zod@3.25.76)
@@ -4177,6 +4180,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -10471,6 +10478,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-forge@1.4.0: {}
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
### Motivation
- The relay path used by token.place static chat wraps the base64 AES key with RSAES-PKCS1-v1_5 (JSEncrypt-compatible), while DSPACE previously used WebCrypto RSA-OAEP, causing `Malformed encrypted token.place response.` in staging.
- Make the minimal compatibility change to accept token.place desktop/relay responses and produce compatible requests without changing the outer relay ciphertext-only invariant.

### Description
- Added `node-forge` and implemented PKCS#1 v1.5 RSA wrap/unwrap helpers (`wrapTokenPlaceAesKey` / `unwrapTokenPlaceAesKey`) to mirror token.place static chat behavior, keeping AES-CBC/PKCS7 (16-byte IV) for the default relay path. (`frontend/src/utils/tokenPlace.js`)
- Switched client keypair generation to produce PEM keys compatible with token.place (public key exported as base64-encoded PEM in `client_public_key`) and retained WebCrypto imports only for explicit AES-GCM paths. (`frontend/src/utils/tokenPlace.js`)
- Updated encryption/decryption flow so outgoing envelopes wrap the base64 AES key with PKCS#1 v1.5 and incoming CBC responses unwrap via the new PKCS#1 path while preserving RSA-OAEP for explicitly-declared GCM responses. (`frontend/src/utils/tokenPlace.js`)
- Adjusted unit tests to exercise the token.place static chat-compatible CBC/PKCS1 relay responses, `chat_history || ciphertext` fallback, 16-byte IV assertion, and use the PEM private key in tests. (`frontend/__tests__/tokenPlace.test.js`) and added `node-forge` to `frontend/package.json` (and lockfile).

### Testing
- Ran unit tests for the token.place client: `cd frontend && npm test -- tokenPlace.test.js` — all relevant tests passed (39 tests in file passed).
- Ran repository checks: `cd frontend && npm run check` — lint/format checks passed.
- Built the frontend: `cd frontend && npm run build` — build completed successfully.

Files changed: `frontend/src/utils/tokenPlace.js`, `frontend/__tests__/tokenPlace.test.js`, `frontend/package.json`, `pnpm-lock.yaml`.

Residual notes: this is a narrow compatibility patch to mirror token.place's current wrapping; follow-ups could replace `node-forge` with a smaller browser-only helper if desired, but the current change keeps the diff minimal and addresses the staging failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378c6a1244832f87cc4462d913b14b)