### PR TITLE
Fix token.place API v1 response parsing

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -916,13 +916,56 @@ ${ragExcerpt.repeat(4000)}`,
         ).resolves.toMatchObject({ text: 'mocked reply' });
     });
 
-    test('parses assistant text and compatibility helper returns string', async () => {
+    test('parses API v1 message assistant text and compatibility helper returns string', async () => {
+        expect(extractTokenPlaceAssistantText({ message: { content: 'api v1 reply' } })).toBe(
+            'api v1 reply'
+        );
+        relayReply = { message: { role: 'assistant', content: 'api v1 relay reply' } };
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'api v1 relay reply'
+        );
+    });
+
+    test('parses OpenAI-compatible choices assistant text', () => {
         expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
             'hi'
         );
+    });
+
+    test('prefers API v1 message assistant text when both response shapes exist', () => {
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'api v1 wins' },
+                choices: [{ message: { content: 'choices fallback' } }],
+            })
+        ).toBe('api v1 wins');
+    });
+
+    test('compatibility helper returns string', async () => {
         await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
             'mocked reply'
         );
+    });
+
+    test('empty, missing, stub, and legacy array assistant content are malformed', () => {
+        const invalidResponses = [
+            { message: { content: '' } },
+            { message: { content: '   ' } },
+            { message: { content: 'stub' } },
+            { choices: [{ message: { content: '' } }] },
+            { choices: [{ message: { content: 'stub' } }] },
+            { usage: { prompt_tokens: 1 } },
+            [
+                { role: 'user', content: 'hello' },
+                { role: 'assistant', content: 'legacy full-history reply' },
+            ],
+        ];
+
+        for (const response of invalidResponses) {
+            expect(() => extractTokenPlaceAssistantText(response)).toThrow(
+                'Malformed token.place response: missing assistant content.'
+            );
+        }
     });
 
     test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,7 +13,7 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+const DEFAULT_RELAY_TIMEOUT_MS = 300_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
 const normalizeTokenPlaceRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
@@ -187,9 +187,15 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
     return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
 };
 
+const isInvalidTokenPlaceAssistantContent = (content) =>
+    typeof content !== 'string' || !content.trim() || content.trim().toLowerCase() === 'stub';
+
 export const extractTokenPlaceAssistantText = (response) => {
-    const content = response?.choices?.[0]?.message?.content;
-    if (typeof content !== 'string' || !content.trim()) {
+    const content =
+        response?.message && typeof response.message === 'object'
+            ? response.message.content
+            : response?.choices?.[0]?.message?.content;
+    if (isInvalidTokenPlaceAssistantContent(content)) {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );


### PR DESCRIPTION
### Motivation
- DSPACE `/chat` was failing with `TokenPlaceError: Malformed token.place response: missing assistant content.` because the client only accepted OpenAI-style `choices[0].message.content` while token.place now returns API v1 `response.message.content`.
- The intent is to accept current token.place API v1 relay responses without reintroducing legacy full-history array support and to keep structured API error handling intact.

### Description
- Update `extractTokenPlaceAssistantText` in `frontend/src/utils/tokenPlace.js` to accept `response.message.content` (API v1) and fall back to `response.choices[0].message.content` (OpenAI-compatible) when present. 
- Add strict assistant-content validation to reject non-string, empty/whitespace, and known invalid placeholders like `"stub"`, and keep legacy full-history array responses treated as malformed. 
- Preserve existing structured error handling by calling `throwStructuredTokenPlaceApiError` before assistant extraction and leaving all error paths unchanged. 
- Increase default relay polling timeout from `30_000` ms to `300_000` ms to align with token.place's current browser client behavior. 
- Add/adjust unit tests in `frontend/__tests__/tokenPlace.test.js` to cover API v1 `message.content`, OpenAI-compatible `choices[0].message.content`, deterministic precedence when both shapes exist, malformed/`stub` cases, and explicit rejection of raw legacy arrays.

### Testing
- Ran unit tests with `cd frontend && npm test -- tokenPlace.test.js`; result: `58 tests` passed (all tests in the file passed). 
- Ran repo checks with `cd frontend && npm run check`; result: succeeded (lint + format check passed). 
- Built the frontend with `cd frontend && npm run build`; result: succeeded (Astro/Vite build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38bf883a6c832fbbb842e3e2a2554a)