### PR TITLE
Add deterministic browser-safe token.place context estimator and tests

### DIFF
--- a/docs/design/token-place-context-tiers.md
+++ b/docs/design/token-place-context-tiers.md
@@ -85,8 +85,9 @@ Llama tokenizer:
 - It operates on the complete sanitized token.place API v1 message payload, after DSPACE's existing
   message shaping has normalized roles, chunked long system messages, and enforced API v1 message
   limits.
-- It counts UTF-8 bytes for message roles and content with `TextEncoder`; it does not rely on
-  JavaScript UTF-16 string length alone.
+- It counts UTF-8 bytes for a stable `JSON.stringify` serialization of the complete sanitized
+  `[{ role, content }]` API v1 payload with `TextEncoder`; it does not rely on JavaScript UTF-16
+  string length alone or sum only individual role/content bytes.
 - It estimates prompt tokens as `ceil(payloadUtf8Bytes / 3)` plus fixed chat-template overhead
   (`16` tokens per chat plus `8` tokens per message). The byte divisor is intentionally more
   conservative than the common four-characters-per-token rule and remains fully offline.
@@ -97,12 +98,14 @@ Llama tokenizer:
   routing code.
 - It returns a structured result with estimated prompt tokens, reserved output tokens,
   safety-margin tokens, estimated total tokens, selected tier, over-limit status, payload UTF-8
-  bytes, message count, per-message byte summaries, and the deterministic estimator version.
+  bytes, message count, per-message byte summaries, public-helper shaping metadata when applicable,
+  and the deterministic estimator version.
 
 Tier selection is pure and deterministic: select `8k-fast` only when prompt estimate plus output
 reservation plus safety margin fits `8,192`; otherwise select `64k-full` only when it fits `65,536`;
-otherwise return `selectedTier: null` and `overLimit: true`. The estimator never truncates and never
-sends prompt text to a server.
+otherwise return `selectedTier: null` and `overLimit: true`. The sanitized-payload estimator never
+truncates; the public helper reports shaping metadata when existing API v1 sanitization changes the
+payload before estimation. The estimator never sends prompt text to a server.
 
 The Phase 0 benchmark now includes estimator output for synthetic fixtures and a calibration section.
 When a lightweight development-only exact Llama 3.1 tokenizer hook is available, the benchmark can

--- a/docs/design/token-place-context-tiers.md
+++ b/docs/design/token-place-context-tiers.md
@@ -78,7 +78,7 @@ route to `8k-fast`; full-fat prompts may require `64k-full`.
 
 ## Phase 0 estimator implementation
 
-P7 adds a deterministic browser-side estimator in
+The Phase 0 token.place context-tier work adds a deterministic browser-side estimator in
 `frontend/src/utils/tokenPlaceContextEstimator.js`. It is a conservative heuristic, not an exact
 Llama tokenizer:
 

--- a/docs/design/token-place-context-tiers.md
+++ b/docs/design/token-place-context-tiers.md
@@ -391,30 +391,31 @@ Rules:
 
 ### Browser-safe conservative token estimate
 
-DSPACE's browser estimate should be deterministic and conservative:
+DSPACE's browser estimate should be deterministic and conservative. The implemented Phase 0
+estimator in `frontend/src/utils/tokenPlaceContextEstimator.js` is the authoritative browser-safe
+policy and estimates the complete deterministic sanitized API v1 payload, not only raw content
+counters:
 
 ```text
-estimatedPromptTokens = max(
-  ceil(totalUtf8Bytes / bytesPerTokenAssumption),
-  ceil(totalContentChars / charsPerTokenAssumption)
-) + chatTemplateOverheadTokens
-
+payloadUtf8Bytes = utf8Bytes(JSON.stringify(sanitizedApiV1Messages))
+estimatedPromptTokens = ceil(payloadUtf8Bytes / 3) + 16 + messageCount * 8
 estimatedTotalContextUse =
   estimatedPromptTokens + reservedOutputTokens + safetyMarginTokens
 ```
 
-Suggested initial assumptions:
+Current Phase 0 constants:
 
-| Parameter | Initial value | Rationale |
+| Parameter | Phase 0 value | Rationale |
 | --- | ---: | --- |
-| `charsPerTokenAssumption` | 4 | Common rough heuristic. |
-| `bytesPerTokenAssumption` | 4 | Helps account for non-ASCII UTF-8 expansion. |
-| `chatTemplateOverheadTokens` | `messageCount * 8 + 64` | Conservative placeholder until exact tokenizer fixtures exist. |
-| `reservedOutputTokens` | 1,024 for full-fat, 512 for token-lite | Prevents consuming the full context with prompt tokens. |
-| `safetyMarginTokens` | max(512, ceil(estimatedPromptTokens * 0.10)) | Buffers tokenizer mismatch and template overhead. |
+| `bytesPerTokenAssumption` | 3 | Conservative UTF-8 payload heuristic over serialized `{ role, content }` messages. |
+| `chatTemplateOverheadTokens` | `16 + messageCount * 8` | Fixed chat plus per-message overhead for the browser-side heuristic. |
+| `reservedOutputTokens` | 512 | Matches the current benchmark response budget by default. |
+| `safetyMarginTokens` | max(256, ceil(estimatedPromptTokens * 0.08)) | Buffers tokenizer mismatch and template overhead. |
 
-The exact constants should be calibrated against compute-side tokenizer measurements from Phase 0
-and Phase 3. DSPACE should treat estimates near a boundary as belonging to the larger tier.
+Older planning drafts used separate character and byte heuristics plus larger placeholder margins;
+those values are superseded by the Phase 0 estimator implementation above. The exact constants
+should still be calibrated against compute-side tokenizer measurements from Phase 0 and Phase 3.
+DSPACE should treat estimates near a boundary as belonging to the larger tier.
 
 ### Tier classification result
 

--- a/docs/design/token-place-context-tiers.md
+++ b/docs/design/token-place-context-tiers.md
@@ -76,6 +76,39 @@ Initial token.place service profiles are expected to be:
 DSPACE should prefer the smallest tier likely to satisfy the request. token-lite should normally
 route to `8k-fast`; full-fat prompts may require `64k-full`.
 
