### PR TITLE
Fix token.place API v1 message shaping

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L907-L921))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1108-L1121))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -115,6 +115,28 @@ const getFetchCall = () => {
     return { url, init, body: init.body ? JSON.parse(init.body) : undefined };
 };
 
+const decryptLastRelayRequest = async (serverKeyIndex = 0) => {
+    const { body } = getFetchCallByPath('/api/v1/relay/requests');
+    return decryptTokenPlaceEnvelope(body, relayServerKeys[serverKeyIndex].privateKey);
+};
+
+const expectValidApiV1Messages = (messages) => {
+    expect(messages.length).toBeLessThanOrEqual(64);
+    expect(
+        messages.every((message) => ['system', 'user', 'assistant'].includes(message.role))
+    ).toBe(true);
+    expect(
+        messages.every((message) => Object.keys(message).sort().join(',') === 'content,role')
+    ).toBe(true);
+    expect(
+        messages.every((message) => typeof message.content === 'string' && message.content.trim())
+    ).toBe(true);
+    expect(messages.every((message) => message.content.length <= 32_768)).toBe(true);
+    expect(
+        messages.reduce((total, message) => total + message.content.length, 0)
+    ).toBeLessThanOrEqual(131_072);
+};
+
 describe('token.place API v1 client', () => {
     beforeEach(async () => {
         relayServerKeys = [
@@ -315,6 +337,80 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('conv-42');
         expect(JSON.stringify(body)).not.toContain('conversation_id');
         expect(JSON.stringify(body)).not.toContain('metadata');
+    });
+
+    test('normal small hi flow sends valid API v1 messages with empty options', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hi' }]);
+        const decrypted = await decryptLastRelayRequest();
+
+        expect(decrypted.api_v1_request.options).toEqual({});
+        expect(decrypted.api_v1_request.messages).toEqual(
+            expect.arrayContaining([expect.objectContaining({ role: 'user', content: 'hi' })])
+        );
+        expectValidApiV1Messages(decrypted.api_v1_request.messages);
+    });
+
+    test('large DSPACE knowledge prompt is shaped to token.place API v1 message limits', async () => {
+        const userPrompt = 'USER_PROMPT_SECRET_SENTINEL';
+        const ragExcerpt = 'DSPACE knowledge base DOCS_RAG_SECRET_SENTINEL ';
+        const playerState = 'PlayerState PLAYER_STATE_SECRET_SENTINEL';
+        await TokenPlaceChatV2([{ role: 'user', content: userPrompt }], {
+            promptPayload: {
+                combinedMessages: [
+                    {
+                        role: 'system',
+                        content: `${playerState}
+${ragExcerpt.repeat(4000)}`,
+                    },
+                    { role: 'assistant', content: 'older assistant context' },
+                    { role: 'user', content: userPrompt },
+                ],
+                contextSources: [{ title: 'local only', url: '/docs/about' }],
+                gameState: {},
+            },
+        });
+
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(decrypted.api_v1_request.options).toEqual({});
+        expect(messages.some((message) => message.content.includes(userPrompt))).toBe(true);
+        expect(messages.filter((message) => message.role === 'system').length).toBeGreaterThan(1);
+        expectValidApiV1Messages(messages);
+
+        const serializedOuterBody = JSON.stringify(body);
+        expect(serializedOuterBody).not.toContain('messages');
+        expect(serializedOuterBody).not.toContain('model');
+        expect(serializedOuterBody).not.toContain(userPrompt);
+        expect(serializedOuterBody).not.toContain('DSPACE knowledge base');
+        expect(serializedOuterBody).not.toContain('PlayerState');
+        expect(serializedOuterBody).not.toContain('DOCS_RAG_SECRET_SENTINEL');
+    });
+
+    test('blank and invalid messages are normalized or removed before encryption', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'developer', content: ' normalized developer prompt ', extra: true },
+                    { role: 'user', content: '   ' },
+                    { role: 'assistant', content: null },
+                    { role: 'assistant', content: [{ type: 'text', text: 'array text content' }] },
+                    { role: 'system', content: { kind: 'json-content', ok: true } },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+        const decrypted = await decryptLastRelayRequest();
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages).toEqual([
+            { role: 'user', content: 'normalized developer prompt' },
+            { role: 'assistant', content: 'array text content' },
+            { role: 'system', content: '{"kind":"json-content","ok":true}' },
+        ]);
+        expectValidApiV1Messages(messages);
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -115,7 +115,7 @@ const getFetchCall = () => {
     return { url, init, body: init.body ? JSON.parse(init.body) : undefined };
 };
 
-const decryptLastRelayRequest = async (serverKeyIndex = 0) => {
+const decryptFirstRelayRequest = async (serverKeyIndex = 0) => {
     const { body } = getFetchCallByPath('/api/v1/relay/requests');
     return decryptTokenPlaceEnvelope(body, relayServerKeys[serverKeyIndex].privateKey);
 };
@@ -341,7 +341,7 @@ describe('token.place API v1 client', () => {
 
     test('normal small hi flow sends valid API v1 messages with empty options', async () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hi' }]);
-        const decrypted = await decryptLastRelayRequest();
+        const decrypted = await decryptFirstRelayRequest();
 
         expect(decrypted.api_v1_request.options).toEqual({});
         expect(decrypted.api_v1_request.messages).toEqual(
@@ -402,13 +402,82 @@ ${ragExcerpt.repeat(4000)}`,
                 gameState: {},
             },
         });
-        const decrypted = await decryptLastRelayRequest();
+        const decrypted = await decryptFirstRelayRequest();
         const messages = decrypted.api_v1_request.messages;
 
         expect(messages).toEqual([
             { role: 'user', content: 'normalized developer prompt' },
             { role: 'assistant', content: 'array text content' },
             { role: 'system', content: '{"kind":"json-content","ok":true}' },
+        ]);
+        expectValidApiV1Messages(messages);
+    });
+
+    test('preserves primary system prompt when latest user input exceeds total budget', async () => {
+        const systemPrompt = 'DSPACE persona and safety guardrails must remain present.';
+        const hugeUserPrompt = 'OVERSIZED_USER_INPUT '.repeat(7000);
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'assistant', content: 'older assistant context' },
+                    { role: 'user', content: hugeUserPrompt },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const decrypted = await decryptFirstRelayRequest();
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages).toContainEqual({ role: 'system', content: systemPrompt });
+        expect(messages.some((message) => message.role === 'user')).toBe(true);
+        expectValidApiV1Messages(messages);
+    });
+
+    test('latest non-blank normalized user message is preserved under budget pressure', async () => {
+        const developerPrompt = 'LATEST_NORMALIZED_DEVELOPER_PROMPT';
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: 'SYSTEM_CONTEXT '.repeat(9000) },
+                    { role: 'user', content: 'older user prompt' },
+                    { role: 'developer', content: developerPrompt },
+                    { role: 'user', content: '   ' },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const decrypted = await decryptFirstRelayRequest();
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages).toEqual(
+            expect.arrayContaining([{ role: 'user', content: developerPrompt }])
+        );
+        expectValidApiV1Messages(messages);
+    });
+
+    test('non-JSON content normalizes to strings before trimming', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'user', content: Symbol('token-place-symbol') },
+                    { role: 'assistant', content: () => 'function content' },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const decrypted = await decryptFirstRelayRequest();
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages).toEqual([
+            { role: 'user', content: 'Symbol(token-place-symbol)' },
+            { role: 'assistant', content: expect.stringContaining('function content') },
         ]);
         expectValidApiV1Messages(messages);
     });

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -413,6 +413,42 @@ ${ragExcerpt.repeat(4000)}`,
         expectValidApiV1Messages(messages);
     });
 
+    test('all-empty or invalid messages fall back to a valid API v1 user message', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'developer', content: '   ', ignored: 'metadata' },
+                    { role: 'assistant', content: null },
+                    { role: 'system', content: undefined },
+                    { role: 'tool', content: [] },
+                    { role: 'function', content: [{ type: 'text', text: '' }, { content: '' }] },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages.length).toBeGreaterThan(0);
+        expect(
+            messages.every((message) => Object.keys(message).sort().join(',') === 'content,role')
+        ).toBe(true);
+        expect(
+            messages.every((message) => ['system', 'user', 'assistant'].includes(message.role))
+        ).toBe(true);
+        expect(messages.every((message) => message.content.trim())).toBe(true);
+        expect(decrypted.api_v1_request.options).toEqual({});
+        expectValidApiV1Messages(messages);
+
+        const serializedOuterBody = JSON.stringify(body);
+        expect(serializedOuterBody).not.toContain('messages');
+        expect(serializedOuterBody).not.toContain('model');
+        expect(serializedOuterBody).not.toContain('Please continue.');
+        expect(serializedOuterBody).not.toContain('metadata');
+    });
+
     test('preserves primary system prompt when latest user input exceeds total budget', async () => {
         const systemPrompt = 'DSPACE persona and safety guardrails must remain present.';
         const hugeUserPrompt = 'OVERSIZED_USER_INPUT '.repeat(7000);

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -22,6 +22,10 @@ export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
 const TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS = 96;
 const TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS =
     TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS - TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS;
+const TOKEN_PLACE_API_V1_FALLBACK_MESSAGE = {
+    role: 'user',
+    content: 'Please continue.',
+};
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -172,9 +176,11 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
         totalChars += candidate.content.length;
     }
 
-    return selected
+    const shapedMessages = selected
         .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
         .map(({ role, content }) => ({ role, content }));
+
+    return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
 };
 
 export const extractTokenPlaceAssistantText = (response) => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -15,6 +15,12 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
+export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
+export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
+const TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS = 96;
+const TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS =
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS - TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS;
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -63,14 +69,103 @@ export const getTokenPlaceChatModel = (options = {}) =>
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-const sanitizeChatMessage = (message) => ({
-    role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
-    content:
-        typeof message?.content === 'string' ? message.content : String(message?.content || ''),
-});
+const stringifyTokenPlaceContent = (content) => {
+    if (typeof content === 'string') return content;
+    if (content == null) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => {
+                if (typeof part === 'string') return part;
+                if (typeof part?.text === 'string') return part.text;
+                if (typeof part?.content === 'string') return part.content;
+                try {
+                    return JSON.stringify(part);
+                } catch {
+                    return '';
+                }
+            })
+            .filter(Boolean)
+            .join('\n');
+    }
+    try {
+        return JSON.stringify(content);
+    } catch {
+        return String(content || '');
+    }
+};
 
