### PR TITLE
Wire token.place 8K/64K context-tier routing and bounded 8K→64K retry

### DIFF
--- a/docs/qa/token-place-context-tiers.md
+++ b/docs/qa/token-place-context-tiers.md
@@ -1,0 +1,28 @@
+# token.place Context-tier QA Notes
+
+DSPACE token.place API v1 chat now estimates the sanitized encrypted request payload locally and
+requests the smallest compatible relay tier: `8k-fast` or `64k-full`. The relay selection request
+carries only coarse routing metadata (`model`, `context_tier`, and DSPACE capability markers); the
+actual chat messages, RAG context, and player state remain inside the encrypted API v1 envelope.
+
+## Expected staging checks
+
+1. Register healthy token.place API v1 compute nodes for both `8k-fast` and `64k-full`.
+2. Send a token-lite request and confirm it estimates `8k-fast`, routes to an 8K node when one is
+   healthy, and succeeds.
+3. Send a small full-fat DSPACE chat request and confirm it estimates `8k-fast` and normally uses
+   an 8K node.
+4. Send a large full-fat/RAG request and confirm it estimates `64k-full`, selects a 64K-capable
+   node, and succeeds when compute-side exact admission fits.
+5. Force an underestimated 8K overflow and confirm DSPACE retries exactly once on `64k-full` using
+   the same sanitized message payload with a new request id, cancel token, and node public key.
+6. Stop or saturate 8K capacity, send a small request, and confirm controlled relay spillover to a
+   `64k-full` node is accepted and recorded as spillover.
+7. Send an over-budget request and confirm DSPACE fails locally before relay selection with a clear
+   context-budget message.
+8. Inspect relay logs and confirm they contain no prompt text, RAG excerpts, player state,
+   decrypted response text, private keys, ciphertext dumps, or raw relay payloads.
+
+Safe diagnostics may include estimated/requested tier, selected tier, spillover, retry escalation,
+estimator version, estimated prompt tokens, reserved output tokens, timeout class, safe error code,
+and timings.

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -55,24 +55,31 @@ const makeRelayFetch = ({
 } = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
-        if (url.endsWith('/api/v1/relay/servers/next')) {
+        const path = new URL(url).pathname;
+        if (path.endsWith('/api/v1/relay/servers/next')) {
             const key =
                 serverFailureOnce &&
                 fetch.mock.calls.filter(([calledUrl]) =>
-                    calledUrl.endsWith('/api/v1/relay/servers/next')
+                    new URL(calledUrl).pathname.endsWith('/api/v1/relay/servers/next')
                 ).length === 1
                     ? relayServerKeys[1]
                     : relayServerKeys[0];
+            const requestedTier = new URL(url).searchParams.get('context_tier') || '8k-fast';
             return {
                 ok: true,
                 status: 200,
-                json: () => Promise.resolve({ server_public_key: key.publicKeyBase64 }),
+                json: () =>
+                    Promise.resolve({
+                        server_public_key: key.publicKeyBase64,
+                        selected_context_tier: requestedTier,
+                        selected_profile_id: `${requestedTier}-profile`,
+                    }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests')) {
+        if (path.endsWith('/api/v1/relay/requests')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ accepted }) };
         }
-        if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+        if (path.endsWith('/api/v1/relay/responses/retrieve')) {
             const status = retrieveStatuses[Math.min(retrieveCount, retrieveStatuses.length - 1)];
             retrieveCount += 1;
             if (status === 202) return { ok: false, status: 202, json: () => Promise.resolve({}) };
@@ -96,7 +103,7 @@ const makeRelayFetch = ({
                 json: () => Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests/cancel')) {
+        if (path.endsWith('/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
         }
         throw new Error(`Unexpected fetch URL ${url}`);
@@ -109,7 +116,8 @@ const getFetchCalls = () =>
         init,
         body: init.body ? JSON.parse(init.body) : undefined,
     }));
-const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+const getFetchCallByPath = (path) =>
+    getFetchCalls().find((call) => new URL(call.url).pathname.endsWith(path));
 
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
@@ -183,17 +191,23 @@ describe('token.place API v1 client', () => {
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        {
+            const selectedUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+            expect(`${selectedUrl.origin}${selectedUrl.pathname}`).toBe(
+                'https://staging.token.place/api/v1/relay/servers/next'
+            );
+        }
     });
 
     test('VITE_TOKEN_PLACE_URL production override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://token.place/api/v1/relay/servers/next'
-        );
+        {
+            const selectedUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+            expect(`${selectedUrl.origin}${selectedUrl.pathname}`).toBe(
+                'https://token.place/api/v1/relay/servers/next'
+            );
+        }
     });
 
     test('explicit url overrides state and runtime compatibility values', async () => {
@@ -203,18 +217,24 @@ describe('token.place API v1 client', () => {
             url: 'https://explicit.token.place/api/v1',
             runtimeUrl: 'https://runtime.token.place',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://explicit.token.place/api/v1/relay/servers/next'
-        );
+        {
+            const selectedUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+            expect(`${selectedUrl.origin}${selectedUrl.pathname}`).toBe(
+                'https://explicit.token.place/api/v1/relay/servers/next'
+            );
+        }
     });
 
     test('state tokenPlace url compatibility override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
         loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://state.token.place/api/v1/relay/servers/next'
-        );
+        {
+            const selectedUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+            expect(`${selectedUrl.origin}${selectedUrl.pathname}`).toBe(
+                'https://state.token.place/api/v1/relay/servers/next'
+            );
+        }
     });
 
     test('runtime url is used before saved state and VITE fallback', async () => {
@@ -223,9 +243,12 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             runtimeUrl: 'https://staging.token.place/api',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        {
+            const selectedUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+            expect(`${selectedUrl.origin}${selectedUrl.pathname}`).toBe(
+                'https://staging.token.place/api/v1/relay/servers/next'
+            );
+        }
     });
 
     test('legacy /api base normalizes without /api/api duplication', () => {
@@ -994,12 +1017,18 @@ ${ragExcerpt.repeat(4000)}`,
                 gameState: {},
             },
         });
-        expect(result).toEqual({
-            text: 'mocked reply',
-            contextSources: dspaceSources,
-            usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
-            metadata: { client: 'dspace', conversation_id: 'conv-42' },
-        });
+        expect(result).toEqual(
+            expect.objectContaining({
+                text: 'mocked reply',
+                contextSources: dspaceSources,
+                usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+                metadata: expect.objectContaining({
+                    client: 'dspace',
+                    conversation_id: 'conv-42',
+                    tokenPlaceContext: expect.any(Object),
+                }),
+            })
+        );
     });
 
     test('passes abort signal to fetch', async () => {
@@ -1221,10 +1250,10 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const serverSelections = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/servers/next')
+            new URL(url).pathname.endsWith('/api/v1/relay/servers/next')
         );
         const dispatches = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/requests')
+            new URL(url).pathname.endsWith('/api/v1/relay/requests')
         );
         expect(serverSelections).toHaveLength(2);
         expect(dispatches).toHaveLength(2);
@@ -1285,7 +1314,8 @@ ${ragExcerpt.repeat(4000)}`,
 
     test('no available compute node, relay unavailable, malformed encrypted response, and disconnected server classify safely', async () => {
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            const path = new URL(url).pathname;
+            if (path.endsWith('/api/v1/relay/servers/next')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({}) };
             }
             throw new Error(`Unexpected URL ${url}`);
@@ -1293,7 +1323,8 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
 
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            const path = new URL(url).pathname;
+            if (path.endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: false,
                     status: 503,
@@ -1306,7 +1337,8 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ status: 503 });
 
         global.fetch = jest.fn(async (url, init = {}) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            const path = new URL(url).pathname;
+            if (path.endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: true,
                     status: 200,
@@ -1314,10 +1346,10 @@ ${ragExcerpt.repeat(4000)}`,
                         Promise.resolve({ server_public_key: relayServerKeys[0].publicKeyBase64 }),
                 };
             }
-            if (url.endsWith('/api/v1/relay/requests')) {
+            if (path.endsWith('/api/v1/relay/requests')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
             }
-            if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+            if (path.endsWith('/api/v1/relay/responses/retrieve')) {
                 return {
                     ok: true,
                     status: 200,
@@ -1349,5 +1381,238 @@ ${ragExcerpt.repeat(4000)}`,
         const serializedRequest = JSON.stringify(getFetchCallByPath('/api/v1/relay/requests').body);
         expect(serializedRequest).not.toMatch(/token\.place is deferred/i);
         expect(serializedRequest).not.toMatch(/chat uses OpenAI/i);
+    });
+});
+
+describe('token.place context tier routing', () => {
+    beforeEach(async () => {
+        relayServerKeys = [
+            await generateTokenPlaceClientKeypair(),
+            await generateTokenPlaceClientKeypair(),
+        ];
+        relayReply = { choices: [{ message: { content: 'mocked reply' } }] };
+        global.fetch = makeRelayFetch();
+        loadGameState.mockReturnValue({});
+        searchDocsRag.mockResolvedValue({ excerptsText: '', sources: [] });
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('server selection receives model and estimated 8K tier and encrypted request repeats routing tier', async () => {
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'small prompt' }], {
+            model: 'tier-test-model',
+        });
+
+        const serverCall = getFetchCallByPath('/api/v1/relay/servers/next');
+        const serverUrl = new URL(serverCall.url);
+        expect(serverUrl.searchParams.get('model')).toBe('tier-test-model');
+        expect(serverUrl.searchParams.get('context_tier')).toBe('8k-fast');
+
+        const decrypted = await decryptFirstRelayRequest();
+        expect(decrypted.api_v1_request.routing).toEqual({
+            context_tier: '8k-fast',
+            selected_profile_id: '8k-fast-profile',
+        });
+        expect(result.metadata.tokenPlaceContext).toEqual(
+            expect.objectContaining({
+                requestedTier: '8k-fast',
+                selectedTier: '8k-fast',
+                spillover: false,
+                estimatorVersion: expect.any(String),
+                estimatedPromptTokens: expect.any(Number),
+                reservedOutputTokens: expect.any(Number),
+                timeoutClass: '8k-fast',
+            })
+        );
+    });
+
+    test('large sanitized prompt selects 64K tier', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [
+                    { role: 'system', content: 'large context '.repeat(22000) },
+                    { role: 'user', content: 'answer from this large context' },
+                ],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+
+        const serverUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+        expect(serverUrl.searchParams.get('context_tier')).toBe('64k-full');
+        const decrypted = await decryptFirstRelayRequest();
+        expect(decrypted.api_v1_request.routing.context_tier).toBe('64k-full');
+    });
+
+    test('over 64K prompt fails locally before relay selection with safe diagnostics', async () => {
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [
+                        { role: 'system', content: 'oversized context '.repeat(90000) },
+                    ],
+                    contextSources: [],
+                    gameState: {},
+                },
+                reservedOutputTokens: 70000,
+            })
+        ).rejects.toMatchObject({
+            code: 'dspace_context_budget_exceeded',
+            contextDiagnostics: {
+                estimatedPromptTokens: expect.any(Number),
+                reservedOutputTokens: expect.any(Number),
+                selectedTier: null,
+                estimatorVersion: expect.any(String),
+            },
+        });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('larger selected tier is accepted as spillover and uses 64K timeout class', async () => {
+        global.fetch = makeRelayFetch();
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn(async (url, init) => {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key: relayServerKeys[0].publicKeyBase64,
+                            selected_context_tier: '64k-full',
+                        }),
+                };
+            }
+            return originalFetch(url, init);
+        });
+
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'small prompt' }]);
+        expect(result.metadata.tokenPlaceContext).toEqual(
+            expect.objectContaining({
+                requestedTier: '8k-fast',
+                selectedTier: '64k-full',
+                spillover: true,
+                timeoutClass: '64k-full',
+            })
+        );
+    });
+
+    test('smaller selected tier fails safely for a 64K request', async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key: relayServerKeys[0].publicKeyBase64,
+                            selected_context_tier: '8k-fast',
+                        }),
+                };
+            }
+            throw new Error(`Unexpected fetch URL ${url}`);
+        });
+
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [
+                        { role: 'system', content: 'large context '.repeat(22000) },
+                        { role: 'user', content: 'answer from this large context' },
+                    ],
+                    contextSources: [],
+                    gameState: {},
+                },
+            })
+        ).rejects.toMatchObject({ type: 'malformed' });
+    });
+
+    test('8K exact overflow retries once on 64K with a new request and unchanged messages', async () => {
+        let requestCount = 0;
+        relayReply = {
+            error: {
+                code: 'compute_node_context_window_exceeded',
+                message: 'context overflow',
+                retryable: true,
+                recommended_context_tier: '64k-full',
+            },
+        };
+        global.fetch = jest.fn(async (url, init = {}) => {
+            const path = new URL(url).pathname;
+            if (path.endsWith('/api/v1/relay/servers/next')) {
+                const tier = new URL(url).searchParams.get('context_tier');
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key:
+                                tier === '64k-full'
+                                    ? relayServerKeys[1].publicKeyBase64
+                                    : relayServerKeys[0].publicKeyBase64,
+                            selected_context_tier: tier,
+                        }),
+                };
+            }
+            if (path.endsWith('/api/v1/relay/requests')) {
+                requestCount += 1;
+                return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
+            }
+            if (path.endsWith('/api/v1/relay/responses/retrieve')) {
+                const body = JSON.parse(init.body);
+                const clientPublicPem = decodeBase64Text(body.client_public_key);
+                const api_v1_response =
+                    requestCount === 1
+                        ? relayReply
+                        : { choices: [{ message: { content: 'retry success' } }] };
+                const encrypted = await encryptTokenPlaceEnvelope(
+                    {
+                        protocol: 'tokenplace_api_v1_relay_e2ee',
+                        version: 1,
+                        request_id: body.request_id,
+                        client_public_key: body.client_public_key,
+                        api_v1_response,
+                    },
+                    clientPublicPem
+                );
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
+                };
+            }
+            throw new Error(`Unexpected fetch URL ${url}`);
+        });
+
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'retry me' }], {
+            promptPayload: {
+                combinedMessages: [{ role: 'user', content: 'retry me' }],
+                contextSources: [{ title: 'source', url: '/docs/about' }],
+                gameState: {},
+            },
+        });
+
+        const requests = getFetchCalls().filter((call) =>
+            new URL(call.url).pathname.endsWith('/api/v1/relay/requests')
+        );
+        expect(requests).toHaveLength(2);
+        expect(requests[0].body.request_id).not.toBe(requests[1].body.request_id);
+        expect(requests[0].body.cancel_token).not.toBe(requests[1].body.cancel_token);
+        const first = await decryptTokenPlaceEnvelope(
+            requests[0].body,
+            relayServerKeys[0].privateKey
+        );
+        const second = await decryptTokenPlaceEnvelope(
+            requests[1].body,
+            relayServerKeys[1].privateKey
+        );
+        expect(second.api_v1_request.messages).toEqual(first.api_v1_request.messages);
+        expect(second.api_v1_request.routing.context_tier).toBe('64k-full');
+        expect(result.text).toBe('retry success');
+        expect(result.contextSources).toEqual([{ title: 'source', url: '/docs/about' }]);
+        expect(result.metadata.tokenPlaceContext.escalationRetry).toBe(true);
     });
 });

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -9,6 +9,10 @@ import {
     TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from './tokenPlaceMessages.js';
 import {
+    estimateTokenPlaceContextForSanitizedMessages,
+    TOKEN_PLACE_CONTEXT_TIERS,
+} from './tokenPlaceContextEstimator.js';
+import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
@@ -19,7 +23,9 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_8K_FAST_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_64K_FULL_TIMEOUT_MS = 120_000;
+const DEFAULT_RELAY_TIMEOUT_MS = TOKEN_PLACE_8K_FAST_TIMEOUT_MS;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 export {
     sanitizeTokenPlaceMessages,
@@ -383,9 +389,41 @@ const fetchJson = async (url, init, unavailableMessage) => {
     }
 };
 
+const TIER_ORDER = Object.freeze(['8k-fast', '64k-full']);
+
+const getTierRank = (tier) => TIER_ORDER.indexOf(String(tier || ''));
+const canSatisfyTier = (selectedTier, requestedTier) => {
+    const selectedRank = getTierRank(selectedTier);
+    const requestedRank = getTierRank(requestedTier);
+    return selectedRank >= 0 && requestedRank >= 0 && selectedRank >= requestedRank;
+};
+
+const readSelectedContextTier = (data) =>
+    data?.selected_context_tier ||
+    data?.selectedContextTier ||
+    data?.context_tier ||
+    data?.contextTier ||
+    data?.profile?.context_tier ||
+    data?.profile?.contextTier ||
+    (Array.isArray(data?.capabilities?.context_tiers)
+        ? data.capabilities.context_tiers[0]
+        : undefined) ||
+    (Array.isArray(data?.capabilities?.contextTiers)
+        ? data.capabilities.contextTiers[0]
+        : undefined);
+
+const buildServerSelectionUrl = (baseUrl, options = {}) => {
+    const url = new URL(`${baseUrl}/api/v1/relay/servers/next`);
+    if (options.model) url.searchParams.set('model', options.model);
+    if (options.contextTier) url.searchParams.set('context_tier', options.contextTier);
+    url.searchParams.set('client', 'dspace');
+    url.searchParams.set('api_v1_e2ee', '1');
+    return url.toString();
+};
+
 export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     const data = await fetchJson(
-        `${baseUrl}/api/v1/relay/servers/next`,
+        buildServerSelectionUrl(baseUrl, options),
         { method: 'GET', signal: options.signal },
         'token.place relay is unavailable.'
     );
@@ -393,7 +431,34 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     if (!rawKey)
         throw createMalformedTokenPlaceResponseError('No token.place compute node is available.');
     const normalized = normalizeTokenPlacePublicKey(rawKey);
-    return { ...data, server_public_key: normalized.base64, serverPublicKeyPem: normalized.pem };
+    const requestedContextTier = options.contextTier;
+    const selectedContextTier = readSelectedContextTier(data);
+    if (requestedContextTier && !selectedContextTier) {
+        throw createMalformedTokenPlaceResponseError(
+            'token.place selected compute node is missing context tier metadata.'
+        );
+    }
+    if (requestedContextTier && !canSatisfyTier(selectedContextTier, requestedContextTier)) {
+        throw createMalformedTokenPlaceResponseError(
+            'token.place selected an incompatible context tier.'
+        );
+    }
+    const selectedProfile = data?.selected_profile || data?.selectedProfile || data?.profile;
+    const selectedProfileId =
+        data?.selected_profile_id ||
+        data?.selectedProfileId ||
+        selectedProfile?.id ||
+        selectedProfile?.profile_id;
+    return {
+        ...data,
+        server_public_key: normalized.base64,
+        serverPublicKeyPem: normalized.pem,
+        requestedContextTier,
+        selectedContextTier,
+        selectedProfile,
+        selectedProfileId,
+        spillover: Boolean(requestedContextTier && selectedContextTier !== requestedContextTier),
+    };
 };
 
 export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
