### PR TITLE
Fix token.place API v1 response parsing

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1284-L1298))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1338-L1351))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -916,13 +916,64 @@ ${ragExcerpt.repeat(4000)}`,
         ).resolves.toMatchObject({ text: 'mocked reply' });
     });
 
-    test('parses assistant text and compatibility helper returns string', async () => {
+    test('parses API v1 response.message assistant text and compatibility helper returns string', async () => {
+        expect(extractTokenPlaceAssistantText({ message: { content: 'api v1 reply' } })).toBe(
+            'api v1 reply'
+        );
+        relayReply = { message: { role: 'assistant', content: 'api v1 relay reply' } };
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
+            'api v1 relay reply'
+        );
+    });
+
+    test('parses OpenAI-compatible choices assistant text', async () => {
         expect(extractTokenPlaceAssistantText({ choices: [{ message: { content: 'hi' } }] })).toBe(
             'hi'
         );
         await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).resolves.toBe(
             'mocked reply'
         );
+    });
+
+    test('prefers API v1 response.message over choices when both response shapes are present', () => {
+        expect(
+            extractTokenPlaceAssistantText({
+                message: { role: 'assistant', content: 'api v1 reply' },
+                choices: [{ message: { content: 'choices reply' } }],
+            })
+        ).toBe('api v1 reply');
+    });
+
+    test('rejects empty, missing, stub, and legacy raw-array assistant responses as malformed', () => {
+        const malformedResponses = [
+            { message: { content: '' } },
+            { message: { content: '   ' } },
+            { message: { content: 'stub' } },
+            { message: {} },
+            { choices: [{ message: { content: '' } }] },
+            [{ role: 'assistant', content: 'legacy history reply' }],
+        ];
+
+        for (const response of malformedResponses) {
+            expect(() => extractTokenPlaceAssistantText(response)).toThrow(
+                'Malformed token.place response: missing assistant content.'
+            );
+        }
+    });
+
+    test('structured API errors are not treated as missing assistant content', async () => {
+        relayReply = {
+            error: {
+                message: 'blocked',
+                type: 'content_policy_violation',
+                code: 'content_blocked',
+            },
+        };
+
+        await expect(tokenPlaceChat([{ role: 'user', content: 'hello' }])).rejects.toMatchObject({
+            type: 'content_policy',
+            status: 400,
+        });
     });
 
     test('richer helper returns text, DSPACE contextSources, usage, and metadata', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -951,6 +951,9 @@ ${ragExcerpt.repeat(4000)}`,
             { message: { content: 'stub' } },
             { message: {} },
             { choices: [{ message: { content: '' } }] },
+            { choices: [{ message: { content: '   ' } }] },
+            { choices: [{ message: { content: 'stub' } }] },
+            { usage: { prompt_tokens: 1 } },
             [{ role: 'assistant', content: 'legacy history reply' }],
         ];
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -192,12 +192,11 @@ export const extractTokenPlaceAssistantText = (response) => {
         response?.message && typeof response.message === 'object'
             ? response.message.content
             : response?.choices?.[0]?.message?.content;
-    if (typeof content !== 'string' || !content.trim()) {
-        throw createMalformedTokenPlaceResponseError(
-            'Malformed token.place response: missing assistant content.'
-        );
-    }
-    if (content.trim().toLowerCase() === 'stub') {
+    if (
+        typeof content !== 'string' ||
+        !content.trim() ||
+        content.trim().toLowerCase() === 'stub'
+    ) {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -192,11 +192,7 @@ export const extractTokenPlaceAssistantText = (response) => {
         response?.message && typeof response.message === 'object'
             ? response.message.content
             : response?.choices?.[0]?.message?.content;
-    if (
-        typeof content !== 'string' ||
-        !content.trim() ||
-        content.trim().toLowerCase() === 'stub'
-    ) {
+    if (typeof content !== 'string' || !content.trim() || content.trim().toLowerCase() === 'stub') {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -188,8 +188,16 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
 };
 
 export const extractTokenPlaceAssistantText = (response) => {
-    const content = response?.choices?.[0]?.message?.content;
+    const content =
+        response?.message && typeof response.message === 'object'
+            ? response.message.content
+            : response?.choices?.[0]?.message?.content;
     if (typeof content !== 'string' || !content.trim()) {
+        throw createMalformedTokenPlaceResponseError(
+            'Malformed token.place response: missing assistant content.'
+        );
+    }
+    if (content.trim().toLowerCase() === 'stub') {
         throw createMalformedTokenPlaceResponseError(
             'Malformed token.place response: missing assistant content.'
         );


### PR DESCRIPTION
### Motivation
- The client-side `/chat` flow failed when token.place returned API v1 relay responses using `response.message.content` because `extractTokenPlaceAssistantText` only handled OpenAI-style `choices[0].message.content`.
- The change aims to accept current API v1 responses without introducing legacy full-history array success paths and while preserving relay E2EE and structured error behavior.

### Description
- Update `extractTokenPlaceAssistantText` to prefer `response.message.content` when `response.message` is an object, falling back to `response.choices[0].message.content` otherwise. 
- Keep strict malformed-response checks and throw the same `Malformed token.place response` error for missing, non-string, empty, whitespace-only, or `"stub"` assistant content. 
- Add unit tests in `frontend/__tests__/tokenPlace.test.js` to cover API v1 `message.content`, OpenAI-compatible `choices` fallback, deterministic precedence when both shapes exist, malformed/stub/legacy-array rejection, and preservation of structured `api_v1_response.error` handling. 
- No legacy raw-array success handling was added and `throwStructuredTokenPlaceApiError` behavior was preserved.

### Testing
- Ran the focused unit tests with `cd frontend && npm test -- tokenPlace.test.js`, which completed successfully (tests passed). 
- Ran repository checks with `cd frontend && npm run check`, which passed formatting and lint checks. 
- Built the frontend with `cd frontend && npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38bfa357a4832f8aa157083e6ed94a)