### PR TITLE
Add privacy-safe token.place prompt benchmarking

### DIFF
--- a/docs/design/token-place-context-benchmarking.md
+++ b/docs/design/token-place-context-benchmarking.md
@@ -1,0 +1,53 @@
+# token.place Context Benchmarking
+
+DSPACE includes a local, privacy-safe benchmark for measuring prompt size before later context-tier routing work. It is Phase 0 instrumentation only: it does not change token.place routing, encryption, relay behavior, response handling, settings, or production chat output.
+
+## Run the benchmark
+
+From the repository root:
+
+```bash
+npm run benchmark:token-place-context
+```
+
+The command writes local artifacts under `artifacts/benchmarks/token-place-context/`:
+
+- `<timestamp>.json` for machine-readable comparisons.
+- `<timestamp>.md` for a readable summary table.
+
+These files are generated from synthetic fixtures and should normally stay uncommitted because timings are machine-specific.
+
+## Metrics
+
+The metrics helper returns counts only, never prompt content:
+
+- `messageCount`: number of chat messages in the measured payload.
+- `roleCounts`: count of messages by role, such as `system`, `user`, and `assistant`.
+- `totalCharacters`: JavaScript string length across message content.
+- `totalUtf8Bytes`: UTF-8 encoded byte length across message content.
+- `perMessage`: index, role, character count, and UTF-8 byte count for each message.
+- `componentTotals`: message, character, and byte totals for identifiable prompt components:
+  - system instructions;
+  - docs RAG / DSPACE knowledge context;
+  - player state;
+  - chat history;
+  - latest user message.
+- `timingsMs.promptBuild`: prompt build duration when the caller supplies it.
+- `timingsMs.rag`: docs RAG duration when available.
+
+## Privacy constraints
+
+Benchmark outputs and prompt metrics must not include user prompts, RAG excerpts, player state, chat content, keys, ciphertext, decrypted responses, or secrets. Component accounting is based on message indexes and size counts. Committed fixtures are synthetic and repository-owned.
+
+## Comparing 8K and 64K readiness
+
+Use the JSON or Markdown report to identify the dominant component and compare the rough prompt size against target tiers:
+
+- `8k-fast` is intended for token-lite and small prompts.
+- `64k-full` is intended for full-fat DSPACE prompts, RAG-heavy prompts, and larger player state.
+
+As a quick screen, divide `totalCharacters` by four for a rough token estimate, then leave room for chat-template overhead, system-added tokens, safety margin, and reserved output tokens. Prompts near or above an 8K budget should be treated as likely `64k-full` candidates until exact compute-side token admission is implemented.
+
+## Character counts are not model tokens
+
+Character counts, byte counts, and whitespace counts are useful for deterministic browser-side measurement, but they are not exact model tokens. Token counts depend on the model tokenizer and chat template. UTF-8 byte counts also diverge from token counts for non-ASCII text. Future phases may add an optional exact Llama 3.1 tokenizer hook for local benchmarking, but the benchmark remains useful without it.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,8 @@
         "postinstall": "node scripts/postinstall.js",
         "playwright:install": "playwright install --with-deps chromium chromium-headless-shell",
         "perf:quests": "node scripts/setup-test-env.js && node scripts/run-quests-perf.mjs",
