### PR TITLE
Add privacy-safe token.place prompt metrics and synthetic benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ frontend/package-lock.json
 
 # Backups
 backups/
+
+# Local benchmark reports
+artifacts/

--- a/docs/benchmarks/token-place-context.md
+++ b/docs/benchmarks/token-place-context.md
@@ -11,7 +11,8 @@ Those generated reports are local artifacts and should not be committed.
 
 ## Metrics
 
-- `messageCount` and `roleCounts`: API-style chat message counts by role.
+- `sourceMessageCount`: synthetic messages before token.place request shaping.
+- `tokenPlaceMessageCount`, `messageCount`, and `roleCounts`: API-style chat message counts after `sanitizeTokenPlaceMessages` applies token.place chunking and request caps.
 - `totalCharacters`: JavaScript UTF-16 string length across message content.
 - `totalUtf8Bytes`: UTF-8 byte length across message content.
 - `perMessage`: content-free size summaries for each message.
@@ -28,11 +29,14 @@ as benchmark-only data.
 ## Comparing 8K and 64K readiness
 
 Use the generated report to identify dominant context components and compare the heuristic token
-count with 8,192-token and 65,536-token tiers. A scenario that does not fit 8K but fits 64K is a
-candidate for full-fat routing in later phases.
+count with 8,192-token and 65,536-token tiers. The readiness flags reserve 640 tokens for
+chat-template overhead and assistant output before marking a tier as fitting. A scenario that does
+not fit 8K but fits 64K is a candidate for full-fat routing in later phases. The report also flags
+whether the token.place-shaped request remains under the 131,072-character request ceiling.
 
 ## Token caveat
 
 Character counts, byte counts, and whitespace are not exact model tokens. Tokenizers split text by
-model-specific rules and chat templates add overhead. The benchmark's heuristic token estimate is
-only a local planning signal until compute-side exact token admission is available.
+model-specific rules and chat templates add overhead. The benchmark's heuristic token estimate,
+reserved-token buffer, and token.place request shaping are only local planning signals until
+compute-side exact token admission is available.

--- a/docs/benchmarks/token-place-context.md
+++ b/docs/benchmarks/token-place-context.md
@@ -1,0 +1,38 @@
+# token.place Context Benchmark
+
+Run the synthetic DSPACE prompt-size benchmark from the repository root:
+
+```bash
+npm run benchmark:token-place-context
+```
+
+The command writes JSON and Markdown reports under `artifacts/benchmarks/token-place-context/`.
+Those generated reports are local artifacts and should not be committed.
+
+## Metrics
+
+- `messageCount` and `roleCounts`: API-style chat message counts by role.
+- `totalCharacters`: JavaScript UTF-16 string length across message content.
+- `totalUtf8Bytes`: UTF-8 byte length across message content.
+- `perMessage`: content-free size summaries for each message.
+- `componentTotals`: content-free totals for system instructions, RAG, player state, chat history,
+  and the latest user message.
+- `promptBuildDurationMs` and `ragDurationMs`: local timing fields when available.
+
+## Privacy constraints
+
+The helper and benchmark must not return, log, or persist user prompts, RAG excerpts, player state,
+chat content, keys, ciphertext, or decrypted responses. Committed fixtures are synthetic and labeled
+as benchmark-only data.
+
+## Comparing 8K and 64K readiness
+
+Use the generated report to identify dominant context components and compare the heuristic token
+count with 8,192-token and 65,536-token tiers. A scenario that does not fit 8K but fits 64K is a
+candidate for full-fat routing in later phases.
+
+## Token caveat
+
+Character counts, byte counts, and whitespace are not exact model tokens. Tokenizers split text by
+model-specific rules and chat templates add overhead. The benchmark's heuristic token estimate is
+only a local planning signal until compute-side exact token admission is available.

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -722,17 +722,38 @@ export const buildChatPrompt = async (messages, options = {}) => {
     };
 
     if (options.includePromptMetrics) {
+        const indexOfMessage = (target) => (target ? combinedMessages.indexOf(target) : -1);
+        const systemMessageIndex = indexOfMessage(systemMessage);
+        const playerStateMessageIndex = indexOfMessage(playerStateMessage);
+        const knowledgeMessageIndex = indexOfMessage(knowledgeMessage);
+        const docsRagMessageIndex = indexOfMessage(docsRagMessage);
+        const latestUserMessageIndex = indexOfMessage(latestUserMessage);
+        const chatHistoryIndexes =
+            latestUserMessageIndex === -1
+                ? []
+                : combinedMessages
+                      .map((message, index) => ({ message, index }))
+                      .filter(
+                          ({ message, index }) =>
+                              index > systemMessageIndex &&
+                              index < latestUserMessageIndex &&
+                              normalizedMessages.includes(message) &&
+                              message.role !== 'system'
+                      )
+                      .map(({ index }) => index);
+        const ragIndexes = [knowledgeMessageIndex, docsRagMessageIndex].filter(
+            (index) => index !== -1
+        );
+
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
-            components: {
-                systemInstructions: systemMessage.content,
-                rag: (knowledgeMessage || docsRagMessage)?.content || '',
-                playerState: playerStateMessage?.content || '',
-                chatHistory: normalizedMessages
-                    .filter((message) => message !== latestUserMessage && message.role !== 'system')
-                    .map((message) => message.content || ''),
-                latestUserMessage: latestUserMessage?.content || '',
+            componentMessageIndexes: {
+                systemInstructions: systemMessageIndex,
+                rag: ragIndexes,
+                playerState: playerStateMessageIndex,
+                chatHistory: chatHistoryIndexes,
+                latestUserMessage: latestUserMessageIndex,
             },
         });
     }

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -727,18 +727,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ragDurationMs,
             components: {
                 systemInstructions: systemMessage.content,
-                rag: [
-                    knowledgeSummary ? `DSPACE knowledge base:\n${knowledgeSummary}` : '',
-                    docsRagPayload.excerptsText || '',
-                ],
+                rag: (knowledgeMessage || docsRagMessage)?.content || '',
                 playerState: playerStateMessage?.content || '',
                 chatHistory: normalizedMessages
-                    .slice(
-                        0,
-                        latestUserMessage
-                            ? normalizedMessages.lastIndexOf(latestUserMessage)
-                            : undefined
-                    )
+                    .filter((message) => message !== latestUserMessage && message.role !== 'system')
                     .map((message) => message.content || ''),
                 latestUserMessage: latestUserMessage?.content || '',
             },

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -6,6 +6,7 @@ import { searchDocsRag } from './docsRag.js';
 import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
