### PR TITLE
Stop sending token.place metadata relay option

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L921-L935))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L907-L921))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -257,10 +257,13 @@ describe('token.place API v1 client', () => {
         expect(serialized).not.toContain('player-inventory-canary-charlie');
         expect(serialized).not.toContain('raw-save-data-canary-delta');
         expect(serialized).not.toContain('secret-canary-echo');
+        expect(serialized).not.toContain('conv-42');
+        expect(serialized).not.toContain('conversation_id');
+        expect(serialized).not.toContain('metadata');
         expect(body).not.toHaveProperty('metadata');
     });
 
-    test('request body includes model, schema-safe messages, safe metadata, and no true stream', async () => {
+    test('relay request body stays ciphertext-only and does not request streaming', async () => {
         await TokenPlaceChatV2([
             {
                 role: 'developer',
@@ -294,7 +297,7 @@ describe('token.place API v1 client', () => {
         expect(body.stream).not.toBe(true);
     });
 
-    test('decrypted API v1 request nests metadata under options', async () => {
+    test('decrypted API v1 request uses empty options and excludes metadata', async () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             metadata: { conversation_id: 'conv-42' },
         });
@@ -305,16 +308,14 @@ describe('token.place API v1 client', () => {
             expect.objectContaining({
                 model: 'llama-3.1-8b-instruct',
                 messages: expect.any(Array),
-                options: {
-                    metadata: {
-                        conversation_id: 'conv-42',
-                        client: 'dspace',
-                        provider: 'token.place',
-                    },
-                },
+                options: {},
             })
         );
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
+        expect(decrypted.api_v1_request.options).not.toHaveProperty('metadata');
+        expect(JSON.stringify(body)).not.toContain('conv-42');
+        expect(JSON.stringify(body)).not.toContain('conversation_id');
+        expect(JSON.stringify(body)).not.toContain('metadata');
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -18,7 +18,6 @@ const {
     generateTokenPlaceClientKeypair,
     validateTokenPlaceResponseEnvelope,
     buildTokenPlaceChatCompletionsUrl,
-    buildTokenPlaceMetadata,
     extractTokenPlaceAssistantText,
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
@@ -538,20 +537,6 @@ describe('token.place API v1 client', () => {
                 },
             })
         ).resolves.toMatchObject({ text: 'mocked reply' });
-    });
-
-    test('safe metadata preserves trusted client and provider fields', () => {
-        expect(
-            buildTokenPlaceMetadata({
-                client: 'attacker',
-                provider: 'openai',
-                conversation_id: 'conv-42',
-            })
-        ).toEqual({
-            conversation_id: 'conv-42',
-            client: 'dspace',
-            provider: 'token.place',
-        });
     });
 
     test('parses assistant text and compatibility helper returns string', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -526,9 +526,7 @@ export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
     messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {
-        metadata: buildTokenPlaceMetadata(options.metadata),
-    },
+    options: {},
 });
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -14,8 +14,6 @@ const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
-const METADATA_DENY_PATTERN =
-    /(?:key|token|secret|credential|password|authorization|auth|inventory|save|state|player)/i;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
 
 const getCrypto = () => globalThis.crypto;
@@ -36,11 +34,6 @@ const stripTrailingSlashes = (value) =>
     String(value || '')
         .trim()
         .replace(/\/+$/g, '');
-
-const isPlainObject = (value) =>
-    Boolean(value) &&
-    typeof value === 'object' &&
-    Object.getPrototypeOf(value) === Object.prototype;
 
 export const resolveTokenPlaceBaseUrl = (options = {}) => {
     const state = options.state || loadGameState();
@@ -78,32 +71,6 @@ const sanitizeChatMessage = (message) => ({
 
 export const sanitizeTokenPlaceMessages = (messages = []) =>
     (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
-
-const sanitizeMetadataValue = (value) => {
-    if (typeof value === 'string') return value.slice(0, 200);
-    if (typeof value === 'number' || typeof value === 'boolean') return value;
-    return undefined;
-};
-
-export const buildTokenPlaceMetadata = (metadata = {}) => {
-    const safeMetadata = {};
-
-    if (isPlainObject(metadata)) {
-        Object.entries(metadata).forEach(([key, value]) => {
-            if (!key || METADATA_DENY_PATTERN.test(key)) return;
-            const safeValue = sanitizeMetadataValue(value);
-            if (safeValue !== undefined) {
-                safeMetadata[key] = safeValue;
-            }
-        });
-    }
-
-    return {
-        ...safeMetadata,
-        client: 'dspace',
-        provider: 'token.place',
-    };
-};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content = response?.choices?.[0]?.message?.content;


### PR DESCRIPTION
### Motivation
- The desktop token.place runtime rejects unknown inference options like `metadata`, so the relay payload must not include metadata under `api_v1_request.options` to avoid structured API v1 errors.

### Description
- Change `buildApiV1Request()` so `api_v1_request.options` is an empty object by default and no longer includes `metadata` (in `frontend/src/utils/tokenPlace.js`).
- Update tests to assert decrypted `api_v1_request.options` does not contain `metadata` and that no plaintext metadata sentinels leak into the outer relay request body (in `frontend/__tests__/tokenPlace.test.js`).

### Testing
- Ran unit tests with `cd frontend && npm test -- tokenPlace.test.js`, which passed (43 tests all green).
- Ran formatting/lint checks with `cd frontend && npm run check`, which passed.
- Built the frontend with `cd frontend && npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38171c3fbc832f9df2e28e3022d148)