### PR TITLE
Adapt token.place API v1 chat messages

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -22,6 +22,9 @@ const {
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
     tokenPlaceChat,
+    TOKEN_PLACE_API_V1_MAX_MESSAGES,
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
+    TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } = await import('../src/utils/tokenPlace.js');
 const { JSEncrypt } = await import('jsencrypt');
 const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
@@ -113,6 +116,32 @@ const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.end
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
     return { url, init, body: init.body ? JSON.parse(init.body) : undefined };
+};
+const decryptDispatchedApiV1Request = async (serverKeyIndex = 0) => {
+    const { body } = getFetchCallByPath('/api/v1/relay/requests');
+    const decrypted = await decryptTokenPlaceEnvelope(
+        body,
+        relayServerKeys[serverKeyIndex].privateKey
+    );
+    return { body, decrypted, apiV1Request: decrypted.api_v1_request };
+};
+
+const expectValidTokenPlaceApiV1Messages = (messages) => {
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.length).toBeLessThanOrEqual(TOKEN_PLACE_API_V1_MAX_MESSAGES);
+    const totalContentChars = messages.reduce((sum, message) => sum + message.content.length, 0);
+    expect(totalContentChars).toBeLessThanOrEqual(TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS);
+    for (const message of messages) {
+        expect(['system', 'user', 'assistant']).toContain(message.role);
+        expect(Object.keys(message).sort()).toEqual(['content', 'role']);
+        expect(typeof message.content).toBe('string');
+        expect(message.content.trim()).toBe(message.content);
+        expect(message.content).not.toBe('');
+        expect(message.content.length).toBeLessThanOrEqual(
+            TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS
+        );
+    }
 };
 
 describe('token.place API v1 client', () => {
@@ -294,6 +323,73 @@ describe('token.place API v1 client', () => {
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('normal hi flow sends validator-safe API v1 messages and empty options', async () => {
+        await tokenPlaceChat([{ role: 'user', content: 'hi' }]);
+
+        const { apiV1Request } = await decryptDispatchedApiV1Request();
+
+        expect(apiV1Request.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiV1Request.messages);
+        expect(apiV1Request.messages).toContainEqual({ role: 'user', content: 'hi' });
+    });
+
+    test('large DSPACE prompt is adapted to token.place API v1 message limits before encryption', async () => {
+        const hugeKnowledge = `DSPACE knowledge base\nPlayerState: fuel=high\n${'DOCS_RAG_EXCERPT_ALPHA '.repeat(9_000)}`;
+        const latestPrompt = 'What should I build next? USER_PROMPT_SENTINEL';
+
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: 'DSPACE system policy' },
+                    { role: 'assistant', content: 'Older assistant context' },
+                    { role: 'system', content: hugeKnowledge },
+                    { role: 'user', content: latestPrompt },
+                ],
+                contextSources: [{ title: 'Local DSPACE docs', url: '/docs/about' }],
+                gameState: {},
+            },
+        });
+
+        const { body, apiV1Request } = await decryptDispatchedApiV1Request();
+
+        expect(apiV1Request.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiV1Request.messages);
+        expect(apiV1Request.messages).toContainEqual({ role: 'user', content: latestPrompt });
+        expect(
+            apiV1Request.messages.some((message) => message.content.includes('PlayerState'))
+        ).toBe(true);
+        expect(JSON.stringify(body)).not.toContain('messages');
+        expect(JSON.stringify(body)).not.toContain('model');
+        expect(JSON.stringify(body)).not.toContain('USER_PROMPT_SENTINEL');
+        expect(JSON.stringify(body)).not.toContain('DSPACE knowledge base');
+        expect(JSON.stringify(body)).not.toContain('PlayerState');
+        expect(JSON.stringify(body)).not.toContain('DOCS_RAG_EXCERPT_ALPHA');
+    });
+
+    test('blank and unsupported messages are removed or normalized before encryption', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'tool', content: '   ' },
+                    { role: 'developer', content: [{ type: 'text', text: 'normalized text' }] },
+                    { role: 'assistant', content: { status: 'ok' }, extra: 'drop-me' },
+                    { role: 'user', content: null },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const { apiV1Request } = await decryptDispatchedApiV1Request();
+
+        expect(apiV1Request.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiV1Request.messages);
+        expect(apiV1Request.messages).toEqual([
+            { role: 'user', content: 'normalized text' },
+            { role: 'assistant', content: '{"status":"ok"}' },
+        ]);
     });
 
     test('decrypted API v1 request uses empty options and excludes metadata', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -15,6 +15,11 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
+export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
+export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
+const TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS = 31_500;
+const TOKEN_PLACE_API_V1_FALLBACK_USER_MESSAGE = 'Continue.';
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -63,14 +68,97 @@ export const getTokenPlaceChatModel = (options = {}) =>
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-const sanitizeChatMessage = (message) => ({
-    role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
-    content:
-        typeof message?.content === 'string' ? message.content : String(message?.content || ''),
-});
+const stringifyTokenPlaceContent = (content) => {
+    if (typeof content === 'string') return content;
+    if (content == null) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => {
+                if (typeof part === 'string') return part;
+                if (typeof part?.text === 'string') return part.text;
+                if (typeof part?.content === 'string') return part.content;
+                return '';
+            })
+            .filter(Boolean)
+            .join('\n');
+    }
+    try {
+        return JSON.stringify(content);
+    } catch {
+        return String(content || '');
+    }
+};
 
