### PR TITLE
Add opt-in Token-lite mode for token.place Chat

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/utils/docsRag.js', () => ({
 }));
 
 const { loadGameState } = await import('../src/utils/gameState/common.js');
+const { searchDocsRag } = await import('../src/utils/docsRag.js');
 const {
     TokenPlaceChatV2,
     decryptTokenPlaceEnvelope,
@@ -22,6 +23,7 @@ const {
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
     tokenPlaceChat,
+    buildTokenPlaceTokenLitePrompt,
 } = await import('../src/utils/tokenPlace.js');
 const { JSEncrypt } = await import('jsencrypt');
 const { getTokenPlaceErrorSummary } = await import('../src/utils/tokenPlaceErrors.js');
@@ -294,6 +296,107 @@ describe('token.place API v1 client', () => {
         expect(body).not.toHaveProperty('mode');
         expect(body).not.toHaveProperty('tag');
         expect(body.stream).not.toBe(true);
+    });
+
+    test('default token.place mode keeps the normal full prompt path', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: false },
+            inventory: [{ id: 'full-prompt-item', name: 'Full Prompt Item', quantity: 1 }],
+        });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'tell me about rockets' }]);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const serializedMessages = JSON.stringify(decrypted.api_v1_request.messages);
+
+        expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        expect(serializedMessages).toContain('DSPACE');
+        expect(serializedMessages).toContain('tell me about rockets');
+        expect(searchDocsRag).toHaveBeenCalled();
+    });
+
+    test('token-lite mode sends a minimal decrypted API v1 request without full DSPACE context', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: true },
+            inventory: [{ id: 'secret-item', name: 'PLAYERSTATE_SECRET_SENTINEL', quantity: 1 }],
+        });
+        const latestUserText = 'LATEST_USER_TOKEN_LITE_SENTINEL';
+        const oldUserText = 'OLDER_CHAT_HISTORY_SENTINEL';
+        const oldAssistantText = 'OLDER_ASSISTANT_HISTORY_SENTINEL';
+
+        await TokenPlaceChatV2([
+            { role: 'user', content: oldUserText },
+            { role: 'assistant', content: oldAssistantText },
+            { role: 'user', content: latestUserText },
+        ]);
+
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const apiRequest = decrypted.api_v1_request;
+        const serializedMessages = JSON.stringify(apiRequest.messages);
+        const totalContentChars = apiRequest.messages.reduce(
+            (total, message) => total + message.content.length,
+            0
+        );
+
+        expect(apiRequest.options).toEqual({});
+        expect(apiRequest.messages).toHaveLength(2);
+        expect(apiRequest.messages).toEqual([
+            {
+                role: 'system',
+                content:
+                    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.",
+            },
+            { role: 'user', content: latestUserText },
+        ]);
+        expect(totalContentChars).toBeLessThan(500);
+        expect(serializedMessages).not.toContain(oldUserText);
+        expect(serializedMessages).not.toContain(oldAssistantText);
+        expect(serializedMessages).not.toContain('PlayerState');
+        expect(serializedMessages).not.toContain('PLAYERSTATE_SECRET_SENTINEL');
+        expect(serializedMessages).not.toContain('DSPACE knowledge base');
+        expect(serializedMessages).not.toContain('DOCS_GROUNDING_SECRET_SENTINEL');
+        expect(JSON.stringify(body)).not.toContain(latestUserText);
+        expect(JSON.stringify(body)).not.toContain('messages');
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    test('token-lite mode can be enabled with test options and gracefully falls back for blank inputs', async () => {
+        await TokenPlaceChatV2(
+            [
+                { role: 'assistant', content: 'assistant-only' },
+                { role: 'user', content: '   ' },
+            ],
+            { tokenPlaceTokenLite: true }
+        );
+
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+
+        expect(decrypted.api_v1_request.messages).toEqual([
+            { role: 'system', content: expect.stringContaining('You are dChat') },
+            { role: 'user', content: 'Hello' },
+        ]);
+        expect(decrypted.api_v1_request.options).toEqual({});
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    test('token-lite prompt helper keeps contextSources empty and omits player state summary', () => {
+        const promptPayload = buildTokenPlaceTokenLitePrompt([
+            { role: 'user', content: 'first' },
+            { role: 'assistant', content: 'ignored' },
+            { role: 'user', content: 'latest' },
+        ]);
+
+        expect(promptPayload).toMatchObject({
+            contextSources: [],
+            playerStateSummary: '',
+            gameState: {},
+        });
+        expect(promptPayload.combinedMessages).toEqual([
+            { role: 'system', content: expect.stringContaining('concise DSPACE assistant') },
+            { role: 'user', content: 'latest' },
+        ]);
     });
 
     test('decrypted API v1 request uses empty options and excludes metadata', async () => {

--- a/frontend/e2e/settings-page.spec.ts
+++ b/frontend/e2e/settings-page.spec.ts
@@ -60,16 +60,40 @@ test.describe('Settings route', () => {
             chatPanel.locator('input[name="chat-provider"][value="token-place"]')
         ).toBeChecked();
         await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).not.toBeChecked();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite mode is disabled.'
+        );
         await expect(
             chatPanel.locator('input:is([type="password"], [type="text"], :not([type]))')
         ).toHaveCount(0);
         await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
+
+        await page.getByTestId('token-place-token-lite-toggle').check();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
+        await expect
+            .poll(async () => {
+                const state = await readStoredGameState(page);
+                return state.settings?.tokenPlaceTokenLite;
+            })
+            .toBe(true);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await waitForHydration(page);
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveText(
+            'Token-lite mode is enabled.'
+        );
 
         await chatPanel.locator('input[name="chat-provider"][value="openai"]').check();
         await expect(
             chatPanel.locator('input[name="chat-provider"][value="openai"]')
         ).toBeChecked();
         await expect(page.getByLabel('OpenAI API key', { exact: true })).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toHaveCount(0);
+        await expect(page.getByTestId('token-place-token-lite-status')).toHaveCount(0);
 
         await expect
             .poll(async () => {
@@ -124,6 +148,7 @@ test.describe('Settings route', () => {
             chatPanel.locator('input[name="chat-provider"][value="token-place"]')
         ).toBeChecked();
         await expect(page.getByTestId('token-place-no-key-note')).toBeVisible();
+        await expect(page.getByTestId('token-place-token-lite-toggle')).toBeChecked();
         await expect(page.getByLabel(/token\.place api key/i)).toHaveCount(0);
         await expect(
             chatPanel.locator('input:is([type="password"], [type="text"], :not([type]))')
@@ -133,10 +158,15 @@ test.describe('Settings route', () => {
                 const state = await readStoredGameState(page);
                 return {
                     chatProvider: state.settings?.chatProvider,
+                    tokenPlaceTokenLite: state.settings?.tokenPlaceTokenLite,
                     tokenPlaceApiKey: state.tokenPlace?.apiKey ?? null,
                 };
             })
-            .toEqual({ chatProvider: 'token-place', tokenPlaceApiKey: null });
+            .toEqual({
+                chatProvider: 'token-place',
+                tokenPlaceTokenLite: true,
+                tokenPlaceApiKey: null,
+            });
 
         await page.goto('/chat');
         await page.waitForLoadState('networkidle');

--- a/frontend/src/components/svelte/ChatProviderSettings.svelte
+++ b/frontend/src/components/svelte/ChatProviderSettings.svelte
@@ -16,11 +16,14 @@
 
     let hydrated = false;
     let selectedProvider = DEFAULT_CHAT_PROVIDER;
+    let tokenPlaceTokenLite = false;
     let statusMessage = '';
     let unsubscribe;
 
     const syncFromState = (value) => {
-        selectedProvider = normalizeSettings(value?.settings).chatProvider;
+        const settings = normalizeSettings(value?.settings);
+        selectedProvider = settings.chatProvider;
+        tokenPlaceTokenLite = settings.tokenPlaceTokenLite;
     };
 
     onMount(async () => {
@@ -33,6 +36,23 @@
     onDestroy(() => {
         unsubscribe?.();
     });
+
+    async function persistTokenPlaceTokenLite(enabled) {
+        tokenPlaceTokenLite = enabled;
+        await ready;
+        const current = loadGameState();
+        const nextSettings = {
+            ...normalizeSettings(current.settings),
+            tokenPlaceTokenLite: enabled,
+        };
+        await saveGameState({
+            ...current,
+            settings: nextSettings,
+        });
+        statusMessage = enabled
+            ? 'Token-lite mode enabled for token.place Chat.'
+            : 'Token-lite mode disabled for token.place Chat.';
+    }
 
     async function persistProvider(provider) {
         selectedProvider = provider;
@@ -107,10 +127,31 @@
                 <OpenAIAPIKeySettings />
             </div>
         {:else}
-            <p class="token-place-note" data-testid="token-place-no-key-note">
-                token.place Chat is ready to use. There is no token.place credential field on this
-                device.
-            </p>
+            <div class="token-place-panel">
+                <p class="token-place-note" data-testid="token-place-no-key-note">
+                    token.place Chat is ready to use. There is no token.place credential field on
+                    this device.
+                </p>
+                <label class="provider-option token-lite-option">
+                    <input
+                        type="checkbox"
+                        data-testid="token-place-token-lite-toggle"
+                        checked={tokenPlaceTokenLite}
+                        on:change={(event) =>
+                            persistTokenPlaceTokenLite(event.currentTarget.checked)}
+                    />
+                    <span>
+                        <strong>Token-lite mode for token.place Chat</strong>
+                        <small>
+                            Debug mode: sends only a tiny system prompt plus your latest message.
+                            Skips RAG, player state, and chat history.
+                        </small>
+                    </span>
+                </label>
+                <p class="token-lite-status" data-testid="token-place-token-lite-status">
+                    Token-lite mode is {tokenPlaceTokenLite ? 'enabled' : 'disabled'}.
+                </p>
+            </div>
         {/if}
     {/if}
 </section>
@@ -130,7 +171,8 @@
 
     .heading,
     fieldset,
-    .openai-panel {
+    .openai-panel,
+    .token-place-panel {
         display: grid;
         gap: 0.75rem;
     }
@@ -174,7 +216,8 @@
         gap: 0.25rem;
     }
 
-    input[type='radio'] {
+    input[type='radio'],
+    input[type='checkbox'] {
         margin-top: 0.2rem;
     }
 
@@ -184,7 +227,8 @@
     }
 
     .status,
-    .token-place-note {
+    .token-place-note,
+    .token-lite-status {
         color: #86efac;
         font-weight: 600;
     }

--- a/frontend/src/utils/settingsDefaults.js
+++ b/frontend/src/utils/settingsDefaults.js
@@ -4,6 +4,7 @@ export const CHAT_PROVIDER_VALUES = new Set([DEFAULT_CHAT_PROVIDER, 'openai']);
 export const DEFAULT_SETTINGS = {
     chatProvider: DEFAULT_CHAT_PROVIDER,
     showChatDebugPayload: false,
+    tokenPlaceTokenLite: false,
     showQuestGraphVisualizer: false,
 };
 
@@ -20,6 +21,7 @@ export const normalizeSettings = (settings = {}) => {
         ...base,
         chatProvider,
         showChatDebugPayload: Boolean(base.showChatDebugPayload),
+        tokenPlaceTokenLite: Boolean(base.tokenPlaceTokenLite),
         showQuestGraphVisualizer: Boolean(base.showQuestGraphVisualizer),
     };
 };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,6 +1,7 @@
 import { JSEncrypt } from 'jsencrypt';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { normalizeSettings } from './settingsDefaults.js';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -15,6 +16,9 @@ const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+const TOKEN_LITE_SYSTEM_MESSAGE =
+    "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.";
+const TOKEN_LITE_FALLBACK_USER_MESSAGE = 'Hello';
 
 const getCrypto = () => globalThis.crypto;
 const textEncoder = new TextEncoder();
@@ -466,6 +470,43 @@ export const pollTokenPlaceRelayResponse = async (baseUrl, body, options = {}) =
     );
 };
 
+const findLatestNonEmptyMessageByRole = (messages = [], role) =>
+    [...(Array.isArray(messages) ? messages : [])]
+        .reverse()
+        .find((message) => message?.role === role && String(message?.content || '').trim());
+
+const resolveTokenPlaceTokenLiteEnabled = (state, options = {}) => {
+    if (typeof options.tokenPlaceTokenLite === 'boolean') return options.tokenPlaceTokenLite;
+    return normalizeSettings(state?.settings).tokenPlaceTokenLite;
+};
+
+export const buildTokenPlaceTokenLitePrompt = (messages = [], options = {}) => {
+    const latestUser = findLatestNonEmptyMessageByRole(messages, 'user');
+    const latestUserContent =
+        String(latestUser?.content || '').trim() || TOKEN_LITE_FALLBACK_USER_MESSAGE;
+    const combinedMessages = [
+        { role: 'system', content: TOKEN_LITE_SYSTEM_MESSAGE },
+        { role: 'user', content: latestUserContent },
+    ];
+
+    return {
+        combinedMessages,
+        debugMessages: combinedMessages,
+        gameState: options.state || {},
+        contextSources: [],
+        playerStateSummary: '',
+    };
+};
+
+const buildTokenPlacePromptPayload = async (messages, options = {}) => {
+    if (options.promptPayload) return options.promptPayload;
+    const state = options.state || loadGameState();
+    if (resolveTokenPlaceTokenLiteEnabled(state, options)) {
+        return buildTokenPlaceTokenLitePrompt(messages, { ...options, state });
+    }
+    return buildChatPrompt(messages, { ...options, state });
+};
+
 export const validateTokenPlaceResponseEnvelope = (envelope, expected) => {
     if (envelope?.protocol !== RELAY_PROTOCOL)
         throw createMalformedTokenPlaceResponseError(
@@ -548,7 +589,7 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
-    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+    const promptPayload = await buildTokenPlacePromptPayload(messages, options);
     const contextSources = Array.isArray(promptPayload.contextSources)
         ? promptPayload.contextSources
         : [];


### PR DESCRIPTION
### Motivation
- Provide a deterministic, tiny-prompt debug path for token.place API v1 validation without changing or weakening the existing full DSPACE dChat prompt flow.
- Make the mode opt-in and persisted so debugging/ops can isolate token.place `/chat` requests from RAG, PlayerState, knowledge packs, and full history.

### Description
- Add a persisted boolean setting `settings.tokenPlaceTokenLite` (default `false`) and normalize it in `normalizeSettings()`.
- Add a token.place-only toggle in the Chat provider panel with stable test IDs `token-place-token-lite-toggle` and `token-place-token-lite-status`, persisted via the existing `loadGameState`/`saveGameState` pattern (`ChatProviderSettings.svelte`).
- Add a token-lite prompt builder and selection helper (`buildTokenPlaceTokenLitePrompt`, `buildTokenPlacePromptPayload`, and helpers) in `tokenPlace.js` that bypasses `buildChatPrompt()` when enabled, emits a minimal system message plus the latest user message, keeps `contextSources: []`, omits PlayerState, RAG/docs/knowledge, and returns `api_v1_request.options = {}` while preserving the existing relay E2EE envelope shape.
- Add unit tests exercising both default full-prompt behavior and the token-lite path and update the settings E2E spec to assert toggle visibility, persistence, and correct UI hiding under the OpenAI provider.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (46 tests; `frontend/__tests__/tokenPlace.test.js`).
- Ran E2E settings spec: `cd frontend && npx playwright test e2e/settings-page.spec.ts` — blocked by environment network issue during Playwright/browser install (failed to download Chromium; error `ENETUNREACH`, missing Playwright browsers), so the Playwright run did not complete in this environment.
- Ran checks and build: `cd frontend && npm run check` — passed (Prettier/lint checks); `cd frontend && npm run build` — passed (Astro build).
- Note: Playwright failures are environmental (browser install/download) and not caused by the code changes; re-running E2E in CI or a network-enabled dev environment is expected to validate the settings-page assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3896de6710832fa59c7700f86dbf63)