+## Phase 0 estimator implementation
+
+P7 adds a deterministic browser-side estimator in
+`frontend/src/utils/tokenPlaceContextEstimator.js`. It is a conservative heuristic, not an exact
+Llama tokenizer:
+
+- It operates on the complete sanitized token.place API v1 message payload, after DSPACE's existing
+  message shaping has normalized roles, chunked long system messages, and enforced API v1 message
+  limits.
+- It counts UTF-8 bytes for message roles and content with `TextEncoder`; it does not rely on
+  JavaScript UTF-16 string length alone.
+- It estimates prompt tokens as `ceil(payloadUtf8Bytes / 3)` plus fixed chat-template overhead
+  (`16` tokens per chat plus `8` tokens per message). The byte divisor is intentionally more
+  conservative than the common four-characters-per-token rule and remains fully offline.
+- It reserves `512` output tokens by default, matching the current DSPACE/token.place expected
+  response budget used by the context benchmark.
+- It adds a documented safety margin of the larger of `256` tokens or `8%` of estimated prompt
+  tokens. Callers may override the output reservation or safety-margin tokens in tests and future
+  routing code.
+- It returns a structured result with estimated prompt tokens, reserved output tokens,
+  safety-margin tokens, estimated total tokens, selected tier, over-limit status, payload UTF-8
+  bytes, message count, per-message byte summaries, and the deterministic estimator version.
+
+Tier selection is pure and deterministic: select `8k-fast` only when prompt estimate plus output
+reservation plus safety margin fits `8,192`; otherwise select `64k-full` only when it fits `65,536`;
+otherwise return `selectedTier: null` and `overLimit: true`. The estimator never truncates and never
+sends prompt text to a server.
+
+The Phase 0 benchmark now includes estimator output for synthetic fixtures and a calibration section.
+When a lightweight development-only exact Llama 3.1 tokenizer hook is available, the benchmark can
+record prompt-token error; otherwise it reports calibration as unavailable and keeps production
+estimation explicitly heuristic.
+
 ## Current-state architecture
 
 ```mermaid

--- a/frontend/__tests__/tokenPlaceContextEstimator.test.js
+++ b/frontend/__tests__/tokenPlaceContextEstimator.test.js
@@ -101,14 +101,20 @@ describe('token.place context estimator', () => {
     });
 
     test('preserves boundary policy: 8K only when total estimate fits 8,192', () => {
-        const near8k = classifyContent(repeat('a', 22000), {
-            reservedOutputTokens: 1,
-            safetyMarginTokens: 0,
-        });
-        const above8k = classifyContent(repeat('a', 25000), {
-            reservedOutputTokens: 1,
-            safetyMarginTokens: 0,
-        });
+        const near8k = estimateTokenPlaceContextForSanitizedMessages(
+            [{ role: 'user', content: repeat('a', 22000) }],
+            {
+                reservedOutputTokens: 1,
+                safetyMarginTokens: 0,
+            }
+        );
+        const above8k = estimateTokenPlaceContextForSanitizedMessages(
+            [{ role: 'user', content: repeat('a', 25000) }],
+            {
+                reservedOutputTokens: 1,
+                safetyMarginTokens: 0,
+            }
+        );
         expect(near8k.estimatedTotalTokens).toBeLessThanOrEqual(8192);
         expect(near8k.selectedTier).toBe('8k-fast');
         expect(above8k.estimatedTotalTokens).toBeGreaterThan(8192);

--- a/frontend/__tests__/tokenPlaceContextEstimator.test.js
+++ b/frontend/__tests__/tokenPlaceContextEstimator.test.js
@@ -1,3 +1,9 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import { describe, expect, test } from 'vitest';
 import {
     DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS,
@@ -11,11 +17,31 @@ const classifyContent = (content, options = {}) =>
     estimateTokenPlaceContext([{ role: 'user', content }], options);
 
 const repeat = (chunk, chars) => chunk.repeat(Math.ceil(chars / chunk.length)).slice(0, chars);
+const utf8Bytes = (value) => new TextEncoder().encode(value).length;
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 describe('token.place context estimator', () => {
     test('exports named 8K and 64K profile constants', () => {
         expect(TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens).toBe(8192);
         expect(TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens).toBe(65536);
+    });
+
+    test('counts the complete serialized API v1 payload bytes', () => {
+        const messages = [
+            { role: 'system', content: 'Use JSON: {"mode":"safe"}' },
+            { role: 'user', content: 'Line 1\nLine 2 🚀' },
+        ];
+        const result = estimateTokenPlaceContextForSanitizedMessages(messages);
+        const serializedPayload = JSON.stringify(messages);
+
+        expect(result.payloadUtf8Bytes).toBe(utf8Bytes(serializedPayload));
+        expect(result.payloadUtf8Bytes).toBeGreaterThan(
+            result.perMessage.reduce((sum, message) => sum + message.utf8Bytes, 0)
+        );
+        expect(result.perMessage.map((message) => message.serializedUtf8Bytes)).toEqual(
+            messages.map((message) => utf8Bytes(JSON.stringify(message)))
+        );
     });
 
     test('classifies ASCII prose into the fast tier', () => {
@@ -65,11 +91,67 @@ describe('token.place context estimator', () => {
         expect(result.estimatedTotalTokens).toBeGreaterThan(8192);
     });
 
-    test('classifies 131,072-character payloads without truncating in the estimator', () => {
-        const result = classifyContent(repeat('a', 131072));
+    test('surfaces public-helper shaping metadata instead of hiding discarded content', () => {
+        const oversizedMessages = [
+            { role: 'system', content: repeat('s', 90000) },
+            { role: 'assistant', content: repeat('a', 90000) },
+            { role: 'user', content: repeat('u', 90000) },
+        ];
+        const result = estimateTokenPlaceContext(oversizedMessages);
+
+        expect(result.sanitizedPayload.changed).toBe(true);
+        expect(result.sanitizedPayload.sourceMessageCount).toBe(3);
+        expect(result.sanitizedPayload.sanitizedMessageCount).toBeGreaterThan(0);
+        expect(result.sanitizedPayload.discardedContentChars).toBeGreaterThan(0);
+        expect(result.sanitizedPayload.chunkedSourceMessageCount).toBeGreaterThan(0);
+    });
+
+    test('classifies 131,072-character sanitized payloads without truncating in the estimator', () => {
+        const result = estimateTokenPlaceContextForSanitizedMessages([
+            { role: 'user', content: repeat('a', 131072) },
+        ]);
         expect(result.payloadUtf8Bytes).toBeGreaterThanOrEqual(131072);
         expect(result.selectedTier).toBe('64k-full');
         expect(result.overLimit).toBe(false);
+    });
+
+    test('benchmark calibration reports invalid exact-token data as unavailable', async () => {
+        const workdir = await mkdtemp(path.join(tmpdir(), 'token-place-context-benchmark-'));
+        const tokenizerModule = path.join(workdir, 'zero-tokenizer.mjs');
+        await writeFile(tokenizerModule, 'export const countPromptTokens = () => 0;\n');
+
+        try {
+            const scriptPath = path.join(repoRoot, 'scripts/benchmark-token-place-context.mjs');
+            await execFileAsync(process.execPath, [scriptPath], {
+                cwd: workdir,
+                env: {
+                    ...process.env,
+                    TOKEN_PLACE_CONTEXT_EXACT_TOKENIZER_MODULE: tokenizerModule,
+                },
+            });
+            const benchmarkDir = path.join(workdir, 'artifacts/benchmarks/token-place-context');
+            const latestJson = (await import('node:fs/promises'))
+                .readdir(benchmarkDir)
+                .then((files) =>
+                    files
+                        .filter((file) => file.endsWith('.json'))
+                        .sort()
+                        .at(-1)
+                );
+            const report = JSON.parse(
+                await readFile(path.join(benchmarkDir, await latestJson), 'utf8')
+            );
+
+            expect(report.scenarios.length).toBeGreaterThan(0);
+            expect(report.scenarios[0].calibration).toMatchObject({
+                exactTokenizerAvailable: false,
+                exactPromptTokens: null,
+                promptTokenError: null,
+                promptTokenErrorPercent: null,
+            });
+        } finally {
+            await rm(workdir, { recursive: true, force: true });
+        }
     });
 
     test('honors output-token reservation', () => {

--- a/frontend/__tests__/tokenPlaceContextEstimator.test.js
+++ b/frontend/__tests__/tokenPlaceContextEstimator.test.js
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -130,17 +130,11 @@ describe('token.place context estimator', () => {
                 },
             });
             const benchmarkDir = path.join(workdir, 'artifacts/benchmarks/token-place-context');
-            const latestJson = (await import('node:fs/promises'))
-                .readdir(benchmarkDir)
-                .then((files) =>
-                    files
-                        .filter((file) => file.endsWith('.json'))
-                        .sort()
-                        .at(-1)
-                );
-            const report = JSON.parse(
-                await readFile(path.join(benchmarkDir, await latestJson), 'utf8')
-            );
+            const latestJson = (await readdir(benchmarkDir))
+                .filter((file) => file.endsWith('.json'))
+                .sort()
+                .at(-1);
+            const report = JSON.parse(await readFile(path.join(benchmarkDir, latestJson), 'utf8'));
 
             expect(report.scenarios.length).toBeGreaterThan(0);
             expect(report.scenarios[0].calibration).toMatchObject({
@@ -148,7 +142,13 @@ describe('token.place context estimator', () => {
                 exactPromptTokens: null,
                 promptTokenError: null,
                 promptTokenErrorPercent: null,
+                note: expect.stringContaining(
+                    'configured exact tokenizer hook returned invalid or non-positive'
+                ),
             });
+            expect(report.scenarios[0].calibration.note).not.toContain(
+                'No lightweight development-only Llama 3.1 tokenizer hook is configured'
+            );
         } finally {
             await rm(workdir, { recursive: true, force: true });
         }

--- a/frontend/__tests__/tokenPlaceContextEstimator.test.js
+++ b/frontend/__tests__/tokenPlaceContextEstimator.test.js
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import {
+    DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS,
+    TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+    TOKEN_PLACE_CONTEXT_TIERS,
+    estimateTokenPlaceContext,
+    estimateTokenPlaceContextForSanitizedMessages,
+} from '../src/utils/tokenPlaceContextEstimator.js';
+
+const classifyContent = (content, options = {}) =>
+    estimateTokenPlaceContext([{ role: 'user', content }], options);
+
+const repeat = (chunk, chars) => chunk.repeat(Math.ceil(chars / chunk.length)).slice(0, chars);
+
+describe('token.place context estimator', () => {
+    test('exports named 8K and 64K profile constants', () => {
+        expect(TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens).toBe(8192);
+        expect(TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens).toBe(65536);
+    });
+
+    test('classifies ASCII prose into the fast tier', () => {
+        const result = classifyContent('DSPACE can explain solar panels and early quests.');
+        expect(result.selectedTier).toBe('8k-fast');
+        expect(result.overLimit).toBe(false);
+        expect(result.payloadUtf8Bytes).toBeGreaterThan(result.messageCount);
+    });
+
+    test('counts UTF-8 bytes for Unicode instead of JavaScript string length only', () => {
+        const result = classifyContent('🚀🌕 café composting');
+        expect(result.payloadUtf8Bytes).toBeGreaterThan('🚀🌕 café composting'.length);
+        expect(result.selectedTier).toBe('8k-fast');
+    });
+
+    test('classifies JSON payloads deterministically', () => {
+        const content = JSON.stringify({ inventory: ['solar-panel'], quests: { start: true } });
+        expect(classifyContent(content)).toMatchObject({
+            selectedTier: '8k-fast',
+            overLimit: false,
+        });
+    });
+
+    test('classifies source code payloads', () => {
+        const content = repeat('function launch(seed) { return seed.map((x) => x + 1); }\n', 30000);
+        const result = classifyContent(content);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('classifies whitespace-heavy content conservatively', () => {
+        const result = estimateTokenPlaceContextForSanitizedMessages([
+            { role: 'user', content: repeat(' \n\t', 24000) },
+        ]);
+        expect(result.estimatedPromptTokens).toBeGreaterThan(7000);
+        expect(result.selectedTier).toBe('64k-full');
+    });
+
+    test('classifies RAG-heavy multi-message content in 64K when it exceeds 8K', () => {
+        const messages = [
+            { role: 'system', content: repeat('DSPACE docs excerpt. ', 28000) },
+            { role: 'system', content: repeat('PlayerState inventory quest process. ', 12000) },
+            { role: 'user', content: 'What should I build next?' },
+        ];
+        const result = estimateTokenPlaceContext(messages);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.estimatedTotalTokens).toBeGreaterThan(8192);
+    });
+
+    test('classifies 131,072-character payloads without truncating in the estimator', () => {
+        const result = classifyContent(repeat('a', 131072));
+        expect(result.payloadUtf8Bytes).toBeGreaterThanOrEqual(131072);
+        expect(result.selectedTier).toBe('64k-full');
+        expect(result.overLimit).toBe(false);
+    });
+
+    test('honors output-token reservation', () => {
+        const defaultResult = classifyContent(repeat('a', 20000));
+        const largerReservation = classifyContent(repeat('a', 20000), {
+            reservedOutputTokens: 4096,
+        });
+        expect(defaultResult.reservedOutputTokens).toBe(
+            DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS
+        );
+        expect(largerReservation.estimatedTotalTokens - defaultResult.estimatedTotalTokens).toBe(
+            4096 - DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS
+        );
+    });
+
+    test('keeps estimator version deterministic', () => {
+        const result = classifyContent('version check');
+        expect(result.estimatorVersion).toBe(TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION);
+        expect(TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION).toBe('dspace-token-context-estimator-v1');
+    });
+
+    test('returns explicit over-limit result', () => {
+        const result = estimateTokenPlaceContextForSanitizedMessages([
+            { role: 'user', content: repeat('x', 210000) },
+        ]);
+        expect(result.selectedTier).toBeNull();
+        expect(result.overLimit).toBe(true);
+        expect(result.estimatedTotalTokens).toBeGreaterThan(65536);
+    });
+
+    test('preserves boundary policy: 8K only when total estimate fits 8,192', () => {
+        const near8k = classifyContent(repeat('a', 22000), {
+            reservedOutputTokens: 1,
+            safetyMarginTokens: 0,
+        });
+        const above8k = classifyContent(repeat('a', 25000), {
+            reservedOutputTokens: 1,
+            safetyMarginTokens: 0,
+        });
+        expect(near8k.estimatedTotalTokens).toBeLessThanOrEqual(8192);
+        expect(near8k.selectedTier).toBe('8k-fast');
+        expect(above8k.estimatedTotalTokens).toBeGreaterThan(8192);
+        expect(above8k.selectedTier).toBe('64k-full');
+    });
+});

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,5 +1,7 @@
 import { sanitizeTokenPlaceMessages } from './tokenPlaceMessages.js';
 
+// Bump this version string whenever any estimation constant or formula below changes so
+// callers, benchmarks, and tests can detect heuristic drift.
 export const TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION = 'dspace-token-context-estimator-v1';
 export const TOKEN_PLACE_CONTEXT_TIERS = Object.freeze({
     '8k-fast': Object.freeze({ id: '8k-fast', totalContextTokens: 8_192 }),

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,0 +1,93 @@
+import { sanitizeTokenPlaceMessages } from './tokenPlaceMessages.js';
+
+export const TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION = 'dspace-token-context-estimator-v1';
+export const TOKEN_PLACE_CONTEXT_TIERS = Object.freeze({
+    '8k-fast': Object.freeze({ id: '8k-fast', totalContextTokens: 8_192 }),
+    '64k-full': Object.freeze({ id: '64k-full', totalContextTokens: 65_536 }),
+});
+
+export const DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS = 512;
+export const TOKEN_PLACE_ESTIMATOR_BYTES_PER_TOKEN = 3;
+export const TOKEN_PLACE_ESTIMATOR_PER_MESSAGE_OVERHEAD_TOKENS = 8;
+export const TOKEN_PLACE_ESTIMATOR_CHAT_OVERHEAD_TOKENS = 16;
+export const TOKEN_PLACE_ESTIMATOR_MIN_SAFETY_MARGIN_TOKENS = 256;
+export const TOKEN_PLACE_ESTIMATOR_SAFETY_MARGIN_RATIO = 0.08;
+
+const textEncoder = new TextEncoder();
+
+const utf8ByteLength = (value) => textEncoder.encode(String(value ?? '')).length;
+
+const normalizeReservation = (value) => {
+    const tokens = Number(value);
+    if (!Number.isFinite(tokens) || tokens < 0)
+        return DEFAULT_TOKEN_PLACE_OUTPUT_RESERVATION_TOKENS;
+    return Math.ceil(tokens);
+};
+
+const estimateContentTokensFromBytes = (bytes) =>
+    Math.ceil(bytes / TOKEN_PLACE_ESTIMATOR_BYTES_PER_TOKEN);
+
+const estimateChatTemplateOverhead = (messageCount) =>
+    TOKEN_PLACE_ESTIMATOR_CHAT_OVERHEAD_TOKENS +
+    messageCount * TOKEN_PLACE_ESTIMATOR_PER_MESSAGE_OVERHEAD_TOKENS;
+
+const estimateSafetyMargin = (promptTokens, configuredMargin) => {
+    if (configuredMargin !== undefined) {
+        const tokens = Number(configuredMargin);
+        if (Number.isFinite(tokens) && tokens >= 0) return Math.ceil(tokens);
+    }
+    return Math.max(
+        TOKEN_PLACE_ESTIMATOR_MIN_SAFETY_MARGIN_TOKENS,
+        Math.ceil(promptTokens * TOKEN_PLACE_ESTIMATOR_SAFETY_MARGIN_RATIO)
+    );
+};
+
+const selectTier = (estimatedTotalTokens) => {
+    if (estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens) {
+        return TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].id;
+    }
+    if (estimatedTotalTokens <= TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens) {
+        return TOKEN_PLACE_CONTEXT_TIERS['64k-full'].id;
+    }
+    return null;
+};
+
+export const estimateTokenPlaceContextForSanitizedMessages = (messages = [], options = {}) => {
+    const sanitizedMessages = Array.isArray(messages) ? messages : [];
+    const perMessage = sanitizedMessages.map((message, index) => {
+        const role = typeof message?.role === 'string' ? message.role : 'user';
+        const contentUtf8Bytes = utf8ByteLength(message?.content);
+        const roleUtf8Bytes = utf8ByteLength(role);
+        return {
+            index,
+            role,
+            contentUtf8Bytes,
+            roleUtf8Bytes,
+            utf8Bytes: contentUtf8Bytes + roleUtf8Bytes,
+        };
+    });
+    const payloadUtf8Bytes = perMessage.reduce((sum, message) => sum + message.utf8Bytes, 0);
+    const promptTokens =
+        estimateContentTokensFromBytes(payloadUtf8Bytes) +
+        estimateChatTemplateOverhead(sanitizedMessages.length);
+    const reservedOutputTokens = normalizeReservation(options.reservedOutputTokens);
+    const safetyMarginTokens = estimateSafetyMargin(promptTokens, options.safetyMarginTokens);
+    const estimatedTotalTokens = promptTokens + reservedOutputTokens + safetyMarginTokens;
+    const selectedTier = selectTier(estimatedTotalTokens);
+
+    return {
+        estimatedPromptTokens: promptTokens,
+        reservedOutputTokens,
+        safetyMarginTokens,
+        estimatedTotalTokens,
+        selectedTier,
+        overLimit: selectedTier === null,
+        estimatorVersion: TOKEN_PLACE_CONTEXT_ESTIMATOR_VERSION,
+        payloadUtf8Bytes,
+        messageCount: sanitizedMessages.length,
+        perMessage,
+    };
+};
+
+export const estimateTokenPlaceContext = (messages = [], options = {}) =>
+    estimateTokenPlaceContextForSanitizedMessages(sanitizeTokenPlaceMessages(messages), options);

--- a/frontend/src/utils/tokenPlaceContextEstimator.js
+++ b/frontend/src/utils/tokenPlaceContextEstimator.js
@@ -1,4 +1,4 @@
-import { sanitizeTokenPlaceMessages } from './tokenPlaceMessages.js';
+import { sanitizeTokenPlaceMessagesWithMetadata } from './tokenPlaceMessages.js';
 
 // Bump this version string whenever any estimation constant or formula below changes so
 // callers, benchmarks, and tests can detect heuristic drift.
@@ -18,6 +18,12 @@ export const TOKEN_PLACE_ESTIMATOR_SAFETY_MARGIN_RATIO = 0.08;
 const textEncoder = new TextEncoder();
 
 const utf8ByteLength = (value) => textEncoder.encode(String(value ?? '')).length;
+
+const toApiV1MessagePayload = (messages) =>
+    messages.map((message) => ({
+        role: typeof message?.role === 'string' ? message.role : 'user',
+        content: String(message?.content ?? ''),
+    }));
 
 const normalizeReservation = (value) => {
     const tokens = Number(value);
@@ -55,20 +61,23 @@ const selectTier = (estimatedTotalTokens) => {
 };
 
 export const estimateTokenPlaceContextForSanitizedMessages = (messages = [], options = {}) => {
-    const sanitizedMessages = Array.isArray(messages) ? messages : [];
+    const sanitizedMessages = toApiV1MessagePayload(Array.isArray(messages) ? messages : []);
+    const serializedPayload = JSON.stringify(sanitizedMessages);
+    const payloadUtf8Bytes = utf8ByteLength(serializedPayload);
     const perMessage = sanitizedMessages.map((message, index) => {
-        const role = typeof message?.role === 'string' ? message.role : 'user';
-        const contentUtf8Bytes = utf8ByteLength(message?.content);
+        const role = message.role;
+        const contentUtf8Bytes = utf8ByteLength(message.content);
         const roleUtf8Bytes = utf8ByteLength(role);
+        const serializedUtf8Bytes = utf8ByteLength(JSON.stringify(message));
         return {
             index,
             role,
             contentUtf8Bytes,
             roleUtf8Bytes,
             utf8Bytes: contentUtf8Bytes + roleUtf8Bytes,
+            serializedUtf8Bytes,
         };
     });
-    const payloadUtf8Bytes = perMessage.reduce((sum, message) => sum + message.utf8Bytes, 0);
     const promptTokens =
         estimateContentTokensFromBytes(payloadUtf8Bytes) +
         estimateChatTemplateOverhead(sanitizedMessages.length);
@@ -91,5 +100,50 @@ export const estimateTokenPlaceContextForSanitizedMessages = (messages = [], opt
     };
 };
 
-export const estimateTokenPlaceContext = (messages = [], options = {}) =>
-    estimateTokenPlaceContextForSanitizedMessages(sanitizeTokenPlaceMessages(messages), options);
+const summarizeShaping = (messages, sanitizedMessages) => {
+    const sourceMessages = Array.isArray(messages) ? messages : [];
+    const sourcePayload = toApiV1MessagePayload(sourceMessages);
+    const sanitizedPayload = toApiV1MessagePayload(sanitizedMessages);
+    const sourceContentChars = sourcePayload.reduce(
+        (sum, message) => sum + message.content.length,
+        0
+    );
+    const sanitizedContentChars = sanitizedPayload.reduce(
+        (sum, message) => sum + message.content.length,
+        0
+    );
+    const sourceIndexes = new Set(
+        sanitizedMessages
+            .map((message) => message.originalIndex)
+            .filter((index) => Number.isInteger(index) && index >= 0)
+    );
+    const chunkedSourceIndexes = new Set(
+        sanitizedMessages
+            .filter((message) => Number.isInteger(message.chunkIndex) && message.chunkIndex > 0)
+            .map((message) => message.originalIndex)
+    );
+    const changed = JSON.stringify(sourcePayload) !== JSON.stringify(sanitizedPayload);
+
+    return {
+        changed,
+        sourceMessageCount: sourceMessages.length,
+        sanitizedMessageCount: sanitizedPayload.length,
+        droppedMessageCount: Math.max(0, sourceMessages.length - sourceIndexes.size),
+        chunkedSourceMessageCount: chunkedSourceIndexes.size,
+        sourceContentChars,
+        sanitizedContentChars,
+        discardedContentChars: Math.max(0, sourceContentChars - sanitizedContentChars),
+    };
+};
+
+export const estimateTokenPlaceContext = (messages = [], options = {}) => {
+    const sanitizedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(messages);
+    const result = estimateTokenPlaceContextForSanitizedMessages(
+        sanitizedMessagesWithMetadata,
+        options
+    );
+    return {
+        ...result,
+        sanitizedPayload: summarizeShaping(messages, sanitizedMessagesWithMetadata),
+    };
+};

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -4,15 +4,15 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
 import {
+  estimateTokenPlaceContextForSanitizedMessages,
+  TOKEN_PLACE_CONTEXT_TIERS,
+} from '../frontend/src/utils/tokenPlaceContextEstimator.js';
+import {
   sanitizeTokenPlaceMessagesWithMetadata,
   TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
-const RESERVED_OUTPUT_TOKENS = 512;
-const CHAT_TEMPLATE_OVERHEAD_TOKENS = 128;
-const TOKEN_BUDGET_BUFFER =
-  RESERVED_OUTPUT_TOKENS + CHAT_TEMPLATE_OVERHEAD_TOKENS;
 const repeat = (label, length) =>
   label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
@@ -121,18 +121,27 @@ const scenarios = [
   ),
 ];
 
-const estimateTokens = (characters) => Math.ceil(characters / 4);
-const tierReadiness = (metrics) => {
-  const heuristicTokens = estimateTokens(metrics.totalCharacters);
+const calibrationFor = (estimate, exactPromptTokens) => {
+  if (!Number.isFinite(exactPromptTokens)) {
+    return {
+      exactTokenizerAvailable: false,
+      exactPromptTokens: null,
+      promptTokenError: null,
+      promptTokenErrorPercent: null,
+      note: 'No lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark.',
+    };
+  }
+  const promptTokenError = estimate.estimatedPromptTokens - exactPromptTokens;
   return {
-    heuristicTokens,
-    reservedTokens: TOKEN_BUDGET_BUFFER,
-    fits8kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 8192,
-    fits64kHeuristic: heuristicTokens + TOKEN_BUDGET_BUFFER <= 65536,
-    fitsTokenPlaceCharCeiling:
-      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
+    exactTokenizerAvailable: true,
+    exactPromptTokens,
+    promptTokenError,
+    promptTokenErrorPercent: Number(
+      ((promptTokenError / exactPromptTokens) * 100).toFixed(2)
+    ),
   };
 };
+
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
@@ -202,17 +211,15 @@ const results = scenarios.map((item) => {
       `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
     );
   }
