### PR TITLE
Stop sending token.place metadata options

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -260,7 +260,7 @@ describe('token.place API v1 client', () => {
         expect(body).not.toHaveProperty('metadata');
     });
 
-    test('request body includes model, schema-safe messages, safe metadata, and no true stream', async () => {
+    test('request body includes model, schema-safe messages, ciphertext-only payload, and no true stream', async () => {
         await TokenPlaceChatV2([
             {
                 role: 'developer',
@@ -294,26 +294,25 @@ describe('token.place API v1 client', () => {
         expect(body.stream).not.toBe(true);
     });
 
-    test('decrypted API v1 request nests metadata under options', async () => {
+    test('decrypted API v1 request keeps metadata out of generation options', async () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             metadata: { conversation_id: 'conv-42' },
         });
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const serializedBody = JSON.stringify(body);
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
 
+        expect(serializedBody).not.toContain('conversation_id');
+        expect(serializedBody).not.toContain('conv-42');
+        expect(serializedBody).not.toContain('metadata');
         expect(decrypted.api_v1_request).toEqual(
             expect.objectContaining({
                 model: 'llama-3.1-8b-instruct',
                 messages: expect.any(Array),
-                options: {
-                    metadata: {
-                        conversation_id: 'conv-42',
-                        client: 'dspace',
-                        provider: 'token.place',
-                    },
-                },
+                options: {},
             })
         );
+        expect(decrypted.api_v1_request.options).not.toHaveProperty('metadata');
         expect(decrypted.api_v1_request).not.toHaveProperty('metadata');
     });
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -526,9 +526,7 @@ export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
     messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {
-        metadata: buildTokenPlaceMetadata(options.metadata),
-    },
+    options: {},
 });
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {


### PR DESCRIPTION
### Motivation
- The desktop token.place runtime rejects unknown `options` fields (notably `metadata`), causing API v1 relay requests to fail; the change prevents sending unsupported metadata in the encrypted inference payload. 

### Description
- Changed `buildApiV1Request()` so `api_v1_request.options` is an empty object by default instead of including `metadata`. (`frontend/src/utils/tokenPlace.js`).
- Updated unit tests to assert the outer relay request remains ciphertext-only and that decrypted `api_v1_request.options` does not contain `metadata`. (`frontend/__tests__/tokenPlace.test.js`).
- Preserved existing behavior where decrypted relay responses continue to populate `metadata` in DSPACE return values (no plaintext metadata leak to the relay request). 

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` which passed (`43 tests, 43 passed`).
- Ran formatting/lint checks: `cd frontend && npm run check` which passed (Prettier and ESLint checks OK).
- Built the frontend: `cd frontend && npm run build` which completed successfully.

All changes were kept minimal and limited to the files allowed by the scope lock to avoid altering relay crypto, routing, or other unrelated code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3817227c80832fa0e9e2ce60448c53)