### PR TITLE
Add token.place context tier estimator

### DIFF
--- a/docs/benchmarks/token-place-context.md
+++ b/docs/benchmarks/token-place-context.md
@@ -19,6 +19,28 @@ Those generated reports are local artifacts and should not be committed.
 - `componentTotals`: content-free totals for system instructions, RAG, player state, chat history,
   and the latest user message.
 - `promptBuildDurationMs` and `ragDurationMs`: local timing fields when available.
+- `contextEstimate`: the deterministic DSPACE context classifier result for the complete sanitized
+  token.place API v1 message payload.
+
+## Context estimator
+
+The production estimator is browser-safe, deterministic, offline, and privacy-preserving. It never
+sends prompt text to a tokenizer service and benchmark output stores only aggregate counts. It uses
+UTF-8 byte counts of the sanitized API v1 message payload, not JavaScript string length alone, then
+adds conservative chat-template overhead.
+
+Named profiles are:
+
+| Profile    | Total context tokens |
+| ---------- | -------------------: |
+| `8k-fast`  |                8,192 |
+| `64k-full` |               65,536 |
+
+The classifier reserves 512 output tokens by default, matching the current DSPACE/token.place
+planning budget. It also applies an 8% safety margin with a 256-token minimum so heuristic estimates
+prefer conservative overestimation. Tier selection is pure: select `8k-fast` only when prompt tokens,
+output reservation, and margin fit 8,192; otherwise select `64k-full` when they fit 65,536; otherwise
+return an explicit over-limit result. The estimator does not truncate prompts or change relay routing.
 
 ## Privacy constraints
 
@@ -28,15 +50,15 @@ as benchmark-only data.
 
 ## Comparing 8K and 64K readiness
 
-Use the generated report to identify dominant context components and compare the heuristic token
-count with 8,192-token and 65,536-token tiers. The readiness flags reserve 640 tokens for
-chat-template overhead and assistant output before marking a tier as fitting. A scenario that does
-not fit 8K but fits 64K is a candidate for full-fat routing in later phases. The report also flags
-whether the token.place-shaped request remains under the 131,072-character request ceiling.
+Use the generated report to identify dominant context components and compare the estimated prompt
+count plus reserved output and safety margin with the 8,192-token and 65,536-token tiers. A scenario
+that does not fit 8K but fits 64K is a candidate for full-fat routing in later phases. The report also
+flags whether the token.place-shaped request remains under the 131,072-character request ceiling.
 
-## Token caveat
+## Token caveat and calibration
 
 Character counts, byte counts, and whitespace are not exact model tokens. Tokenizers split text by
