### PR TITLE
Add token-lite debug mode for token.place Chat

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/utils/docsRag.js', () => ({
 }));
 
 const { loadGameState } = await import('../src/utils/gameState/common.js');
+const { searchDocsRag } = await import('../src/utils/docsRag.js');
 const {
     TokenPlaceChatV2,
     decryptTokenPlaceEnvelope,
@@ -294,6 +295,95 @@ describe('token.place API v1 client', () => {
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('default token.place mode uses the normal full dChat prompt path', async () => {
+        searchDocsRag.mockClear();
+        loadGameState.mockReturnValue({ settings: { tokenPlaceTokenLite: false } });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'normal prompt please' }]);
+
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const contents = decrypted.api_v1_request.messages.map((message) => message.content);
+        expect(contents.some((content) => content.includes('DSPACE'))).toBe(true);
+        expect(contents.some((content) => content.includes('normal prompt please'))).toBe(true);
+        expect(decrypted.api_v1_request.options).toEqual({});
+    });
+
+    test('token-lite mode sends only tiny system and latest user messages', async () => {
+        searchDocsRag.mockClear();
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: true },
+            inventory: { canary: 'PlayerState should not leak' },
+        });
+        const latest = 'latest tiny user text canary';
+
+        await TokenPlaceChatV2([
+            { role: 'user', content: 'older user history should not leak' },
+            { role: 'assistant', content: 'older assistant history should not leak' },
+            { role: 'user', content: latest },
+        ]);
+
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const outerBody = JSON.stringify(body);
+        expect(outerBody).not.toContain(latest);
+        expect(outerBody).not.toContain('messages');
+        expect(outerBody).not.toContain('model');
+        expect(outerBody).not.toContain('PlayerState');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const messages = decrypted.api_v1_request.messages;
+        expect(messages).toEqual([
+            {
+                role: 'system',
+                content:
+                    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.",
+            },
+            { role: 'user', content: latest },
+        ]);
+        expect(decrypted.api_v1_request.options).toEqual({});
+        const serializedMessages = JSON.stringify(messages);
+        expect(serializedMessages).not.toContain('older user history should not leak');
+        expect(serializedMessages).not.toContain('older assistant history should not leak');
+        expect(serializedMessages).not.toContain('PlayerState');
+        expect(serializedMessages).not.toContain('DSPACE knowledge base');
+        expect(serializedMessages).not.toContain('DocsRAG');
+        expect(messages.reduce((total, message) => total + message.content.length, 0)).toBeLessThan(
+            300
+        );
+    });
+
+    test('token-lite override enables tiny prompt without saved setting', async () => {
+        searchDocsRag.mockClear();
+        loadGameState.mockReturnValue({ settings: { tokenPlaceTokenLite: false } });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'override canary' }], {
+            tokenPlaceTokenLite: true,
+        });
+
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        expect(decrypted.api_v1_request.messages).toHaveLength(2);
+        expect(decrypted.api_v1_request.messages[1]).toEqual({
+            role: 'user',
+            content: 'override canary',
+        });
+    });
+
+    test('token-lite mode rejects blank or non-user input before relay encryption', async () => {
+        loadGameState.mockReturnValue({ settings: { tokenPlaceTokenLite: true } });
+
+        await expect(
+            TokenPlaceChatV2([
+                { role: 'assistant', content: 'assistant only' },
+                { role: 'user', content: '   ' },
+            ])
+        ).rejects.toThrow('Token-lite mode requires a non-empty user message.');
+
+        expect(fetch).not.toHaveBeenCalled();
     });
 
     test('decrypted API v1 request uses empty options and excludes metadata', async () => {

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -60,16 +60,36 @@ test.describe('Settings route', () => {
             chatPanel.locator('input[name="chat-provider"][value="token-place"]')
         ).toBeChecked();
         await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite mode is disabled.'
+        );
         await expect(
             chatPanel.locator('input:is([type="password"], [type="text"], :not([type]))')
         ).toHaveCount(0);
         await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
+
+        await page.getByTestId('token-place-token-lite-toggle').check();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite mode is enabled.'
+        );
+        await expect
+            .poll(async () => {
+                const state = await readStoredGameState(page);
+                return state.settings?.tokenPlaceTokenLite;
+            })
+            .toBe(true);
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
 
         await chatPanel.locator('input[name="chat-provider"][value="openai"]').check();
         await expect(
             chatPanel.locator('input[name="chat-provider"][value="openai"]')
         ).toBeChecked();
         await expect(page.getByLabel('OpenAI API key', { exact: true })).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toHaveCount(0);
 
         await expect
             .poll(async () => {
@@ -133,10 +153,15 @@ test.describe('Settings route', () => {
                 const state = await readStoredGameState(page);
                 return {
                     chatProvider: state.settings?.chatProvider,
+                    tokenPlaceTokenLite: state.settings?.tokenPlaceTokenLite,
                     tokenPlaceApiKey: state.tokenPlace?.apiKey ?? null,
                 };
             })
-            .toEqual({ chatProvider: 'token-place', tokenPlaceApiKey: null });
+            .toEqual({
+                chatProvider: 'token-place',
+                tokenPlaceTokenLite: true,
+                tokenPlaceApiKey: null,
+            });
 
         await page.goto('/chat');
         await page.waitForLoadState('networkidle');

--- a/frontend/src/components/svelte/ChatProviderSettings.svelte
+++ b/frontend/src/components/svelte/ChatProviderSettings.svelte
@@ -16,11 +16,14 @@
 
     let hydrated = false;
     let selectedProvider = DEFAULT_CHAT_PROVIDER;
+    let tokenPlaceTokenLite = false;
     let statusMessage = '';
     let unsubscribe;
 
     const syncFromState = (value) => {
-        selectedProvider = normalizeSettings(value?.settings).chatProvider;
+        const settings = normalizeSettings(value?.settings);
+        selectedProvider = settings.chatProvider;
+        tokenPlaceTokenLite = settings.tokenPlaceTokenLite;
     };
 
     onMount(async () => {
@@ -33,6 +36,23 @@
     onDestroy(() => {
         unsubscribe?.();
     });
+
+    async function persistTokenPlaceTokenLite(enabled) {
+        tokenPlaceTokenLite = enabled;
+        await ready;
+        const current = loadGameState();
+        const nextSettings = {
+            ...normalizeSettings(current.settings),
+            tokenPlaceTokenLite: enabled,
+        };
+        await saveGameState({
+            ...current,
+            settings: nextSettings,
+        });
+        statusMessage = enabled
+            ? 'Token-lite mode enabled for token.place Chat.'
+            : 'Token-lite mode disabled for token.place Chat.';
+    }
 
     async function persistProvider(provider) {
         selectedProvider = provider;
@@ -107,10 +127,33 @@
                 <OpenAIAPIKeySettings />
             </div>
         {:else}
-            <p class="token-place-note" data-testid="token-place-no-key-note">
-                token.place Chat is ready to use. There is no token.place credential field on this
-                device.
-            </p>
+            <div class="token-place-panel">
+                <p class="token-place-note" data-testid="token-place-no-key-note">
+                    token.place Chat is ready to use. There is no token.place credential field on
+                    this device.
+                </p>
+                <label class="token-lite-option">
+                    <input
+                        type="checkbox"
+                        checked={tokenPlaceTokenLite}
+                        data-testid="token-place-token-lite-toggle"
+                        on:change={(event) =>
+                            persistTokenPlaceTokenLite(event.currentTarget.checked)}
+                    />
+                    <span>
+                        <strong>Token-lite mode for token.place Chat</strong>
+                        <small>
+                            Debug mode: sends only a tiny system prompt plus your latest message.
+                            Skips RAG, player state, and chat history.
+                        </small>
+                        <small data-testid="token-place-token-lite-status">
+                            {tokenPlaceTokenLite
+                                ? 'Token-lite mode is enabled.'
+                                : 'Token-lite mode is disabled.'}
+                        </small>
+                    </span>
+                </label>
+            </div>
         {/if}
     {/if}
 </section>
@@ -130,7 +173,8 @@
 
     .heading,
     fieldset,
-    .openai-panel {
+    .openai-panel,
+    .token-place-panel {
         display: grid;
         gap: 0.75rem;
     }
@@ -158,7 +202,8 @@
         font-weight: 700;
     }
 
-    .provider-option {
+    .provider-option,
+    .token-lite-option {
         display: flex;
         gap: 0.75rem;
         align-items: flex-start;
@@ -169,12 +214,14 @@
         cursor: pointer;
     }
 
-    .provider-option span {
+    .provider-option span,
+    .token-lite-option span {
         display: grid;
         gap: 0.25rem;
     }
 
-    input[type='radio'] {
+    input[type='radio'],
+    input[type='checkbox'] {
         margin-top: 0.2rem;
     }
 

--- a/frontend/src/utils/settingsDefaults.js
+++ b/frontend/src/utils/settingsDefaults.js
@@ -5,6 +5,7 @@ export const DEFAULT_SETTINGS = {
     chatProvider: DEFAULT_CHAT_PROVIDER,
     showChatDebugPayload: false,
     showQuestGraphVisualizer: false,
+    tokenPlaceTokenLite: false,
 };
 
 export const normalizeSettings = (settings = {}) => {
@@ -21,5 +22,6 @@ export const normalizeSettings = (settings = {}) => {
         chatProvider,
         showChatDebugPayload: Boolean(base.showChatDebugPayload),
         showQuestGraphVisualizer: Boolean(base.showQuestGraphVisualizer),
+        tokenPlaceTokenLite: Boolean(base.tokenPlaceTokenLite),
     };
 };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,6 +1,7 @@
 import { JSEncrypt } from 'jsencrypt';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { normalizeSettings } from './settingsDefaults.js';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -15,6 +16,53 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+
+const TOKEN_LITE_SYSTEM_MESSAGE =
+    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.";
+
+const findLatestUserMessageContent = (messages = []) => {
+    const list = Array.isArray(messages) ? messages : [];
+    for (let index = list.length - 1; index >= 0; index -= 1) {
+        const message = list[index];
+        if (message?.role !== 'user') continue;
+        const content = typeof message.content === 'string' ? message.content.trim() : '';
+        if (content) return content;
+    }
+    return '';
+};
+
+const resolveTokenLiteEnabled = (state, options = {}) => {
+    if (typeof options.tokenPlaceTokenLite === 'boolean') return options.tokenPlaceTokenLite;
+    return normalizeSettings(state?.settings).tokenPlaceTokenLite;
+};
+
+export const buildTokenPlaceTokenLitePrompt = (messages = [], options = {}) => {
+    const latestUserContent = findLatestUserMessageContent(messages);
+    if (!latestUserContent) {
+        throw new Error('Token-lite mode requires a non-empty user message.');
+    }
+    const gameState = options.state || loadGameState();
+    const combinedMessages = [
+        { role: 'system', content: TOKEN_LITE_SYSTEM_MESSAGE },
+        { role: 'user', content: latestUserContent },
+    ];
+    return {
+        combinedMessages,
+        debugMessages: combinedMessages,
+        gameState,
+        contextSources: [],
+        playerStateSummary: '',
+    };
+};
+
+const buildTokenPlacePromptPayload = async (messages, options = {}) => {
+    if (options.promptPayload) return options.promptPayload;
+    const state = options.state || loadGameState();
+    if (resolveTokenLiteEnabled(state, options)) {
+        return buildTokenPlaceTokenLitePrompt(messages, { ...options, state });
+    }
+    return buildChatPrompt(messages, options);
+};
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -548,7 +596,7 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
-    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const promptPayload = await buildTokenPlacePromptPayload(messages, options);
     const contextSources = Array.isArray(promptPayload.contextSources)
         ? promptPayload.contextSources
         : [];


### PR DESCRIPTION
### Motivation
- Provide an opt-in, deterministic small-prompt path for token.place so `/chat` can be validated against token.place API v1 with a tiny payload for debugging and diagnostics.
- Keep the normal/full dChat prompt builder and P8f work untouched so production token.place continues to use full PlayerState, RAG, knowledge, and history.
- Preserve relay E2EE and ciphertext-only relay envelopes while avoiding docs RAG/search, PlayerState, full history, and knowledge excerpts for token-lite requests.

### Description
- Add a persisted boolean setting `settings.tokenPlaceTokenLite` defaulting to `false` and normalize it in `normalizeSettings()` (`frontend/src/utils/settingsDefaults.js`).
- Add a checkbox toggle in the token.place section of `ChatProviderSettings.svelte` with stable test IDs `token-place-token-lite-toggle` and `token-place-token-lite-status`, and persist via the existing `loadGameState`/`saveGameState` pattern (`frontend/src/components/svelte/ChatProviderSettings.svelte`).
- Implement a token-lite prompt path in `tokenPlace.js`: `buildTokenPlaceTokenLitePrompt` that uses a minimal system message plus the latest non-empty user message, `buildTokenPlacePromptPayload`/`resolveTokenLiteEnabled` to choose token-lite vs full prompt, and keep `contextSources: []` and `api_v1_request.options: {}` while preserving the existing relay E2EE flow (`frontend/src/utils/tokenPlace.js`).
- Update `TokenPlaceChatV2` to use the new prompt payload builder and add unit + E2E test coverage adjustments for token-lite behavior and persistence (`frontend/__tests__/tokenPlace.test.js`, `frontend/e2e/settings-page.spec.ts`).

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all token.place unit tests passed (46 tests; green).
- Ran settings E2E: `cd frontend && npx playwright test e2e/settings-page.spec.ts` — blocked by environment network/browser install failures (Playwright Chromium download and apt dependency installs failed with `ENETUNREACH`), so full E2E verification could not complete in this environment.
- Ran formatting/lint/build checks: `cd frontend && npm run check` and `cd frontend && npm run build` — both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3896c2ba40832f9029042330145c6d)