### PR TITLE
Add deterministic browser-safe token.place context estimator and tier classifier

### DIFF
--- a/docs/design/token-place-context-tiers.md
+++ b/docs/design/token-place-context-tiers.md
@@ -54,11 +54,11 @@ state, and chat history.
 
 Current DSPACE API v1 message shaping limits are:
 
-| Limit | Current value | Notes |
-| --- | ---: | --- |
-| Maximum API v1 messages | 64 | Sanitized before encryption. |
-| Maximum characters per message content | 32,768 | Long messages are chunked or excluded by current shaping. |
-| Maximum total message-content characters | 131,072 | Across all API v1 message `content` fields. |
+| Limit                                    | Current value | Notes                                                     |
+| ---------------------------------------- | ------------: | --------------------------------------------------------- |
+| Maximum API v1 messages                  |            64 | Sanitized before encryption.                              |
+| Maximum characters per message content   |        32,768 | Long messages are chunked or excluded by current shaping. |
+| Maximum total message-content characters |       131,072 | Across all API v1 message `content` fields.               |
 
 The 131,072-character ceiling is roughly 32K tokens under the common four-characters-per-token
 heuristic. That is only a rough browser-side estimate. It is not an exact tokenizer result, does not
@@ -68,10 +68,10 @@ may also exceed a 64K runtime after exact tokenization and output reservation.
 
 Initial token.place service profiles are expected to be:
 
-| Tier ID | Total context tokens | Intended use |
-| --- | ---: | --- |
-| `8k-fast` | 8,192 | Small, low-latency requests; token-lite should normally fit here. |
-| `64k-full` | 65,536 | Full-fat DSPACE prompts and RAG-heavy requests. |
+| Tier ID    | Total context tokens | Intended use                                                      |
+| ---------- | -------------------: | ----------------------------------------------------------------- |
+| `8k-fast`  |                8,192 | Small, low-latency requests; token-lite should normally fit here. |
+| `64k-full` |               65,536 | Full-fat DSPACE prompts and RAG-heavy requests.                   |
 
 DSPACE should prefer the smallest tier likely to satisfy the request. token-lite should normally
 route to `8k-fast`; full-fat prompts may require `64k-full`.
@@ -149,15 +149,15 @@ DSPACE should capture a deterministic prompt summary for token-lite and full-fat
 - UTF-8 byte count per component and total message content.
 - Conservative estimated tokens per component and total.
 - Component-level contribution, for example:
-  - base system instructions;
-  - persona or NPC instructions;
-  - docs-RAG excerpts;
-  - player state;
-  - chat history;
-  - latest user turn;
-  - chat-template overhead estimate;
-  - reserved output tokens;
-  - safety margin.
+    - base system instructions;
+    - persona or NPC instructions;
+    - docs-RAG excerpts;
+    - player state;
+    - chat history;
+    - latest user turn;
+    - chat-template overhead estimate;
+    - reserved output tokens;
+    - safety margin.
 - Prompt-build time.
 - RAG lookup time.
 - Encryption time.
@@ -168,14 +168,14 @@ DSPACE should capture a deterministic prompt summary for token-lite and full-fat
 
 Representative benchmark scenarios:
 
-| Scenario | Purpose |
-| --- | --- |
-| token-lite baseline | Confirms small prompt behavior and `8k-fast` fit. |
-| Minimal new-game state | Measures a fresh full-fat chat with little save data. |
-| Typical mid-game state | Represents common player state, inventory, quests, and docs-RAG. |
-| RAG-heavy state | Exercises large docs excerpts and source merging. |
-| Long chat history | Exercises accumulated user/assistant messages. |
-| Large player-state payload | Exercises save snapshots, inventory, completed quests, and process state. |
+| Scenario                          | Purpose                                                                                 |
+| --------------------------------- | --------------------------------------------------------------------------------------- |
+| token-lite baseline               | Confirms small prompt behavior and `8k-fast` fit.                                       |
+| Minimal new-game state            | Measures a fresh full-fat chat with little save data.                                   |
+| Typical mid-game state            | Represents common player state, inventory, quests, and docs-RAG.                        |
+| RAG-heavy state                   | Exercises large docs excerpts and source merging.                                       |
+| Long chat history                 | Exercises accumulated user/assistant messages.                                          |
+| Large player-state payload        | Exercises save snapshots, inventory, completed quests, and process state.               |
 | Near-DSPACE API character ceiling | Exercises current 64-message, 32,768-character, and 131,072-total-character boundaries. |
 
 Benchmark outputs should be local artifacts that are safe to inspect and easy to delete:
@@ -193,10 +193,10 @@ Goal: ship predictable tier routing with exactly one warmed runtime per operator
 
 Initial physical target mapping:
 
-| Hardware | Target tier | Notes |
-| --- | --- | --- |
-| Mac Mini M4 Pro with 24 GB unified memory | `8k-fast` | Small, fast requests and token-lite. |
-| Windows PC with RTX 4090 24 GB VRAM and 128 GB DDR5 | `64k-full` | Full-fat prompts and larger context. |
+| Hardware                                            | Target tier | Notes                                |
+| --------------------------------------------------- | ----------- | ------------------------------------ |
+| Mac Mini M4 Pro with 24 GB unified memory           | `8k-fast`   | Small, fast requests and token-lite. |
+| Windows PC with RTX 4090 24 GB VRAM and 128 GB DDR5 | `64k-full`  | Full-fat prompts and larger context. |
 
 Operational constraints:
 