-export const sanitizeTokenPlaceMessages = (messages = []) =>
-    (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
+const chunkText = (content, maxChars) => {
+    const chunks = [];
+    for (let offset = 0; offset < content.length; offset += maxChars) {
+        chunks.push(content.slice(offset, offset + maxChars));
+    }
+    return chunks;
+};
+
+const splitTokenPlaceMessage = (message, index) => {
+    const role = VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user';
+    const content = stringifyTokenPlaceContent(message?.content).trim();
+    if (!content) return [];
+
+    if (content.length <= TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS) {
+        return [{ role, content, originalIndex: index, chunkIndex: 0 }];
+    }
+
+    if (role === 'system') {
+        const chunks = chunkText(content, TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS);
+        return chunks.map((chunk, chunkIndex) => ({
+            role,
+            content: `[DSPACE context chunk ${chunkIndex + 1}/${chunks.length}]\n${chunk}`,
+            originalIndex: index,
+            chunkIndex,
+        }));
+    }
+
+    // Keep oversized conversation turns deterministic and valid. If later limits force trimming,
+    // the priority pass below preserves the latest user turn before older history/context.
+    return chunkText(content, TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS).map(
+        (chunk, chunkIndex) => ({ role, content: chunk, originalIndex: index, chunkIndex })
+    );
+};
+
+const getTokenPlaceMessagePriority = (message, latestUserIndex) => {
+    if (message.originalIndex === latestUserIndex) return 0;
+    if (message.role === 'system') return 1;
+    if (message.role === 'user') return 2;
+    return 3;
+};
+
+export const sanitizeTokenPlaceMessages = (messages = []) => {
+    const sourceMessages = Array.isArray(messages) ? messages : [];
+    const latestUserIndex = sourceMessages.reduce(
+        (latest, message, index) => (message?.role === 'user' ? index : latest),
+        -1
+    );
+    const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
+    const selected = [];
+    let totalChars = 0;
+
+    for (const candidate of [...candidates].sort((a, b) => {
+        const priorityDelta =
+            getTokenPlaceMessagePriority(a, latestUserIndex) -
+            getTokenPlaceMessagePriority(b, latestUserIndex);
+        if (priorityDelta) return priorityDelta;
+        if (a.role === 'system')
+            return a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex;
+        return b.originalIndex - a.originalIndex || a.chunkIndex - b.chunkIndex;
+    })) {
+        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) break;
+        if (totalChars + candidate.content.length > TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS) {
+            continue;
+        }
+        selected.push(candidate);
+        totalChars += candidate.content.length;
+    }
+
+    return selected
+        .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
+        .map(({ role, content }) => ({ role, content }));
+};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content = response?.choices?.[0]?.message?.content;

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -15,6 +15,7 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+const normalizeTokenPlaceRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
 export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
 export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
 export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
