### PR TITLE
Support token.place API v1 `response.message.content` in extractor

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -916,13 +916,54 @@ ${ragExcerpt.repeat(4000)}`,
         ).resolves.toMatchObject({ text: 'mocked reply' });
     });
 
-    test('parses assistant text and compatibility helper returns string', async () => {
+    test('parses API v1 message assistant text and compatibility helper returns string', async () => {
+        relayReply = { message: { role: 'assistant', content: 'mocked API v1 reply' } };
+
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'hi from API v1' },
+            })
+        ).toBe('hi from API v1');
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'mocked API v1 reply'
+        );
+    });
+
+    test('parses OpenAI-compatible choices assistant text', () => {
         expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
             'hi'
         );
-        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
-            'mocked reply'
+    });
+
+    test('prefers API v1 message content when both successful shapes are present', () => {
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'api v1 wins' },
+                choices: [{ message: { content: 'choices fallback' } }],
+            })
+        ).toBe('api v1 wins');
+    });
+
+    test.each([
+        ['empty API v1 message content', { message: { content: '' } }],
+        ['whitespace API v1 message content', { message: { content: '   ' } }],
+        ['missing assistant content', { message: { role: 'assistant' } }],
+        ['stub API v1 message content', { message: { content: 'stub' } }],
+    ])('%s throws malformed token.place response error', (_label, response) => {
+        expect(() => extractTokenPlaceAssistantText(response)).toThrow(
+            'Malformed token.place response: missing assistant content.'
         );
+    });
+
+    test('rejects legacy raw chat-history array responses as malformed', () => {
+        // DSPACE intentionally supports only token.place API v1 response objects here, not
+        // legacy non-API-v1 full-history arrays.
+        expect(() =>
+            extractTokenPlaceAssistantText([
+                { role: 'user', content: 'hello' },
+                { role: 'assistant', content: 'legacy reply' },
+            ])
+        ).toThrow('Malformed token.place response: missing assistant content.');
     });
 
     test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -187,9 +187,13 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
     return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
 };
 
+const isInvalidTokenPlaceAssistantContent = (content) =>
+    typeof content !== 'string' || !content.trim() || content.trim().toLowerCase() === 'stub';
+
 export const extractTokenPlaceAssistantText = (response) => {
-    const content = response?.choices?.[0]?.message?.content;
-    if (typeof content !== 'string' || !content.trim()) {
+    const message = response && typeof response.message === 'object' ? response.message : null;
+    const content = message ? message.content : response?.choices?.[0]?.message?.content;
+    if (isInvalidTokenPlaceAssistantContent(content)) {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );


### PR DESCRIPTION
### Motivation
- token.place now returns API v1 relay responses with `response.message.content` which DSPACE did not accept, causing client-side `TokenPlaceError: Malformed token.place response: missing assistant content.`
- The change should accept the current API v1 shape while preserving existing OpenAI-compatible `choices[0].message.content` and existing structured error handling.
- Maintain constraints: do not add legacy full-history array support, keep relay E2EE envelope shape and error semantics unchanged.

### Description
- Update `extractTokenPlaceAssistantText` in `frontend/src/utils/tokenPlace.js` to accept `response.message.content` when `response.message` is an object and otherwise fall back to `response.choices[0].message.content`, with deterministic precedence for the API v1 shape.
- Introduce `isInvalidTokenPlaceAssistantContent` to reject missing, non-string, empty/whitespace-only, or known placeholder content (`'stub'`).
- Add unit tests in `frontend/__tests__/tokenPlace.test.js` to cover: accepting API v1 `message.content`, retaining OpenAI-compatible `choices[0].message.content`, deterministic precedence when both shapes exist, malformed-content cases (empty/whitespace/missing/stub), and explicit rejection of legacy raw array chat-history responses.
- Preserve existing behavior that `api_v1_response.error` is handled by `throwStructuredTokenPlaceApiError` before assistant extraction and do not add any legacy array success paths.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` which executed the token.place test suite and reported `Tests 61 passed (61)` (success).
- Ran linting/format checks: `cd frontend && npm run check` which completed with Prettier/ESLint checks passing (success).
- Built the frontend: `cd frontend && npm run build` which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38bf93ed20832fae607dd1069c3d89)