@@ -295,52 +295,52 @@ DSPACE should produce a deterministic summary that never contains user content:
 
 ```json
 {
-  "schemaVersion": 1,
-  "client": "dspace",
-  "promptMode": "full-fat",
-  "model": "llama-3.1-8b-instruct",
-  "messageCount": 12,
-  "contentChars": 18420,
-  "contentUtf8Bytes": 19105,
-  "components": [
-    {
-      "id": "system",
-      "messageCount": 1,
-      "contentChars": 3200,
-      "contentUtf8Bytes": 3200,
-      "estimatedTokens": 900
+    "schemaVersion": 1,
+    "client": "dspace",
+    "promptMode": "full-fat",
+    "model": "llama-3.1-8b-instruct",
+    "messageCount": 12,
+    "contentChars": 18420,
+    "contentUtf8Bytes": 19105,
+    "components": [
+        {
+            "id": "system",
+            "messageCount": 1,
+            "contentChars": 3200,
+            "contentUtf8Bytes": 3200,
+            "estimatedTokens": 900
+        },
+        {
+            "id": "docs_rag",
+            "messageCount": 3,
+            "contentChars": 7200,
+            "contentUtf8Bytes": 7390,
+            "estimatedTokens": 2100
+        }
+    ],
+    "estimate": {
+        "estimatedPromptTokens": 6100,
+        "reservedOutputTokens": 1024,
+        "chatTemplateOverheadTokens": 256,
+        "safetyMarginTokens": 768,
+        "estimatedTotalContextUse": 7892
     },
-    {
-      "id": "docs_rag",
-      "messageCount": 3,
-      "contentChars": 7200,
-      "contentUtf8Bytes": 7390,
-      "estimatedTokens": 2100
+    "classification": {
+        "selectedTier": "8k-fast",
+        "estimatedPromptTokens": 6100,
+        "reservedOutputTokens": 1024,
+        "safetyMarginTokens": 768,
+        "estimatedTotalContextUse": 7892,
+        "overLimit": false,
+        "reason": "fits"
+    },
+    "timingMs": {
+        "promptBuild": 42,
+        "rag": 18,
+        "encryption": 0,
+        "queueRetrieval": 0,
+        "endToEnd": 0
     }
-  ],
-  "estimate": {
-    "estimatedPromptTokens": 6100,
-    "reservedOutputTokens": 1024,
-    "chatTemplateOverheadTokens": 256,
-    "safetyMarginTokens": 768,
-    "estimatedTotalContextUse": 7892
-  },
-  "classification": {
-    "selectedTier": "8k-fast",
-    "estimatedPromptTokens": 6100,
-    "reservedOutputTokens": 1024,
-    "safetyMarginTokens": 768,
-    "estimatedTotalContextUse": 7892,
-    "overLimit": false,
-    "reason": "fits"
-  },
-  "timingMs": {
-    "promptBuild": 42,
-    "rag": 18,
-    "encryption": 0,
-    "queueRetrieval": 0,
-    "endToEnd": 0
-  }
 }
 ```
 
@@ -369,13 +369,13 @@ estimatedTotalContextUse =
 
 Suggested initial assumptions:
 
-| Parameter | Initial value | Rationale |
-| --- | ---: | --- |
-| `charsPerTokenAssumption` | 4 | Common rough heuristic. |
-| `bytesPerTokenAssumption` | 4 | Helps account for non-ASCII UTF-8 expansion. |
-| `chatTemplateOverheadTokens` | `messageCount * 8 + 64` | Conservative placeholder until exact tokenizer fixtures exist. |
-| `reservedOutputTokens` | 1,024 for full-fat, 512 for token-lite | Prevents consuming the full context with prompt tokens. |
-| `safetyMarginTokens` | max(512, ceil(estimatedPromptTokens * 0.10)) | Buffers tokenizer mismatch and template overhead. |
+| Parameter                    |                                 Initial value | Rationale                                                      |
+| ---------------------------- | --------------------------------------------: | -------------------------------------------------------------- |
+| `charsPerTokenAssumption`    |                                             4 | Common rough heuristic.                                        |
+| `bytesPerTokenAssumption`    |                                             4 | Helps account for non-ASCII UTF-8 expansion.                   |
+| `chatTemplateOverheadTokens` |                       `messageCount * 8 + 64` | Conservative placeholder until exact tokenizer fixtures exist. |
+| `reservedOutputTokens`       |        1,024 for full-fat, 512 for token-lite | Prevents consuming the full context with prompt tokens.        |
+| `safetyMarginTokens`         | max(512, ceil(estimatedPromptTokens \* 0.10)) | Buffers tokenizer mismatch and template overhead.              |
 
 The exact constants should be calibrated against compute-side tokenizer measurements from Phase 0
 and Phase 3. DSPACE should treat estimates near a boundary as belonging to the larger tier.
