### PR TITLE
Fix token.place API v1 message shaping

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -21,6 +21,9 @@ const {
     extractTokenPlaceAssistantText,
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
+    TOKEN_PLACE_API_V1_MAX_MESSAGES,
+    TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
     tokenPlaceChat,
 } = await import('../src/utils/tokenPlace.js');
 const { JSEncrypt } = await import('jsencrypt');
@@ -109,6 +112,31 @@ const getFetchCalls = () =>
         body: init.body ? JSON.parse(init.body) : undefined,
     }));
 const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+const getDecryptedRelayRequest = async () =>
+    decryptTokenPlaceEnvelope(
+        getFetchCallByPath('/api/v1/relay/requests').body,
+        relayServerKeys[0].privateKey
+    );
+const expectValidApiV1Messages = (messages) => {
+    expect(messages.length).toBeLessThanOrEqual(TOKEN_PLACE_API_V1_MAX_MESSAGES);
+    expect(
+        messages.every((message) => ['system', 'user', 'assistant'].includes(message.role))
+    ).toBe(true);
+    expect(
+        messages.every((message) => Object.keys(message).sort().join(',') === 'content,role')
+    ).toBe(true);
+    expect(
+        messages.every((message) => typeof message.content === 'string' && message.content.trim())
+    ).toBe(true);
+    expect(
+        messages.every(
+            (message) => message.content.length <= TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS
+        )
+    ).toBe(true);
+    expect(
+        messages.reduce((total, message) => total + message.content.length, 0)
+    ).toBeLessThanOrEqual(TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS);
+};
 
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
@@ -315,6 +343,77 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('conv-42');
         expect(JSON.stringify(body)).not.toContain('conversation_id');
         expect(JSON.stringify(body)).not.toContain('metadata');
+    });
+
+    test('small hi relay request decrypts to valid API v1 messages and empty options', async () => {
+        await tokenPlaceChat([{ role: 'user', content: 'hi' }]);
+
+        const decrypted = await getDecryptedRelayRequest();
+        expect(decrypted.api_v1_request.options).toEqual({});
+        expectValidApiV1Messages(decrypted.api_v1_request.messages);
+        expect(decrypted.api_v1_request.messages.at(-1)).toEqual({ role: 'user', content: 'hi' });
+    });
+
+    test('large DSPACE knowledge prompt is chunked within token.place API v1 limits', async () => {
+        const largeKnowledge = [
+            'DSPACE knowledge base',
+            'PlayerState: oxygen=stable',
+            'DOCS_RAG_EXCERPT_SECRET '.repeat(7_000),
+        ].join('\n');
+        const latestUserPrompt = 'LATEST_USER_PROMPT_SENTINEL';
+
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: 'DSPACE system policy' },
+                    { role: 'system', content: largeKnowledge },
+                    { role: 'assistant', content: 'older assistant history' },
+                    { role: 'user', content: 'older user history' },
+                    { role: 'user', content: latestUserPrompt },
+                ],
+                contextSources: [{ title: 'local only' }],
+                gameState: {},
+            },
+        });
+
+        const relayBody = getFetchCallByPath('/api/v1/relay/requests').body;
+        const serializedRelayBody = JSON.stringify(relayBody);
+        expect(serializedRelayBody).not.toContain('messages');
+        expect(serializedRelayBody).not.toContain('model');
+        expect(serializedRelayBody).not.toContain(latestUserPrompt);
+        expect(serializedRelayBody).not.toContain('DSPACE knowledge base');
+        expect(serializedRelayBody).not.toContain('PlayerState');
+        expect(serializedRelayBody).not.toContain('DOCS_RAG_EXCERPT_SECRET');
+
+        const decrypted = await decryptTokenPlaceEnvelope(relayBody, relayServerKeys[0].privateKey);
+        const { messages, options } = decrypted.api_v1_request;
+        expect(options).toEqual({});
+        expectValidApiV1Messages(messages);
+        expect(messages.some((message) => message.content.includes(latestUserPrompt))).toBe(true);
+        expect(messages.filter((message) => message.role === 'system').length).toBeGreaterThan(1);
+    });
+
+    test('blank and invalid messages are normalized or removed before encryption', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'tool', content: '   ' },
+                    { role: 'developer', content: [{ type: 'text', text: 'normalized text' }] },
+                    { role: 'assistant', content: null },
+                    { role: 'user', content: { nested: 'safe object text' }, extra: 'drop me' },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const decrypted = await getDecryptedRelayRequest();
+        const { messages } = decrypted.api_v1_request;
+        expectValidApiV1Messages(messages);
+        expect(messages).toEqual([
+            { role: 'user', content: 'normalized text' },
+            { role: 'user', content: '{"nested":"safe object text"}' },
+        ]);
     });
 
     test('decryption accepts chat_history as the response ciphertext', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -15,6 +15,9 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
+export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
+export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -63,14 +66,92 @@ export const getTokenPlaceChatModel = (options = {}) =>
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
 
-const sanitizeChatMessage = (message) => ({
-    role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
-    content:
-        typeof message?.content === 'string' ? message.content : String(message?.content || ''),
-});
+const stringifyTokenPlaceContent = (content) => {
+    if (typeof content === 'string') return content;
+    if (content == null) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => {
+                if (typeof part === 'string') return part;
+                if (typeof part?.text === 'string') return part.text;
+                if (typeof part?.content === 'string') return part.content;
+                try {
+                    return JSON.stringify(part);
+                } catch {
+                    return String(part || '');
+                }
+            })
+            .join('\n');
+    }
+    try {
+        return JSON.stringify(content);
+    } catch {
+        return String(content || '');
+    }
+};
 