-model-specific rules and chat templates add overhead. The benchmark's heuristic token estimate,
-reserved-token buffer, and token.place request shaping are only local planning signals until
-compute-side exact token admission is available.
+model-specific rules and chat templates add overhead. The benchmark labels these values as estimates,
+not exact token counts. When an existing lightweight development-only Llama 3.1 tokenizer path is
+available, benchmark output may include exact-token calibration error; otherwise calibration is marked
+unavailable.

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,0 +1,87 @@
+const textEncoder = new TextEncoder();
+
+export const TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION = 'dspace-context-estimator-v1';
+export const TOKEN_PLACE_CONTEXT_TIERS = Object.freeze({
+    '8k-fast': Object.freeze({ id: '8k-fast', totalContextTokens: 8_192 }),
+    '64k-full': Object.freeze({ id: '64k-full', totalContextTokens: 65_536 }),
+});
+
+export const DEFAULT_TOKEN_PLACE_OUTPUT_TOKEN_RESERVATION = 512;
+export const TOKEN_PLACE_CHAT_TEMPLATE_BASE_TOKENS = 16;
+export const TOKEN_PLACE_CHAT_TEMPLATE_TOKENS_PER_MESSAGE = 8;
+export const TOKEN_PLACE_ESTIMATED_BYTES_PER_TOKEN = 3;
+export const TOKEN_PLACE_SAFETY_MARGIN_RATIO = 0.08;
+export const TOKEN_PLACE_MIN_SAFETY_MARGIN_TOKENS = 256;
+
+const byteLength = (value) => textEncoder.encode(String(value ?? '')).length;
+
+const stableApiV1MessagePayload = (messages = []) =>
+    (Array.isArray(messages) ? messages : []).map((message) => ({
+        role: typeof message?.role === 'string' ? message.role : 'user',
+        content: String(message?.content ?? ''),
+    }));
+
+export const estimateTokenPlacePromptTokens = (messages = [], options = {}) => {
+    const payload = stableApiV1MessagePayload(messages);
+    const serializedPayload = JSON.stringify(payload);
+    const payloadUtf8Bytes = byteLength(serializedPayload);
+    const contentUtf8Bytes = payload.reduce((sum, message) => sum + byteLength(message.content), 0);
+    const conservativeByteTokens = Math.ceil(
+        payloadUtf8Bytes / (options.estimatedBytesPerToken ?? TOKEN_PLACE_ESTIMATED_BYTES_PER_TOKEN)
+    );
+    const chatTemplateOverheadTokens =
+        (options.chatTemplateBaseTokens ?? TOKEN_PLACE_CHAT_TEMPLATE_BASE_TOKENS) +
+        payload.length *
+            (options.chatTemplateTokensPerMessage ?? TOKEN_PLACE_CHAT_TEMPLATE_TOKENS_PER_MESSAGE);
+
+    return {
+        estimatedPromptTokens: conservativeByteTokens + chatTemplateOverheadTokens,
+        payloadUtf8Bytes,
+        contentUtf8Bytes,
+        messageCount: payload.length,
+        chatTemplateOverheadTokens,
+    };
+};
+
+const calculateSafetyMarginTokens = (estimatedPromptTokens, options = {}) => {
+    if (Number.isFinite(options.safetyMarginTokens)) {
+        return Math.max(0, Math.ceil(options.safetyMarginTokens));
+    }
+    const ratio = options.safetyMarginRatio ?? TOKEN_PLACE_SAFETY_MARGIN_RATIO;
+    const minimum = options.minSafetyMarginTokens ?? TOKEN_PLACE_MIN_SAFETY_MARGIN_TOKENS;
+    return Math.max(Math.ceil(estimatedPromptTokens * ratio), minimum);
+};
+
+export const classifyTokenPlaceContextTier = (messages = [], options = {}) => {
+    const promptEstimate = estimateTokenPlacePromptTokens(messages, options);
+    const reservedOutputTokens = Math.max(
+        0,
+        Math.ceil(options.reservedOutputTokens ?? DEFAULT_TOKEN_PLACE_OUTPUT_TOKEN_RESERVATION)
+    );
+    const safetyMarginTokens = calculateSafetyMarginTokens(
+        promptEstimate.estimatedPromptTokens,
+        options
+    );
+    const estimatedTotalTokens =
+        promptEstimate.estimatedPromptTokens + reservedOutputTokens + safetyMarginTokens;
+    const selectedTier =
+        estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens
+            ? TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].id
+            : estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens
+              ? TOKEN_PLACE_CONTEXT_TIERS['64k-full'].id
+              : null;
+
+    return {
+        estimatorVersion: TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+        estimatedPromptTokens: promptEstimate.estimatedPromptTokens,
+        reservedOutputTokens,
+        safetyMarginTokens,
+        estimatedTotalTokens,
+        selectedTier,
+        overLimit: selectedTier === null,
+        payloadUtf8Bytes: promptEstimate.payloadUtf8Bytes,
+        contentUtf8Bytes: promptEstimate.contentUtf8Bytes,
+        messageCount: promptEstimate.messageCount,
+        chatTemplateOverheadTokens: promptEstimate.chatTemplateOverheadTokens,
+    };
+};

