### PR TITLE
Add DSPACE token.place context estimator

### DIFF
--- a/docs/benchmarks/token-place-context.md
+++ b/docs/benchmarks/token-place-context.md
@@ -19,6 +19,8 @@ Those generated reports are local artifacts and should not be committed.
 - `componentTotals`: content-free totals for system instructions, RAG, player state, chat history,
   and the latest user message.
 - `promptBuildDurationMs` and `ragDurationMs`: local timing fields when available.
+- `estimator`: deterministic DSPACE tier classification for the sanitized API v1 message payload, including estimated prompt tokens, reserved output tokens, safety margin, selected `8k-fast`/`64k-full` tier, over-limit status, and estimator version.
+- `calibration`: exact-token error fields when a lightweight development-only Llama 3.1 tokenizer hook is available; otherwise `null`.
 
 ## Privacy constraints
 
@@ -29,14 +31,8 @@ as benchmark-only data.
 ## Comparing 8K and 64K readiness
 
 Use the generated report to identify dominant context components and compare the heuristic token
-count with 8,192-token and 65,536-token tiers. The readiness flags reserve 640 tokens for
-chat-template overhead and assistant output before marking a tier as fitting. A scenario that does
-not fit 8K but fits 64K is a candidate for full-fat routing in later phases. The report also flags
-whether the token.place-shaped request remains under the 131,072-character request ceiling.
+count with the named `8k-fast` (8,192 total context tokens) and `64k-full` (65,536 total context tokens) profiles. The estimator reserves 512 output tokens by default, adds chat-template overhead per message, then applies an 8% safety margin before marking a tier as fitting. A scenario that does not fit 8K but fits 64K is a candidate for full-fat routing in later phases. The report also flags whether the token.place-shaped request remains under the 131,072-character request ceiling.
 
 ## Token caveat
 
-Character counts, byte counts, and whitespace are not exact model tokens. Tokenizers split text by
-model-specific rules and chat templates add overhead. The benchmark's heuristic token estimate,
-reserved-token buffer, and token.place request shaping are only local planning signals until
-compute-side exact token admission is available.
+Character counts, byte counts, and whitespace are not exact model tokens. Tokenizers split text by model-specific rules and chat templates add overhead. The estimator counts UTF-8 bytes as well as JavaScript characters, intentionally overestimates common prompt shapes, and works offline in the browser without sending text to any server. These estimates are only local planning signals until compute-side exact token admission is available; heuristic estimates must not be labeled as exact.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,6 +13,12 @@ import {
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
 } from './tokenPlaceErrors.js';
+export {
+    estimateTokenPlaceContext,
+    TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    TOKEN_PLACE_CONTEXT_TIER_PROFILES,
+    TOKEN_PLACE_DEFAULT_OUTPUT_TOKEN_RESERVATION,
+} from './tokenPlaceContextEstimator.js';
 
 const DEFAULT_ORIGIN = 'https://token.place';
 const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,0 +1,71 @@