-export const sanitizeTokenPlaceMessages = (messages = []) =>
-    (Array.isArray(messages) ? messages : []).map(sanitizeChatMessage);
+const chunkMessageContent = (content) => {
+    const chunks = [];
+    for (
+        let start = 0;
+        start < content.length;
+        start += TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS
+    ) {
+        chunks.push(content.slice(start, start + TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS));
+    }
+    return chunks;
+};
+
+export const sanitizeTokenPlaceMessages = (messages = []) => buildTokenPlaceApiV1Messages(messages);
+
+const getTokenPlaceMessagePriority = (message, index, latestUserIndex) => {
+    if (index === latestUserIndex) return 0;
+    if (message.role === 'system' && index === 0) return 1;
+    if (message.role === 'system' && /playerstate|player state/i.test(message.content)) return 2;
+    if (message.role === 'system') return 3;
+    return 4;
+};
+
+export const buildTokenPlaceApiV1Messages = (messages = []) => {
+    const normalized = (Array.isArray(messages) ? messages : [])
+        .map((message, index) => ({
+            role: VALID_CHAT_ROLES.has(message?.role) ? message.role : 'user',
+            content: stringifyTokenPlaceContent(message?.content).trim(),
+            index,
+        }))
+        .filter((message) => message.content);
+    const latestUserIndex = normalized.findLast((message) => message.role === 'user')?.index ?? -1;
+    const chunks = normalized.flatMap((message) =>
+        chunkMessageContent(message.content).map((content, chunkIndex) => ({
+            role: message.role,
+            content,
+            index: message.index,
+            chunkIndex,
+            priority: getTokenPlaceMessagePriority(message, message.index, latestUserIndex),
+        }))
+    );
+    const selected = [];
+    let totalChars = 0;
+    for (const chunk of [...chunks].sort(
+        (a, b) =>
+            a.priority - b.priority ||
+            (a.priority === 4 ? b.index - a.index : a.index - b.index) ||
+            a.chunkIndex - b.chunkIndex
+    )) {
+        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) break;
+        const remaining = TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS - totalChars;
+        if (remaining <= 0) break;
+        // Older history/context chunks are lower priority; when only partial room remains,
+        // truncate that chunk instead of dropping the latest user intent already selected.
+        const content = chunk.content.slice(0, remaining);
+        if (!content.trim()) continue;
+        selected.push({ ...chunk, content });
+        totalChars += content.length;
+    }
+    return selected
+        .sort((a, b) => a.index - b.index || a.chunkIndex - b.chunkIndex)
+        .map(({ role, content }) => ({ role, content }));
+};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content = response?.choices?.[0]?.message?.content;


### PR DESCRIPTION
### Motivation

- DSPACE builds dChat prompts that can include large system/RAG excerpts which violate token.place API v1 message format and size constraints, causing desktop nodes to reject requests with "Invalid chat message format".
- The client must enforce token.place v1 limits and message shape before encrypting and dispatching relay requests while keeping the relay payload ciphertext-only.

### Description

- Implemented a strict token.place API v1 message adapter and limits in `frontend/src/utils/tokenPlace.js`, adding constants: `TOKEN_PLACE_API_V1_MAX_MESSAGES`, `TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS`, and `TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS`.
- Added content normalization and shaping helpers: `stringifyTokenPlaceContent`, `chunkMessageContent`, and `buildTokenPlaceApiV1Messages`, and wired them into `sanitizeTokenPlaceMessages` so outgoing `api_v1_request.messages` contain only `{ role, content }`, use only `system|user|assistant` roles, drop blank/unsupported messages, and perform deterministic chunking/truncation with priority for latest user intent and system persona.
- Preserved `api_v1_request.options` as an empty object and kept the relay request ciphertext-only invariant; the adapter runs before envelope encryption so no plaintext artifacts reach the relay request body.
- Added and updated focused unit tests in `frontend/__tests__/tokenPlace.test.js` to cover normal small flows, large DSPACE knowledge/RAG chunking, blank/invalid message normalization, and assertions that the decrypted `api_v1_request` meets role/key/size/count constraints.

### Testing

- Ran the focused unit tests: `cd frontend && npm test -- tokenPlace.test.js` and all tests passed (Test Files: 1 passed, Tests: 45 passed).
- Ran repository checks: `cd frontend && npm run check` which passed (lint/format checks succeeded).
- Built the frontend: `cd frontend && npm run build` which completed successfully.
- New tests assert that decrypted `api_v1_request.messages` only contain allowed roles and keys, have no blank content, respect per-message and total-character budgets, contain at most 64 messages, and that the outer `/api/v1/relay/requests` body remains ciphertext-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38948f5430832fac218bf452c9d686)