### PR TITLE
Constrain token.place API v1 chat messages

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -115,6 +115,33 @@ const getFetchCall = () => {
     return { url, init, body: init.body ? JSON.parse(init.body) : undefined };
 };
 
+const decryptOutgoingApiV1Request = async (relayKeyIndex = 0) => {
+    const { body } = getFetchCallByPath('/api/v1/relay/requests');
+    const decrypted = await decryptTokenPlaceEnvelope(
+        body,
+        relayServerKeys[relayKeyIndex].privateKey
+    );
+    return { body, apiRequest: decrypted.api_v1_request };
+};
+
+const expectValidTokenPlaceApiV1Messages = (messages) => {
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.length).toBeLessThanOrEqual(64);
+    expect(
+        messages.every((message) => ['system', 'user', 'assistant'].includes(message.role))
+    ).toBe(true);
+    expect(messages.map((message) => Object.keys(message).sort().join(','))).toEqual(
+        messages.map(() => 'content,role')
+    );
+    expect(messages.every((message) => typeof message.content === 'string')).toBe(true);
+    expect(messages.every((message) => message.content.trim().length > 0)).toBe(true);
+    expect(messages.every((message) => message.content.length <= 32_768)).toBe(true);
+    expect(
+        messages.reduce((total, message) => total + message.content.length, 0)
+    ).toBeLessThanOrEqual(131_072);
+};
+
 describe('token.place API v1 client', () => {
     beforeEach(async () => {
         relayServerKeys = [
@@ -315,6 +342,82 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('conv-42');
         expect(JSON.stringify(body)).not.toContain('conversation_id');
         expect(JSON.stringify(body)).not.toContain('metadata');
+    });
+
+    test('decrypted API v1 request fits token.place desktop message validation limits', async () => {
+        const userPrompt = 'please help me launch a tiny satellite';
+        const ragExcerpt =
+            'DSPACE knowledge base\n' + 'docs/RAG excerpt about rockets. '.repeat(5000);
+        const playerState = 'PlayerState: inventory=solar-panel; process=launch-rocket';
+        const promptPayload = {
+            combinedMessages: [
+                { role: 'system', content: 'You are dChat, a helpful DSPACE guide.' },
+                { role: 'system', content: `${playerState}\n\n${ragExcerpt}` },
+                { role: 'assistant', content: 'Older assistant context. '.repeat(500) },
+                { role: 'user', content: 'older user message' },
+                { role: 'user', content: userPrompt },
+            ],
+            contextSources: [{ title: 'Rocket docs', url: '/docs/solar' }],
+            gameState: {},
+        };
+
+        await TokenPlaceChatV2([{ role: 'user', content: userPrompt }], { promptPayload });
+        const { body, apiRequest } = await decryptOutgoingApiV1Request();
+
+        expect(apiRequest.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiRequest.messages);
+        expect(apiRequest.messages.some((message) => message.content.includes(userPrompt))).toBe(
+            true
+        );
+        expect(
+            apiRequest.messages.filter((message) => message.role === 'system').length
+        ).toBeGreaterThan(1);
+
+        const serializedOuterBody = JSON.stringify(body);
+        expect(serializedOuterBody).not.toContain('messages');
+        expect(serializedOuterBody).not.toContain('model');
+        expect(serializedOuterBody).not.toContain(userPrompt);
+        expect(serializedOuterBody).not.toContain('DSPACE knowledge base');
+        expect(serializedOuterBody).not.toContain('PlayerState');
+        expect(serializedOuterBody).not.toContain('docs/RAG excerpt');
+    });
+
+    test('normal small hi flow produces strict API v1 messages and empty options', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hi' }]);
+        const { apiRequest } = await decryptOutgoingApiV1Request();
+
+        expect(apiRequest.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiRequest.messages);
+        expect(
+            apiRequest.messages.some(
+                (message) => message.role === 'user' && message.content === 'hi'
+            )
+        ).toBe(true);
+    });
+
+    test('blank and invalid messages are removed or normalized before encryption', async () => {
+        const promptPayload = {
+            combinedMessages: [
+                { role: 'tool', content: '   ' },
+                { role: 'developer', content: [{ type: 'text', text: 'normalized content' }] },
+                { role: 'assistant', content: null },
+                { role: 'user', content: { text: 'object text content' }, extra: 'not sent' },
+            ],
+            contextSources: [],
+            gameState: {},
+        };
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'object text content' }], {
+            promptPayload,
+        });
+        const { apiRequest } = await decryptOutgoingApiV1Request();
+
+        expect(apiRequest.options).toEqual({});
+        expectValidTokenPlaceApiV1Messages(apiRequest.messages);
+        expect(apiRequest.messages).toEqual([
+            { role: 'user', content: 'normalized content' },
+            { role: 'user', content: 'object text content' },
+        ]);
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -15,6 +15,10 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
+const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
+const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
+const TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS = 32_000;
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -63,14 +67,98 @@ export const getTokenPlaceChatModel = (options = {}) =>
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-const sanitizeChatMessage = (message) => ({
-    role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
-    content:
-        typeof message?.content === 'string' ? message.content : String(message?.content || ''),
-});
+const toTokenPlaceMessageText = (content) => {
+    if (typeof content === 'string') return content;
+    if (content == null) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => {
+                if (typeof part === 'string') return part;
+                if (typeof part?.text === 'string') return part.text;
+                if (typeof part?.content === 'string') return part.content;
+                return '';
+            })
+            .filter(Boolean)
+            .join('\n');
+    }
+    if (typeof content === 'object') {
+        if (typeof content.text === 'string') return content.text;
+        if (typeof content.content === 'string') return content.content;
+        try {
+            return JSON.stringify(content);
+        } catch {
+            return '';
+        }
+    }
+    return String(content);
+};
 