@@ -400,13 +400,13 @@ type TierClassification = {
 
 ### Tier-selection decision table
 
-| Estimated total context use | Selected tier | DSPACE behavior |
-| ---: | --- | --- |
-| `<= 8,192` and not boundary-risky | `8k-fast` | Request an `8k-fast` node. |
-| `> 8,192` and `<= 65,536` | `64k-full` | Request a `64k-full` node. |
-| Boundary-risky near 8K after safety margin | `64k-full` | Prefer larger tier to avoid likely overflow. |
-| `> 65,536` | none | Surface a user-visible over-limit state before dispatch, unless a future truncation design exists. |
-| Invalid or empty prompt after shaping | none | Use existing validation/error handling; do not dispatch malformed API v1. |
+|                Estimated total context use | Selected tier | DSPACE behavior                                                                                    |
+| -----------------------------------------: | ------------- | -------------------------------------------------------------------------------------------------- |
+|          `<= 8,192` and not boundary-risky | `8k-fast`     | Request an `8k-fast` node.                                                                         |
+|                  `> 8,192` and `<= 65,536` | `64k-full`    | Request a `64k-full` node.                                                                         |
+| Boundary-risky near 8K after safety margin | `64k-full`    | Prefer larger tier to avoid likely overflow.                                                       |
+|                                 `> 65,536` | none          | Surface a user-visible over-limit state before dispatch, unless a future truncation design exists. |
+|      Invalid or empty prompt after shaping | none          | Use existing validation/error handling; do not dispatch malformed API v1.                          |
 
 ### Request routing and encrypted request contents
 
@@ -437,10 +437,10 @@ mismatch after decryption without exposing details to the relay.
 
 DSPACE should set context-aware polling deadlines:
 
-| Tier | Suggested initial deadline | Notes |
-| --- | ---: | --- |
-| `8k-fast` | 5,000 ms | Small prompts should fail fast when the node is unavailable. |
-| `64k-full` | 30,000 ms | Larger prefill and queue times are expected; tune from Phase 0 measurements. |
+| Tier       | Suggested initial deadline | Notes                                                                        |
+| ---------- | -------------------------: | ---------------------------------------------------------------------------- |
+| `8k-fast`  |                   5,000 ms | Small prompts should fail fast when the node is unavailable.                 |
+| `64k-full` |                  30,000 ms | Larger prefill and queue times are expected; tune from Phase 0 measurements. |
 
 Retry policy:
 
@@ -482,67 +482,67 @@ must not be committed when they are generated from real play sessions.
 
 ```json
 {
-  "schemaVersion": 1,
-  "generatedAt": "2026-06-22T00:00:00.000Z",
-  "scenario": "typical-mid-game",
-  "source": "synthetic-fixture",
-  "client": {
-    "name": "dspace",
-    "build": "local"
-  },
-  "request": {
-    "promptMode": "full-fat",
-    "model": "llama-3.1-8b-instruct",
-    "messageCount": 12,
-    "contentChars": 18420,
-    "contentUtf8Bytes": 19105,
-    "componentCounts": [
-      {
-        "id": "player_state",
-        "messageCount": 1,
-        "contentChars": 5200,
-        "contentUtf8Bytes": 5400,
-        "estimatedTokens": 1500
-      }
-    ]
-  },
-  "classification": {
-    "selectedTier": "8k-fast",
-    "estimatedPromptTokens": 6100,
-    "reservedOutputTokens": 1024,
-    "safetyMarginTokens": 768,
-    "estimatedTotalContextUse": 7892,
-    "overLimit": false
-  },
-  "timingMs": {
-    "promptBuild": 42,
-    "rag": 18,
-    "encryption": 7,
-    "queueRetrieval": 1200,
-    "endToEnd": 1850
-  },
-  "result": {
-    "status": "success",
-    "safeErrorCode": null,
-    "retryCount": 0
-  }
+    "schemaVersion": 1,
+    "generatedAt": "2026-06-22T00:00:00.000Z",
+    "scenario": "typical-mid-game",
+    "source": "synthetic-fixture",
+    "client": {
+        "name": "dspace",
+        "build": "local"
+    },
+    "request": {
+        "promptMode": "full-fat",
+        "model": "llama-3.1-8b-instruct",
+        "messageCount": 12,
+        "contentChars": 18420,
+        "contentUtf8Bytes": 19105,
+        "componentCounts": [
+            {
+                "id": "player_state",
+                "messageCount": 1,
+                "contentChars": 5200,
+                "contentUtf8Bytes": 5400,
+                "estimatedTokens": 1500
+            }
+        ]
+    },
+    "classification": {
+        "selectedTier": "8k-fast",
+        "estimatedPromptTokens": 6100,
+        "reservedOutputTokens": 1024,
+        "safetyMarginTokens": 768,
+        "estimatedTotalContextUse": 7892,
+        "overLimit": false
+    },
+    "timingMs": {
+        "promptBuild": 42,
+        "rag": 18,
+        "encryption": 7,
+        "queueRetrieval": 1200,
+        "endToEnd": 1850
+    },
+    "result": {
+        "status": "success",
+        "safeErrorCode": null,
+        "retryCount": 0
+    }
 }
 ```
 
 ## Failure-mode table
 
-| Failure mode | Where detected | DSPACE behavior | Retry? | User-facing result |
-| --- | --- | --- | --- | --- |
-| Browser estimate exceeds all tiers | DSPACE estimator | Do not dispatch. | No | Explain that the request is too large. |
-| No node for selected tier | Relay selection | Surface capacity/unavailable state. | No automatic tier retry unless smaller tier was selected and larger tier is explicitly eligible. | Ask user to retry later. |
-| Exact context overflow on `8k-fast` | Compute after decrypt/tokenize | Decrypt structured overflow response and escalate once to `64k-full`. | Yes, once | Show escalation/progress state. |
-| Exact context overflow on `64k-full` | Compute after decrypt/tokenize | Stop. Do not truncate silently. | No | Explain that the request exceeds available context. |
-| Policy/content error | Compute/API v1 response | Preserve safe structured error summary. | No | Show policy/provider message. |
-| Network or relay timeout | Fetch/polling | Abort or surface timeout. | No | Show retry-later message. |
-| Malformed encrypted response | DSPACE validation | Reject response. | No | Show provider response error. |
-| Decryption failure | DSPACE decrypt step | Reject response; do not log plaintext/ciphertext. | No | Show secure response error. |
-| Rate limit or quota | Decrypted API v1 response | Preserve status/type/code safely. | No | Show capacity/quota message. |
-| General provider failure | Decrypted API v1 response | Preserve safe summary. | No | Show provider failure message. |
+| Failure mode                         | Where detected                 | DSPACE behavior                                                       | Retry?                                                                                           | User-facing result                                  |
+| ------------------------------------ | ------------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| Browser estimate exceeds all tiers   | DSPACE estimator               | Do not dispatch.                                                      | No                                                                                               | Explain that the request is too large.              |
+| No node for selected tier            | Relay selection                | Surface capacity/unavailable state.                                   | No automatic tier retry unless smaller tier was selected and larger tier is explicitly eligible. | Ask user to retry later.                            |
+| Exact context overflow on `8k-fast`  | Compute after decrypt/tokenize | Decrypt structured overflow response and escalate once to `64k-full`. | Yes, once                                                                                        | Show escalation/progress state.                     |
+| Exact context overflow on `64k-full` | Compute after decrypt/tokenize | Stop. Do not truncate silently.                                       | No                                                                                               | Explain that the request exceeds available context. |
+| Policy/content error                 | Compute/API v1 response        | Preserve safe structured error summary.                               | No                                                                                               | Show policy/provider message.                       |
+| Network or relay timeout             | Fetch/polling                  | Abort or surface timeout.                                             | No                                                                                               | Show retry-later message.                           |
+| Malformed encrypted response         | DSPACE validation              | Reject response.                                                      | No                                                                                               | Show provider response error.                       |
+| Decryption failure                   | DSPACE decrypt step            | Reject response; do not log plaintext/ciphertext.                     | No                                                                                               | Show secure response error.                         |
+| Rate limit or quota                  | Decrypted API v1 response      | Preserve status/type/code safely.                                     | No                                                                                               | Show capacity/quota message.                        |
+| General provider failure             | Decrypted API v1 response      | Preserve safe summary.                                                | No                                                                                               | Show provider failure message.                      |
 
 ## Acceptance and testing strategy
 
@@ -627,3 +627,41 @@ Long-term issue themes beyond the initial implementation:
 - Speculative decoding where it improves non-streaming end-to-end latency without reducing output
   quality.
 - API v2 streaming as a separate future design, not part of this API v1 context-tier plan.
+
+## Implemented DSPACE browser estimator (P7)
+
+DSPACE now includes a deterministic browser-side estimator for the complete sanitized API v1
+message payload. The estimator is intentionally conservative and privacy-preserving:
+
+- It first applies the existing API v1 message shaping/sanitization rules, then estimates only from
+  the resulting `{ role, content }` messages.
+- It counts UTF-8 bytes with `TextEncoder` and converts bytes to prompt tokens with a conservative
+  bytes-per-token heuristic. This avoids JavaScript UTF-16 string-length undercounting for Unicode.
+- It adds fixed chat-template overhead plus per-message overhead so multi-message prompts are not
+  treated as raw text only.
+- It reserves 512 output tokens by default, matching the Phase 0 benchmark budget used for current
+  token.place/DSPACE chat planning.
+- It adds a documented 10% safety margin with a 256-token floor.
+- It never sends text to a tokenizer service and does not expose prompt content in benchmark output.
+- It does not silently truncate for tier classification; over-limit payloads return an explicit
+  `overLimit: true` result.
+
+The named profiles are:
+
+| Tier ID    | Total context tokens | Selection rule                                                                            |
+| ---------- | -------------------: | ----------------------------------------------------------------------------------------- |
+| `8k-fast`  |                8,192 | Selected only when estimated prompt tokens plus output reservation and safety margin fit. |
+| `64k-full` |               65,536 | Selected when the same total exceeds 8K but fits 64K.                                     |
+| over-limit |                  n/a | Returned when the estimated total exceeds 64K.                                            |
+
+Estimator results include `estimatedPromptTokens`, `reservedOutputTokens`,
+`safetyMarginTokens`, `estimatedTotalTokens`, `selectedTier`, `overLimit`, and an
+`estimatorVersion`. These values are currently wired only into focused tests and the local Phase 0
+benchmark report. They are not yet used for relay routing, server selection, retries, encryption
+envelopes, or UI provider behavior.
+
+The benchmark report continues to use synthetic repository-owned fixtures. It now records estimator
+output for each scenario and includes exact-token calibration fields. If a future lightweight
+Llama 3.1 development-only tokenizer hook is added, the same report can populate exact prompt
+tokens and calibration error; until then the calibration fields explicitly state that exact-token
+data is unavailable. Heuristic estimates must not be described as exact tokenizer counts.

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1351,3 +1351,95 @@ ${ragExcerpt.repeat(4000)}`,
         expect(serializedRequest).not.toMatch(/chat uses OpenAI/i);
     });
 });
+
+const {
+    classifyTokenPlaceContextTier,
+    estimateTokenPlacePromptTokens,
+    TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    TOKEN_PLACE_CONTEXT_TIERS,
+    TOKEN_PLACE_DEFAULT_RESERVED_OUTPUT_TOKENS,
+} = await import('../src/utils/tokenPlaceContextEstimator.js');
+
+const message = (content, role = 'user') => ({ role, content });
+const repeated = (text, chars) => text.repeat(Math.ceil(chars / text.length)).slice(0, chars);
+const classify = (content, options) => classifyTokenPlaceContextTier([message(content)], options);
+
+describe('token.place context estimator', () => {
+    test('exports named 8K and 64K profile constants', () => {
+        expect(TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens).toBe(8_192);
+        expect(TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens).toBe(65_536);
+    });
+
+    test('classifies ASCII prose into 8k-fast', () => {
+        const result = classify('A short DSPACE chat prompt about launch readiness.');
+        expect(result.selectedTier).toBe('8k-fast');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('counts UTF-8 bytes for Unicode conservatively', () => {
+        const ascii = estimateTokenPlacePromptTokens([message('x'.repeat(100))]);
+        const unicode = estimateTokenPlacePromptTokens([message('🚀'.repeat(100))]);
+        expect(unicode).toBeGreaterThan(ascii);
+    });
+
+    test('classifies JSON payloads deterministically', () => {
+        const content = JSON.stringify({ inventory: ['solar-panel'], quests: { active: true } });
+        expect(classify(content)).toMatchObject({ selectedTier: '8k-fast', overLimit: false });
+    });
+
+    test('classifies source code payloads', () => {
+        const content = repeated('function launch(step) { return step + 1; }\n', 12_000);
+        expect(classify(content).selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies whitespace-heavy content using bytes rather than trimmed string length alone', () => {
+        const content = `start\n${' \n\t'.repeat(4000)}end`;
+        const result = classify(content);
+        expect(result.estimatedPromptTokens).toBeGreaterThan(4_000);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies RAG-heavy content into 64k-full when it exceeds 8K', () => {
+        const content = repeated(
+            'DSPACE docs RAG excerpt with process and inventory gates. ',
+            30_000
+        );
+        const result = classify(content);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.estimatedTotalTokens).toBeGreaterThan(8_192);
+    });
+
+    test('classifies 131,072-character payloads without truncating in the estimator', () => {
+        const result = classify('a'.repeat(131_072));
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('honors output-token reservation', () => {
+        const payload = 'a'.repeat(21_000);
+        expect(classify(payload, { reservedOutputTokens: 0 }).selectedTier).toBe('8k-fast');
+        expect(classify(payload, { reservedOutputTokens: 4_000 }).selectedTier).toBe('64k-full');
+    });
+
+    test('returns deterministic estimator versioning', () => {
+        const first = classify('version check');
+        const second = classify('version check');
+        expect(first.estimatorVersion).toBe(TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION);
+        expect(second).toEqual(first);
+    });
+
+    test('returns explicit over-limit behavior', () => {
+        const result = classify('🚀'.repeat(180_000));
+        expect(result.selectedTier).toBeNull();
+        expect(result.overLimit).toBe(true);
+        expect(result.estimatedTotalTokens).toBeGreaterThan(
+            TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens
+        );
+    });
+
+    test('defaults to current expected output budget', () => {
+        expect(classify('hello').reservedOutputTokens).toBe(
+            TOKEN_PLACE_DEFAULT_RESERVED_OUTPUT_TOKENS
+        );
+    });
+});

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,0 +1,73 @@
+import { sanitizeTokenPlaceMessages } from './tokenPlaceMessages.js';
+
+export const TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION = 'dspace-token-place-context-estimator-v1';
+
+export const TOKEN_PLACE_CONTEXT_TIERS = Object.freeze({
+    '8k-fast': Object.freeze({ id: '8k-fast', totalContextTokens: 8_192 }),
+    '64k-full': Object.freeze({ id: '64k-full', totalContextTokens: 65_536 }),
+});
+
+export const TOKEN_PLACE_DEFAULT_RESERVED_OUTPUT_TOKENS = 512;
+export const TOKEN_PLACE_CHAT_TEMPLATE_BASE_TOKENS = 16;
+export const TOKEN_PLACE_CHAT_TEMPLATE_TOKENS_PER_MESSAGE = 6;
+export const TOKEN_PLACE_ESTIMATOR_BYTES_PER_TOKEN = 3;
+export const TOKEN_PLACE_SAFETY_MARGIN_RATIO = 0.1;
+export const TOKEN_PLACE_MIN_SAFETY_MARGIN_TOKENS = 256;
+
+const textEncoder = new TextEncoder();
+
+const utf8ByteLength = (value) => textEncoder.encode(String(value ?? '')).length;
+
+const positiveIntegerOrDefault = (value, fallback) => {
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? Math.ceil(number) : fallback;
+};
+
+export const estimateTokenPlacePromptTokens = (messages = []) => {
+    const sanitizedMessages = sanitizeTokenPlaceMessages(messages);
+    const contentTokens = sanitizedMessages.reduce(
+        (sum, message) =>
+            sum +
+            Math.ceil(utf8ByteLength(message.content) / TOKEN_PLACE_ESTIMATOR_BYTES_PER_TOKEN),
+        0
+    );
+    const templateTokens =
+        TOKEN_PLACE_CHAT_TEMPLATE_BASE_TOKENS +
+        sanitizedMessages.length * TOKEN_PLACE_CHAT_TEMPLATE_TOKENS_PER_MESSAGE;
+    return contentTokens + templateTokens;
+};
+
+export const classifyTokenPlaceContextTier = (messages = [], options = {}) => {
+    const sanitizedMessages = sanitizeTokenPlaceMessages(messages);
+    const estimatedPromptTokens = estimateTokenPlacePromptTokens(sanitizedMessages);
+    const reservedOutputTokens = positiveIntegerOrDefault(
+        options.reservedOutputTokens,
+        TOKEN_PLACE_DEFAULT_RESERVED_OUTPUT_TOKENS
+    );
+    const safetyMarginTokens = positiveIntegerOrDefault(
+        options.safetyMarginTokens,
+        Math.max(
+            TOKEN_PLACE_MIN_SAFETY_MARGIN_TOKENS,
+            Math.ceil(
+                (estimatedPromptTokens + reservedOutputTokens) * TOKEN_PLACE_SAFETY_MARGIN_RATIO
+            )
+        )
+    );
+    const estimatedTotalTokens = estimatedPromptTokens + reservedOutputTokens + safetyMarginTokens;
+    const selectedTier =
+        estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens
+            ? TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].id
+            : estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens
+              ? TOKEN_PLACE_CONTEXT_TIERS['64k-full'].id
+              : null;
+
+    return {
+        estimatedPromptTokens,
+        reservedOutputTokens,
+        safetyMarginTokens,
+        estimatedTotalTokens,
+        selectedTier,
+        overLimit: selectedTier === null,
+        estimatorVersion: TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    };
+};

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -4,242 +4,214 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
 import {
-  sanitizeTokenPlaceMessagesWithMetadata,
-  TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+    classifyTokenPlaceContextTier,
+    TOKEN_PLACE_CONTEXT_TIERS,
+} from '../frontend/src/utils/tokenPlaceContextEstimator.js';
+import {
+    sanitizeTokenPlaceMessagesWithMetadata,
+    TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
-const RESERVED_OUTPUT_TOKENS = 512;
-const CHAT_TEMPLATE_OVERHEAD_TOKENS = 128;
-const TOKEN_BUDGET_BUFFER =
-  RESERVED_OUTPUT_TOKENS + CHAT_TEMPLATE_OVERHEAD_TOKENS;
-const repeat = (label, length) =>
-  label.repeat(Math.ceil(length / label.length)).slice(0, length);
+const repeat = (label, length) => label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
 const syntheticState = (chars) =>
-  `SYNTHETIC_PLAYER_STATE:${repeat(' inventory=synthetic-item quest=synthetic-step ', chars)}`;
+    `SYNTHETIC_PLAYER_STATE:${repeat(' inventory=synthetic-item quest=synthetic-step ', chars)}`;
 const syntheticRag = (chars) =>
-  `SYNTHETIC_RAG_EXCERPTS:${repeat(' docs synthetic guidance for benchmark only. ', chars)}`;
+    `SYNTHETIC_RAG_EXCERPTS:${repeat(' docs synthetic guidance for benchmark only. ', chars)}`;
 const syntheticHistory = (turns, chars) =>
-  Array.from({ length: turns }, (_, index) => [
-    {
-      role: 'user',
-      content: `synthetic user turn ${index}: ${repeat('u ', chars)}`,
-    },
-    {
-      role: 'assistant',
-      content: `synthetic assistant turn ${index}: ${repeat('a ', chars)}`,
-    },
-  ]).flat();
+    Array.from({ length: turns }, (_, index) => [
+        {
+            role: 'user',
+            content: `synthetic user turn ${index}: ${repeat('u ', chars)}`,
+        },
+        {
+            role: 'assistant',
+            content: `synthetic assistant turn ${index}: ${repeat('a ', chars)}`,
+        },
+    ]).flat();
 
 const scenario = (
-  id,
-  description,
-  { system = 500, rag = 0, state = 0, history = [], latest = 80 }
-) => {
-  const systemContent = `SYNTHETIC_SYSTEM:${repeat(' system policy. ', system)}`;
-  const ragContent = rag ? syntheticRag(rag) : '';
-  const stateContent = state ? syntheticState(state) : '';
-  const latestContent = `synthetic latest user message: ${repeat('latest ', latest)}`;
-  const combinedMessages = [
-    { role: 'system', content: systemContent },
-    ...(ragContent ? [{ role: 'system', content: ragContent }] : []),
-    ...(stateContent ? [{ role: 'system', content: stateContent }] : []),
-    ...history,
-    { role: 'user', content: latestContent },
-  ];
-  const systemIndex = 0;
-  const ragIndex = ragContent ? 1 : -1;
-  const playerStateIndex = stateContent ? 1 + (ragContent ? 1 : 0) : -1;
-  const historyStartIndex = 1 + (ragContent ? 1 : 0) + (stateContent ? 1 : 0);
-  const latestUserMessageIndex = combinedMessages.length - 1;
-  return {
     id,
     description,
-    combinedMessages,
-    componentSourceIndexes: {
-      systemInstructions: systemIndex,
-      rag: ragIndex,
-      playerState: playerStateIndex,
-      chatHistory: history.map((_, index) => historyStartIndex + index),
-      latestUserMessage: latestUserMessageIndex,
-    },
-  };
+    { system = 500, rag = 0, state = 0, history = [], latest = 80 }
+) => {
+    const systemContent = `SYNTHETIC_SYSTEM:${repeat(' system policy. ', system)}`;
+    const ragContent = rag ? syntheticRag(rag) : '';
+    const stateContent = state ? syntheticState(state) : '';
+    const latestContent = `synthetic latest user message: ${repeat('latest ', latest)}`;
+    const combinedMessages = [
+        { role: 'system', content: systemContent },
+        ...(ragContent ? [{ role: 'system', content: ragContent }] : []),
+        ...(stateContent ? [{ role: 'system', content: stateContent }] : []),
+        ...history,
+        { role: 'user', content: latestContent },
+    ];
+    const systemIndex = 0;
+    const ragIndex = ragContent ? 1 : -1;
+    const playerStateIndex = stateContent ? 1 + (ragContent ? 1 : 0) : -1;
+    const historyStartIndex = 1 + (ragContent ? 1 : 0) + (stateContent ? 1 : 0);
+    const latestUserMessageIndex = combinedMessages.length - 1;
+    return {
+        id,
+        description,
+        combinedMessages,
+        componentSourceIndexes: {
+            systemInstructions: systemIndex,
+            rag: ragIndex,
+            playerState: playerStateIndex,
+            chatHistory: history.map((_, index) => historyStartIndex + index),
+            latestUserMessage: latestUserMessageIndex,
+        },
+    };
 };
 
 const scenarios = [
-  scenario('token-lite-baseline', 'Small token-lite style prompt.', {
-    system: 180,
-    latest: 40,
-  }),
-  scenario('minimal-full-fat', 'Minimal full-fat DSPACE prompt.', {
-    system: 1200,
-    state: 800,
-    latest: 80,
-  }),
-  scenario(
-    'typical-mid-game',
-    'Typical mid-game state, RAG, and short history.',
-    {
-      system: 1800,
-      rag: 6000,
-      state: 8000,
-      history: syntheticHistory(6, 160),
-      latest: 180,
-    }
-  ),
-  scenario('rag-heavy', 'Large synthetic docs-RAG excerpts.', {
-    system: 1800,
-    rag: 36000,
-    state: 5000,
-    history: syntheticHistory(4, 120),
-    latest: 160,
-  }),
-  scenario('long-chat-history', 'Long accumulated chat history.', {
-    system: 1500,
-    state: 4000,
-    history: syntheticHistory(30, 420),
-    latest: 160,
-  }),
-  scenario('large-player-state', 'Large save/player-state snapshot.', {
-    system: 1500,
-    rag: 2500,
-    state: 52000,
-    history: syntheticHistory(4, 120),
-    latest: 160,
-  }),
-  scenario(
-    'near-token-place-ceiling',
-    `Synthetic payload near the ${TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS.toLocaleString('en-US')}-character request ceiling.`,
-    {
-      system: 2000,
-      rag: 44000,
-      state: 44000,
-      history: syntheticHistory(10, 1700),
-      latest: 900,
-    }
-  ),
+    scenario('token-lite-baseline', 'Small token-lite style prompt.', {
+        system: 180,
+        latest: 40,
+    }),
+    scenario('minimal-full-fat', 'Minimal full-fat DSPACE prompt.', {
+        system: 1200,
+        state: 800,
+        latest: 80,
+    }),
+    scenario('typical-mid-game', 'Typical mid-game state, RAG, and short history.', {
+        system: 1800,
+        rag: 6000,
+        state: 8000,
+        history: syntheticHistory(6, 160),
+        latest: 180,
+    }),
+    scenario('rag-heavy', 'Large synthetic docs-RAG excerpts.', {
+        system: 1800,
+        rag: 36000,
+        state: 5000,
+        history: syntheticHistory(4, 120),
+        latest: 160,
+    }),
+    scenario('long-chat-history', 'Long accumulated chat history.', {
+        system: 1500,
+        state: 4000,
+        history: syntheticHistory(30, 420),
+        latest: 160,
+    }),
+    scenario('large-player-state', 'Large save/player-state snapshot.', {
+        system: 1500,
+        rag: 2500,
+        state: 52000,
+        history: syntheticHistory(4, 120),
+        latest: 160,
+    }),
+    scenario(
+        'near-token-place-ceiling',
+        `Synthetic payload near the ${TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS.toLocaleString('en-US')}-character request ceiling.`,
+        {
+            system: 2000,
+            rag: 44000,
+            state: 44000,
+            history: syntheticHistory(10, 1700),
+            latest: 900,
+        }
+    ),
 ];
 
-const estimateTokens = (characters) => Math.ceil(characters / 4);
-const tierReadiness = (metrics) => {
-  const heuristicTokens = estimateTokens(metrics.totalCharacters);
-  return {
-    heuristicTokens,
-    reservedTokens: TOKEN_BUDGET_BUFFER,
-    fits8kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 8192,
-    fits64kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 65536,
-    fitsTokenPlaceCharCeiling:
-      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
-  };
-};
+const exactTokenizerCalibration = (estimator) => ({
+    available: false,
+    exactPromptTokens: null,
+    absoluteErrorTokens: null,
+    percentError: null,
+    note: 'No existing lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark.',
+    estimatorPromptTokens: estimator.estimatedPromptTokens,
+});
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
 
 const indexesForShapedMessages = (shapedMessages, sourceIndexes) => {
-  const sourceIndexSet = new Set(
-    (Array.isArray(sourceIndexes) ? sourceIndexes : [sourceIndexes]).filter(
-      Number.isInteger
-    )
-  );
-  return shapedMessages
-    .map((message, index) =>
-      sourceIndexSet.has(message.originalIndex) ? index : null
-    )
-    .filter(Number.isInteger);
+    const sourceIndexSet = new Set(
+        (Array.isArray(sourceIndexes) ? sourceIndexes : [sourceIndexes]).filter(Number.isInteger)
+    );
+    return shapedMessages
+        .map((message, index) => (sourceIndexSet.has(message.originalIndex) ? index : null))
+        .filter(Number.isInteger);
 };
 
-const componentIndexesForShapedMessages = (
-  shapedMessages,
-  componentSourceIndexes
-) =>
-  Object.fromEntries(
-    Object.entries(componentSourceIndexes).map(([name, sourceIndexes]) => [
-      name,
-      indexesForShapedMessages(shapedMessages, sourceIndexes),
-    ])
-  );
+const componentIndexesForShapedMessages = (shapedMessages, componentSourceIndexes) =>
+    Object.fromEntries(
+        Object.entries(componentSourceIndexes).map(([name, sourceIndexes]) => [
+            name,
+            indexesForShapedMessages(shapedMessages, sourceIndexes),
+        ])
+    );
 
 const componentTotalsSum = (componentTotals, field) =>
-  Object.values(componentTotals).reduce((sum, total) => sum + total[field], 0);
+    Object.values(componentTotals).reduce((sum, total) => sum + total[field], 0);
 
 const results = scenarios.map((item) => {
-  const startedAt = performance.now();
-  const shapedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(
-    item.combinedMessages
-  );
-  const tokenPlaceMessages = shapedMessagesWithMetadata.map(
-    ({ role, content }) => ({
-      role,
-      content,
-    })
-  );
-  const metrics = buildPromptMetrics(
-    { combinedMessages: tokenPlaceMessages },
-    {
-      componentMessageIndexes: componentIndexesForShapedMessages(
-        shapedMessagesWithMetadata,
-        item.componentSourceIndexes
-      ),
-      promptBuildDurationMs: performance.now() - startedAt,
-      ragDurationMs: item.componentSourceIndexes.rag === -1 ? null : 0,
+    const startedAt = performance.now();
+    const shapedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(
+        item.combinedMessages
+    );
+    const tokenPlaceMessages = shapedMessagesWithMetadata.map(({ role, content }) => ({
+        role,
+        content,
+    }));
+    const metrics = buildPromptMetrics(
+        { combinedMessages: tokenPlaceMessages },
+        {
+            componentMessageIndexes: componentIndexesForShapedMessages(
+                shapedMessagesWithMetadata,
+                item.componentSourceIndexes
+            ),
+            promptBuildDurationMs: performance.now() - startedAt,
+            ragDurationMs: item.componentSourceIndexes.rag === -1 ? null : 0,
+        }
+    );
+    if (componentTotalsSum(metrics.componentTotals, 'characters') !== metrics.totalCharacters) {
+        throw new Error(`Component character totals do not sum to payload total for ${item.id}`);
     }
-  );
-  if (
-    componentTotalsSum(metrics.componentTotals, 'characters') !==
-    metrics.totalCharacters
-  ) {
-    throw new Error(
-      `Component character totals do not sum to payload total for ${item.id}`
-    );
-  }
-  if (
-    componentTotalsSum(metrics.componentTotals, 'utf8Bytes') !==
-    metrics.totalUtf8Bytes
-  ) {
-    throw new Error(
-      `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
-    );
-  }
-  return {
-    id: item.id,
-    description: item.description,
-    sourceMessageCount: item.combinedMessages.length,
-    tokenPlaceMessageCount: tokenPlaceMessages.length,
-    metrics,
-    tierReadiness: tierReadiness(metrics),
-    exactTokenizer: {
-      available: false,
-      note: 'No production-safe Llama 3.1 tokenizer hook is configured for this benchmark.',
-    },
-  };
+    if (componentTotalsSum(metrics.componentTotals, 'utf8Bytes') !== metrics.totalUtf8Bytes) {
+        throw new Error(`Component UTF-8 byte totals do not sum to payload total for ${item.id}`);
+    }
+    const estimator = classifyTokenPlaceContextTier(tokenPlaceMessages);
+    return {
+        id: item.id,
+        description: item.description,
+        sourceMessageCount: item.combinedMessages.length,
+        tokenPlaceMessageCount: tokenPlaceMessages.length,
+        metrics,
+        estimator,
+        exactTokenizer: exactTokenizerCalibration(estimator),
+    };
 });
 
 const jsonPath = path.join(OUTPUT_DIR, `${timestamp}.json`);
 const mdPath = path.join(OUTPUT_DIR, `${timestamp}.md`);
 const json = {
-  generatedAt: new Date().toISOString(),
-  fixturePolicy:
-    'synthetic repository-owned benchmark data only; no user prompts or secrets',
-  scenarios: results,
+    generatedAt: new Date().toISOString(),
+    fixturePolicy: 'synthetic repository-owned benchmark data only; no user prompts or secrets',
+    scenarios: results,
 };
 const markdown = [
-  '# token.place Context Benchmark',
-  '',
-  `Generated: ${json.generatedAt}`,
-  '',
-  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Heuristic tokens | Reserved tokens | 8K | 64K | Char ceiling | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
-  ...results.map((result) => {
-    const entries = Object.entries(result.metrics.componentTotals);
-    const [dominant] = entries.sort(
-      (a, b) => b[1].characters - a[1].characters
-    )[0];
-    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.reservedTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${dominant} |`;
-  }),
-  '',
-  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token counts are four-characters-per-token heuristics, not exact model tokens; tier fit reserves output and chat-template headroom.',
+    '# token.place Context Benchmark',
+    '',
+    `Generated: ${json.generatedAt}`,
+    '',
+    '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Prompt est. | Reserved | Margin | Total est. | Tier | Over limit | Exact calibration | Dominant component |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
+    ...results.map((result) => {
+        const entries = Object.entries(result.metrics.componentTotals);
+        const [dominant] = entries.sort((a, b) => b[1].characters - a[1].characters)[0];
+        const calibration = result.exactTokenizer.available
+            ? `${result.exactTokenizer.absoluteErrorTokens} tokens / ${result.exactTokenizer.percentError}%`
+            : 'not available';
+        return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.estimator.estimatedPromptTokens} | ${result.estimator.reservedOutputTokens} | ${result.estimator.safetyMarginTokens} | ${result.estimator.estimatedTotalTokens} | ${result.estimator.selectedTier ?? 'over-limit'} | ${result.estimator.overLimit ? 'yes' : 'no'} | ${calibration} | ${dominant} |`;
+    }),
+    '',
+    `Estimator version: ${results[0]?.estimator.estimatorVersion ?? 'unknown'}. Profiles: 8k-fast=${TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens}, 64k-full=${TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens}.`,
+    '',
+    'All values are content-free counts from synthetic fixtures after token.place request shaping. Token estimates use a conservative UTF-8 byte heuristic with chat-template overhead, output reservation, and a safety margin; they are not exact model tokens. Exact Llama 3.1 calibration error is reported only when a development tokenizer hook is available.',
 ].join('\n');
 
 await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);


