### PR TITLE
Add privacy-safe token.place prompt benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ frontend/package-lock.json
 
 # Backups
 backups/
+
+# Local benchmark reports
+artifacts/benchmarks/

--- a/docs/token-place-context-benchmarking.md
+++ b/docs/token-place-context-benchmarking.md
@@ -1,0 +1,39 @@
+# token.place context benchmarking
+
+Run the privacy-safe DSPACE prompt benchmark from the repository root:
+
+```bash
+npm run benchmark:token-place-context
+```
+
+The command writes JSON and Markdown reports under `artifacts/benchmarks/token-place-context/`.
+Those generated reports are local artifacts and should not be committed.
+
+## Metrics
+
+- `messageCount` and `roleCounts`: API-style chat message shape counts.
+- `totalCharacters`: JavaScript string length across message content.
+- `totalUtf8Bytes`: encoded UTF-8 bytes across message content.
+- `messages`: per-message index, role, character count, and byte count only.
+- `componentTotals`: size totals for system instructions, docs RAG, player state, chat history, and latest user message when safely identified.
+- `timings`: prompt-build and RAG durations when the caller supplies them.
+
+## Privacy constraints
+
+The metrics helper and benchmark reports must never return or write actual prompts, RAG excerpts,
+player state, chat content, keys, ciphertext, or user text. Committed benchmark scenarios use
+synthetic fixture strings only.
+
+## Comparing 8K and 64K readiness
+
+Use the Markdown table to find scenarios whose heuristic token count approaches 8,192 or 65,536.
+Prompts near 8K should be treated as candidates for a larger tier because exact chat-template tokens,
+reserved output tokens, and tokenizer behavior can push them over the limit. Prompts approaching 64K
+need prompt reduction before production routing.
+
+## Character counts are not model tokens
+
+Character counts, byte counts, and whitespace counts are deterministic browser-side measurements,
+but Llama 3.1 tokenization depends on the model tokenizer and chat template. The benchmark therefore
+labels `characters / 4` as a heuristic only. Exact tokenizer results may be added later when a small
+server-side tokenizer is available without changing the production browser bundle.

--- a/frontend/__tests__/openAI.test.js
+++ b/frontend/__tests__/openAI.test.js
@@ -124,6 +124,17 @@ describe('gpt-5 chat responses utility', () => {
         expect(result).toBe('mocked reply');
     });
 
