### PR TITLE
Handle token.place API v1 `message.content` responses and validate assistant text

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -916,13 +916,62 @@ ${ragExcerpt.repeat(4000)}`,
         ).resolves.toMatchObject({ text: 'mocked reply' });
     });
 
-    test('parses assistant text and compatibility helper returns string', async () => {
+    test('parses API v1 response.message assistant text', async () => {
+        relayReply = { message: { role: 'assistant', content: 'api v1 reply' } };
+
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'api v1 reply' },
+            })
+        ).toBe('api v1 reply');
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'api v1 reply'
+        );
+    });
+
+    test('parses OpenAI-compatible choices assistant text and compatibility helper returns string', async () => {
         expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
             'hi'
         );
         await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
             'mocked reply'
         );
+    });
+
+    test('response.message content deterministically takes precedence over choices content', () => {
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'api v1 reply' },
+                choices: [{ message: { content: 'choices reply' } }],
+            })
+        ).toBe('api v1 reply');
+    });
+
+    test('empty missing and stub assistant content are malformed token.place responses', () => {
+        const malformedCases = [
+            {},
+            { message: {} },
+            { message: { content: '' } },
+            { message: { content: '   ' } },
+            { message: { content: 'stub' } },
+            { choices: [{ message: { content: '' } }] },
+            { choices: [{ message: { content: 'stub' } }] },
+        ];
+
+        for (const payload of malformedCases) {
+            expect(() => extractTokenPlaceAssistantText(payload)).toThrow(
+                'Malformed token.place response: missing assistant content.'
+            );
+        }
+    });
+
+    test('raw array full-history responses are rejected as unsupported legacy responses', () => {
+        expect(() =>
+            extractTokenPlaceAssistantText([
+                { role: 'user', content: 'hello' },
+                { role: 'assistant', content: 'legacy array reply' },
+            ])
+        ).toThrow('Malformed token.place response: missing assistant content.');
     });
 
     test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,7 +13,7 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+const DEFAULT_RELAY_TIMEOUT_MS = 300_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
 const normalizeTokenPlaceRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
@@ -187,9 +187,17 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
     return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
 };
 
+const isValidTokenPlaceAssistantContent = (content) =>
+    typeof content === 'string' && content.trim() && content.trim().toLowerCase() !== 'stub';
+
 export const extractTokenPlaceAssistantText = (response) => {
-    const content = response?.choices?.[0]?.message?.content;
-    if (typeof content !== 'string' || !content.trim()) {
+    const messageContent =
+        response?.message && typeof response.message === 'object'
+            ? response.message.content
+            : undefined;
+    const choiceContent = response?.choices?.[0]?.message?.content;
+    const content = messageContent !== undefined ? messageContent : choiceContent;
+    if (!isValidTokenPlaceAssistantContent(content)) {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );


### PR DESCRIPTION
### Motivation

- DSPACE was failing to render token.place replies when the relay returned API v1 responses using `response.message.content` instead of OpenAI-style `choices[0].message.content`.
- The fix must accept API v1 shapes while preserving existing relay E2EE flow and structured API error handling, and must not reintroduce legacy full-history array success handling.

### Description

- Update `extractTokenPlaceAssistantText` to accept `response.message.content` (API v1) and fall back to `response.choices[0].message.content` (OpenAI-compatible), with deterministic precedence for `message` when both are present.
- Add `isValidTokenPlaceAssistantContent` validation to reject missing, non-string, empty, whitespace-only, or known placeholder content like `"stub"` and throw the existing malformed error when invalid.
- Add unit tests in `frontend/__tests__/tokenPlace.test.js` covering API v1 `message.content`, OpenAI `choices` handling, precedence, malformed/stub cases, and explicit rejection of raw legacy array/full-history responses.
- Increase default relay polling timeout `DEFAULT_RELAY_TIMEOUT_MS` from `30_000` to `300_000` ms to align with token.place browser client behavior (secondary, safe change covered by tests).

### Testing

- Ran unit tests for token.place client: `cd frontend && npm test -- tokenPlace.test.js` — 58 tests passed (all green).
- Ran checks: `cd frontend && npm run check` — linting and format checks passed.
- Built the frontend: `cd frontend && npm run build` — build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38bf9d05f8832f8af0a824adf216bd)