@@ -554,12 +619,38 @@ const resolveTokenPlacePromptPayload = async (messages, options = {}) => {
 
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
-    messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
+    messages:
+        options.sanitizedMessages || sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
     options: {},
+    routing: {
+        context_tier: options.contextTier,
+        ...(options.selectedProfileId ? { selected_profile_id: options.selectedProfileId } : {}),
+    },
 });
 
+const getTimeoutForTier = (tier) =>
+    tier === '64k-full' ? TOKEN_PLACE_64K_FULL_TIMEOUT_MS : TOKEN_PLACE_8K_FAST_TIMEOUT_MS;
+
+const createLocalContextLimitError = (estimate) => {
+    const error = createTokenPlaceHttpError(413, {
+        error: {
+            code: 'dspace_context_budget_exceeded',
+            message:
+                'This DSPACE chat prompt is too large for token.place 64K context. Try a shorter request or reduce attached context.',
+        },
+    });
+    error.contextDiagnostics = {
+        estimatedPromptTokens: estimate.estimatedPromptTokens,
+        reservedOutputTokens: estimate.reservedOutputTokens,
+        selectedTier: null,
+        estimatorVersion: estimate.estimatorVersion,
+    };
+    return error;
+};
+
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
-    const server = await selectTokenPlaceRelayServer(baseUrl, options);
+    const model = getTokenPlaceChatModel(options);
+    const server = await selectTokenPlaceRelayServer(baseUrl, { ...options, model });
     const clientKeys = options.clientKeys || (await generateTokenPlaceClientKeypair());
     const requestId = options.requestId || randomBase64Url();
     const cancelToken = options.cancelToken || randomBase64Url();
