### PR TITLE
Stop sending metadata in token.place API v1 relay options

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -294,27 +294,23 @@ describe('token.place API v1 client', () => {
         expect(body.stream).not.toBe(true);
     });
 
-    test('decrypted API v1 request nests metadata under options', async () => {
+    test('decrypted API v1 request sends empty options without metadata', async () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
-            metadata: { conversation_id: 'conv-42' },
+            metadata: { conversation_id: 'conv-42-metadata-canary' },
         });
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
 
+        expect(JSON.stringify(body)).not.toContain('conv-42-metadata-canary');
         expect(decrypted.api_v1_request).toEqual(
             expect.objectContaining({
                 model: 'llama-3.1-8b-instruct',
                 messages: expect.any(Array),
-                options: {
-                    metadata: {
-                        conversation_id: 'conv-42',
-                        client: 'dspace',
-                        provider: 'token.place',
-                    },
-                },
+                options: {},
             })
         );
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+        expect(decrypted.api_v1_request.options).not.toHaveProperty('metadata');
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -526,9 +526,7 @@ export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
     messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {
-        metadata: buildTokenPlaceMetadata(options.metadata),
-    },
+    options: {},
 });
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {


### PR DESCRIPTION
### Motivation
- The desktop token.place runtime rejects unknown inference options (specifically `metadata`), causing API v1 relay requests to fail, so remove unsupported metadata from the encrypted `api_v1_request.options` payload.

### Description
- Change `buildApiV1Request()` to set `api_v1_request.options` to an empty object (`{}`) instead of embedding `metadata`, and preserve response-side metadata handling so DSPACE still surfaces metadata returned by the compute node.
- Update unit tests in `frontend/__tests__/tokenPlace.test.js` to assert the decrypted `api_v1_request.options` is empty and that a plaintext metadata canary does not appear in the outer relay request body.

### Testing
- Ran `cd frontend && npm test -- tokenPlace.test.js` and the test file passed (43 tests, 0 failed).
- Ran `cd frontend && npm run check` and lint/format checks passed.
- Ran `cd frontend && npm run build` and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381712855c832fba1ec6f779cab6d1)