### PR DESCRIPTION
### Motivation
- Provide a deterministic, offline, privacy-preserving browser estimator to classify token.place prompts into `8k-fast`, `64k-full`, or explicit over-limit results so DSPACE can later request appropriately-tiered compute nodes without leaking prompt text. 
- Use a conservative UTF-8 byte → token heuristic plus chat-template overhead, output reservation, and a safety margin so the estimator prefers overestimation to underestimation and remains safe for routing hints.

### Description
- Added a new estimator module `frontend/src/utils/tokenPlaceContextEstimator.js` that exports tier constants (`8k-fast`, `64k-full`), `estimateTokenPlacePromptTokens()`, and `classifyTokenPlaceContextTier()`; it uses `TextEncoder` for UTF-8 byte counts, a bytes-per-token heuristic, chat-template overhead, configurable reserved output tokens (default 512), and a safety margin (10% with 256-token floor). 
- Wired the estimator into the Phase 0 benchmark `scripts/benchmark-token-place-context.mjs` so each synthetic scenario records estimator output and exact-token calibration placeholders (no prompt text sent anywhere). 
- Added focused unit tests (merged into existing `frontend/__tests__/tokenPlace.test.js`) that validate tier constants, ASCII/Unicode/JSON/source-code/whitespace/RAG-heavy payload handling, 131,072-char payload behavior, output-token reservation effects, deterministic versioning, and explicit over-limit results. 
- Documented the implemented estimator policy, safety assumptions, and non-routing scope in `docs/design/token-place-context-tiers.md`; the estimator is currently used only in tests and the local benchmark output and does not change relay routing, encryption envelopes, retries, or UI provider behavior.

### Testing
- Ran frontend unit tests: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed (`70 tests passed`).
- Ran format/lint checks: `cd frontend && npm run check` — succeeded (Prettier check and ESLint run completed cleanly).
- Built the frontend app: `cd frontend && npm run build` — succeeded (Astro/Vite build completed).
- Ran the Phase 0 benchmark: `npm run benchmark:token-place-context` — produced `artifacts/benchmarks/token-place-context/<timestamp>.json` and `.md` and included estimator outputs and calibration placeholders.
- Ran repository safety check: `git diff --check` — no whitespace/errors reported.

All automated checks exercised locally succeeded; the estimator is intentionally conservative and is currently wired only to tests and benchmark reporting (no changes to token.place request dispatch, server selection, or encryption).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3adbc05cb8832fa35274b8f6e4e4f0)