@@ -568,7 +659,10 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         version: RELAY_VERSION,
         request_id: requestId,
         client_public_key: clientKeys.publicKeyBase64,
-        api_v1_request: buildApiV1Request(promptPayload, options),
+        api_v1_request: buildApiV1Request(promptPayload, {
+            ...options,
+            selectedProfileId: server.selectedProfileId,
+        }),
     };
     const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
     const dispatched = await dispatchTokenPlaceRelayRequest(
@@ -590,7 +684,13 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     const encryptedResponse = await pollTokenPlaceRelayResponse(
         baseUrl,
         { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
-        { ...options, cancelToken }
+        {
+            ...options,
+            cancelToken,
+            timeoutMs:
+                options.timeoutMs ??
+                getTimeoutForTier(server.selectedContextTier || options.contextTier),
+        }
     );
     if (encryptedResponse?.terminalSelectedServerFailure) return encryptedResponse;
     let responseEnvelope;
@@ -602,10 +702,24 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     } catch (error) {
         throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
     }
-    return validateTokenPlaceResponseEnvelope(responseEnvelope, {
+    const apiResponse = validateTokenPlaceResponseEnvelope(responseEnvelope, {
         requestId,
         clientPublicKey: clientKeys.publicKeyBase64,
     });
+    return {
+        apiResponse,
+        diagnostics: {
+            requestedTier: options.contextTier,
+            selectedTier: server.selectedContextTier,
+            spillover: server.spillover,
+            timeoutClass:
+                (server.selectedContextTier || options.contextTier) === '64k-full'
+                    ? '64k-full'
+                    : '8k-fast',
+            requestId,
+            cancelToken,
+        },
+    };
 };
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
@@ -620,18 +734,53 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         runtimeUrl: options.runtimeUrl,
     });
 