+  const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(tokenPlaceMessages);
   return {
     id: item.id,
     description: item.description,
     sourceMessageCount: item.combinedMessages.length,
     tokenPlaceMessageCount: tokenPlaceMessages.length,
     metrics,
-    tierReadiness: tierReadiness(metrics),
-    exactTokenizer: {
-      available: false,
-      note: 'No production-safe Llama 3.1 tokenizer hook is configured for this benchmark.',
-    },
+    contextEstimate,
+    calibration: calibrationFor(contextEstimate, null),
   };
 });
 
@@ -229,17 +236,19 @@ const markdown = [
   '',
   `Generated: ${json.generatedAt}`,
   '',
-  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Heuristic tokens | Reserved tokens | 8K | 64K | Char ceiling | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
+  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Est. prompt tokens | Reserved output | Safety margin | Est. total | Selected tier | Over limit | Calibration | Dominant component |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
   ...results.map((result) => {
     const entries = Object.entries(result.metrics.componentTotals);
     const [dominant] = entries.sort(
       (a, b) => b[1].characters - a[1].characters
     )[0];
-    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.tierReadiness.heuristicTokens} | ${result.tierReadiness.reservedTokens} | ${result.tierReadiness.fits8kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fits64kHeuristic ? 'yes' : 'no'} | ${result.tierReadiness.fitsTokenPlaceCharCeiling ? 'yes' : 'no'} | ${dominant} |`;
+    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.contextEstimate.estimatedPromptTokens} | ${result.contextEstimate.reservedOutputTokens} | ${result.contextEstimate.safetyMarginTokens} | ${result.contextEstimate.estimatedTotalTokens} | ${result.contextEstimate.selectedTier || 'over-limit'} | ${result.contextEstimate.overLimit ? 'yes' : 'no'} | ${result.calibration.exactTokenizerAvailable ? `${result.calibration.promptTokenErrorPercent}%` : 'n/a'} | ${dominant} |`;
   }),
   '',