-export const sanitizeTokenPlaceMessages = (messages = []) =>
-    (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
+const chunkTokenPlaceContent = (content) => {
+    const chunks = [];
+    for (let index = 0; index < content.length; index += TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS) {
+        chunks.push(content.slice(index, index + TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS));
+    }
+    return chunks;
+};
+
+const getTokenPlaceMessagePriority = (message, index, latestUserIndex) => {
+    if (index === latestUserIndex) return 0;
+    if (index === 0 && message.role === 'system') return 1;
+    if (message.role === 'system') return 2;
+    return 3;
+};
+
+export const sanitizeTokenPlaceMessages = (messages = []) => {
+    const normalized = (Array.isArray(messages) ? messages : [])
+        .map((message, index) => ({
+            index,
+            role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
+            content: toTokenPlaceMessageText(message?.content).trim(),
+        }))
+        .filter((message) => message.content.length > 0);
+
+    let latestUserIndex;
+    for (const message of normalized) {
+        if (message.role === 'user') latestUserIndex = message.index;
+    }
+    const expanded = normalized.flatMap((message) => {
+        const chunks = chunkTokenPlaceContent(message.content);
+        return chunks.map((content, chunkIndex) => ({
+            role: message.role,
+            content,
+            originalIndex: message.index,
+            priority: getTokenPlaceMessagePriority(message, message.index, latestUserIndex),
+            chunkIndex,
+        }));
+    });
+
+    let totalChars = 0;
+    const selected = [];
+    for (const message of [...expanded].sort(
+        (left, right) =>
+            left.priority - right.priority ||
+            left.originalIndex - right.originalIndex ||
+            left.chunkIndex - right.chunkIndex
+    )) {
+        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) break;
+        if (message.content.length > TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS) continue;
+        if (totalChars + message.content.length > TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS) {
+            continue;
+        }
+        selected.push(message);
+        totalChars += message.content.length;
+    }
+
+    // Keep the outbound prompt contract-valid under token.place API v1 limits. If the
+    // prompt is too large, lower-priority older history/context is omitted before the latest
+    // user message; oversized individual messages have already been deterministically chunked.
+    return selected
+        .sort(
+            (left, right) =>
+                left.originalIndex - right.originalIndex || left.chunkIndex - right.chunkIndex
+        )
+        .map(({ role, content }) => ({ role, content }));
+};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content = response?.choices?.[0]?.message?.content;


### PR DESCRIPTION
### Motivation
- token.place desktop API v1 rejects decrypted chat messages when DSPACE sends unsupported/oversized message shapes, so the relay-encrypted `api_v1_request.messages` must conform to strict role/shape/size limits. 
- Keep relay request ciphertext-only while preserving dChat grounding priorities (system/persona, latest user, player state, then RAG/older history). 

### Description
- Added conservative token.place API v1 limits and chunking constants (`TOKEN_PLACE_API_V1_MAX_MESSAGES`, `TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS`, `TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS`, `TOKEN_PLACE_API_V1_CHUNK_CONTENT_CHARS`) in `frontend/src/utils/tokenPlace.js`.
- Replaced the previous generic sanitizer with a strict adapter `sanitizeTokenPlaceMessages()` that:
  - normalizes unsupported content shapes into plain text (`toTokenPlaceMessageText`), allows only `system|user|assistant` roles, and emits only `{ role, content }` objects;
  - drops blank/empty messages and removes unsupported keys;
  - deterministically chunks oversized messages into safe-sized pieces and drops single chunks that would exceed per-message or total limits;
  - prioritizes latest user message and system/persona content when selecting which chunks/messages to keep so the latest intent and persona are preserved over older history.
- Kept `api_v1_request.options` as an empty object and preserved ciphertext-only outer relay request structure; integration points (envelope build + dispatch) are unchanged aside from using the new sanitizer.
- Added unit test helpers and focused tests in `frontend/__tests__/tokenPlace.test.js` that decrypt the outgoing test relay envelope and assert the decrypted `api_v1_request.messages` meet token.place API v1 validation rules and that the outer relay body remains ciphertext-only.

### Testing
- Ran the focused unit tests: `cd frontend && npm test -- tokenPlace.test.js`, which completed successfully (all tokenPlace tests passed).
- Ran repository checks: `cd frontend && npm run check` (lint/format checks passed).
- Built the frontend: `cd frontend && npm run build` (build completed successfully).
- Tests added verify: decrypted messages only contain allowed roles and keys, no blank content, per-message ≤ 32,768 chars, total content ≤ 131,072 chars, ≤ 64 messages, `options: {}`, and that the outer `/api/v1/relay/requests` body is ciphertext-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3894884178832f99a054fe41b28812)