+import { buildPromptMetrics } from './promptMetrics.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -604,6 +605,7 @@ async function createChatResponse(openai, input) {
 }
 
 export const buildChatPrompt = async (messages, options = {}) => {
+    const promptBuildStartedAt = performance.now();
     await ready;
     const normalizedMessages = Array.isArray(messages) ? messages : [];
     const rawGameState = loadGameState();
@@ -652,9 +654,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
+    const docsRagStartedAt = performance.now();
     const docsRagPayload = latestUserMessage
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
+    const ragDurationMs = performance.now() - docsRagStartedAt;
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -709,13 +713,39 @@ export const buildChatPrompt = async (messages, options = {}) => {
 
     const contextSources = mergeSources(knowledgePack.sources || [], docsRagPayload.sources || []);
 
-    return {
+    const promptPayload = {
         combinedMessages,
         debugMessages,
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
     };
+
+    if (options.includePromptMetrics) {
+        promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
+            promptBuildDurationMs: performance.now() - promptBuildStartedAt,
+            ragDurationMs,
+            components: {
+                systemInstructions: systemMessage.content,
+                rag: [
+                    knowledgeSummary ? `DSPACE knowledge base:\n${knowledgeSummary}` : '',
+                    docsRagPayload.excerptsText || '',
+                ],
+                playerState: playerStateMessage?.content || '',
+                chatHistory: normalizedMessages
+                    .slice(
+                        0,
+                        latestUserMessage
+                            ? normalizedMessages.lastIndexOf(latestUserMessage)
+                            : undefined
+                    )
+                    .map((message) => message.content || ''),
+                latestUserMessage: latestUserMessage?.content || '',
+            },
+        });
+    }
+
+    return promptPayload;
 };
 
 export const GPT5Chat = async (messages, options = {}) => {

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -727,20 +727,18 @@ export const buildChatPrompt = async (messages, options = {}) => {
         const playerStateMessageIndex = indexOfMessage(playerStateMessage);
         const knowledgeMessageIndex = indexOfMessage(knowledgeMessage);
         const docsRagMessageIndex = indexOfMessage(docsRagMessage);
-        const latestUserMessageIndex = indexOfMessage(latestUserMessage);
-        const chatHistoryIndexes =
-            latestUserMessageIndex === -1
-                ? []
-                : combinedMessages
-                      .map((message, index) => ({ message, index }))
-                      .filter(
-                          ({ message, index }) =>
-                              index > systemMessageIndex &&
-                              index < latestUserMessageIndex &&
-                              normalizedMessages.includes(message) &&
-                              message.role !== 'system'
-                      )
-                      .map(({ index }) => index);
+        const latestUserMessageIndex = latestUserMessage
+            ? combinedMessages.lastIndexOf(latestUserMessage)
+            : -1;
+        const chatHistoryIndexes = combinedMessages
+            .map((message, index) => ({ message, index }))
+            .filter(
+                ({ message, index }) =>
+                    index !== latestUserMessageIndex &&
+                    normalizedMessages.includes(message) &&
+                    message.role !== 'system'
+            )
+            .map(({ index }) => index);
         const ragIndexes = [knowledgeMessageIndex, docsRagMessageIndex].filter(
             (index) => index !== -1
         );

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -1,0 +1,63 @@
+const utf8ByteLength = (value) => new TextEncoder().encode(String(value ?? '')).length;
+
+const summarizeText = (value) => {
+    const text = String(value ?? '');
+    return {
+        characters: text.length,
+        utf8Bytes: utf8ByteLength(text),
+    };
+};
+
+const emptyComponentTotals = () => ({
+    systemInstructions: { characters: 0, utf8Bytes: 0 },
+    rag: { characters: 0, utf8Bytes: 0 },
+    playerState: { characters: 0, utf8Bytes: 0 },
+    chatHistory: { characters: 0, utf8Bytes: 0 },
+    latestUserMessage: { characters: 0, utf8Bytes: 0 },
+});
+
+const addSize = (target, size) => {
+    target.characters += size.characters;
+    target.utf8Bytes += size.utf8Bytes;
+};
+
+export const buildPromptMetrics = (promptPayload, metadata = {}) => {
+    const messages = Array.isArray(promptPayload?.combinedMessages)
+        ? promptPayload.combinedMessages
+        : Array.isArray(promptPayload?.messages)
+          ? promptPayload.messages
+          : [];
+    const roleCounts = {};
+    const perMessage = messages.map((message, index) => {
+        const role = typeof message?.role === 'string' ? message.role : 'unknown';
+        roleCounts[role] = (roleCounts[role] || 0) + 1;
+        const size = summarizeText(message?.content);
+        return { index, role, ...size };
+    });
+    const totalCharacters = perMessage.reduce((sum, message) => sum + message.characters, 0);
+    const totalUtf8Bytes = perMessage.reduce((sum, message) => sum + message.utf8Bytes, 0);
+    const componentTotals = emptyComponentTotals();
+
+    for (const [name, value] of Object.entries(metadata.components || {})) {
+        if (!Object.prototype.hasOwnProperty.call(componentTotals, name)) continue;
+        if (Array.isArray(value)) {
+            for (const entry of value) addSize(componentTotals[name], summarizeText(entry));
+        } else {
+            addSize(componentTotals[name], summarizeText(value));
+        }
+    }
+
+    return {
+        messageCount: messages.length,
+        roleCounts,
+        totalCharacters,
+        totalUtf8Bytes,
+        perMessage,
+        componentTotals,
+        promptBuildDurationMs: Number(metadata.promptBuildDurationMs || 0),
+        ragDurationMs:
+            metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
+                ? null
+                : Number(metadata.ragDurationMs),
+    };
+};

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -21,6 +21,12 @@ const addSize = (target, size) => {
     target.utf8Bytes += size.utf8Bytes;
 };
 
+const normalizeIndexes = (value) => {
+    if (Array.isArray(value)) return value;
+    if (Number.isInteger(value)) return [value];
+    return [];
+};
+
 export const buildPromptMetrics = (promptPayload, metadata = {}) => {
     const messages = Array.isArray(promptPayload?.combinedMessages)
         ? promptPayload.combinedMessages
@@ -37,6 +43,14 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
     const totalCharacters = perMessage.reduce((sum, message) => sum + message.characters, 0);
     const totalUtf8Bytes = perMessage.reduce((sum, message) => sum + message.utf8Bytes, 0);
     const componentTotals = emptyComponentTotals();
+
+    for (const [name, value] of Object.entries(metadata.componentMessageIndexes || {})) {
+        if (!Object.prototype.hasOwnProperty.call(componentTotals, name)) continue;
+        for (const index of normalizeIndexes(value)) {
+            const messageSummary = perMessage[index];
+            if (messageSummary) addSize(componentTotals[name], messageSummary);
+        }
+    }
 
     for (const [name, value] of Object.entries(metadata.components || {})) {
         if (!Object.prototype.hasOwnProperty.call(componentTotals, name)) continue;

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -1,10 +1,10 @@
-const utf8ByteLength = (value) => new TextEncoder().encode(String(value ?? '')).length;
+const textEncoder = new TextEncoder();
 
 const summarizeText = (value) => {
     const text = String(value ?? '');
     return {
         characters: text.length,
-        utf8Bytes: utf8ByteLength(text),
+        utf8Bytes: textEncoder.encode(text).length,
     };
 };
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -3,6 +3,12 @@ import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
 import { normalizeSettings } from './settingsDefaults.js';
 import {
+    sanitizeTokenPlaceMessages,
+    TOKEN_PLACE_API_V1_MAX_MESSAGES,
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
+    TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+} from './tokenPlaceMessages.js';
+import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
@@ -15,17 +21,11 @@ const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
 const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
-const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
-const normalizeTokenPlaceRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
-export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
-export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
-export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
-const TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS = 96;
-const TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS =
-    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS - TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS;
-const TOKEN_PLACE_API_V1_FALLBACK_MESSAGE = {
-    role: 'user',
-    content: 'Please continue.',
+export {
+    sanitizeTokenPlaceMessages,
+    TOKEN_PLACE_API_V1_MAX_MESSAGES,
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
+    TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 };
 const TOKEN_LITE_SYSTEM_MESSAGE =
     "You are dChat, a concise DSPACE assistant. Answer the user's message. If game-specific context is missing, say you do not know.";
@@ -77,115 +77,6 @@ export const getTokenPlaceChatModel = (options = {}) =>
             readEnvValue('VITE_TOKEN_PLACE_CHAT_MODEL') ||
             DEFAULT_CHAT_MODEL
     ).trim() || DEFAULT_CHAT_MODEL;
-
-const stringifyJsonOrString = (content) => {
-    try {
-        const serialized = JSON.stringify(content);
-        return typeof serialized === 'string' ? serialized : String(content);
-    } catch {
-        return String(content);
-    }
-};
-
-const stringifyTokenPlaceContent = (content) => {
-    if (typeof content === 'string') return content;
-    if (content == null) return '';
-    if (Array.isArray(content)) {
-        return content
-            .map((part) => {
-                if (typeof part === 'string') return part;
-                if (typeof part?.text === 'string') return part.text;
-                if (typeof part?.content === 'string') return part.content;
-                return stringifyJsonOrString(part);
-            })
-            .filter(Boolean)
-            .join('\n');
-    }
-    return stringifyJsonOrString(content);
-};
-
-const chunkText = (content, maxChars) => {
-    const chunks = [];
-    for (let offset = 0; offset < content.length; offset += maxChars) {
-        chunks.push(content.slice(offset, offset + maxChars));
-    }
-    return chunks;
-};
-
-const splitTokenPlaceMessage = (message, index) => {
-    const role = normalizeTokenPlaceRole(message?.role);
-    const content = stringifyTokenPlaceContent(message?.content).trim();
-    if (!content) return [];
-
-    if (content.length <= TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS) {
-        return [{ role, content, originalIndex: index, chunkIndex: 0 }];
-    }
-
-    if (role === 'system') {
-        const chunks = chunkText(content, TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS);
-        return chunks.map((chunk, chunkIndex) => ({
-            role,
-            content: `[DSPACE context chunk ${chunkIndex + 1}/${chunks.length}]\n${chunk}`,
-            originalIndex: index,
-            chunkIndex,
-        }));
-    }
-
-    // Keep oversized conversation turns deterministic and valid. If later limits force trimming,
-    // the priority pass below preserves the latest user turn before older history/context.
-    return chunkText(content, TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS).map(
-        (chunk, chunkIndex) => ({ role, content: chunk, originalIndex: index, chunkIndex })
-    );
-};
-
-const getTokenPlaceMessagePriority = (message, latestUserIndex, requiredSystemMessage) => {
-    if (
-        requiredSystemMessage &&
-        message.originalIndex === requiredSystemMessage.originalIndex &&
-        message.chunkIndex === requiredSystemMessage.chunkIndex
-    ) {
-        return 0;
-    }
-    if (message.originalIndex === latestUserIndex) return 1;
-    if (message.role === 'system') return 2;
-    if (message.role === 'user') return 3;
-    return 4;
-};
-
-export const sanitizeTokenPlaceMessages = (messages = []) => {
-    const sourceMessages = Array.isArray(messages) ? messages : [];
-    const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
-    const latestUserIndex = candidates.reduce(
-        (latest, message) => (message.role === 'user' ? message.originalIndex : latest),
-        -1
-    );
-    const requiredSystemMessage = candidates.find((message) => message.role === 'system');
-    const selected = [];
-    let totalChars = 0;
-
-    for (const candidate of [...candidates].sort((a, b) => {
-        const priorityDelta =
-            getTokenPlaceMessagePriority(a, latestUserIndex, requiredSystemMessage) -
-            getTokenPlaceMessagePriority(b, latestUserIndex, requiredSystemMessage);
-        if (priorityDelta) return priorityDelta;
-        if (a.role === 'system')
-            return a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex;
-        return b.originalIndex - a.originalIndex || a.chunkIndex - b.chunkIndex;
-    })) {
-        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) break;
-        if (totalChars + candidate.content.length > TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS) {
-            continue;
-        }
-        selected.push(candidate);
-        totalChars += candidate.content.length;
-    }
-
-    const shapedMessages = selected
-        .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
-        .map(({ role, content }) => ({ role, content }));
-
-    return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
-};
 
 export const extractTokenPlaceAssistantText = (response) => {
     const content =

--- a/frontend/src/utils/tokenPlaceMessages.js
+++ b/frontend/src/utils/tokenPlaceMessages.js
@@ -83,7 +83,7 @@ const getTokenPlaceMessagePriority = (message, latestUserIndex, requiredSystemMe
     return 4;
 };
 
-export const sanitizeTokenPlaceMessages = (messages = []) => {
+export const sanitizeTokenPlaceMessagesWithMetadata = (messages = []) => {
     const sourceMessages = Array.isArray(messages) ? messages : [];
     const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
     const latestUserIndex = candidates.reduce(
@@ -113,7 +113,20 @@ export const sanitizeTokenPlaceMessages = (messages = []) => {
 
     const shapedMessages = selected
         .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
-        .map(({ role, content }) => ({ role, content }));
+        .map(({ role, content, originalIndex, chunkIndex }) => ({
+            role,
+            content,
+            originalIndex,
+            chunkIndex,
+        }));
 
-    return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
+    return shapedMessages.length
+        ? shapedMessages
+        : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE, originalIndex: -1, chunkIndex: 0 }];
 };
+
+export const sanitizeTokenPlaceMessages = (messages = []) =>
+    sanitizeTokenPlaceMessagesWithMetadata(messages).map(({ role, content }) => ({
+        role,
+        content,
+    }));

--- a/frontend/src/utils/tokenPlaceMessages.js
+++ b/frontend/src/utils/tokenPlaceMessages.js
@@ -1,0 +1,119 @@
+const VALID_CHAT_ROLES = new Set(['user', 'assistant', 'system']);
+const normalizeTokenPlaceRole = (role) => (VALID_CHAT_ROLES.has(role) ? role : 'user');
+export const TOKEN_PLACE_API_V1_MAX_MESSAGES = 64;
+export const TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS = 32_768;
+export const TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS = 131_072;
+const TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS = 96;
+const TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS =
+    TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS - TOKEN_PLACE_API_V1_CHUNK_LABEL_CHARS;
+const TOKEN_PLACE_API_V1_FALLBACK_MESSAGE = {
+    role: 'user',
+    content: 'Please continue.',
+};
+
+const stringifyJsonOrString = (content) => {
+    try {
+        const serialized = JSON.stringify(content);
+        return typeof serialized === 'string' ? serialized : String(content);
+    } catch {
+        return String(content);
+    }
+};
+
+const stringifyTokenPlaceContent = (content) => {
+    if (typeof content === 'string') return content;
+    if (content == null) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => {
+                if (typeof part === 'string') return part;
+                if (typeof part?.text === 'string') return part.text;
+                if (typeof part?.content === 'string') return part.content;
+                return stringifyJsonOrString(part);
+            })
+            .filter(Boolean)
+            .join('\n');
+    }
+    return stringifyJsonOrString(content);
+};
+
+const chunkText = (content, maxChars) => {
+    const chunks = [];
+    for (let offset = 0; offset < content.length; offset += maxChars) {
+        chunks.push(content.slice(offset, offset + maxChars));
+    }
+    return chunks;
+};
+
+const splitTokenPlaceMessage = (message, index) => {
+    const role = normalizeTokenPlaceRole(message?.role);
+    const content = stringifyTokenPlaceContent(message?.content).trim();
+    if (!content) return [];
+
+    if (content.length <= TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS) {
+        return [{ role, content, originalIndex: index, chunkIndex: 0 }];
+    }
+
+    if (role === 'system') {
+        const chunks = chunkText(content, TOKEN_PLACE_API_V1_SYSTEM_CHUNK_CHARS);
+        return chunks.map((chunk, chunkIndex) => ({
+            role,
+            content: `[DSPACE context chunk ${chunkIndex + 1}/${chunks.length}]\n${chunk}`,
+            originalIndex: index,
+            chunkIndex,
+        }));
+    }
+
+    return chunkText(content, TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS).map(
+        (chunk, chunkIndex) => ({ role, content: chunk, originalIndex: index, chunkIndex })
+    );
+};
+
+const getTokenPlaceMessagePriority = (message, latestUserIndex, requiredSystemMessage) => {
+    if (
+        requiredSystemMessage &&
+        message.originalIndex === requiredSystemMessage.originalIndex &&
+        message.chunkIndex === requiredSystemMessage.chunkIndex
+    ) {
+        return 0;
+    }
+    if (message.originalIndex === latestUserIndex) return 1;
+    if (message.role === 'system') return 2;
+    if (message.role === 'user') return 3;
+    return 4;
+};
+
+export const sanitizeTokenPlaceMessages = (messages = []) => {
+    const sourceMessages = Array.isArray(messages) ? messages : [];
+    const candidates = sourceMessages.flatMap(splitTokenPlaceMessage);
+    const latestUserIndex = candidates.reduce(
+        (latest, message) => (message.role === 'user' ? message.originalIndex : latest),
+        -1
+    );
+    const requiredSystemMessage = candidates.find((message) => message.role === 'system');
+    const selected = [];
+    let totalChars = 0;
+
+    for (const candidate of [...candidates].sort((a, b) => {
+        const priorityDelta =
+            getTokenPlaceMessagePriority(a, latestUserIndex, requiredSystemMessage) -
+            getTokenPlaceMessagePriority(b, latestUserIndex, requiredSystemMessage);
+        if (priorityDelta) return priorityDelta;
+        if (a.role === 'system')
+            return a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex;
+        return b.originalIndex - a.originalIndex || a.chunkIndex - b.chunkIndex;
+    })) {
+        if (selected.length >= TOKEN_PLACE_API_V1_MAX_MESSAGES) break;
+        if (totalChars + candidate.content.length > TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS) {
+            continue;
+        }
+        selected.push(candidate);
+        totalChars += candidate.content.length;
+    }
+
+    const shapedMessages = selected
+        .sort((a, b) => a.originalIndex - b.originalIndex || a.chunkIndex - b.chunkIndex)
+        .map(({ role, content }) => ({ role, content }));
+
+    return shapedMessages.length ? shapedMessages : [{ ...TOKEN_PLACE_API_V1_FALLBACK_MESSAGE }];
+};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "lint:a11y": "cd frontend && npm run lint:a11y",
     "dev:legacy": "npm run dev",
     "playwright:install": "npm --prefix frontend run playwright:install",
-    "build:meta": "node scripts/write-build-meta.mjs"
+    "build:meta": "node scripts/write-build-meta.mjs",
+    "benchmark:token-place-context": "node scripts/benchmark-token-place-context.mjs"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -3,9 +3,16 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+import {
+  sanitizeTokenPlaceMessages,
+  TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+} from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
-const CEILING = 131_072;
+const RESERVED_OUTPUT_TOKENS = 512;
+const CHAT_TEMPLATE_OVERHEAD_TOKENS = 128;
+const TOKEN_BUDGET_BUFFER =
+  RESERVED_OUTPUT_TOKENS + CHAT_TEMPLATE_OVERHEAD_TOKENS;
 const repeat = (label, length) =>
   label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
@@ -98,7 +105,7 @@ const scenarios = [
   }),
   scenario(
     'near-token-place-ceiling',
-    'Synthetic payload near the 131,072-character request ceiling.',
+    `Synthetic payload near the ${TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS.toLocaleString('en-US')}-character request ceiling.`,
     {
       system: 2000,
       rag: 44000,
@@ -110,26 +117,37 @@ const scenarios = [
 ];
 
 const estimateTokens = (characters) => Math.ceil(characters / 4);
-const tierReadiness = (metrics) => ({
-  heuristicTokens: estimateTokens(metrics.totalCharacters),
-  fits8kHeuristic: estimateTokens(metrics.totalCharacters) <= 8192,
-  fits64kHeuristic: estimateTokens(metrics.totalCharacters) <= 65536,
-});
+const tierReadiness = (metrics) => {
+  const heuristicTokens = estimateTokens(metrics.totalCharacters);
+  return {
+    heuristicTokens,
+    reservedTokens: TOKEN_BUDGET_BUFFER,
+    fits8kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 8192,
+    fits64kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 65536,
+    fitsTokenPlaceCharCeiling:
+      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+  };
+};
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
 
 const results = scenarios.map((item) => {
   const startedAt = performance.now();
-  const metrics = buildPromptMetrics(item, {
-    components: item.components,
-    promptBuildDurationMs: 0,
-    ragDurationMs: item.components.rag ? 0 : null,
-  });
-  metrics.promptBuildDurationMs = performance.now() - startedAt;
+  const tokenPlaceMessages = sanitizeTokenPlaceMessages(item.combinedMessages);
+  const metrics = buildPromptMetrics(
+    { combinedMessages: tokenPlaceMessages },
+    {
+      components: item.components,
+      promptBuildDurationMs: performance.now() - startedAt,
+      ragDurationMs: item.components.rag ? 0 : null,
+    }
+  );
   return {
     id: item.id,
     description: item.description,
+    sourceMessageCount: item.combinedMessages.length,
+    tokenPlaceMessageCount: tokenPlaceMessages.length,
     metrics,
     tierReadiness: tierReadiness(metrics),
     exactTokenizer: {
@@ -152,17 +170,17 @@ const markdown = [
   '',
   `Generated: ${json.generatedAt}`,
   '',
-  '| Scenario | Messages | Chars | UTF-8 bytes | Heuristic tokens | 8K | 64K | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | --- | --- | --- |',
+  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Heuristic tokens | Reserved tokens | 8K | 64K | Char ceiling | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
   ...results.map((result) => {
     const entries = Object.entries(result.metrics.componentTotals);
     const [dominant] = entries.sort(
       (a, b) => b[1].characters - a[1].characters
     )[0];
-    return `| ${result.id} | ${result.metrics.messageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${dominant} |`;
+    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.reservedTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${dominant} |`;
   }),
   '',
-  'All values are content-free counts from synthetic fixtures. Token counts are four-characters-per-token heuristics, not exact model tokens.',
+  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token counts are four-characters-per-token heuristics, not exact model tokens; tier fit reserves output and chat-template headroom.',
 ].join('\n');
 
 await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+
+const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
+const CEILING = 131_072;
+const repeat = (label, length) =>
+  label.repeat(Math.ceil(length / label.length)).slice(0, length);
+
+const syntheticState = (chars) =>
+  `SYNTHETIC_PLAYER_STATE:${repeat(' inventory=synthetic-item quest=synthetic-step ', chars)}`;
+const syntheticRag = (chars) =>
+  `SYNTHETIC_RAG_EXCERPTS:${repeat(' docs synthetic guidance for benchmark only. ', chars)}`;
+const syntheticHistory = (turns, chars) =>
+  Array.from({ length: turns }, (_, index) => [
+    {
+      role: 'user',
+      content: `synthetic user turn ${index}: ${repeat('u ', chars)}`,
+    },
+    {
+      role: 'assistant',
+      content: `synthetic assistant turn ${index}: ${repeat('a ', chars)}`,
+    },
+  ]).flat();
+
+const scenario = (
+  id,
+  description,
+  { system = 500, rag = 0, state = 0, history = [], latest = 80 }
+) => {
+  const systemContent = `SYNTHETIC_SYSTEM:${repeat(' system policy. ', system)}`;
+  const ragContent = rag ? syntheticRag(rag) : '';
+  const stateContent = state ? syntheticState(state) : '';
+  const latestContent = `synthetic latest user message: ${repeat('latest ', latest)}`;
+  const combinedMessages = [
+    { role: 'system', content: systemContent },
+    ...(ragContent ? [{ role: 'system', content: ragContent }] : []),
+    ...(stateContent ? [{ role: 'system', content: stateContent }] : []),
+    ...history,
+    { role: 'user', content: latestContent },
+  ];
+  return {
+    id,
+    description,
+    combinedMessages,
+    components: {
+      systemInstructions: systemContent,
+      rag: ragContent,
+      playerState: stateContent,
+      chatHistory: history.map((m) => m.content),
+      latestUserMessage: latestContent,
+    },
+  };
+};
+
+const scenarios = [
+  scenario('token-lite-baseline', 'Small token-lite style prompt.', {
+    system: 180,
+    latest: 40,
+  }),
+  scenario('minimal-full-fat', 'Minimal full-fat DSPACE prompt.', {
+    system: 1200,
+    state: 800,
+    latest: 80,
+  }),
+  scenario(
+    'typical-mid-game',
+    'Typical mid-game state, RAG, and short history.',
+    {
+      system: 1800,
+      rag: 6000,
+      state: 8000,
+      history: syntheticHistory(6, 160),
+      latest: 180,
+    }
+  ),
+  scenario('rag-heavy', 'Large synthetic docs-RAG excerpts.', {
+    system: 1800,
+    rag: 36000,
+    state: 5000,
+    history: syntheticHistory(4, 120),
+    latest: 160,
+  }),
+  scenario('long-chat-history', 'Long accumulated chat history.', {
+    system: 1500,
+    state: 4000,
+    history: syntheticHistory(30, 420),
+    latest: 160,
+  }),
+  scenario('large-player-state', 'Large save/player-state snapshot.', {
+    system: 1500,
+    rag: 2500,
+    state: 52000,
+    history: syntheticHistory(4, 120),
+    latest: 160,
+  }),
+  scenario(
+    'near-token-place-ceiling',
+    'Synthetic payload near the 131,072-character request ceiling.',
+    {
+      system: 2000,
+      rag: 44000,
+      state: 44000,
+      history: syntheticHistory(10, 1700),
+      latest: 900,
+    }
+  ),
+];
+
+const estimateTokens = (characters) => Math.ceil(characters / 4);
+const tierReadiness = (metrics) => ({
+  heuristicTokens: estimateTokens(metrics.totalCharacters),
+  fits8kHeuristic: estimateTokens(metrics.totalCharacters) <= 8192,
+  fits64kHeuristic: estimateTokens(metrics.totalCharacters) <= 65536,
+});
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+await mkdir(OUTPUT_DIR, { recursive: true });
+
+const results = scenarios.map((item) => {
+  const startedAt = performance.now();
+  const metrics = buildPromptMetrics(item, {
+    components: item.components,
+    promptBuildDurationMs: 0,
+    ragDurationMs: item.components.rag ? 0 : null,
+  });
+  metrics.promptBuildDurationMs = performance.now() - startedAt;
+  return {
+    id: item.id,
+    description: item.description,
+    metrics,
+    tierReadiness: tierReadiness(metrics),
+    exactTokenizer: {
+      available: false,
+      note: 'No production-safe Llama 3.1 tokenizer hook is configured for this benchmark.',
+    },
+  };
+});
+
+const jsonPath = path.join(OUTPUT_DIR, `${timestamp}.json`);
+const mdPath = path.join(OUTPUT_DIR, `${timestamp}.md`);
+const json = {
+  generatedAt: new Date().toISOString(),
+  fixturePolicy:
+    'synthetic repository-owned benchmark data only; no user prompts or secrets',
+  scenarios: results,
+};
+const markdown = [
+  '# token.place Context Benchmark',
+  '',
+  `Generated: ${json.generatedAt}`,
+  '',
+  '| Scenario | Messages | Chars | UTF-8 bytes | Heuristic tokens | 8K | 64K | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | --- | --- | --- |',
+  ...results.map((result) => {
+    const entries = Object.entries(result.metrics.componentTotals);
+    const [dominant] = entries.sort(
+      (a, b) => b[1].characters - a[1].characters
+    )[0];
+    return `| ${result.id} | ${result.metrics.messageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${dominant} |`;
+  }),
+  '',
+  'All values are content-free counts from synthetic fixtures. Token counts are four-characters-per-token heuristics, not exact model tokens.',
+].join('\n');
+
+await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);
+await writeFile(mdPath, `${markdown}\n`);
+console.log(`Wrote ${jsonPath}`);
+console.log(`Wrote ${mdPath}`);

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
 import {
-  sanitizeTokenPlaceMessages,
+  sanitizeTokenPlaceMessagesWithMetadata,
   TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
@@ -48,16 +48,21 @@ const scenario = (
     ...history,
     { role: 'user', content: latestContent },
   ];
+  const systemIndex = 0;
+  const ragIndex = ragContent ? 1 : -1;
+  const playerStateIndex = stateContent ? 1 + (ragContent ? 1 : 0) : -1;
+  const historyStartIndex = 1 + (ragContent ? 1 : 0) + (stateContent ? 1 : 0);
+  const latestUserMessageIndex = combinedMessages.length - 1;
   return {
     id,
     description,
     combinedMessages,
-    components: {
-      systemInstructions: systemContent,
-      rag: ragContent,
-      playerState: stateContent,
-      chatHistory: history.map((m) => m.content),
-      latestUserMessage: latestContent,
+    componentSourceIndexes: {
+      systemInstructions: systemIndex,
+      rag: ragIndex,
+      playerState: playerStateIndex,
+      chatHistory: history.map((_, index) => historyStartIndex + index),
+      latestUserMessage: latestUserMessageIndex,
     },
   };
 };
@@ -132,17 +137,71 @@ const tierReadiness = (metrics) => {
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
 
+const indexesForShapedMessages = (shapedMessages, sourceIndexes) => {
+  const sourceIndexSet = new Set(
+    (Array.isArray(sourceIndexes) ? sourceIndexes : [sourceIndexes]).filter(
+      Number.isInteger
+    )
+  );
+  return shapedMessages
+    .map((message, index) =>
+      sourceIndexSet.has(message.originalIndex) ? index : null
+    )
+    .filter(Number.isInteger);
+};
+
+const componentIndexesForShapedMessages = (
+  shapedMessages,
+  componentSourceIndexes
+) =>
+  Object.fromEntries(
+    Object.entries(componentSourceIndexes).map(([name, sourceIndexes]) => [
+      name,
+      indexesForShapedMessages(shapedMessages, sourceIndexes),
+    ])
+  );
+
+const componentTotalsSum = (componentTotals, field) =>
+  Object.values(componentTotals).reduce((sum, total) => sum + total[field], 0);
+
 const results = scenarios.map((item) => {
   const startedAt = performance.now();
-  const tokenPlaceMessages = sanitizeTokenPlaceMessages(item.combinedMessages);
+  const shapedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(
+    item.combinedMessages
+  );
+  const tokenPlaceMessages = shapedMessagesWithMetadata.map(
+    ({ role, content }) => ({
+      role,
+      content,
+    })
+  );
   const metrics = buildPromptMetrics(
     { combinedMessages: tokenPlaceMessages },
     {
-      components: item.components,
+      componentMessageIndexes: componentIndexesForShapedMessages(
+        shapedMessagesWithMetadata,
+        item.componentSourceIndexes
+      ),
       promptBuildDurationMs: performance.now() - startedAt,
-      ragDurationMs: item.components.rag ? 0 : null,
+      ragDurationMs: item.componentSourceIndexes.rag === -1 ? null : 0,
     }
   );
+  if (
+    componentTotalsSum(metrics.componentTotals, 'characters') !==
+    metrics.totalCharacters
+  ) {
+    throw new Error(
+      `Component character totals do not sum to payload total for ${item.id}`
+    );
+  }
+  if (
+    componentTotalsSum(metrics.componentTotals, 'utf8Bytes') !==
+    metrics.totalUtf8Bytes
+  ) {
+    throw new Error(
+      `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
+    );
+  }
   return {
     id: item.id,
     description: item.description,

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -97,9 +97,12 @@ describe('buildPromptMetrics', () => {
 
     const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
     const userMessage = 'Where should I go next?';
-    const instrumented = await buildChatPrompt([{ role: 'user', content: userMessage }], {
-      includePromptMetrics: true,
-    });
+    const instrumented = await buildChatPrompt(
+      [{ role: 'user', content: userMessage }],
+      {
+        includePromptMetrics: true,
+      }
+    );
     const ragMessages = instrumented.combinedMessages.filter((message) =>
       message.content.includes('DSPACE knowledge base:')
     );
@@ -114,8 +117,53 @@ describe('buildPromptMetrics', () => {
     expect(instrumented.promptMetrics.componentTotals.rag.characters).toBe(
       ragMessages[0].content.length
     );
-    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(userMessage);
-    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(docsExcerpt);
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(
+      userMessage
+    );
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(
+      docsExcerpt
+    );
+  });
+
+  test('buildChatPrompt counts assistant messages after the latest user as chat history', async () => {
+    const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
+    const latestUser = { role: 'user', content: 'latest repeated prompt' };
+    const trailingAssistant = {
+      role: 'assistant',
+      content: 'assistant after latest user',
+    };
+    const instrumented = await buildChatPrompt(
+      [
+        { role: 'user', content: 'earlier prompt' },
+        latestUser,
+        trailingAssistant,
+      ],
+      { includePromptMetrics: true }
+    );
+
+    const latestIndex = instrumented.combinedMessages.lastIndexOf(latestUser);
+    const assistantIndex =
+      instrumented.combinedMessages.indexOf(trailingAssistant);
+    const earlierIndex = instrumented.combinedMessages.findIndex(
+      (message) => message.content === 'earlier prompt'
+    );
+    const latestSummary = instrumented.promptMetrics.perMessage[latestIndex];
+    const assistantSummary =
+      instrumented.promptMetrics.perMessage[assistantIndex];
+    const earlierSummary = instrumented.promptMetrics.perMessage[earlierIndex];
+
+    expect(
+      instrumented.promptMetrics.componentTotals.latestUserMessage.characters
+    ).toBe(latestSummary.characters);
+    expect(
+      instrumented.promptMetrics.componentTotals.chatHistory.characters
+    ).toBe(earlierSummary.characters + assistantSummary.characters);
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(
+      latestUser.content
+    );
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(
+      trailingAssistant.content
+    );
   });
 
   test('buildChatPrompt leaves instrumentation disabled unless requested', async () => {

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+import { buildDchatKnowledgePack } from '../frontend/src/utils/dchatKnowledge.js';
+import { searchDocsRag } from '../frontend/src/utils/docsRag.js';
 
 vi.mock('../frontend/src/utils/gameState/common.js', () => ({
   loadGameState: vi.fn(() => ({})),
@@ -15,11 +17,22 @@ vi.mock('../frontend/src/utils/docsRag.js', () => ({
 }));
 
 describe('buildPromptMetrics', () => {
+  beforeEach(() => {
+    vi.mocked(buildDchatKnowledgePack).mockReturnValue({
+      summary: '',
+      sources: [],
+    });
+    vi.mocked(searchDocsRag).mockResolvedValue({
+      excerptsText: '',
+      sources: [],
+    });
+  });
+
   test('returns content-free prompt metrics', () => {
     const secret = 'synthetic secret prompt text';
     const metrics = buildPromptMetrics(
       { combinedMessages: [{ role: 'user', content: secret }] },
-      { components: { latestUserMessage: secret } }
+      { componentMessageIndexes: { latestUserMessage: 0 } }
     );
     const serialized = JSON.stringify(metrics);
     expect(serialized).not.toContain(secret);
@@ -40,7 +53,7 @@ describe('buildPromptMetrics', () => {
     expect(metrics.totalUtf8Bytes).toBe(7);
   });
 
-  test('component accounting is deterministic', () => {
+  test('component accounting is deterministic from final message indexes', () => {
     const payload = {
       combinedMessages: [
         { role: 'system', content: 'system' },
@@ -50,11 +63,11 @@ describe('buildPromptMetrics', () => {
       ],
     };
     const metadata = {
-      components: {
-        systemInstructions: 'system',
-        rag: 'rag',
-        chatHistory: ['history'],
-        latestUserMessage: 'latest',
+      componentMessageIndexes: {
+        systemInstructions: 0,
+        rag: [1],
+        chatHistory: [2],
+        latestUserMessage: 3,
       },
     };
     expect(buildPromptMetrics(payload, metadata)).toEqual(
@@ -68,6 +81,41 @@ describe('buildPromptMetrics', () => {
         latestUserMessage: { characters: 6, utf8Bytes: 6 },
       }
     );
+  });
+
+  test('buildChatPrompt metrics count only the RAG message included in the final prompt', async () => {
+    const knowledgeSummary = 'synthetic knowledge summary';
+    const docsExcerpt = 'synthetic docs excerpt omitted from final prompt';
+    vi.mocked(buildDchatKnowledgePack).mockReturnValue({
+      summary: knowledgeSummary,
+      sources: [],
+    });
+    vi.mocked(searchDocsRag).mockResolvedValue({
+      excerptsText: docsExcerpt,
+      sources: [],
+    });
+
+    const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
+    const userMessage = 'Where should I go next?';
+    const instrumented = await buildChatPrompt([{ role: 'user', content: userMessage }], {
+      includePromptMetrics: true,
+    });
+    const ragMessages = instrumented.combinedMessages.filter((message) =>
+      message.content.includes('DSPACE knowledge base:')
+    );
+
+    expect(ragMessages).toHaveLength(1);
+    expect(ragMessages[0].content).toContain(knowledgeSummary);
+    expect(ragMessages[0].content).toContain(docsExcerpt);
+    expect(instrumented.combinedMessages).not.toContainEqual({
+      role: 'system',
+      content: docsExcerpt,
+    });
+    expect(instrumented.promptMetrics.componentTotals.rag.characters).toBe(
+      ragMessages[0].content.length
+    );
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(userMessage);
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain(docsExcerpt);
   });
 
   test('buildChatPrompt leaves instrumentation disabled unless requested', async () => {

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from 'vitest';
+import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+
+vi.mock('../frontend/src/utils/gameState/common.js', () => ({
+  loadGameState: vi.fn(() => ({})),
+  ready: Promise.resolve(),
+}));
+
+vi.mock('../frontend/src/utils/dchatKnowledge.js', () => ({
+  buildDchatKnowledgePack: vi.fn(() => ({ summary: '', sources: [] })),
+}));
+
+vi.mock('../frontend/src/utils/docsRag.js', () => ({
+  searchDocsRag: vi.fn(async () => ({ excerptsText: '', sources: [] })),
+}));
+
+describe('buildPromptMetrics', () => {
+  test('returns content-free prompt metrics', () => {
+    const secret = 'synthetic secret prompt text';
+    const metrics = buildPromptMetrics(
+      { combinedMessages: [{ role: 'user', content: secret }] },
+      { components: { latestUserMessage: secret } }
+    );
+    const serialized = JSON.stringify(metrics);
+    expect(serialized).not.toContain(secret);
+    expect(metrics.perMessage[0]).toEqual({
+      index: 0,
+      role: 'user',
+      characters: secret.length,
+      utf8Bytes: new TextEncoder().encode(secret).length,
+    });
+  });
+
+  test('counts UTF-8 bytes correctly', () => {
+    const content = 'A🚀é';
+    const metrics = buildPromptMetrics({
+      combinedMessages: [{ role: 'user', content }],
+    });
+    expect(metrics.totalCharacters).toBe(4);
+    expect(metrics.totalUtf8Bytes).toBe(7);
+  });
+
+  test('component accounting is deterministic', () => {
+    const payload = {
+      combinedMessages: [
+        { role: 'system', content: 'system' },
+        { role: 'system', content: 'rag' },
+        { role: 'user', content: 'history' },
+        { role: 'user', content: 'latest' },
+      ],
+    };
+    const metadata = {
+      components: {
+        systemInstructions: 'system',
+        rag: 'rag',
+        chatHistory: ['history'],
+        latestUserMessage: 'latest',
+      },
+    };
+    expect(buildPromptMetrics(payload, metadata)).toEqual(
+      buildPromptMetrics(payload, metadata)
+    );
+    expect(buildPromptMetrics(payload, metadata).componentTotals).toMatchObject(
+      {
+        systemInstructions: { characters: 6, utf8Bytes: 6 },
+        rag: { characters: 3, utf8Bytes: 3 },
+        chatHistory: { characters: 7, utf8Bytes: 7 },
+        latestUserMessage: { characters: 6, utf8Bytes: 6 },
+      }
+    );
+  });
+
+  test('buildChatPrompt leaves instrumentation disabled unless requested', async () => {
+    const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
+    const messages = [{ role: 'user', content: 'hello' }];
+    const baseline = await buildChatPrompt(messages);
+    const instrumented = await buildChatPrompt(messages, {
+      includePromptMetrics: true,
+    });
+    expect(baseline.promptMetrics).toBeUndefined();
+    expect(instrumented.combinedMessages).toEqual(baseline.combinedMessages);
+    expect(instrumented.promptMetrics.messageCount).toBe(
+      instrumented.combinedMessages.length
+    );
+    expect(JSON.stringify(instrumented.promptMetrics)).not.toContain('hello');
+  });
+});

--- a/tests/tokenPlaceBenchmarkFixtures.test.ts
+++ b/tests/tokenPlaceBenchmarkFixtures.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
@@ -15,5 +16,40 @@ describe('token.place context benchmark fixtures', () => {
     expect(source).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY/);
     expect(source).not.toMatch(/sk-[A-Za-z0-9]/);
     expect(source).not.toMatch(/ciphertext/i);
+  });
+
+  test('generated component totals sum to shaped payload totals for every scenario', () => {
+    const output = execFileSync(
+      'node',
+      ['scripts/benchmark-token-place-context.mjs'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      }
+    );
+    const jsonPath = output.match(
+      /Wrote (artifacts\/benchmarks\/token-place-context\/[^\s]+\.json)/
+    )?.[1];
+    expect(jsonPath).toBeTruthy();
+    const report = JSON.parse(
+      readFileSync(resolve(repoRoot, jsonPath ?? ''), 'utf8')
+    );
+
+    for (const scenario of report.scenarios) {
+      const componentTotals = Object.values(
+        scenario.metrics.componentTotals
+      ) as Array<{
+        characters: number;
+        utf8Bytes: number;
+      }>;
+      expect(
+        componentTotals.reduce((sum, total) => sum + total.characters, 0),
+        scenario.id
+      ).toBe(scenario.metrics.totalCharacters);
+      expect(
+        componentTotals.reduce((sum, total) => sum + total.utf8Bytes, 0),
+        scenario.id
+      ).toBe(scenario.metrics.totalUtf8Bytes);
+    }
   });
 });

--- a/tests/tokenPlaceBenchmarkFixtures.test.ts
+++ b/tests/tokenPlaceBenchmarkFixtures.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('token.place context benchmark fixtures', () => {
+  test('script uses synthetic fixtures and no secret-like literals', () => {
+    const source = readFileSync(
+      resolve(repoRoot, 'scripts/benchmark-token-place-context.mjs'),
+      'utf8'
+    );
+    expect(source).toContain('SYNTHETIC_');
+    expect(source).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY/);
+    expect(source).not.toMatch(/sk-[A-Za-z0-9]/);
+    expect(source).not.toMatch(/ciphertext/i);
+  });
+});


### PR DESCRIPTION
### Motivation

- Implement Phase 0 DSPACE prompt benchmarking and privacy-safe instrumentation to measure full-fat token.place chat composition without exposing user content. 
- Provide deterministic, repeatable, repository-owned synthetic scenarios to identify which prompt components dominate context use and to compare 8K/64K readiness heuristics.
- Ensure instrumentation is opt-in and non-breaking so production behavior and existing token-lite/chat flows remain unchanged.

### Description

- Add a pure, content-free metrics helper `buildPromptMetrics` in `frontend/src/utils/promptMetrics.js` that returns message counts, role counts, total characters, total UTF-8 bytes, per-message size summaries, component totals, and prompt/RAG durations without returning prompt strings. 
- Wire optional instrumentation into `buildChatPrompt` via `options.includePromptMetrics` so the original return shape is preserved when disabled and diagnostics are attached only when requested (`frontend/src/utils/openAI.js`).
- Add a deterministic synthetic benchmark harness `scripts/benchmark-token-place-context.mjs` that runs multiple scenarios (token-lite baseline, minimal full-fat, typical mid-game, RAG-heavy, long history, large player state, near the 131,072-character ceiling), emits machine-readable JSON and a Markdown summary to `artifacts/benchmarks/token-place-context/`, and provides heuristic 4-char/token estimates and 8K/64K readiness flags.
- Add documentation `docs/benchmarks/token-place-context.md`, register the benchmark CLI in `package.json` as `benchmark:token-place-context`, and ignore local benchmark outputs via `.gitignore` (artifact path `artifacts/`).
- Add focused tests: `tests/promptMetrics.test.ts` (content-free assurance, UTF-8 sizing, deterministic component accounting, and instrumentation opt-in behavior) and `tests/tokenPlaceBenchmarkFixtures.test.ts` (ensures benchmark script uses synthetic fixtures and contains no secret-like literals).

### Testing

- Ran unit/integration checks:
  - `npm run test:root -- tests/promptMetrics.test.ts tests/tokenPlaceBenchmarkFixtures.test.ts` — passed (all tests in those files passed).
  - `cd frontend && npm test -- tokenPlace.test.js` — passed (existing token.place client tests passed).
  - `cd frontend && npm run check` — passed (lint + Prettier checks OK).
  - `cd frontend && npm run build` — passed (Astro build completed).
  - `npm run benchmark:token-place-context` — ran successfully and wrote JSON/Markdown reports under `artifacts/benchmarks/token-place-context/` (local artifacts only).
  - `git diff --check` — no outstanding whitespace/errors.

All new tests passed and the benchmark executed against synthetic fixtures; no user data, request text, RAG excerpts, player state, keys, ciphertext, or decrypted responses are logged or persisted by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a47e46b58832f856b678361d696ae)