-    let data = await runRelayAttempt(baseUrl, promptPayload, options);
-    if (data?.terminalSelectedServerFailure) {
-        data = await runRelayAttempt(baseUrl, promptPayload, {
-            ...options,
+    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+    const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
+        reservedOutputTokens: options.reservedOutputTokens,
+        safetyMarginTokens: options.safetyMarginTokens,
+    });
+    if (contextEstimate.overLimit) throw createLocalContextLimitError(contextEstimate);
+    const initialContextTier =
+        contextEstimate.selectedTier || TOKEN_PLACE_CONTEXT_TIERS['64k-full'].id;
+    const attemptOptions = { ...options, sanitizedMessages, contextTier: initialContextTier };
+
+    let attempt = await runRelayAttempt(baseUrl, promptPayload, attemptOptions);
+    if (attempt?.terminalSelectedServerFailure) {
+        attempt = await runRelayAttempt(baseUrl, promptPayload, {
+            ...attemptOptions,
             requestId: undefined,
             cancelToken: undefined,
         });
-        if (data?.terminalSelectedServerFailure) {
+        if (attempt?.terminalSelectedServerFailure) {
             throw createMalformedTokenPlaceResponseError(
                 'No token.place compute node is available.'
             );
         }
+    }
+
+    let data = attempt.apiResponse;
+    const shouldRetry64k =
+        initialContextTier === '8k-fast' &&
+        attempt.diagnostics?.selectedTier !== '64k-full' &&
+        data?.error?.code === 'compute_node_context_window_exceeded' &&
+        (data.error.retryable === true ||
+            data.error.recommended_context_tier === '64k-full' ||
+            data.error.recommendedContextTier === '64k-full');
+    if (shouldRetry64k) {
+        const retry = await runRelayAttempt(baseUrl, promptPayload, {
+            ...options,
+            sanitizedMessages,
+            contextTier: '64k-full',
+            requestId: undefined,
+            cancelToken: undefined,
+        });
+        if (retry?.terminalSelectedServerFailure) {
+            throw createMalformedTokenPlaceResponseError(
+                'No token.place 64K compute node is available.'
+            );
+        }
+        attempt = retry;
+        data = retry.apiResponse;
     }
 
     throwStructuredTokenPlaceApiError(data);
@@ -642,7 +791,19 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         text,
         contextSources,
         usage: data?.usage,
-        metadata: data?.metadata,
+        metadata: {
+            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+            tokenPlaceContext: {
+                requestedTier: initialContextTier,
+                selectedTier: attempt.diagnostics?.selectedTier,
+                spillover: Boolean(attempt.diagnostics?.spillover),
+                escalationRetry: shouldRetry64k,
+                estimatorVersion: contextEstimate.estimatorVersion,
+                estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
+                reservedOutputTokens: contextEstimate.reservedOutputTokens,
+                timeoutClass: attempt.diagnostics?.timeoutClass,
+            },
+        },
     };
 };
 