-        "perf:quests:slowcpu": "node scripts/setup-test-env.js && cross-env QUESTS_TTI_CPU_SLOWDOWN=4 node scripts/run-quests-perf.mjs"
+        "perf:quests:slowcpu": "node scripts/setup-test-env.js && cross-env QUESTS_TTI_CPU_SLOWDOWN=4 node scripts/run-quests-perf.mjs",
+        "benchmark:token-place-context": "node ../scripts/benchmark-token-place-context.mjs"
     },
     "devDependencies": {
         "@astrojs/svelte": "^6.0.0",

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -6,6 +6,7 @@ import { searchDocsRag } from './docsRag.js';
 import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
+import { PROMPT_COMPONENTS, buildPromptMetrics } from './promptMetrics.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -604,6 +605,8 @@ async function createChatResponse(openai, input) {
 }
 
 export const buildChatPrompt = async (messages, options = {}) => {
+    const promptBuildStartedAt =
+        typeof performance !== 'undefined' ? performance.now() : Date.now();
     await ready;
     const normalizedMessages = Array.isArray(messages) ? messages : [];
     const rawGameState = loadGameState();
@@ -652,9 +655,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
+    const ragStartedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
     const docsRagPayload = latestUserMessage
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
+    const ragFinishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -709,13 +714,42 @@ export const buildChatPrompt = async (messages, options = {}) => {
 
     const contextSources = mergeSources(knowledgePack.sources || [], docsRagPayload.sources || []);
 
-    return {
+    const result = {
         combinedMessages,
         debugMessages,
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
     };
+
+    if (options.includePromptMetrics) {
+        const latestUserIndex = latestUserMessage
+            ? combinedMessages.lastIndexOf(latestUserMessage)
+            : -1;
+        const componentByMessageIndex = {};
+        combinedMessages.forEach((message, index) => {
+            if (message === systemMessage) {
+                componentByMessageIndex[index] = PROMPT_COMPONENTS.systemInstructions;
+            } else if (message === playerStateMessage) {
+                componentByMessageIndex[index] = PROMPT_COMPONENTS.playerState;
+            } else if (message === knowledgeMessage || message === docsRagMessage) {
+                componentByMessageIndex[index] = PROMPT_COMPONENTS.rag;
+            } else if (index === latestUserIndex) {
+                componentByMessageIndex[index] = PROMPT_COMPONENTS.latestUserMessage;
+            } else if (normalizedMessages.includes(message)) {
+                componentByMessageIndex[index] = PROMPT_COMPONENTS.chatHistory;
+            }
+        });
+        result.promptMetrics = buildPromptMetrics(result, {
+            componentByMessageIndex,
+            promptBuildMs:
+                (typeof performance !== 'undefined' ? performance.now() : Date.now()) -
+                promptBuildStartedAt,
+            ragMs: ragFinishedAt - ragStartedAt,
+        });
+    }
+
+    return result;
 };
 
 export const GPT5Chat = async (messages, options = {}) => {

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -1,0 +1,70 @@
+const textEncoder = new TextEncoder();
+
+export const PROMPT_COMPONENTS = Object.freeze({
+    systemInstructions: 'systemInstructions',
+    rag: 'rag',
+    playerState: 'playerState',
+    chatHistory: 'chatHistory',
+    latestUserMessage: 'latestUserMessage',
+});
+
+export const summarizeTextSize = (value) => {
+    const text = typeof value === 'string' ? value : value == null ? '' : String(value);
+    return {
+        characters: text.length,
+        utf8Bytes: textEncoder.encode(text).byteLength,
+    };
+};
+
+const emptyComponentTotals = () =>
+    Object.fromEntries(
+        Object.values(PROMPT_COMPONENTS).map((component) => [
+            component,
+            { messageCount: 0, characters: 0, utf8Bytes: 0 },
+        ])
+    );
+
+const addSize = (target, size) => {
+    target.messageCount += 1;
+    target.characters += size.characters;
+    target.utf8Bytes += size.utf8Bytes;
+};
+
+export const buildPromptMetrics = (promptPayload, metadata = {}) => {
+    const messages = Array.isArray(promptPayload?.combinedMessages)
+        ? promptPayload.combinedMessages
+        : Array.isArray(promptPayload?.messages)
+          ? promptPayload.messages
+          : [];
+    const componentByMessageIndex = metadata.componentByMessageIndex || {};
+    const componentTotals = emptyComponentTotals();
+    const roleCounts = {};
+    let totalCharacters = 0;
+    let totalUtf8Bytes = 0;
+
+    const perMessage = messages.map((message, index) => {
+        const role = typeof message?.role === 'string' ? message.role : 'unknown';
+        const size = summarizeTextSize(message?.content);
+        roleCounts[role] = (roleCounts[role] || 0) + 1;
+        totalCharacters += size.characters;
+        totalUtf8Bytes += size.utf8Bytes;
+        const component = componentByMessageIndex[index];
+        if (component && componentTotals[component]) {
+            addSize(componentTotals[component], size);
+        }
+        return { index, role, characters: size.characters, utf8Bytes: size.utf8Bytes };
+    });
+
+    return {
+        messageCount: messages.length,
+        roleCounts,
+        totalCharacters,
+        totalUtf8Bytes,
+        perMessage,
+        componentTotals,
+        timingsMs: {
+            promptBuild: Number.isFinite(metadata.promptBuildMs) ? metadata.promptBuildMs : null,
+            rag: Number.isFinite(metadata.ragMs) ? metadata.ragMs : null,
+        },
+    };
+};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "lint:a11y": "cd frontend && npm run lint:a11y",
     "dev:legacy": "npm run dev",
     "playwright:install": "npm --prefix frontend run playwright:install",
-    "build:meta": "node scripts/write-build-meta.mjs"
+    "build:meta": "node scripts/write-build-meta.mjs",
+    "benchmark:token-place-context": "node scripts/benchmark-token-place-context.mjs"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import {
+  buildPromptMetrics,
+  PROMPT_COMPONENTS,
+} from '../frontend/src/utils/promptMetrics.js';
+
+const outDir = join(
+  process.cwd(),
+  'artifacts',
+  'benchmarks',
+  'token-place-context'
+);
+const repeat = (label, count) =>
+  Array.from({ length: count }, (_, i) => `${label} ${i + 1}`).join('\n');
+
+const scenarios = [
+  {
+    name: 'token-lite baseline',
+    messages: [{ role: 'user', content: 'Synthetic token-lite ping.' }],
+    components: { 0: PROMPT_COMPONENTS.latestUserMessage },
+  },
+  {
+    name: 'minimal full-fat prompt',
+    messages: [
+      { role: 'system', content: 'Synthetic DSPACE system instructions.' },
+      { role: 'user', content: 'Start a new synthetic run.' },
+    ],
+    components: {
+      0: PROMPT_COMPONENTS.systemInstructions,
+      1: PROMPT_COMPONENTS.latestUserMessage,
+    },
+  },
+  {
+    name: 'typical mid-game prompt',
+    messages: [
+      {
+        role: 'system',
+        content: repeat('Synthetic DSPACE operating rules.', 30),
+      },
+      {
+        role: 'system',
+        content: repeat('Synthetic inventory and quest state.', 80),
+      },
+      {
+        role: 'assistant',
+        content: repeat('Synthetic assistant history.', 15),
+      },
+      { role: 'user', content: 'What should the synthetic player build next?' },
+    ],
+    components: {
+      0: PROMPT_COMPONENTS.systemInstructions,
+      1: PROMPT_COMPONENTS.playerState,
+      2: PROMPT_COMPONENTS.chatHistory,
+      3: PROMPT_COMPONENTS.latestUserMessage,
+    },
+  },
+  {
+    name: 'RAG-heavy prompt',
+    messages: [
+      { role: 'system', content: repeat('Synthetic rules.', 25) },
+      {
+        role: 'system',
+        content: repeat(
+          'Synthetic repository-owned docs excerpt about power, oxygen, habitats, and launch gates.',
+          650
+        ),
+      },
+      { role: 'user', content: 'Summarize relevant synthetic docs.' },
+    ],
+    components: {
+      0: PROMPT_COMPONENTS.systemInstructions,
+      1: PROMPT_COMPONENTS.rag,
+      2: PROMPT_COMPONENTS.latestUserMessage,
+    },
+  },
+  {
+    name: 'long chat history',
+    messages: [
+      { role: 'system', content: 'Synthetic DSPACE system instructions.' },
+      ...Array.from({ length: 60 }, (_, i) => ({
+        role: i % 2 ? 'assistant' : 'user',
+        content: `Synthetic history turn ${i + 1}: ${repeat('planning detail', 20)}`,
+      })),
+      { role: 'user', content: 'Continue from the synthetic long history.' },
+    ],
+    components: {},
+  },
+  {
+    name: 'large player state',
+    messages: [
+      { role: 'system', content: 'Synthetic DSPACE system instructions.' },
+      {
+        role: 'system',
+        content: repeat(
+          'Synthetic save-state item, quest, process, achievement, and storage entry.',
+          1500
+        ),
+      },
+      { role: 'user', content: 'Analyze this synthetic save state.' },
+    ],
+    components: {
+      0: PROMPT_COMPONENTS.systemInstructions,
+      1: PROMPT_COMPONENTS.playerState,
+      2: PROMPT_COMPONENTS.latestUserMessage,
+    },
+  },
+  {
+    name: 'near 131072-character ceiling',
+    messages: [
+      {
+        role: 'system',
+        content: repeat('Synthetic DSPACE system instruction block.', 300),
+      },
+      { role: 'system', content: 'R'.repeat(50000) },
+      { role: 'assistant', content: 'H'.repeat(30000) },
+      { role: 'system', content: 'P'.repeat(45000) },
+      { role: 'user', content: 'U'.repeat(4000) },
+    ],
+    components: {
+      0: PROMPT_COMPONENTS.systemInstructions,
+      1: PROMPT_COMPONENTS.rag,
+      2: PROMPT_COMPONENTS.chatHistory,
+      3: PROMPT_COMPONENTS.playerState,
+      4: PROMPT_COMPONENTS.latestUserMessage,
+    },
+  },
+];
+scenarios[4].messages.forEach((_, i) => {
+  scenarios[4].components[i] =
+    i === 0
+      ? PROMPT_COMPONENTS.systemInstructions
+      : i === scenarios[4].messages.length - 1
+        ? PROMPT_COMPONENTS.latestUserMessage
+        : PROMPT_COMPONENTS.chatHistory;
+});
+
+const results = scenarios.map((scenario) => {
+  const started = performance.now();
+  const metrics = buildPromptMetrics(
+    { combinedMessages: scenario.messages },
+    {
+      componentByMessageIndex: scenario.components,
+      promptBuildMs: 0,
+      ragMs: scenario.name === 'RAG-heavy prompt' ? 0 : null,
+    }
+  );
+  metrics.timingsMs.benchmarkMetrics = performance.now() - started;
+  return {
+    name: scenario.name,
+    metrics,
+    tokenEstimates: {
+      heuristicFourCharsPerToken: Math.ceil(metrics.totalCharacters / 4),
+      exact: null,
+      exactTokenizer: null,
+    },
+  };
+});
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+await mkdir(outDir, { recursive: true });
+const jsonPath = join(outDir, `${timestamp}.json`);
+const mdPath = join(outDir, `${timestamp}.md`);
+await writeFile(
+  jsonPath,
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      privacy: 'Synthetic fixtures only; no prompt content is written.',
+      results,
+    },
+    null,
+    2
+  )
+);
+const md = [
+  '# token.place Context Benchmark',
+  '',
+  'Synthetic, privacy-safe prompt size benchmark.',
+  '',
+  '| Scenario | Messages | Chars | UTF-8 bytes | ~tokens /4 | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | --- |',
+  ...results.map(({ name, metrics, tokenEstimates }) => {
+    const entries = Object.entries(metrics.componentTotals).sort(
+      (a, b) => b[1].characters - a[1].characters
+    );
+    return `| ${name} | ${metrics.messageCount} | ${metrics.totalCharacters} | ${metrics.totalUtf8Bytes} | ${tokenEstimates.heuristicFourCharsPerToken} | ${entries[0][0]} (${entries[0][1].characters}) |`;
+  }),
+  '',
+].join('\n');
+await writeFile(mdPath, md);
+console.log(`Wrote ${jsonPath}`);
+console.log(`Wrote ${mdPath}`);

--- a/tests/openAIPromptMetrics.test.ts
+++ b/tests/openAIPromptMetrics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('openai', () => ({ default: vi.fn() }));
+vi.mock('../frontend/src/utils/gameState/common.js', () => ({
+  loadGameState: vi.fn(() => ({})),
+  ready: Promise.resolve(),
+}));
+vi.mock('../frontend/src/utils/docsRag.js', () => ({
+  searchDocsRag: vi.fn(async () => ({ excerptsText: '', sources: [] })),
+}));
+
+describe('buildChatPrompt prompt metrics option', () => {
+  it('keeps instrumentation disabled behavior unchanged', async () => {
+    const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
+    const messages = [{ role: 'user', content: 'hello' }];
+    const withoutMetrics = await buildChatPrompt(messages);
+    const withMetrics = await buildChatPrompt(messages, {
+      includePromptMetrics: true,
+    });
+
+    expect(withoutMetrics.promptMetrics).toBeUndefined();
+    expect(withMetrics.promptMetrics).toEqual(
+      expect.objectContaining({
+        messageCount: withMetrics.combinedMessages.length,
+      })
+    );
+    expect(withoutMetrics.combinedMessages).toEqual(
+      withMetrics.combinedMessages
+    );
+  });
+});

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildPromptMetrics,
+  PROMPT_COMPONENTS,
+  summarizeTextSize,
+} from '../frontend/src/utils/promptMetrics.js';
+
+describe('prompt metrics', () => {
+  test('returns sizes without prompt content strings', () => {
+    const metrics = buildPromptMetrics(
+      {
+        combinedMessages: [
+          { role: 'user', content: 'PRIVATE_SYNTHETIC_SENTINEL' },
+        ],
+      },
+      { componentByMessageIndex: { 0: PROMPT_COMPONENTS.latestUserMessage } }
+    );
+
+    expect(metrics.messageCount).toBe(1);
+    expect(JSON.stringify(metrics)).not.toContain('PRIVATE_SYNTHETIC_SENTINEL');
+    expect(metrics.perMessage[0]).toEqual({
+      index: 0,
+      role: 'user',
+      characters: 'PRIVATE_SYNTHETIC_SENTINEL'.length,
+      utf8Bytes: 'PRIVATE_SYNTHETIC_SENTINEL'.length,
+    });
+  });
+
+  test('counts UTF-8 bytes independently from JavaScript characters', () => {
+    expect(summarizeTextSize('aé🚀')).toEqual({ characters: 4, utf8Bytes: 7 });
+  });
+
+  test('accounts components deterministically', () => {
+    const metrics = buildPromptMetrics(
+      {
+        combinedMessages: [
+          { role: 'system', content: 'abcd' },
+          { role: 'system', content: 'éé' },
+          { role: 'assistant', content: 'history' },
+          { role: 'user', content: 'latest' },
+        ],
+      },
+      {
+        componentByMessageIndex: {
+          0: PROMPT_COMPONENTS.systemInstructions,
+          1: PROMPT_COMPONENTS.rag,
+          2: PROMPT_COMPONENTS.chatHistory,
+          3: PROMPT_COMPONENTS.latestUserMessage,
+        },
+        promptBuildMs: 12,
+        ragMs: 3,
+      }
+    );
+
+    expect(metrics.roleCounts).toEqual({ system: 2, assistant: 1, user: 1 });
+    expect(metrics.componentTotals.systemInstructions).toEqual({
+      messageCount: 1,
+      characters: 4,
+      utf8Bytes: 4,
+    });
+    expect(metrics.componentTotals.rag).toEqual({
+      messageCount: 1,
+      characters: 2,
+      utf8Bytes: 4,
+    });
+    expect(metrics.timingsMs).toEqual({ promptBuild: 12, rag: 3 });
+  });
+});