+const textEncoder = new TextEncoder();
+
+export const TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION = 'dspace-token-place-context-estimator-v1';
+export const TOKEN_PLACE_DEFAULT_OUTPUT_TOKEN_RESERVATION = 512;
+export const TOKEN_PLACE_CONTEXT_SAFETY_MARGIN_RATIO = 0.08;
+export const TOKEN_PLACE_CHAT_TEMPLATE_BASE_OVERHEAD_TOKENS = 8;
+export const TOKEN_PLACE_CHAT_TEMPLATE_PER_MESSAGE_OVERHEAD_TOKENS = 12;
+
+export const TOKEN_PLACE_CONTEXT_TIER_PROFILES = Object.freeze({
+    '8k-fast': Object.freeze({ id: '8k-fast', totalContextTokens: 8_192 }),
+    '64k-full': Object.freeze({ id: '64k-full', totalContextTokens: 65_536 }),
+});
+
+const normalizeMessages = (messages = []) => (Array.isArray(messages) ? messages : []);
+
+const utf8ByteLength = (value) => textEncoder.encode(String(value ?? '')).length;
+
+const estimateContentTokens = (content) => {
+    const text = String(content ?? '');
+    if (!text) return 0;
+    const characters = text.length;
+    const utf8Bytes = utf8ByteLength(text);
+
+    // Conservative offline heuristic for Llama-family chat payloads:
+    // - UTF-8 bytes catch non-ASCII cost that JS string length hides.
+    // - characters/3 overestimates typical ASCII prose/code versus the common chars/4 planning
+    //   shortcut.
+    // - bytes/3 keeps Unicode and emoji payloads from being undercounted.
+    // This is intentionally not an exact tokenizer and must not be used as compute admission.
+    return Math.ceil(Math.max(characters, utf8Bytes) / 3);
+};
+
+const estimateMessageTokens = (message) =>
+    estimateContentTokens(message?.content) + TOKEN_PLACE_CHAT_TEMPLATE_PER_MESSAGE_OVERHEAD_TOKENS;
+
+const selectTier = (estimatedTotalTokens) => {
+    if (estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIER_PROFILES['8k-fast'].totalContextTokens) {
+        return TOKEN_PLACE_CONTEXT_TIER_PROFILES['8k-fast'].id;
+    }
+    if (estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIER_PROFILES['64k-full'].totalContextTokens) {
+        return TOKEN_PLACE_CONTEXT_TIER_PROFILES['64k-full'].id;
+    }
+    return null;
+};
+
+export const estimateTokenPlaceContext = (messages = [], options = {}) => {
+    const normalizedMessages = normalizeMessages(messages);
+    const reservedOutputTokens = Number.isFinite(options.reservedOutputTokens)
+        ? Math.max(0, Math.ceil(options.reservedOutputTokens))
+        : TOKEN_PLACE_DEFAULT_OUTPUT_TOKEN_RESERVATION;
+    const contentAndMessageTokens = normalizedMessages.reduce(
+        (sum, message) => sum + estimateMessageTokens(message),
+        TOKEN_PLACE_CHAT_TEMPLATE_BASE_OVERHEAD_TOKENS
+    );
+    const estimatedPromptTokens = Math.ceil(contentAndMessageTokens);
+    const safetyMarginTokens = Math.ceil(
+        (estimatedPromptTokens + reservedOutputTokens) * TOKEN_PLACE_CONTEXT_SAFETY_MARGIN_RATIO
+    );
+    const estimatedTotalTokens = estimatedPromptTokens + reservedOutputTokens + safetyMarginTokens;
+    const selectedTier = selectTier(estimatedTotalTokens);
+
+    return {
+        estimatedPromptTokens,
+        reservedOutputTokens,
+        safetyMarginTokens,
+        estimatedTotalTokens,
+        selectedTier,
+        overLimit: selectedTier === null,
+        estimatorVersion: TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    };
+};