### PR DESCRIPTION
### Motivation

- Route full-fat DSPACE chat through the local P7 estimator to request the smallest compatible token.place tier (`8k-fast` or `64k-full`) and provide a safe, bounded escalation path when compute-side exact admission overflows an 8K node. 
- Preserve relay blindness and API v1 E2EE while surfacing privacy-safe diagnostics and using tier-aware deadlines so small work stays on 8K nodes and large RAG fits 64K nodes when needed.

### Description

- Use the existing browser estimator by calling `estimateTokenPlaceContextForSanitizedMessages` on the single sanitized API v1 payload and select `context_tier` (`8k-fast` or `64k-full`) or fail locally if over 64K. (changes in `frontend/src/utils/tokenPlace.js`)
- Call the relay `/api/v1/relay/servers/next` with model and `context_tier` query params, validate the relay response (selected tier, public key, profile), accept larger selected tiers as controlled spillover, and record `spillover` diagnostics. (server selection url and validation in `selectTokenPlaceRelayServer`)
- Embed routing metadata inside the encrypted API v1 request as `api_v1_request.routing.context_tier` and include selected-profile echo if present, while keeping the outer relay dispatch ciphertext-only. (build and encrypt envelope in `runRelayAttempt` / `buildApiV1Request`)
- Add named, testable timeouts `TOKEN_PLACE_8K_FAST_TIMEOUT_MS` and `TOKEN_PLACE_64K_FULL_TIMEOUT_MS` and use the selected tier to choose the safer polling timeout; ensure cancellation posts `requests/cancel`. (timeout constants and usage)
- Implement one bounded retry path that triggers only when initial request requested `8k-fast`, selected node was not already `64k-full`, decrypted error code is `compute_node_context_window_exceeded`, and the error is retryable or recommends `64k-full`; the retry reuses the exact sanitized messages but re-encrypts for a fresh server with a new request id and cancel token. (retry orchestration in `TokenPlaceChatV2`)
- Fail locally and early if the estimator reports over 64K with a clear `dspace_context_budget_exceeded` error and attach safe diagnostics (estimated tokens, reserved output, estimator version). (local-over-limit handling)
- Preserve token-lite behavior and E2EE path while passing additional context diagnostics into result metadata under `metadata.tokenPlaceContext`. (token-lite preservation and metadata enrichment)
- Tests and QA: extend and adjust `frontend/__tests__/tokenPlace.test.js` to cover model+tier server selection, encrypted routing presence, selected-profile echo, spillover acceptance, smaller-tier rejection, local over-limit, and bounded retry behavior; add QA notes `docs/qa/token-place-context-tiers.md`.

### Testing

- Ran `cd frontend && npm test -- tokenPlace.test.js` which executed 64 tests and reported all tests passing after the changes. 
- Ran `cd frontend && npm run check` which ran lint/format checks and passed with Prettier formatting OK. 
- Built the client/server with `cd frontend && npm run build` which completed successfully. 
- Ran the context benchmark `npm run benchmark:token-place-context` which wrote artifacts and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de4285454832f9091cf442d57745f)