--- a/tests/tokenPlaceBenchmarkFixtures.test.ts
+++ b/tests/tokenPlaceBenchmarkFixtures.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+describe('token.place benchmark fixtures', () => {
+  it('use synthetic data and do not include common secret markers', () => {
+    const script = readFileSync(
+      join(repoRoot, 'scripts', 'benchmark-token-place-context.mjs'),
+      'utf8'
+    );
+    expect(script).toContain('Synthetic');
+    expect(script).not.toMatch(/sk-[A-Za-z0-9]/);
+    expect(script).not.toMatch(/ghp_[A-Za-z0-9]/);
+    expect(script).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY/);
+    expect(script).not.toContain('PRIVATE_SYNTHETIC_SENTINEL');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide Phase 0 deterministic, privacy-safe instrumentation to measure DSPACE prompt composition for later context-tier routing without ever logging prompt content or changing production chat behavior. 
- Enable developers to identify which prompt components (system, RAG, player state, history, latest user) dominate context use and produce repeatable local artifacts for comparison.

### Description
- Add a new metrics helper `frontend/src/utils/promptMetrics.js` that computes message counts, role counts, total characters, total UTF-8 bytes, per-message size summaries, component totals, and timings while returning no prompt content strings. 
- Add optional, non-breaking instrumentation to `buildChatPrompt` (`frontend/src/utils/openAI.js`) exposed via `includePromptMetrics: true` so default production behavior is unchanged unless explicitly enabled. 
- Add a deterministic benchmark script `scripts/benchmark-token-place-context.mjs` that exercises seven synthetic scenarios (token-lite, minimal full-fat, mid-game, RAG-heavy, long history, large state, near-ceiling) and emits machine-readable JSON and a readable Markdown summary to `artifacts/benchmarks/token-place-context/`. 
- Add npm scripts in the root and `frontend` packages: `benchmark:token-place-context`. 
- Add documentation `docs/design/token-place-context-benchmarking.md` describing how to run the benchmark, metrics meanings, privacy constraints, and 8K/64K readiness guidance. 
- Add focused tests `tests/promptMetrics.test.ts`, `tests/openAIPromptMetrics.test.ts`, and `tests/tokenPlaceBenchmarkFixtures.test.ts` verifying that metrics do not include prompt strings, UTF-8 counts are correct, component accounting is deterministic, and instrumentation-disabled behavior matches existing behavior. 

### Testing
- Ran unit tests for the new helpers and integration checks with: `npm run test:root -- tests/promptMetrics.test.ts tests/openAIPromptMetrics.test.ts tests/tokenPlaceBenchmarkFixtures.test.ts`, and all passed. 
- Ran frontend token.place tests with: `cd frontend && npm test -- tokenPlace.test.js`, and the existing `tokenPlace` test suite passed (58 tests). 
- Ran the deterministic benchmark once with: `npm run benchmark:token-place-context`, which wrote JSON and Markdown artifacts to `artifacts/benchmarks/token-place-context/` (successful). 
- Checked formatting and build with: `cd frontend && npm run check` and `cd frontend && npm run build`, both succeeded and Prettier matched. 

Follow-ups / notes: the optional exact-token Llama 3.1 tokenizer hook is not added in this phase (benchmark includes a heuristic 4-chars-per-token estimate and leaves room for a distinct exact-token extension later), benchmark artifacts are machine-specific and should not be committed, and production behavior is unchanged unless `includePromptMetrics` is enabled by callers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a47dc83d0832fa5abc00377afa5fe)