-  'All values are content-free counts from synthetic fixtures after token.place request shaping. Token counts are four-characters-per-token heuristics, not exact model tokens; tier fit reserves output and chat-template headroom.',
+  `Profiles: 8k-fast=${TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens} tokens; 64k-full=${TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens} tokens.`,
+  '',
+  'All values are content-free counts from synthetic fixtures after token.place request shaping. Estimator values are deterministic conservative heuristics over UTF-8 bytes plus chat-template overhead, output reservation, and safety margin; they are not exact model tokens. Calibration error is reported only when an exact development tokenizer is available.',
 ].join('\n');
 
 await writeFile(jsonPath, `${JSON.stringify(json, null, 2)}\n`);

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -142,7 +142,7 @@ const countExactPromptTokens = async (tokenizer, messages) => {
 };
 
 const calibrationFor = (estimate, exactPromptTokens) => {
-  if (!Number.isFinite(exactPromptTokens)) {
+  if (!Number.isFinite(exactPromptTokens) || exactPromptTokens <= 0) {
     return {
       exactTokenizerAvailable: false,
       exactPromptTokens: null,

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { performance } from 'node:perf_hooks';
 import { buildPromptMetrics } from '../frontend/src/utils/promptMetrics.js';
 import {
@@ -13,6 +15,7 @@ import {
 } from '../frontend/src/utils/tokenPlaceMessages.js';
 
 const OUTPUT_DIR = 'artifacts/benchmarks/token-place-context';
+const EXACT_TOKENIZER_MODULE_ENV = 'TOKEN_PLACE_CONTEXT_EXACT_TOKENIZER_MODULE';
 const repeat = (label, length) =>
   label.repeat(Math.ceil(length / label.length)).slice(0, length);
 
@@ -121,6 +124,23 @@ const scenarios = [
   ),
 ];
 
+const loadExactTokenizer = async () => {
+  const modulePath = process.env[EXACT_TOKENIZER_MODULE_ENV];
+  if (!modulePath) return null;
+  const resolvedModulePath = path.resolve(modulePath);
+  if (!existsSync(resolvedModulePath)) return null;
+
+  const module = await import(pathToFileURL(resolvedModulePath).href);
+  const countPromptTokens = module.countPromptTokens ?? module.default;
+  return typeof countPromptTokens === 'function' ? countPromptTokens : null;
+};
+
+const countExactPromptTokens = async (tokenizer, messages) => {
+  if (typeof tokenizer !== 'function') return null;
+  const exactPromptTokens = await tokenizer(messages);
+  return Number.isFinite(exactPromptTokens) ? exactPromptTokens : null;
+};
+
 const calibrationFor = (estimate, exactPromptTokens) => {
   if (!Number.isFinite(exactPromptTokens)) {
     return {
@@ -128,7 +148,7 @@ const calibrationFor = (estimate, exactPromptTokens) => {
       exactPromptTokens: null,
       promptTokenError: null,
       promptTokenErrorPercent: null,
-      note: 'No lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark.',
+      note: `No lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark. Set ${EXACT_TOKENIZER_MODULE_ENV} to a module exporting countPromptTokens(messages) to enable calibration.`,
     };
   }
   const promptTokenError = estimate.estimatedPromptTokens - exactPromptTokens;
@@ -136,15 +156,16 @@ const calibrationFor = (estimate, exactPromptTokens) => {
     exactTokenizerAvailable: true,
     exactPromptTokens,
     promptTokenError,
-    promptTokenErrorPercent: Number(
-      ((promptTokenError / exactPromptTokens) * 100).toFixed(2)
-    ),
+    promptTokenErrorPercent:
+      exactPromptTokens > 0
+        ? Number(((promptTokenError / exactPromptTokens) * 100).toFixed(2))
+        : null,
   };
 };
 
-
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
+const exactTokenizer = await loadExactTokenizer();
 
 const indexesForShapedMessages = (shapedMessages, sourceIndexes) => {
   const sourceIndexSet = new Set(
@@ -173,55 +194,65 @@ const componentIndexesForShapedMessages = (
 const componentTotalsSum = (componentTotals, field) =>
   Object.values(componentTotals).reduce((sum, total) => sum + total[field], 0);
 
-const results = scenarios.map((item) => {
-  const startedAt = performance.now();
-  const shapedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(
-    item.combinedMessages
-  );
-  const tokenPlaceMessages = shapedMessagesWithMetadata.map(
-    ({ role, content }) => ({
-      role,
-      content,
-    })
-  );
-  const metrics = buildPromptMetrics(
-    { combinedMessages: tokenPlaceMessages },
-    {
-      componentMessageIndexes: componentIndexesForShapedMessages(
-        shapedMessagesWithMetadata,
-        item.componentSourceIndexes
-      ),
-      promptBuildDurationMs: performance.now() - startedAt,
-      ragDurationMs: item.componentSourceIndexes.rag === -1 ? null : 0,
+const results = await Promise.all(
+  scenarios.map(async (item) => {
+    const startedAt = performance.now();
+    const shapedMessagesWithMetadata = sanitizeTokenPlaceMessagesWithMetadata(
+      item.combinedMessages
+    );
+    const tokenPlaceMessages = shapedMessagesWithMetadata.map(
+      ({ role, content }) => ({
+        role,
+        content,
+      })
+    );
+    const metrics = buildPromptMetrics(
+      { combinedMessages: tokenPlaceMessages },
+      {
+        componentMessageIndexes: componentIndexesForShapedMessages(
+          shapedMessagesWithMetadata,
+          item.componentSourceIndexes
+        ),
+        promptBuildDurationMs: performance.now() - startedAt,
+        ragDurationMs: item.componentSourceIndexes.rag === -1 ? null : 0,
+      }
+    );
+    if (
+      componentTotalsSum(metrics.componentTotals, 'characters') !==
+      metrics.totalCharacters
+    ) {
+      throw new Error(
+        `Component character totals do not sum to payload total for ${item.id}`
+      );
     }
-  );
-  if (
-    componentTotalsSum(metrics.componentTotals, 'characters') !==
-    metrics.totalCharacters
-  ) {
-    throw new Error(
-      `Component character totals do not sum to payload total for ${item.id}`
+    if (
+      componentTotalsSum(metrics.componentTotals, 'utf8Bytes') !==
+      metrics.totalUtf8Bytes
+    ) {
+      throw new Error(
+        `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
+      );
+    }
+    const contextEstimate =
+      estimateTokenPlaceContextForSanitizedMessages(tokenPlaceMessages);
+    const charCeiling =
+      metrics.totalCharacters <= TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS;
+    const exactPromptTokens = await countExactPromptTokens(
+      exactTokenizer,
+      tokenPlaceMessages
     );
-  }
-  if (
-    componentTotalsSum(metrics.componentTotals, 'utf8Bytes') !==
-    metrics.totalUtf8Bytes
-  ) {
-    throw new Error(
-      `Component UTF-8 byte totals do not sum to payload total for ${item.id}`
-    );
-  }
-  const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(tokenPlaceMessages);
-  return {
-    id: item.id,
-    description: item.description,
-    sourceMessageCount: item.combinedMessages.length,
-    tokenPlaceMessageCount: tokenPlaceMessages.length,
-    metrics,
-    contextEstimate,
-    calibration: calibrationFor(contextEstimate, null),
-  };
-});
+    return {
+      id: item.id,
+      description: item.description,
+      sourceMessageCount: item.combinedMessages.length,
+      tokenPlaceMessageCount: tokenPlaceMessages.length,
+      metrics,
+      charCeiling,
+      contextEstimate,
+      calibration: calibrationFor(contextEstimate, exactPromptTokens),
+    };
+  })
+);
 
 const jsonPath = path.join(OUTPUT_DIR, `${timestamp}.json`);
 const mdPath = path.join(OUTPUT_DIR, `${timestamp}.md`);
@@ -236,14 +267,14 @@ const markdown = [
   '',
   `Generated: ${json.generatedAt}`,
   '',
-  '| Scenario | Source messages | token.place messages | Chars | UTF-8 bytes | Est. prompt tokens | Reserved output | Safety margin | Est. total | Selected tier | Over limit | Calibration | Dominant component |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
+  '| Scenario | Source messages | token.place messages | Chars | Char ceiling | UTF-8 bytes | Est. prompt tokens | Reserved output | Safety margin | Est. total | Selected tier | Over limit | Calibration | Dominant component |',
+  '| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- |',
   ...results.map((result) => {
     const entries = Object.entries(result.metrics.componentTotals);
     const [dominant] = entries.sort(
       (a, b) => b[1].characters - a[1].characters
     )[0];
-    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.metrics.totalUtf8Bytes} | ${result.contextEstimate.estimatedPromptTokens} | ${result.contextEstimate.reservedOutputTokens} | ${result.contextEstimate.safetyMarginTokens} | ${result.contextEstimate.estimatedTotalTokens} | ${result.contextEstimate.selectedTier || 'over-limit'} | ${result.contextEstimate.overLimit ? 'yes' : 'no'} | ${result.calibration.exactTokenizerAvailable ? `${result.calibration.promptTokenErrorPercent}%` : 'n/a'} | ${dominant} |`;
+    return `| ${result.id} | ${result.sourceMessageCount} | ${result.tokenPlaceMessageCount} | ${result.metrics.totalCharacters} | ${result.charCeiling ? 'yes' : 'no'} | ${result.metrics.totalUtf8Bytes} | ${result.contextEstimate.estimatedPromptTokens} | ${result.contextEstimate.reservedOutputTokens} | ${result.contextEstimate.safetyMarginTokens} | ${result.contextEstimate.estimatedTotalTokens} | ${result.contextEstimate.selectedTier || 'over-limit'} | ${result.contextEstimate.overLimit ? 'yes' : 'no'} | ${result.calibration.exactTokenizerAvailable ? `${result.calibration.promptTokenErrorPercent}%` : 'n/a'} | ${dominant} |`;
   }),
   '',
   `Profiles: 8k-fast=${TOKEN_PLACE_CONTEXT_TIERS['8k-fast'].totalContextTokens} tokens; 64k-full=${TOKEN_PLACE_CONTEXT_TIERS['64k-full'].totalContextTokens} tokens.`,

--- a/scripts/benchmark-token-place-context.mjs
+++ b/scripts/benchmark-token-place-context.mjs
@@ -141,14 +141,16 @@ const countExactPromptTokens = async (tokenizer, messages) => {
   return Number.isFinite(exactPromptTokens) ? exactPromptTokens : null;
 };
 
-const calibrationFor = (estimate, exactPromptTokens) => {
+const calibrationFor = (estimate, exactPromptTokens, exactTokenizerConfigured) => {
   if (!Number.isFinite(exactPromptTokens) || exactPromptTokens <= 0) {
     return {
       exactTokenizerAvailable: false,
       exactPromptTokens: null,
       promptTokenError: null,
       promptTokenErrorPercent: null,
-      note: `No lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark. Set ${EXACT_TOKENIZER_MODULE_ENV} to a module exporting countPromptTokens(messages) to enable calibration.`,
+      note: exactTokenizerConfigured
+        ? 'The configured exact tokenizer hook returned invalid or non-positive prompt-token data, so calibration is unavailable for this scenario.'
+        : `No lightweight development-only Llama 3.1 tokenizer hook is configured for this benchmark. Set ${EXACT_TOKENIZER_MODULE_ENV} to a module exporting countPromptTokens(messages) to enable calibration.`,
     };
   }
   const promptTokenError = estimate.estimatedPromptTokens - exactPromptTokens;
@@ -166,6 +168,7 @@ const calibrationFor = (estimate, exactPromptTokens) => {
 const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 await mkdir(OUTPUT_DIR, { recursive: true });
 const exactTokenizer = await loadExactTokenizer();
+const exactTokenizerConfigured = typeof exactTokenizer === 'function';
 
 const indexesForShapedMessages = (shapedMessages, sourceIndexes) => {
   const sourceIndexSet = new Set(
@@ -249,7 +252,11 @@ const results = await Promise.all(
       metrics,
       charCeiling,
       contextEstimate,
-      calibration: calibrationFor(contextEstimate, exactPromptTokens),
+      calibration: calibrationFor(
+        contextEstimate,
+        exactPromptTokens,
+        exactTokenizerConfigured
+      ),
     };
   })
 );

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
       'frontend/__tests__/ShoppingForm.test.js',
       'frontend/__tests__/offlineWorkerRegistration.test.js',
       'frontend/__tests__/tokenPlace.test.js',
+      'frontend/__tests__/tokenPlaceContextEstimator.test.js',
       'frontend/__tests__/tokenPlaceErrors.test.js',
     ],
     exclude: ['frontend/e2e/**'],


### PR DESCRIPTION
### Motivation
- Provide a deterministic, offline, privacy-preserving browser-side estimator to classify token.place prompts into `8k-fast`, `64k-full`, or explicit over-limit so DSPACE can safely choose a routing hint without exposing prompt text or calling a server. 
- Calibrate and document a conservative Phase 0 heuristic that works on the already-sanitized API v1 payload and reserves output tokens and a safety margin to avoid underestimation.

### Description
- Added a production-safe estimator at `frontend/src/utils/tokenPlaceContextEstimator.js` that operates on sanitized API v1 messages, counts UTF-8 bytes via `TextEncoder`, conservatively estimates prompt tokens (`ceil(bytes / 3)`), adds chat-template and per-message overhead, applies a default 512-token output reservation, and adds a safety margin (max of 256 tokens or 8% of prompt tokens), then selects a tier or returns over-limit; the estimator returns a structured result and includes a stable `estimatorVersion` constant. 
- Introduced named profile constants: `8k-fast` (8,192 tokens) and `64k-full` (65,536 tokens) and exposed `estimateTokenPlaceContext` and `estimateTokenPlaceContextForSanitizedMessages` helpers. 
- Added focused unit tests at `frontend/__tests__/tokenPlaceContextEstimator.test.js` to cover tier boundaries, ASCII, Unicode, JSON, source code, whitespace-heavy content, RAG-heavy multi-message payloads, 131,072-character payloads, output-token reservation, deterministic estimator versioning, and explicit over-limit behavior. 
- Integrated estimator output into the Phase 0 benchmark script (`scripts/benchmark-token-place-context.mjs`) and documented the estimator and calibration behavior in `docs/design/token-place-context-tiers.md`; also added the new test file to Vitest include list so it runs under normal frontend test runs.

### Testing
- Ran the estimator unit tests: `cd frontend && npm test -- tokenPlaceContextEstimator.test.js` — all tests passed. ✅
- Re-ran token.place client tests to ensure no regressions: `cd frontend && npm test -- tokenPlace.test.js` — all tests passed. ✅
- Ran the Phase 0 benchmark to produce and inspect synthetic JSON/Markdown output (no user data): `node scripts/benchmark-token-place-context.mjs` — artifacts produced and inspected, then removed. ✅
- Formatting/lint/build checks: `cd frontend && npm run check` and `cd frontend && npm run build` — both completed successfully. ✅
- Repository clean checks: `git diff --check` ran with no reported whitespace/errors. ✅

Notes: the estimator is intentionally conservative and deterministic; it never truncates payloads or sends prompt text to a server and is intended as a routing hint only (compute-side exact admission remains authoritative).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3adba5a0d8832f80b96b0128c1b35c)