@@ -69,6 +70,15 @@ export const getTokenPlaceChatModel = (options = {}) =>
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
+const stringifyJsonOrString = (content) => {
+    try {
+        const serialized = JSON.stringify(content);
+        return typeof serialized === 'string' ? serialized : String(content);
+    } catch {
+        return String(content);
+    }
+};
+
 const stringifyTokenPlaceContent = (content) => {
     if (typeof content === 'string') return content;
     if (content == null) return '';
@@ -78,20 +88,12 @@ const stringifyTokenPlaceContent = (content) => {
                 if (typeof part === 'string') return part;
                 if (typeof part?.text === 'string') return part.text;
                 if (typeof part?.content === 'string') return part.content;
-                try {
-                    return JSON.stringify(part);
-                } catch {
-                    return '';
-                }
+                return stringifyJsonOrString(part);
             })
             .filter(Boolean)
             .join('\n');
     }
-    try {
-        return JSON.stringify(content);
-    } catch {
-        return String(content || '');
-    }
+    return stringifyJsonOrString(content);
 };
 
 const chunkText = (content, maxChars) => {
@@ -103,7 +105,7 @@ const chunkText = (content, maxChars) => {
 };
 
 const splitTokenPlaceMessage = (message, index) => {
-    const role = VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user';
+    const role = normalizeTokenPlaceRole(message?.role);
     const content = stringifyTokenPlaceContent(message?.content).trim();
     if (!content) return [];
 
@@ -128,27 +130,35 @@ const splitTokenPlaceMessage = (message, index) => {
     );
 };
 
-const getTokenPlaceMessagePriority = (message, latestUserIndex) => {
-    if (message.originalIndex === latestUserIndex) return 0;
-    if (message.role === 'system') return 1;
-    if (message.role === 'user') return 2;
-    return 3;
+const getTokenPlaceMessagePriority = (message, latestUserIndex, requiredSystemMessage) => {
+    if (
+        requiredSystemMessage &&
+        message.originalIndex === requiredSystemMessage.originalIndex &&
+        message.chunkIndex === requiredSystemMessage.chunkIndex
+    ) {
+        return 0;
+    }
+    if (message.originalIndex === latestUserIndex) return 1;
+    if (message.role === 'system') return 2;
+    if (message.role === 'user') return 3;
+    return 4;
 };
 
 export const sanitizeTokenPlaceMessages = (messages = []) => {
     const sourceMessages = Array.isArray(messages) ? messages : [];
-    const latestUserIndex = sourceMessages.reduce(
-        (latest, message, index) => (message?.role === 'user' ? index : latest),
+    const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
+    const latestUserIndex = candidates.reduce(
+        (latest, message) => (message.role === 'user' ? message.originalIndex : latest),
         -1
     );
-    const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
+    const requiredSystemMessage = candidates.find((message) => message.role === 'system');
     const selected = [];
     let totalChars = 0;
 
     for (const candidate of [...candidates].sort((a, b) => {
         const priorityDelta =
-            getTokenPlaceMessagePriority(a, latestUserIndex) -
-            getTokenPlaceMessagePriority(b, latestUserIndex);
+            getTokenPlaceMessagePriority(a, latestUserIndex, requiredSystemMessage) -
+            getTokenPlaceMessagePriority(b, latestUserIndex, requiredSystemMessage);
         if (priorityDelta) return priorityDelta;
         if (a.role === 'system')
             return a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex;


### PR DESCRIPTION
### Motivation
- token.place desktop API v1 rejects decrypted `api_v1_request.messages` when DSPACE sends unsupported/oversized message shapes, causing "Invalid chat message format" errors.
- Ensure the relay envelope is still ciphertext-only while making the decrypted `api_v1_request.messages` conform to token.place v1 requirements (roles, keys, lengths, counts).

### Description
- Add conservative API v1 limits and helpers in `frontend/src/utils/tokenPlace.js`: `TOKEN_PLACE_API_V1_MAX_MESSAGES`, `TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS`, and `TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS`, plus chunking label/layout constants.
- Replace the loose `sanitizeTokenPlaceMessages()` with a stricter adapter that:
  - normalizes/serializes arbitrary content into safe text (`stringifyTokenPlaceContent`),
  - enforces allowed roles (`system`, `user`, `assistant`),
  - drops blank/empty messages, and restricts message object keys to only `role` and `content`,
  - deterministically chunks oversized `system` (RAG/context) messages into labeled system chunks and chunks oversized conversation turns, and
  - enforces per-message, total-content, and message-count limits while prioritizing latest user intent and system/persona first.
- Keep `api_v1_request.options` as `{}` and preserve the ciphertext-only outer relay request shape and metadata exclusion.
- Add unit tests in `frontend/__tests__/tokenPlace.test.js` that decrypt the in-test relay envelope and assert the final `api_v1_request.messages` comply with token.place v1 constraints, including tests for a small `hi` flow, oversized DSPACE knowledge/RAG prompting, ciphertext-only outer payload, and blank/invalid-message normalization.

### Testing
- Ran `cd frontend && npm test -- tokenPlace.test.js` and the new/updated tests passed: `45 tests passed` (all tests in the file succeeded). ✅
- Ran `cd frontend && npm run check` (lint + prettier-format check) and it succeeded (no lint/prettier failures). ✅
- Ran `cd frontend && npm run build` and the frontend build completed successfully. ✅

Commands used for verification:
- `cd frontend && npm test -- tokenPlace.test.js`
- `cd frontend && npm run check`
- `cd frontend && npm run build`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3894816168832fa0f5ea4f709431cb)