### PR TITLE
Stop sending token.place metadata option

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -294,27 +294,26 @@ describe('token.place API v1 client', () => {
         expect(body.stream).not.toBe(true);
     });
 
-    test('decrypted API v1 request nests metadata under options', async () => {
+    test('decrypted API v1 request sends empty options without metadata', async () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             metadata: { conversation_id: 'conv-42' },
         });
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const serializedBody = JSON.stringify(body);
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
 
+        expect(serializedBody).not.toContain('conversation_id');
+        expect(serializedBody).not.toContain('conv-42');
+        expect(serializedBody).not.toContain('metadata');
         expect(decrypted.api_v1_request).toEqual(
             expect.objectContaining({
                 model: 'llama-3.1-8b-instruct',
                 messages: expect.any(Array),
-                options: {
-                    metadata: {
-                        conversation_id: 'conv-42',
-                        client: 'dspace',
-                        provider: 'token.place',
-                    },
-                },
+                options: {},
             })
         );
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+        expect(decrypted.api_v1_request.options).not.toHaveProperty('metadata');
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -526,9 +526,7 @@ export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
     messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {
-        metadata: buildTokenPlaceMetadata(options.metadata),
-    },
+    options: {},
 });
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {


### PR DESCRIPTION
### Motivation
- The desktop token.place runtime rejects unknown inference options (specifically `metadata`) in API v1 relay requests, causing compute-node rejections; the relay payload should only contain supported generation options.

### Description
- Change `buildApiV1Request()` so `api_v1_request.options` is an empty object (`{}`) and stop nesting DSPACE `metadata` under inference `options`, and update `frontend/__tests__/tokenPlace.test.js` to assert the decrypted `api_v1_request.options` does not contain `metadata` and that plaintext metadata does not appear in the outer relay request body.

### Testing
- Executed `cd frontend && npm test -- tokenPlace.test.js` (43 tests passed), `cd frontend && npm run check` (lint/format checks passed), and `cd frontend && npm run build` (Astro build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38170649f8832f8b0d1b8e430b3244)