--- a/frontend/tests/tokenPlaceContextEstimator.test.ts
+++ b/frontend/tests/tokenPlaceContextEstimator.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest';
+import {
+    classifyTokenPlaceContextTier,
+    DEFAULT_TOKEN_PLACE_OUTPUT_TOKEN_RESERVATION,
+    TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    TOKEN_PLACE_CONTEXT_TIERS,
+} from '../src/utils/tokenPlaceContextEstimator.js';
+import { sanitizeTokenPlaceMessages } from '../src/utils/tokenPlaceMessages.js';
+
+const message = (content, role = 'user') => ({ role, content });
+const classify = (messages, options = {}) =>
+    classifyTokenPlaceContextTier(sanitizeTokenPlaceMessages(messages), options);
+const classifyRaw = (messages, options = {}) => classifyTokenPlaceContextTier(messages, options);
+
+const fitByTokenBudget = (targetTotalTokens) => {
+    const fixedOverhead = 24;
+    const payloadJsonOverhead = '[{"role":"user","content":""}]'.length;
+    const contentBytes = Math.max(0, (targetTotalTokens - fixedOverhead) * 3 - payloadJsonOverhead);
+    return 'a'.repeat(contentBytes);
+};
+
+describe('token.place context estimator', () => {
+    test('exports named 8k-fast and 64k-full profiles', () => {
+        expect(TOKEN_PLACE_CONTEXT_TIERS['8k-fast']).toEqual({
+            id: '8k-fast',
+            totalContextTokens: 8_192,
+        });
+        expect(TOKEN_PLACE_CONTEXT_TIERS['64k-full']).toEqual({
+            id: '64k-full',
+            totalContextTokens: 65_536,
+        });
+    });
+
+    test('classifies tier boundaries deterministically', () => {
+        const options = { reservedOutputTokens: 0, safetyMarginTokens: 0 };
+        expect(classifyRaw([message(fitByTokenBudget(8_192))], options)).toMatchObject({
+            selectedTier: '8k-fast',
+            overLimit: false,
+            estimatedTotalTokens: 8_192,
+        });
+        expect(classifyRaw([message(fitByTokenBudget(8_193))], options)).toMatchObject({
+            selectedTier: '64k-full',
+            overLimit: false,
+            estimatedTotalTokens: 8_193,
+        });
+        expect(classifyRaw([message(fitByTokenBudget(65_536))], options)).toMatchObject({
+            selectedTier: '64k-full',
+            overLimit: false,
+            estimatedTotalTokens: 65_536,
+        });
+        expect(classifyRaw([message(fitByTokenBudget(65_537))], options)).toMatchObject({
+            selectedTier: null,
+            overLimit: true,
+            estimatedTotalTokens: 65_537,
+        });
+    });
+
+    test('classifies ASCII prose as 8k-fast', () => {
+        expect(
+            classify([message('DSPACE should explain the next practical quest step.')])
+        ).toMatchObject({
+            selectedTier: '8k-fast',
+            overLimit: false,
+        });
+    });
+
+    test('counts UTF-8 bytes for Unicode instead of JavaScript string length only', () => {
+        const ascii = classify([message('a'.repeat(128))]);
+        const unicode = classify([message('🚀'.repeat(128))]);
+        expect(unicode.contentUtf8Bytes).toBeGreaterThan(ascii.contentUtf8Bytes);
+        expect(unicode.estimatedPromptTokens).toBeGreaterThan(ascii.estimatedPromptTokens);
+    });
+
+    test('classifies JSON content', () => {
+        const result = classify([
+            message(
+                JSON.stringify({
+                    inventory: ['solar-panel', 'battery', 'charge-controller'],
+                    quests: { solar: 'site-check', energy: 'verify' },
+                })
+            ),
+        ]);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies source code content', () => {
+        const result = classify([
+            message(
+                `function estimate(input) {\n    return input.map((x) => x.trim()).join('\\n');\n}`
+            ),
+        ]);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies whitespace-heavy content conservatively', () => {
+        const result = classify([message(`start ${' \n\t'.repeat(2_000)} end`)]);
+        expect(result.estimatedPromptTokens).toBeGreaterThan(2_000);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies RAG-heavy content into the 64k-full tier when needed', () => {
+        const result = classify([
+            message('System instructions for DSPACE.', 'system'),
+            message('docs excerpt '.repeat(15_000), 'system'),
+            message('What should I do next?'),
+        ]);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('classifies 131,072-character payloads without truncating inside the estimator', () => {
+        const result = classify([message('a'.repeat(131_072))], {
+            reservedOutputTokens: 512,
+            safetyMarginTokens: 256,
+        });
+        expect(result.contentUtf8Bytes).toBe(131_072);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('applies configurable output-token reservation with the documented default', () => {
+        const defaultResult = classify([message('hello')]);
+        const largerReservation = classify([message('hello')], { reservedOutputTokens: 2_048 });
+        expect(defaultResult.reservedOutputTokens).toBe(
+            DEFAULT_TOKEN_PLACE_OUTPUT_TOKEN_RESERVATION
+        );
+        expect(largerReservation.estimatedTotalTokens - defaultResult.estimatedTotalTokens).toBe(
+            2_048 - DEFAULT_TOKEN_PLACE_OUTPUT_TOKEN_RESERVATION
+        );
+    });
+
+    test('returns deterministic estimator versioning', () => {
+        const first = classify([message('stable')]);
+        const second = classify([message('stable')]);
+        expect(first).toEqual(second);
+        expect(first.estimatorVersion).toBe(TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION);
+    });
+
+    test('returns explicit over-limit behavior', () => {
+        const result = classifyRaw([message('a'.repeat(220_000))]);
+        expect(result.selectedTier).toBeNull();
+        expect(result.overLimit).toBe(true);
+    });
+});

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -4,15 +4,15 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
 import {
+  classifyTokenPlaceContextTier,
+  TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+} from '../frontend/src/utils/tokenPlaceContextEstimator.js';
+import {
   sanitizeTokenPlaceMessagesWithMetadata,
   TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
-const RESERVED_OUTPUT_TOKENS = 512;
-const CHAT_TEMPLATE_OVERHEAD_TOKENS = 128;
-const TOKEN_BUDGET_BUFFER =
-  RESERVED_OUTPUT_TOKENS + CHAT_TEMPLATE_OVERHEAD_TOKENS;
 const repeat = (label, length) =>
   label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
@@ -121,18 +121,13 @@ const scenarios = [
   ),
 ];
 
-const estimateTokens = (characters) => Math.ceil(characters / 4);
-const tierReadiness = (metrics) => {
-  const heuristicTokens = estimateTokens(metrics.totalCharacters);
-  return {
-    heuristicTokens,
-    reservedTokens: TOKEN_BUDGET_BUFFER,
-    fits8kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 8192,
-    fits64kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 65536,
-    fitsTokenPlaceCharCeiling:
-      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
-  };
-};
+const exactTokenizer = () => ({
+  available: false,
+  exactPromptTokens: null,
+  calibrationErrorTokens: null,
+  calibrationErrorPercent: null,
+  note: 'No existing lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark.',
+});
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
@@ -208,11 +203,12 @@ const results = scenarios.map((item) => {
     sourceMessageCount: item.combinedMessages.length,
     tokenPlaceMessageCount: tokenPlaceMessages.length,
     metrics,
-    tierReadiness: tierReadiness(metrics),
-    exactTokenizer: {
-      available: false,
-      note: 'No production-safe Llama 3.1 tokenizer hook is configured for this benchmark.',
+    contextEstimate: {
+      ...classifyTokenPlaceContextTier(tokenPlaceMessages),
+      fitsTokenPlaceCharCeiling:
+        metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
     },
+    exactTokenizer: exactTokenizer(),
   };
 });
 
@@ -229,17 +225,22 @@ const markdown = [
   '',
   `Generated: ${json.generatedAt}`,
   '',
-  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Heuristic tokens | Reserved tokens | 8K | 64K | Char ceiling | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
+  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Est. prompt tokens | Output reserve | Safety margin | Est. total | Tier | Over limit | Char ceiling | Exact calibration | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |',
   ...results.map((result) => {
     const entries = Object.entries(result.metrics.componentTotals);
     const [dominant] = entries.sort(
       (a, b) => b[1].characters - a[1].characters
     )[0];
-    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.reservedTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${dominant} |`;
+    const calibration = result.exactTokenizer.available
+      ? `${result.exactTokenizer.calibrationErrorTokens} tokens / ${result.exactTokenizer.calibrationErrorPercent}%`
+      : 'unavailable';
+    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.contextEstimate.estimatedPromptTokens} | ${result.contextEstimate.reservedOutputTokens} | ${result.contextEstimate.safetyMarginTokens} | ${result.contextEstimate.estimatedTotalTokens} | ${result.contextEstimate.selectedTier ?? 'over-limit'} | ${result.contextEstimate.overLimit ? 'yes' : 'no'} | ${result.contextEstimate.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${calibration} | ${dominant} |`;
   }),
   '',
-  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token counts are four-characters-per-token heuristics, not exact model tokens; tier fit reserves output and chat-template headroom.',
+  `Estimator version: ${TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION}`,
+  '',
+  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token estimates use a conservative offline UTF-8-byte heuristic plus chat-template overhead, output reservation, and safety margin; they are not exact model tokens. Exact Llama 3.1 calibration is reported only when an existing lightweight development tokenizer hook is available.',
 ].join('\n');
 
 await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);


### PR DESCRIPTION
### Motivation
- Provide a deterministic, browser-safe, privacy-preserving estimator to classify token.place prompts into `8k-fast`, `64k-full`, or over-limit without changing routing or API behavior.
- Make Phase 0 benchmark outputs include a conservative offline estimate and a calibration placeholder to help tune later exact-token admission.

### Description
- Add a production-safe estimator at `frontend/src/utils/tokenPlaceContextEstimator.js` that: counts UTF-8 bytes of the sanitized API v1 message payload, applies conservative chat-template overhead, a default 512 output-token reservation, an 8% safety margin with a 256-token minimum, and returns a structured result containing `estimatedPromptTokens`, `reservedOutputTokens`, `safetyMarginTokens`, `estimatedTotalTokens`, `selectedTier`, `overLimit`, and `estimatorVersion`.
- Introduce named tier constants `8k-fast` (8,192) and `64k-full` (65,536) and keep the classifier pure and deterministic.
- Add focused tests at `frontend/tests/tokenPlaceContextEstimator.test.ts` covering tier boundaries, ASCII, Unicode (UTF-8 byte counting), JSON, source code, whitespace-heavy content, RAG-heavy content, 131,072-character payloads, output-token reservation, deterministic versioning, and explicit over-limit behavior.
- Integrate estimator output into the Phase 0 benchmark: update `scripts/benchmark-token-place-context.mjs` to include `contextEstimate` and a calibration placeholder when no exact Llama 3.1 tokenizer hook is available, and add the estimator version to the markdown report.
- Update documentation `docs/benchmarks/token-place-context.md` describing the estimator, profiles, defaults, privacy constraints, and calibration caveat.
- No changes were made to token.place API calls, encryption envelopes, relay selection, retries, or UI/provider behavior.

### Testing
- Ran focused unit tests: `cd frontend && npm test -- ../frontend/tests/tokenPlaceContextEstimator.test.ts tokenPlace.test.js`; result: all tests passed (estimator tests and existing `tokenPlace.test.js` passed).
- Ran benchmark: `npm run benchmark:token-place-context`; result: successful, JSON/MD artifacts written to `artifacts/benchmarks/token-place-context/` and include estimator output.
- Repo checks: `git diff --check` passed (no whitespace errors), `cd frontend && npm run check` passed (lint + format check), and `cd frontend && npm run build` succeeded (Astro build completed).

Files changed/added: `frontend/src/utils/tokenPlaceContextEstimator.js`, `frontend/tests/tokenPlaceContextEstimator.test.ts`, `scripts/benchmark-token-place-context.mjs`, `docs/benchmarks/token-place-context.md`.

Residual notes: the benchmark includes a calibration placeholder and will report exact-token calibration only when a safe lightweight Llama 3.1 tokenizer hook is later provided; routing and compute-side exact admission remain unchanged for a later Phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3adbb2d7f0832fa89ac4b41641feea)