-export const sanitizeTokenPlaceMessages = (messages = []) =>
-    (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
+const getTokenPlaceMessageRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
+
+const chunkTokenPlaceMessage = (message, originalIndex) => {
+    const chunks = [];
+    const content = message.content;
+    for (
+        let offset = 0;
+        offset < content.length;
+        offset += TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS
+    ) {
+        chunks.push({
+            role: message.role,
+            content: content.slice(offset, offset + TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS),
+            originalIndex,
+            chunkIndex: chunks.length,
+        });
+    }
+    return chunks;
+};
+
+const trimTokenPlaceApiV1Messages = (messages) => {
+    const latestUserIndex = messages.reduce(
+        (latest, message, index) => (message.role === 'user' ? index : latest),
+        -1
+    );
+    const latestUser = latestUserIndex >= 0 ? messages[latestUserIndex] : undefined;
+    const selected = [];
+    let totalChars = 0;
+
+    const tryAdd = (message) => {
+        if (!message || selected.includes(message)) return false;
+        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) return false;
+        if (totalChars + message.content.length > TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS) {
+            return false;
+        }
+        selected.push(message);
+        totalChars += message.content.length;
+        return true;
+    };
+
+    // Preserve the latest user intent before spending the remaining budget on grounding/history.
+    tryAdd(latestUser);
+
+    for (const message of messages) {
+        if (message.role === 'system') tryAdd(message);
+    }
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        if (messages[index].role !== 'system') tryAdd(messages[index]);
+    }
+
+    return selected
+        .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
+        .map(({ role, content }) => ({ role, content }));
+};
+
+export const sanitizeTokenPlaceMessages = (messages = []) => {
+    const normalized = (Array.isArray(messages) ? messages : [])
+        .map((message) => ({
+            role: getTokenPlaceMessageRole(message?.role),
+            content: stringifyTokenPlaceContent(message?.content).trim(),
+        }))
+        .filter((message) => message.content);
+
+    if (!normalized.length) {
+        normalized.push({ role: 'user', content: TOKEN_PLACE_API_V1_FALLBACK_USER_MESSAGE });
+    }
+
+    const chunked = normalized.flatMap((message, index) => chunkTokenPlaceMessage(message, index));
+    return trimTokenPlaceApiV1Messages(chunked);
+};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content = response?.choices?.[0]?.message?.content;


### PR DESCRIPTION
### Motivation
- token.place desktop validator started rejecting DSPACE chat requests with "Invalid chat message format" because DSPACE sent messages with unsupported roles/shapes and very large system/RAG content.  
- The relay must remain ciphertext-only and E2EE; the adapter must enforce token.place API v1 message contract limits (roles, keys, per-message and total sizes, message count) before encryption.

### Description
- Add conservative token.place API v1 limits and a stricter message adapter in `frontend/src/utils/tokenPlace.js` including constants `TOKEN_PLACE_API_V1_MAX_MESSAGES`, `TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS`, and `TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS`.  
- Implement safe content stringification, role normalization to `system|user|assistant`, blank message dropping with a fallback user message, deterministic chunking of oversized messages, and trimming that preserves latest user intent then system grounding then newer non-system history.  
- Ensure `api_v1_request.messages` contains only `role` and `content`, that `options` is `{}`, and the outer `/api/v1/relay/requests` body remains ciphertext-only.  
- Files changed: `frontend/src/utils/tokenPlace.js` (implementation) and `frontend/__tests__/tokenPlace.test.js` (unit tests and helpers that decrypt the test relay envelope and validate the outbound `api_v1_request.messages`).

### Testing
- Ran focused unit tests that decrypt the in-test relay envelope and assert v1 message contract: `cd frontend && npm test -- tokenPlace.test.js` (result: all tests passed; `45 passed`).  
- Ran lint/format checks: `cd frontend && npm run check` (result: passed).  
- Built the frontend to verify bundling: `cd frontend && npm run build` (result: passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38946c17bc832f9b4dbacd9480d266)