### PR TITLE
Add opt-in "token-lite" debug mode for token.place Chat

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/utils/docsRag.js', () => ({
 }));
 
 const { loadGameState } = await import('../src/utils/gameState/common.js');
+const { searchDocsRag } = await import('../src/utils/docsRag.js');
 const {
     TokenPlaceChatV2,
     decryptTokenPlaceEnvelope,
@@ -22,6 +23,7 @@ const {
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
     tokenPlaceChat,
+    buildTokenPlaceTokenLitePrompt,
 } = await import('../src/utils/tokenPlace.js');
 const { JSEncrypt } = await import('jsencrypt');
 const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
@@ -124,6 +126,7 @@ describe('token.place API v1 client', () => {
         relayReply = { choices: [{ message: { content: 'mocked reply' } }] };
         global.fetch = makeRelayFetch();
         loadGameState.mockReturnValue({});
+        searchDocsRag.mockResolvedValue({ excerptsText: '', sources: [] });
     });
 
     afterEach(() => {
@@ -294,6 +297,80 @@ describe('token.place API v1 client', () => {
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('default setting uses the normal DSPACE prompt path', async () => {
+        loadGameState.mockReturnValue({ settings: { tokenPlaceTokenLite: false } });
+        await TokenPlaceChatV2([{ role: 'user', content: 'where is the launch quest?' }]);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const messages = decrypted.api_v1_request.messages;
+
+        expect(messages.length).toBeGreaterThan(2);
+        expect(JSON.stringify(messages)).toContain('DSPACE');
+        expect(searchDocsRag).toHaveBeenCalled();
+    });
+
+    test('token-lite sends a tiny decrypted API v1 message set without RAG or player state', async () => {
+        const latestUserText = 'latest token-lite user canary';
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: true },
+            inventory: [{ name: 'PlayerState canary' }],
+        });
+        await TokenPlaceChatV2([
+            { role: 'user', content: 'older history canary' },
+            { role: 'assistant', content: 'older assistant canary' },
+            { role: 'user', content: latestUserText },
+        ]);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const apiRequest = decrypted.api_v1_request;
+        const serializedMessages = JSON.stringify(apiRequest.messages);
+        const totalChars = apiRequest.messages.reduce(
+            (sum, message) => sum + message.content.length,
+            0
+        );
+
+        expect(apiRequest.options).toEqual({});
+        expect(apiRequest.messages).toEqual([
+            {
+                role: 'system',
+                content:
+                    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.",
+            },
+            { role: 'user', content: latestUserText },
+        ]);
+        expect(apiRequest.messages).toHaveLength(2);
+        expect(totalChars).toBeLessThan(500);
+        expect(serializedMessages).not.toContain('older history canary');
+        expect(serializedMessages).not.toContain('older assistant canary');
+        expect(serializedMessages).not.toMatch(/PlayerState|DSPACE knowledge base|docs RAG/i);
+        expect(JSON.stringify(body)).not.toContain(latestUserText);
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    test('token-lite handles blank or non-user inputs with a safe fallback user message', async () => {
+        loadGameState.mockReturnValue({ settings: { tokenPlaceTokenLite: true } });
+        await TokenPlaceChatV2([
+            { role: 'assistant', content: 'assistant-only history' },
+            { role: 'user', content: '   ' },
+        ]);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+
+        expect(decrypted.api_v1_request.messages).toHaveLength(2);
+        expect(decrypted.api_v1_request.messages[1]).toEqual({ role: 'user', content: 'Hello' });
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    test('token-lite helper keeps context sources empty and prompt shape compatible', () => {
+        expect(buildTokenPlaceTokenLitePrompt([{ role: 'user', content: 'hi' }])).toEqual({
+            combinedMessages: expect.any(Array),
+            debugMessages: expect.any(Array),
+            gameState: {},
+            contextSources: [],
+            playerStateSummary: {},
+        });
     });
 
     test('decrypted API v1 request uses empty options and excludes metadata', async () => {

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -60,16 +60,37 @@ test.describe('Settings route', () => {
             chatPanel.locator('input[name="chat-provider"][value="token-place"]')
         ).toBeChecked();
         await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).not.toBeChecked();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite is off.'
+        );
         await expect(
             chatPanel.locator('input:is([type="password"], [type="text"], :not([type]))')
         ).toHaveCount(0);
         await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
+
+        await page.getByTestId('token-place-token-lite-toggle').check();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite is enabled.'
+        );
+        await expect
+            .poll(async () => {
+                const state = await readStoredGameState(page);
+                return state.settings?.tokenPlaceTokenLite;
+            })
+            .toBe(true);
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
 
         await chatPanel.locator('input[name="chat-provider"][value="openai"]').check();
         await expect(
             chatPanel.locator('input[name="chat-provider"][value="openai"]')
         ).toBeChecked();
         await expect(page.getByLabel('OpenAI API key', { exact: true })).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toHaveCount(0);
+        await expect(page.getByTestId('token-place-no-key-note')).toHaveCount(0);
 
         await expect
             .poll(async () => {
@@ -124,6 +145,7 @@ test.describe('Settings route', () => {
             chatPanel.locator('input[name="chat-provider"][value="token-place"]')
         ).toBeChecked();
         await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
         await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
         await expect(
             chatPanel.locator('input:is([type="password"], [type="text"], :not([type]))')
@@ -134,9 +156,14 @@ test.describe('Settings route', () => {
                 return {
                     chatProvider: state.settings?.chatProvider,
                     tokenPlaceApiKey: state.tokenPlace?.apiKey ?? null,
+                    tokenPlaceTokenLite: state.settings?.tokenPlaceTokenLite,
                 };
             })
-            .toEqual({ chatProvider: 'token-place', tokenPlaceApiKey: null });
+            .toEqual({
+                chatProvider: 'token-place',
+                tokenPlaceApiKey: null,
+                tokenPlaceTokenLite: true,
+            });
 
         await page.goto('/chat');
         await page.waitForLoadState('networkidle');

--- a/frontend/src/components/svelte/ChatProviderSettings.svelte
+++ b/frontend/src/components/svelte/ChatProviderSettings.svelte
@@ -17,10 +17,13 @@
     let hydrated = false;
     let selectedProvider = DEFAULT_CHAT_PROVIDER;
     let statusMessage = '';
+    let tokenLiteEnabled = false;
     let unsubscribe;
 
     const syncFromState = (value) => {
-        selectedProvider = normalizeSettings(value?.settings).chatProvider;
+        const settings = normalizeSettings(value?.settings);
+        selectedProvider = settings.chatProvider;
+        tokenLiteEnabled = settings.tokenPlaceTokenLite;
     };
 
     onMount(async () => {
@@ -33,6 +36,23 @@
     onDestroy(() => {
         unsubscribe?.();
     });
+
+    async function persistTokenLite(enabled) {
+        tokenLiteEnabled = enabled;
+        await ready;
+        const current = loadGameState();
+        const nextSettings = {
+            ...normalizeSettings(current.settings),
+            tokenPlaceTokenLite: enabled,
+        };
+        await saveGameState({
+            ...current,
+            settings: nextSettings,
+        });
+        statusMessage = enabled
+            ? 'Token-lite mode enabled for token.place Chat.'
+            : 'Token-lite mode disabled for token.place Chat.';
+    }
 
     async function persistProvider(provider) {
         selectedProvider = provider;
@@ -107,10 +127,30 @@
                 <OpenAIAPIKeySettings />
             </div>
         {:else}
-            <p class="token-place-note" data-testid="token-place-no-key-note">
-                token.place Chat is ready to use. There is no token.place credential field on this
-                device.
-            </p>
+            <div class="token-place-panel">
+                <p class="token-place-note" data-testid="token-place-no-key-note">
+                    token.place Chat is ready to use. There is no token.place credential field on
+                    this device.
+                </p>
+                <label class="token-lite-option">
+                    <input
+                        data-testid="token-place-token-lite-toggle"
+                        type="checkbox"
+                        checked={tokenLiteEnabled}
+                        on:change={(event) => persistTokenLite(event.currentTarget.checked)}
+                    />
+                    <span>
+                        <strong>Token-lite mode for token.place Chat</strong>
+                        <small>
+                            Debug mode: sends only a tiny system prompt plus your latest message.
+                            Skips RAG, player state, and chat history.
+                        </small>
+                        <small data-testid="token-place-token-lite-status">
+                            {tokenLiteEnabled ? 'Token-lite is enabled.' : 'Token-lite is off.'}
+                        </small>
+                    </span>
+                </label>
+            </div>
         {/if}
     {/if}
 </section>
@@ -130,7 +170,8 @@
 
     .heading,
     fieldset,
-    .openai-panel {
+    .openai-panel,
+    .token-place-panel {
         display: grid;
         gap: 0.75rem;
     }
@@ -158,7 +199,8 @@
         font-weight: 700;
     }
 
-    .provider-option {
+    .provider-option,
+    .token-lite-option {
         display: flex;
         gap: 0.75rem;
         align-items: flex-start;
@@ -169,12 +211,14 @@
         cursor: pointer;
     }
 
-    .provider-option span {
+    .provider-option span,
+    .token-lite-option span {
         display: grid;
         gap: 0.25rem;
     }
 
-    input[type='radio'] {
+    input[type='radio'],
+    input[type='checkbox'] {
         margin-top: 0.2rem;
     }
 

--- a/frontend/src/utils/settingsDefaults.js
+++ b/frontend/src/utils/settingsDefaults.js
@@ -4,6 +4,7 @@ export const CHAT_PROVIDER_VALUES = new Set([DEFAULT_CHAT_PROVIDER, 'openai']);
 export const DEFAULT_SETTINGS = {
     chatProvider: DEFAULT_CHAT_PROVIDER,
     showChatDebugPayload: false,
+    tokenPlaceTokenLite: false,
     showQuestGraphVisualizer: false,
 };
 
@@ -20,6 +21,7 @@ export const normalizeSettings = (settings = {}) => {
         ...base,
         chatProvider,
         showChatDebugPayload: Boolean(base.showChatDebugPayload),
+        tokenPlaceTokenLite: Boolean(base.tokenPlaceTokenLite),
         showQuestGraphVisualizer: Boolean(base.showQuestGraphVisualizer),
     };
 };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,6 +1,7 @@
 import { JSEncrypt } from 'jsencrypt';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { normalizeSettings } from './settingsDefaults.js';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -15,6 +16,43 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+
+const TOKEN_LITE_SYSTEM_MESSAGE =
+    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.";
+const TOKEN_LITE_FALLBACK_USER_MESSAGE = 'Hello';
+
+const findLatestTokenPlaceUserMessage = (messages = []) => {
+    const normalizedMessages = Array.isArray(messages) ? messages : [];
+    const latestUserMessage = [...normalizedMessages]
+        .reverse()
+        .find((message) => message?.role === 'user' && String(message?.content || '').trim());
+    return String(latestUserMessage?.content || TOKEN_LITE_FALLBACK_USER_MESSAGE).trim();
+};
+
+export const buildTokenPlaceTokenLitePrompt = (messages = {}) => {
+    const latestUserContent = findLatestTokenPlaceUserMessage(messages);
+    const combinedMessages = [
+        { role: 'system', content: TOKEN_LITE_SYSTEM_MESSAGE },
+        { role: 'user', content: latestUserContent },
+    ];
+    return {
+        combinedMessages,
+        debugMessages: combinedMessages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            kind: 'main',
+        })),
+        gameState: {},
+        contextSources: [],
+        playerStateSummary: {},
+    };
+};
+
+const isTokenPlaceTokenLiteEnabled = (options = {}) => {
+    if (typeof options.tokenPlaceTokenLite === 'boolean') return options.tokenPlaceTokenLite;
+    if (typeof options.tokenLite === 'boolean') return options.tokenLite;
+    return normalizeSettings(loadGameState()?.settings).tokenPlaceTokenLite;
+};
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -548,7 +586,12 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
-    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const tokenLiteEnabled = !options.promptPayload && isTokenPlaceTokenLiteEnabled(options);
+    const promptPayload =
+        options.promptPayload ||
+        (tokenLiteEnabled
+            ? buildTokenPlaceTokenLitePrompt(messages)
+            : await buildChatPrompt(messages, options));
     const contextSources = Array.isArray(promptPayload.contextSources)
         ? promptPayload.contextSources
         : [];


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic token.place API v1 prompt path for debugging that deliberately avoids the full dChat prompt/RAG/player-state/history construction. 
- Keep the default/full DSPACE token.place path unchanged so P8f/P8-letter work is not weakened. 
- Add an opt-in, persisted toggle in the settings UI so operators can enable the tiny prompt for troubleshooting without affecting normal behavior.

### Description
- Add a persisted boolean setting `settings.tokenPlaceTokenLite` with default `false` and normalization in `frontend/src/utils/settingsDefaults.js`.
- Add a checkbox and status text in the token.place section of `ChatProviderSettings.svelte` with test IDs `token-place-token-lite-toggle` and `token-place-token-lite-status`, persisting via the existing `loadGameState`/`saveGameState` pattern.
- Implement `buildTokenPlaceTokenLitePrompt`, `findLatestTokenPlaceUserMessage`, and `isTokenPlaceTokenLiteEnabled` in `frontend/src/utils/tokenPlace.js`, and wire them into `TokenPlaceChatV2` so token-lite (when enabled and not overridden by `promptPayload`) builds a minimal API v1 payload: one small system message + the latest non-empty user message, `contextSources: []`, `options: {}`, omitted `playerStateSummary`, no RAG/search, and compatible `messages` shape.
- Preserve all relay E2EE behavior and ciphertext-only outer relay body; token-lite only changes the internal decrypted `api_v1_request.messages` shape sent inside the envelope.
- Add/adjust tests: unit tests in `frontend/__tests__/tokenPlace.test.js` to cover default (full prompt) and token-lite behavior, and update `frontend/e2e/settings-page.spec.ts` to assert the toggle is visible, persists to `localStorage.gameState.settings.tokenPlaceTokenLite`, survives reload, and is hidden when OpenAI provider is selected.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (`frontend/__tests__/tokenPlace.test.js`: 46 tests, 46 passed). 
- Attempted E2E: `cd frontend && npx playwright test e2e/settings-page.spec.ts` — blocked by environment network/browser installation failures (Playwright failed to download Chromium and apt Release files; `ENETUNREACH`), so E2E could not complete in this environment. 
- Ran formatting/lint/build checks: `cd frontend && npm run check` ✅ and `cd frontend && npm run build` ✅. 

Notes and follow-ups: 
- Token-lite is opt-in and off by default; the full dChat payload path remains unchanged and is selected unless token-lite is explicitly enabled or `promptPayload` is provided. 
- E2E verification should be re-run in CI or a network-enabled dev environment (run `npx playwright install`/`playwright:install` then `npx playwright test`) to validate UI persistence in a browser-capable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3896d85448832f9b81176ed50742dd)