+    test('buildChatPrompt instrumentation is opt-in and preserves payload shape', async () => {
+        const messages = [{ role: 'user', content: 'hello instrumentation' }];
+        const plain = await buildChatPrompt(messages);
+        const instrumented = await buildChatPrompt(messages, { includePromptMetrics: true });
+        expect(plain.promptMetrics).toBeUndefined();
+        expect(instrumented.combinedMessages).toEqual(plain.combinedMessages);
+        expect(instrumented.contextSources).toEqual(plain.contextSources);
+        expect(instrumented.playerStateSummary).toEqual(plain.playerStateSummary);
+        expect(JSON.stringify(instrumented.promptMetrics)).not.toContain('hello instrumentation');
+    });
+
     test('buildChatPrompt labels RAG content for debug', async () => {
         const { debugMessages } = await buildChatPrompt([]);
         const ragMessages = debugMessages.filter((message) => message.kind === 'rag');

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -19,6 +19,7 @@ const {
     generateTokenPlaceClientKeypair,
     validateTokenPlaceResponseEnvelope,
     buildTokenPlaceChatCompletionsUrl,
+    buildTokenPlaceTokenLitePrompt,
     extractTokenPlaceAssistantText,
     getTokenPlaceChatModel,
     resolveTokenPlaceBaseUrl,
@@ -155,6 +156,20 @@ describe('token.place API v1 client', () => {
         delete process.env.VITE_TOKEN_PLACE_URL;
         delete process.env.VITE_TOKEN_PLACE_CHAT_MODEL;
         delete process.env.VITE_TOKEN_PLACE_ENABLED;
+    });
+
+    test('token-lite instrumentation is opt-in and does not change messages', () => {
+        const messages = [{ role: 'user', content: 'hello' }];
+        const plain = buildTokenPlaceTokenLitePrompt(messages, {});
+        const instrumented = buildTokenPlaceTokenLitePrompt(
+            messages,
+            {},
+            { includePromptMetrics: true }
+        );
+        expect(plain.promptMetrics).toBeUndefined();
+        expect(instrumented.combinedMessages).toEqual(plain.combinedMessages);
+        expect(instrumented.debugMessages).toEqual(plain.debugMessages);
+        expect(JSON.stringify(instrumented.promptMetrics)).not.toContain('hello');
     });
 
     test('fresh/default state uses token.place relay E2EE routes', async () => {

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -6,6 +6,7 @@ import { searchDocsRag } from './docsRag.js';
 import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
+import { collectPromptMetrics } from './promptMetrics.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -604,6 +605,7 @@ async function createChatResponse(openai, input) {
 }
 
 export const buildChatPrompt = async (messages, options = {}) => {
+    const promptBuildStartedAt = performance.now();
     await ready;
     const normalizedMessages = Array.isArray(messages) ? messages : [];
     const rawGameState = loadGameState();
@@ -652,9 +654,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
+    const ragStartedAt = performance.now();
     const docsRagPayload = latestUserMessage
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
+    const ragMs = performance.now() - ragStartedAt;
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -708,14 +712,36 @@ export const buildChatPrompt = async (messages, options = {}) => {
     }));
 
     const contextSources = mergeSources(knowledgePack.sources || [], docsRagPayload.sources || []);
-
-    return {
+    const result = {
         combinedMessages,
         debugMessages,
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
     };
+
+    if (options.includePromptMetrics) {
+        const componentByMessageIndex = {};
+        combinedMessages.forEach((message, index) => {
+            if (message === systemMessage) componentByMessageIndex[index] = 'systemInstructions';
+            if (message === playerStateMessage) componentByMessageIndex[index] = 'playerState';
+            if (message === knowledgeMessage || message === docsRagMessage)
+                componentByMessageIndex[index] = 'rag';
+            if (message === latestUserMessage) componentByMessageIndex[index] = 'latestUserMessage';
+        });
+        combinedMessages.forEach((message, index) => {
+            if (!componentByMessageIndex[index] && normalizedMessages.includes(message)) {
+                componentByMessageIndex[index] = 'chatHistory';
+            }
+        });
+        result.promptMetrics = collectPromptMetrics(result, {
+            componentByMessageIndex,
+            promptBuildMs: performance.now() - promptBuildStartedAt,
+            ragMs,
+        });
+    }
+
+    return result;
 };
 
 export const GPT5Chat = async (messages, options = {}) => {

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -1,0 +1,85 @@
+const textEncoder = new TextEncoder();
+const COMPONENT_NAMES = [
+    'systemInstructions',
+    'rag',
+    'playerState',
+    'chatHistory',
+    'latestUserMessage',
+];
+
+const byteLength = (value) => textEncoder.encode(String(value || '')).byteLength;
+
+const summarizeText = (text) => {
+    const content = String(text || '');
+    return {
+        characters: content.length,
+        utf8Bytes: byteLength(content),
+    };
+};
+
+const emptyComponent = () => ({ messages: 0, characters: 0, utf8Bytes: 0 });
+
+const normalizeComponentName = (name) => {
+    if (name === 'system') return 'systemInstructions';
+    if (name === 'system-instructions') return 'systemInstructions';
+    if (name === 'player-state') return 'playerState';
+    if (name === 'latest-user') return 'latestUserMessage';
+    if (COMPONENT_NAMES.includes(name)) return name;
+    return null;
+};
+
+const addComponentText = (totals, component, text) => {
+    const name = normalizeComponentName(component);
+    if (!name) return;
+    const summary = summarizeText(text);
+    totals[name].messages += 1;
+    totals[name].characters += summary.characters;
+    totals[name].utf8Bytes += summary.utf8Bytes;
+};
+
+export const collectPromptMetrics = (promptPayload, metadata = {}) => {
+    const sourceMessages = Array.isArray(promptPayload?.combinedMessages)
+        ? promptPayload.combinedMessages
+        : Array.isArray(promptPayload?.messages)
+          ? promptPayload.messages
+          : [];
+    const messages = sourceMessages.map((message, index) => {
+        const role = typeof message?.role === 'string' ? message.role : 'unknown';
+        const summary = summarizeText(message?.content);
+        return { index, role, ...summary };
+    });
+    const roleCounts = messages.reduce((counts, message) => {
+        counts[message.role] = (counts[message.role] || 0) + 1;
+        return counts;
+    }, {});
+    const componentTotals = Object.fromEntries(
+        COMPONENT_NAMES.map((name) => [name, emptyComponent()])
+    );
+
+    for (const component of Array.isArray(metadata.components) ? metadata.components : []) {
+        addComponentText(componentTotals, component?.name, component?.content);
+    }
+
+    if (metadata.componentByMessageIndex && typeof metadata.componentByMessageIndex === 'object') {
+        sourceMessages.forEach((message, index) => {
+            addComponentText(
+                componentTotals,
+                metadata.componentByMessageIndex[index],
+                message?.content
+            );
+        });
+    }
+
+    return {
+        messageCount: messages.length,
+        roleCounts,
+        totalCharacters: messages.reduce((total, message) => total + message.characters, 0),
+        totalUtf8Bytes: messages.reduce((total, message) => total + message.utf8Bytes, 0),
+        messages,
+        componentTotals,
+        timings: {
+            promptBuildMs: Number.isFinite(metadata.promptBuildMs) ? metadata.promptBuildMs : null,
+            ragMs: Number.isFinite(metadata.ragMs) ? metadata.ragMs : null,
+        },
+    };
+};

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -1,6 +1,7 @@
 import { JSEncrypt } from 'jsencrypt';
 import { loadGameState, ready } from './gameState/common.js';
 import { buildChatPrompt, validateChatResponseText } from './openAI.js';
+import { collectPromptMetrics } from './promptMetrics.js';
 import { normalizeSettings } from './settingsDefaults.js';
 import {
     createMalformedTokenPlaceResponseError,
@@ -623,10 +624,14 @@ const findLatestTokenLiteUserMessage = (messages = []) => {
     return TOKEN_LITE_FALLBACK_USER_MESSAGE;
 };
 
-export const buildTokenPlaceTokenLitePrompt = (messages = [], state = loadGameState()) => {
+export const buildTokenPlaceTokenLitePrompt = (
+    messages = [],
+    state = loadGameState(),
+    options = {}
+) => {
     const latestUserMessage = findLatestTokenLiteUserMessage(messages);
     const tokenPlaceUrl = state?.tokenPlace?.url;
-    return {
+    const result = {
         combinedMessages: [
             { role: 'system', content: TOKEN_LITE_SYSTEM_MESSAGE },
             { role: 'user', content: latestUserMessage },
@@ -645,6 +650,14 @@ export const buildTokenPlaceTokenLitePrompt = (messages = [], state = loadGameSt
         contextSources: [],
         playerStateSummary: '',
     };
+    if (options.includePromptMetrics) {
+        result.promptMetrics = collectPromptMetrics(result, {
+            componentByMessageIndex: { 0: 'systemInstructions', 1: 'latestUserMessage' },
+            promptBuildMs: 0,
+            ragMs: null,
+        });
+    }
+    return result;
 };
 
 const resolveTokenPlaceTokenLiteEnabled = (options = {}, state) => {
@@ -655,7 +668,7 @@ const resolveTokenPlaceTokenLiteEnabled = (options = {}, state) => {
 const resolveTokenPlacePromptPayload = async (messages, options = {}) => {
     const state = loadGameState();
     if (resolveTokenPlaceTokenLiteEnabled(options, state)) {
-        return buildTokenPlaceTokenLitePrompt(messages, state);
+        return buildTokenPlaceTokenLitePrompt(messages, state, options);
     }
     if (options.promptPayload) return options.promptPayload;
     return buildChatPrompt(messages, options);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "lint:a11y": "cd frontend && npm run lint:a11y",
     "dev:legacy": "npm run dev",
     "playwright:install": "npm --prefix frontend run playwright:install",
-    "build:meta": "node scripts/write-build-meta.mjs"
+    "build:meta": "node scripts/write-build-meta.mjs",
+    "benchmark:token-place-context": "node scripts/benchmark-token-place-context.mjs"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { collectPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+
+const outDir = join(process.cwd(), 'artifacts', 'benchmarks', 'token-place-context');
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const repeat = (label, chars) => `${label} ${'x'.repeat(Math.max(0, chars - label.length - 1))}`;
+
+const makePayload = ({ system = 500, rag = 0, state = 0, history = [], latest = 80 }) => {
+    const messages = [{ role: 'system', content: repeat('synthetic system instructions', system) }];
+    const componentByMessageIndex = { 0: 'systemInstructions' };
+    if (state) {
+        componentByMessageIndex[messages.length] = 'playerState';
+        messages.push({ role: 'system', content: repeat('synthetic player state', state) });
+    }
+    if (rag) {
+        componentByMessageIndex[messages.length] = 'rag';
+        messages.push({ role: 'system', content: repeat('synthetic docs rag excerpt', rag) });
+    }
+    for (const entry of history) {
+        componentByMessageIndex[messages.length] = 'chatHistory';
+        messages.push(entry);
+    }
+    componentByMessageIndex[messages.length] = 'latestUserMessage';
+    messages.push({ role: 'user', content: repeat('synthetic latest user question', latest) });
+    return { combinedMessages: messages, meta: { componentByMessageIndex } };
+};
+
+const scenarios = [
+    ['token-lite baseline', makePayload({ system: 140, latest: 48 })],
+    ['minimal full-fat prompt', makePayload({ system: 1200, state: 350, latest: 80 })],
+    [
+        'typical mid-game prompt',
+        makePayload({
+            system: 1800,
+            state: 5000,
+            rag: 12000,
+            history: Array.from({ length: 8 }, (_, i) => ({
+                role: i % 2 ? 'assistant' : 'user',
+                content: repeat(`synthetic history ${i}`, 600),
+            })),
+            latest: 180,
+        }),
+    ],
+    ['RAG-heavy prompt', makePayload({ system: 1800, state: 2500, rag: 50000, latest: 220 })],
+    [
+        'long chat history',
+        makePayload({
+            system: 1800,
+            state: 2500,
+            history: Array.from({ length: 50 }, (_, i) => ({
+                role: i % 2 ? 'assistant' : 'user',
+                content: repeat(`synthetic history ${i}`, 1200),
+            })),
+            latest: 200,
+        }),
+    ],
+    ['large player state', makePayload({ system: 1800, state: 60000, rag: 8000, latest: 200 })],
+    [
+        'near 131072-character ceiling',
+        makePayload({
+            system: 12000,
+            state: 30000,
+            rag: 50000,
+            history: Array.from({ length: 12 }, (_, i) => ({
+                role: i % 2 ? 'assistant' : 'user',
+                content: repeat(`synthetic ceiling history ${i}`, 3000),
+            })),
+            latest: 2500,
+        }),
+    ],
+];
+
+const results = scenarios.map(([name, { combinedMessages, meta }]) => {
+    const start = performance.now();
+    const metrics = collectPromptMetrics(
+        { combinedMessages },
+        { ...meta, promptBuildMs: 0, ragMs: name.includes('RAG') ? 0 : null }
+    );
+    metrics.timings.metricsCollectionMs = Number((performance.now() - start).toFixed(3));
+    return {
+        name,
+        metrics,
+        heuristicTokens: Math.ceil(metrics.totalCharacters / 4),
+        exactTokenizer: null,
+    };
+});
+
+const json = {
+    generatedAt: new Date().toISOString(),
+    privacy: 'synthetic fixtures only; no prompt content emitted',
+    results,
+};
+const md = [
+    '# token.place context benchmark',
+    '',
+    `Generated: ${json.generatedAt}`,
+    '',
+    '| Scenario | Messages | Chars | UTF-8 bytes | Heuristic tokens | Dominant component |',
+    '| --- | ---: | ---: | ---: | ---: | --- |',
+    ...results.map(({ name, metrics, heuristicTokens }) => {
+        const dominant = Object.entries(metrics.componentTotals).sort(
+            (a, b) => b[1].characters - a[1].characters
+        )[0];
+        return `| ${name} | ${metrics.messageCount} | ${metrics.totalCharacters} | ${metrics.totalUtf8Bytes} | ${heuristicTokens} | ${dominant[0]} (${dominant[1].characters}) |`;
+    }),
+    '',
+    'Counts are privacy-safe sizes from synthetic fixtures. Heuristic tokens use characters / 4 and are not exact model tokens.',
+].join('\n');
+
+await mkdir(outDir, { recursive: true });
+const jsonPath = join(outDir, `${stamp}.json`);
+const mdPath = join(outDir, `${stamp}.md`);
+await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);
+await writeFile(mdPath, `${md}\n`);
+console.log(`Wrote ${jsonPath}`);
+console.log(`Wrote ${mdPath}`);

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { collectPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+
+const payload = {
+    combinedMessages: [
+        { role: 'system', content: 'system only' },
+        { role: 'user', content: 'hello 🌙' },
+    ],
+};
+
+describe('prompt metrics', () => {
+    it('returns sizes without prompt content', () => {
+        const metrics = collectPromptMetrics(payload, {
+            componentByMessageIndex: { 0: 'systemInstructions', 1: 'latestUserMessage' },
+        });
+        expect(JSON.stringify(metrics)).not.toContain('system only');
+        expect(JSON.stringify(metrics)).not.toContain('hello');
+        expect(metrics.messageCount).toBe(2);
+        expect(metrics.roleCounts).toEqual({ system: 1, user: 1 });
+    });
+
+    it('counts UTF-8 bytes correctly', () => {
+        const metrics = collectPromptMetrics(payload);
+        expect(metrics.messages[1].characters).toBe(8);
+        expect(metrics.messages[1].utf8Bytes).toBe(10);
+        expect(metrics.totalUtf8Bytes).toBe(21);
+    });
+
+    it('accounts for components deterministically', () => {
+        const first = collectPromptMetrics(payload, {
+            componentByMessageIndex: { 0: 'systemInstructions', 1: 'latestUserMessage' },
+            promptBuildMs: 12,
+            ragMs: 3,
+        });
+        const second = collectPromptMetrics(payload, {
+            componentByMessageIndex: { 0: 'systemInstructions', 1: 'latestUserMessage' },
+            promptBuildMs: 12,
+            ragMs: 3,
+        });
+        expect(first).toEqual(second);
+        expect(first.componentTotals.systemInstructions.characters).toBe(11);
+        expect(first.componentTotals.latestUserMessage.utf8Bytes).toBe(10);
+    });
+
+    it('benchmark fixtures avoid obvious secrets and real user data', () => {
+        const script = readFileSync('scripts/benchmark-token-place-context.mjs', 'utf8');
+        expect(script).not.toMatch(/sk-[A-Za-z0-9]/);
+        expect(script).not.toMatch(/BEGIN (?:RSA |OPENSSH |)PRIVATE KEY/);
+        expect(script).toContain('synthetic');
+    });
+});


### PR DESCRIPTION
### Motivation
- Implement Phase 0 measurement and privacy-safe instrumentation for DSPACE prompt builds to inform token.place tiering without exposing prompt content. 
- Provide deterministic, local benchmarking scenarios that exercise token-lite and full-fat prompt shapes (RAG, player state, history, and near-ceiling loads).
- Ensure instrumentation is opt-in and does not change production chat behavior or leak user data.

### Description
- Add a pure metrics helper `collectPromptMetrics()` that returns message count, per-role counts, total characters, UTF-8 byte counts, per-message size summaries, component totals (system instructions, RAG, player state, chat history, latest user message), and timing fields while never returning prompt text (`frontend/src/utils/promptMetrics.js`).
- Make prompt metrics opt-in via `options.includePromptMetrics` in `buildChatPrompt()` and token-lite builder so existing return shapes and production paths are unchanged when disabled (`frontend/src/utils/openAI.js`, `frontend/src/utils/tokenPlace.js`).
- Add a deterministic synthetic benchmark harness and npm script `benchmark:token-place-context` that emits local JSON and Markdown reports under `artifacts/benchmarks/token-place-context/` using only repository-owned synthetic fixtures (`scripts/benchmark-token-place-context.mjs`, `package.json`, and `.gitignore` entry to ignore artifacts).
- Add focused unit tests validating privacy (no content returned), UTF-8 byte counts, deterministic component accounting, opt-in instrumentation behavior, and that benchmark fixtures do not contain secrets (`tests/promptMetrics.test.ts`), and small test additions keeping existing token.place tests covering opt-in behavior (`frontend/__tests__/*`).
- Document how to run the benchmark, metric meanings, privacy constraints, 8K/64K readiness guidance, and why character heuristics are not exact model tokens (`docs/token-place-context-benchmarking.md`).
- Note: the harness reports a heuristic token estimate (`characters / 4`) and leaves room for adding an exact tokenizer later as an optional, clearly-labeled result.

### Testing
- Ran the new unit tests: `npm run test:root -- tests/promptMetrics.test.ts` — passed (4 tests). ✅
- Ran token.place integration tests: `cd frontend && npm test -- tokenPlace.test.js` — all existing token.place tests passed including the new opt-in check (59 tests). ✅
- Ran the benchmark: `npm run benchmark:token-place-context` — produced local artifacts (example files written: `artifacts/benchmarks/token-place-context/<timestamp>.json` and `.md`). ✅
- Ran frontend checks and build: `cd frontend && npm run check` and `cd frontend && npm run build` — succeeded (format/lint/build). ✅
- Verified repository hygiene: `git diff --check` returned no whitespace/format errors and benchmark outputs are ignored by `.gitignore`. ✅

Commands used during verification (all successful): `npm run test:root -- tests/promptMetrics.test.ts`, `cd frontend && npm test -- tokenPlace.test.js`, `npm run benchmark:token-place-context`, `cd frontend && npm run check`, `cd frontend && npm run build`, and `git diff --check`.

Testing notes and follow-ups: the benchmark currently emits heuristic token estimates only; adding an exact tokenizer is a planned follow-up once a small non-bundling tokenizer (server-side or optional dev dependency) is approved and available so exact-token results are clearly distinguished from heuristics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a47fe8e90832fabe933aa3504a045)