--- a/frontend/tests/tokenPlaceContextEstimator.test.ts
+++ b/frontend/tests/tokenPlaceContextEstimator.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+    estimateTokenPlaceContext,
+    TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    TOKEN_PLACE_CONTEXT_TIER_PROFILES,
+    TOKEN_PLACE_DEFAULT_OUTPUT_TOKEN_RESERVATION,
+} from '../src/utils/tokenPlaceContextEstimator.js';
+
+const message = (content, role = 'user') => ({ role, content });
+const classify = (content, options) => estimateTokenPlaceContext([message(content)], options);
+
+describe('token.place context estimator', () => {
+    it('exports named tier profile constants', () => {
+        expect(TOKEN_PLACE_CONTEXT_TIER_PROFILES['8k-fast'].totalContextTokens).toBe(8192);
+        expect(TOKEN_PLACE_CONTEXT_TIER_PROFILES['64k-full'].totalContextTokens).toBe(65536);
+    });
+
+    it('classifies ASCII prose into 8k-fast when it fits', () => {
+        const result = classify('Launch the rocket after checking oxygen and battery telemetry.');
+        expect(result.selectedTier).toBe('8k-fast');
+        expect(result.overLimit).toBe(false);
+    });
+
+    it('counts UTF-8 bytes for Unicode content', () => {
+        const ascii = classify('a'.repeat(300));
+        const unicode = classify('🚀'.repeat(300));
+        expect(unicode.estimatedPromptTokens).toBeGreaterThan(ascii.estimatedPromptTokens);
+    });
+
+    it('classifies JSON payloads deterministically', () => {
+        const payload = JSON.stringify({
+            inventory: ['oxygen', 'water'],
+            quests: { active: true },
+        });
+        expect(classify(payload)).toMatchObject({ selectedTier: '8k-fast', overLimit: false });
+    });
+
+    it('classifies source code payloads', () => {
+        const source = 'function launch(step) { return step + 1; }\n'.repeat(100);
+        expect(classify(source).selectedTier).toBe('8k-fast');
+    });
+
+    it('classifies whitespace-heavy content conservatively', () => {
+        const result = classify(' \n\t'.repeat(2000));
+        expect(result.estimatedPromptTokens).toBeGreaterThan(2000);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    it('classifies RAG-heavy content into 64k-full when it exceeds 8k', () => {
+        const result = estimateTokenPlaceContext([
+            message('DSPACE system instructions.'.repeat(100), 'system'),
+            message('Retrieved docs context. '.repeat(3000), 'system'),
+            message('What should I do next?'),
+        ]);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    it('classifies a 131,072-character payload without truncating', () => {
+        const result = classify('a'.repeat(131_072));
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    it('honors output-token reservation', () => {
+        const smallReservation = classify('a'.repeat(20_000), { reservedOutputTokens: 0 });
+        const largeReservation = classify('a'.repeat(20_000), { reservedOutputTokens: 4096 });
+        expect(largeReservation.estimatedTotalTokens).toBeGreaterThan(
+            smallReservation.estimatedTotalTokens
+        );
+        expect(largeReservation.reservedOutputTokens).toBe(4096);
+    });
+
+    it('returns deterministic estimator versioning', () => {
+        expect(classify('same input')).toEqual(classify('same input'));
+        expect(classify('same input').estimatorVersion).toBe(TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION);
+        expect(classify('same input').reservedOutputTokens).toBe(
+            TOKEN_PLACE_DEFAULT_OUTPUT_TOKEN_RESERVATION
+        );
+    });
+
+    it('returns explicit over-limit behavior', () => {
+        const result = classify('🚀'.repeat(90_000));
+        expect(result.selectedTier).toBeNull();
+        expect(result.overLimit).toBe(true);
+        expect(result.estimatedTotalTokens).toBeGreaterThan(65_536);
+    });
+
+    it('keeps the 8k boundary strict after reservation and margin', () => {
+        const fits8k = classify('a'.repeat(20_000), { reservedOutputTokens: 512 });
+        const exceeds8k = classify('a'.repeat(22_700), { reservedOutputTokens: 512 });
+        expect(fits8k.estimatedTotalTokens).toBeLessThanOrEqual(8192);
+        expect(fits8k.selectedTier).toBe('8k-fast');
+        expect(exceeds8k.estimatedTotalTokens).toBeGreaterThan(8192);
+        expect(exceeds8k.selectedTier).toBe('64k-full');
+    });
+});

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -3,16 +3,13 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
+import { estimateTokenPlaceContext } from '../frontend/src/utils/tokenPlaceContextEstimator.js';
 import {
   sanitizeTokenPlaceMessagesWithMetadata,
   TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
-const RESERVED_OUTPUT_TOKENS = 512;
-const CHAT_TEMPLATE_OVERHEAD_TOKENS = 128;
-const TOKEN_BUDGET_BUFFER =
-  RESERVED_OUTPUT_TOKENS + CHAT_TEMPLATE_OVERHEAD_TOKENS;
 const repeat = (label, length) =>
   label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
@@ -121,16 +118,13 @@ const scenarios = [
   ),
 ];
 
-const estimateTokens = (characters) => Math.ceil(characters / 4);
-const tierReadiness = (metrics) => {
-  const heuristicTokens = estimateTokens(metrics.totalCharacters);
+const calibrationFor = (estimator, exactTokenCount) => {
+  if (!Number.isFinite(exactTokenCount)) return null;
+  const estimated = estimator.estimatedPromptTokens;
   return {
-    heuristicTokens,
-    reservedTokens: TOKEN_BUDGET_BUFFER,
-    fits8kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 8192,
-    fits64kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 65536,
-    fitsTokenPlaceCharCeiling:
-      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+    exactPromptTokens: exactTokenCount,
+    promptTokenDelta: estimated - exactTokenCount,
+    promptTokenErrorRatio: (estimated - exactTokenCount) / exactTokenCount,
   };
 };
 
@@ -202,16 +196,18 @@ const results = scenarios.map((item) => {
       `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
     );
   }
+  const estimator = estimateTokenPlaceContext(tokenPlaceMessages);
   return {
     id: item.id,
     description: item.description,
     sourceMessageCount: item.combinedMessages.length,
     tokenPlaceMessageCount: tokenPlaceMessages.length,
     metrics,
-    tierReadiness: tierReadiness(metrics),
+    estimator,
+    calibration: calibrationFor(estimator, null),
     exactTokenizer: {
       available: false,
-      note: 'No production-safe Llama 3.1 tokenizer hook is configured for this benchmark.',
+      note: 'No existing lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark.',
     },
   };
 });
@@ -229,17 +225,17 @@ const markdown = [
   '',
   `Generated: ${json.generatedAt}`,
   '',
-  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Heuristic tokens | Reserved tokens | 8K | 64K | Char ceiling | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
+  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Est. prompt tokens | Reserved output | Safety margin | Est. total | Tier | Over limit | Calibration error | Char ceiling | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | --- |',
   ...results.map((result) => {
     const entries = Object.entries(result.metrics.componentTotals);
     const [dominant] = entries.sort(
       (a, b) => b[1].characters - a[1].characters
     )[0];
-    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.reservedTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${dominant} |`;
+    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.estimator.estimatedPromptTokens} | ${result.estimator.reservedOutputTokens} | ${result.estimator.safetyMarginTokens} | ${result.estimator.estimatedTotalTokens} | ${result.estimator.selectedTier || 'over-limit'} | ${result.estimator.overLimit ? 'yes' : 'no'} | ${result.calibration ? result.calibration.promptTokenErrorRatio.toFixed(4) : 'n/a'} | ${result.metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS ? 'yes' : 'no'} | ${dominant} |`;
   }),
   '',
-  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token counts are four-characters-per-token heuristics, not exact model tokens; tier fit reserves output and chat-template headroom.',
+  'All values are content-free counts from synthetic fixtures after token.place request shaping. Estimator totals are conservative offline heuristics, not exact model tokens; calibration error is reported only when an exact development tokenizer hook is available.',
 ].join('\n');
 
 await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);


### PR DESCRIPTION
### Motivation

- Provide a deterministic, browser-safe, privacy-preserving estimator to classify sanitized token.place API v1 prompts into `8k-fast` (8,192) or `64k-full` (65,536) tiers so the client can surface routing hints and UX safeguards without changing relay behavior. 
- Use a conservative, offline heuristic that counts UTF-8 bytes, accounts for per-message/chat-template overhead, reserves output tokens, and exposes a stable estimator version for repeatable diagnostics and benchmarking.

### Description

- Added `frontend/src/utils/tokenPlaceContextEstimator.js` which defines named tier profiles, counts UTF-8 bytes, applies per-message/chat-template overhead, a default `512` reserved output tokens, an `8%` safety margin, and returns a structured result containing estimated prompt tokens, reserved tokens, safety margin, estimated total, selected tier, over-limit boolean, and `estimatorVersion`.
- Re-exported the estimator and constants from `frontend/src/utils/tokenPlace.js` for debug/benchmark consumers without modifying any token.place API v1 request shaping, encryption, server selection, retries, or UI provider behavior.
- Updated the phase-0 benchmark `scripts/benchmark-token-place-context.mjs` and `docs/benchmarks/token-place-context.md` to include estimator output and a calibration placeholder for exact-token comparisons when/if a development tokenizer hook is available, while preserving the privacy constraints of the benchmark outputs.
- Added focused tests at `frontend/tests/tokenPlaceContextEstimator.test.ts` covering tier boundaries, ASCII, Unicode, JSON, source code, whitespace-heavy payloads, RAG-heavy payloads, 131,072-char payloads, output-reservation behavior, deterministic versioning, and explicit over-limit behavior.

### Testing

- Ran unit/test suite for token.place and estimator: `cd frontend && npm test -- tokenPlaceContextEstimator.test.ts tokenPlace.test.js`, and all tests passed (`frontend/tests/tokenPlaceContextEstimator.test.ts` 12 tests passed; `frontend/__tests__/tokenPlace.test.js` 58 tests passed). 
- Ran formatting/lint checks: `cd frontend && npm run check`, which succeeded with Prettier/lint checks passing. 
- Built the frontend app: `cd frontend && npm run build`, which completed successfully. 
- Ran the benchmark to generate artifacts: `npm run benchmark:token-place-context`, which produced JSON/MD artifacts under `artifacts/benchmarks/token-place-context/` and completed successfully. 

Notes: the estimator is intentionally conservative and explicitly labeled a heuristic (not an exact tokenizer); it is offline, deterministic, and does not change relay routing or server selection in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3adbb9dd34832fb98047f0082fd9a0)