### PR TITLE
Wire token.place 8K/64K context-tier routing

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -48,31 +48,43 @@ let relayReply = {
     choices: [{ message: { content: 'mocked reply' } }],
 };
 
+const urlPath = (url) => new URL(url).pathname;
+const urlSearch = (url) => Object.fromEntries(new URL(url).searchParams.entries());
 const makeRelayFetch = ({
     retrieveStatuses = [200],
     serverFailureOnce = false,
     accepted = true,
+    serverResponses = null,
 } = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
-        if (url.endsWith('/api/v1/relay/servers/next')) {
+        if (urlPath(url).endsWith('/api/v1/relay/servers/next')) {
             const key =
                 serverFailureOnce &&
                 fetch.mock.calls.filter(([calledUrl]) =>
-                    calledUrl.endsWith('/api/v1/relay/servers/next')
+                    urlPath(calledUrl).endsWith('/api/v1/relay/servers/next')
                 ).length === 1
                     ? relayServerKeys[1]
                     : relayServerKeys[0];
             return {
                 ok: true,
                 status: 200,
-                json: () => Promise.resolve({ server_public_key: key.publicKeyBase64 }),
+                json: () =>
+                    Promise.resolve({
+                        server_public_key: key.publicKeyBase64,
+                        context_tier: urlSearch(url).context_tier || '8k-fast',
+                        ...(serverResponses?.[
+                            fetch.mock.calls.filter(([calledUrl]) =>
+                                urlPath(calledUrl).endsWith('/api/v1/relay/servers/next')
+                            ).length - 1
+                        ] || {}),
+                    }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests')) {
+        if (urlPath(url).endsWith('/api/v1/relay/requests')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ accepted }) };
         }
-        if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+        if (urlPath(url).endsWith('/api/v1/relay/responses/retrieve')) {
             const status = retrieveStatuses[Math.min(retrieveCount, retrieveStatuses.length - 1)];
             retrieveCount += 1;
             if (status === 202) return { ok: false, status: 202, json: () => Promise.resolve({}) };
@@ -96,7 +108,7 @@ const makeRelayFetch = ({
                 json: () => Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests/cancel')) {
+        if (urlPath(url).endsWith('/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
         }
         throw new Error(`Unexpected fetch URL ${url}`);
@@ -109,7 +121,8 @@ const getFetchCalls = () =>
         init,
         body: init.body ? JSON.parse(init.body) : undefined,
     }));
-const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+const getFetchCallByPath = (path) =>
+    getFetchCalls().find((call) => urlPath(call.url).endsWith(path));
 
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
@@ -183,17 +196,19 @@ describe('token.place API v1 client', () => {
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                urlPath(getFetchCallByPath('/api/v1/relay/servers/next').url)
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('VITE_TOKEN_PLACE_URL production override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                urlPath(getFetchCallByPath('/api/v1/relay/servers/next').url)
+        ).toBe('https://token.place/api/v1/relay/servers/next');
     });
 
     test('explicit url overrides state and runtime compatibility values', async () => {
@@ -203,18 +218,20 @@ describe('token.place API v1 client', () => {
             url: 'https://explicit.token.place/api/v1',
             runtimeUrl: 'https://runtime.token.place',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://explicit.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                urlPath(getFetchCallByPath('/api/v1/relay/servers/next').url)
+        ).toBe('https://explicit.token.place/api/v1/relay/servers/next');
     });
 
     test('state tokenPlace url compatibility override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
         loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://state.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                urlPath(getFetchCallByPath('/api/v1/relay/servers/next').url)
+        ).toBe('https://state.token.place/api/v1/relay/servers/next');
     });
 
     test('runtime url is used before saved state and VITE fallback', async () => {
@@ -223,9 +240,10 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             runtimeUrl: 'https://staging.token.place/api',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                urlPath(getFetchCallByPath('/api/v1/relay/servers/next').url)
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('legacy /api base normalizes without /api/api duplication', () => {
@@ -358,6 +376,113 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+    });
+
+    test('servers/next receives model and estimated context tier, and encrypted routing is private', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello routing' }], {
+            model: 'test-model',
+        });
+        const serverCall = getFetchCallByPath('/api/v1/relay/servers/next');
+        expect(urlSearch(serverCall.url)).toMatchObject({
+            model: 'test-model',
+            context_tier: '8k-fast',
+            client_supports_context_tiers: 'true',
+        });
+        const relayBody = getFetchCallByPath('/api/v1/relay/requests').body;
+        expect(JSON.stringify(relayBody)).not.toContain('hello routing');
+        const decrypted = await decryptTokenPlaceEnvelope(relayBody, relayServerKeys[0].privateKey);
+        expect(decrypted.api_v1_request.routing).toMatchObject({ context_tier: '8k-fast' });
+    });
+
+    test('64K estimates request 64k-full and over-limit prompts fail locally', async () => {
+        const large = 'x'.repeat(30_000);
+        await TokenPlaceChatV2([], {
+            promptPayload: { combinedMessages: [{ role: 'user', content: large }], gameState: {} },
+        });
+        expect(urlSearch(getFetchCallByPath('/api/v1/relay/servers/next').url).context_tier).toBe(
+            '64k-full'
+        );
+
+        fetch.mockClear();
+        const overLimit = 'x'.repeat(250_000);
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [{ role: 'user', content: overLimit }],
+                    gameState: {},
+                },
+                safetyMarginTokens: 70_000,
+            })
+        ).rejects.toMatchObject({ code: 'token_place_context_over_limit' });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('larger selected tier records spillover and smaller selected tier fails safely', async () => {
+        global.fetch = makeRelayFetch({ serverResponses: [{ context_tier: '64k-full' }] });
+        const spill = await TokenPlaceChatV2([{ role: 'user', content: 'small spillover' }]);
+        expect(spill.metadata.tokenPlaceContext).toMatchObject({
+            requestedTier: '8k-fast',
+            selectedTier: '64k-full',
+            spillover: true,
+            timeoutClass: '64k-full',
+        });
+
+        global.fetch = makeRelayFetch({ serverResponses: [{ context_tier: '8k-fast' }] });
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [{ role: 'user', content: 'x'.repeat(30_000) }],
+                    gameState: {},
+                },
+            })
+        ).rejects.toMatchObject({ type: 'malformed' });
+    });
+
+    test('8K exact overflow retries once on 64K with unchanged messages and fresh request', async () => {
+        relayReply = {
+            error: {
+                code: 'compute_node_context_window_exceeded',
+                status: 400,
+                retryable: true,
+                recommended_context_tier: '64k-full',
+            },
+        };
+        let retrieveCount = 0;
+        global.fetch = makeRelayFetch({
+            serverResponses: [{ context_tier: '8k-fast' }, { context_tier: '64k-full' }],
+        });
+        const baseFetch = global.fetch;
+        global.fetch = vi.fn(async (url, init) => {
+            if (urlPath(url).endsWith('/api/v1/relay/responses/retrieve')) {
+                retrieveCount += 1;
+                if (retrieveCount === 2) relayReply = { message: { content: 'retry reply' } };
+            }
+            return baseFetch(url, init);
+        });
+
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'retry me' }]);
+        expect(result.text).toBe('retry reply');
+        expect(result.metadata.tokenPlaceContext).toMatchObject({
+            requestedTier: '64k-full',
+            selectedTier: '64k-full',
+            escalationRetry: true,
+        });
+        const requests = getFetchCalls().filter((call) =>
+            urlPath(call.url).endsWith('/api/v1/relay/requests')
+        );
+        expect(requests).toHaveLength(2);
+        expect(requests[0].body.request_id).not.toBe(requests[1].body.request_id);
+        const first = await decryptTokenPlaceEnvelope(
+            requests[0].body,
+            relayServerKeys[0].privateKey
+        );
+        const second = await decryptTokenPlaceEnvelope(
+            requests[1].body,
+            relayServerKeys[0].privateKey
+        );
+        expect(second.api_v1_request.messages).toEqual(first.api_v1_request.messages);
+        expect(first.api_v1_request.routing.context_tier).toBe('8k-fast');
+        expect(second.api_v1_request.routing.context_tier).toBe('64k-full');
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {
@@ -994,11 +1119,22 @@ ${ragExcerpt.repeat(4000)}`,
                 gameState: {},
             },
         });
-        expect(result).toEqual({
+        expect(result).toMatchObject({
             text: 'mocked reply',
             contextSources: dspaceSources,
             usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
-            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+            metadata: {
+                client: 'dspace',
+                conversation_id: 'conv-42',
+                tokenPlaceContext: {
+                    estimatedTier: '8k-fast',
+                    requestedTier: '8k-fast',
+                    selectedTier: '8k-fast',
+                    spillover: false,
+                    escalationRetry: false,
+                    estimatorVersion: 'dspace-token-context-estimator-v1',
+                },
+            },
         });
     });
 
@@ -1210,7 +1346,7 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const retrieveCalls = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/responses/retrieve')
+            urlPath(url).endsWith('/api/v1/relay/responses/retrieve')
         );
         expect(retrieveCalls).toHaveLength(3);
     });
@@ -1221,10 +1357,10 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const serverSelections = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/servers/next')
+            urlPath(url).endsWith('/api/v1/relay/servers/next')
         );
         const dispatches = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/requests')
+            urlPath(url).endsWith('/api/v1/relay/requests')
         );
         expect(serverSelections).toHaveLength(2);
         expect(dispatches).toHaveLength(2);
@@ -1239,7 +1375,7 @@ ${ragExcerpt.repeat(4000)}`,
             })
         ).rejects.toMatchObject({ status: 408 });
         expect(
-            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/requests/cancel'))
+            fetch.mock.calls.some(([url]) => urlPath(url).endsWith('/api/v1/relay/requests/cancel'))
         ).toBe(true);
     });
 
@@ -1251,7 +1387,9 @@ ${ragExcerpt.repeat(4000)}`,
             message: 'token.place relay rejected the request.',
         });
         expect(
-            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/responses/retrieve'))
+            fetch.mock.calls.some(([url]) =>
+                urlPath(url).endsWith('/api/v1/relay/responses/retrieve')
+            )
         ).toBe(false);
     });
 
@@ -1285,7 +1423,7 @@ ${ragExcerpt.repeat(4000)}`,
 
     test('no available compute node, relay unavailable, malformed encrypted response, and disconnected server classify safely', async () => {
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPath(url).endsWith('/api/v1/relay/servers/next')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({}) };
             }
             throw new Error(`Unexpected URL ${url}`);
@@ -1293,7 +1431,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
 
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPath(url).endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: false,
                     status: 503,
@@ -1306,7 +1444,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ status: 503 });
 
         global.fetch = jest.fn(async (url, init = {}) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPath(url).endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: true,
                     status: 200,
@@ -1314,10 +1452,10 @@ ${ragExcerpt.repeat(4000)}`,
                         Promise.resolve({ server_public_key: relayServerKeys[0].publicKeyBase64 }),
                 };
             }
-            if (url.endsWith('/api/v1/relay/requests')) {
+            if (urlPath(url).endsWith('/api/v1/relay/requests')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
             }
-            if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+            if (urlPath(url).endsWith('/api/v1/relay/responses/retrieve')) {
                 return {
                     ok: true,
                     status: 200,

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -38,20 +38,14 @@ default.
 
 ## v3.1 / P8 relay E2EE implementation target
 
-The relay E2EE flow below is the v3.1 / P8 implementation target and the production/staging
-promotion gate for P8b. Until that client implementation lands, the shipped DSPACE Chat client is
-being corrected from its legacy plaintext token.place API v1 request path. Operators should not use
-the relay-route sequence below as evidence that today's shipped `/chat` client already dispatches
-relay-blind requests; use it as the required target for the P8b implementation PR and release
-sign-off.
-
-DSPACE v3.1 / P8 requires token.place API v1 relay E2EE routes for the default Chat path. The
-browser must generate a DSPACE `/chat` client keypair, fetch a compute node with
-`GET /api/v1/relay/servers/next`, build a `tokenplace_api_v1_relay_e2ee` envelope with
-`client_public_key`, encrypt that API v1 chat request envelope for the compute node, dispatch
-ciphertext with `POST /api/v1/relay/requests`, poll
-`POST /api/v1/relay/responses/retrieve`, then decrypt and validate the response client-side
-before reading `api_v1_response.choices[0].message.content`.
+DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The
+browser generates a DSPACE `/chat` client keypair, estimates the sanitized API v1 message payload
+locally, requests a compute node with `GET /api/v1/relay/servers/next`, builds a
+`tokenplace_api_v1_relay_e2ee` envelope with `client_public_key`, encrypts that API v1 chat request
+envelope for the compute node, dispatches ciphertext with `POST /api/v1/relay/requests`, polls
+`POST /api/v1/relay/responses/retrieve`, then decrypts and validates the response client-side
+before reading `api_v1_response.message.content` or
+`api_v1_response.choices[0].message.content`.
 
 The relay request payload must be ciphertext-only plus safe routing metadata. token.place
 relay-owned state and logs must not receive plaintext DSPACE prompt messages, player state, docs
@@ -59,6 +53,35 @@ grounding, raw inventory, save data, OpenAI keys, token.place credentials, or ot
 default Chat path must not send plaintext `{ model, messages }` directly to
 `/api/v1/chat/completions`, use token.place API v2, stream responses, use the token.place npm
 package, send token.place auth/API keys, or fall back to deprecated legacy relay routes.
+
+## Context-tier routing and overflow handling
+
+DSPACE builds and sanitizes the final token.place API v1 `messages` array once per user send. The
+local DSPACE estimator then classifies that exact sanitized payload as `8k-fast`, `64k-full`, or
+over the 64K budget. The estimator uses only local message sizes, reserved output tokens, and a
+safety margin; it never sends prompt text, RAG excerpts, player state, or estimator internals to a
+server for sizing.
+
+Server selection passes the selected model and requested `context_tier` to
+`/api/v1/relay/servers/next`. DSPACE validates that the selected node can satisfy the requested tier,
+accepts deliberate token.place spillover from `8k-fast` to a larger `64k-full` node, and records only
+safe diagnostic fields such as requested tier, selected tier, spillover, estimator version,
+estimated prompt tokens, reserved output tokens, timeout class, safe error code, and timing data.
+The encrypted API v1 request also includes `api_v1_request.routing.context_tier`; exact token
+counts and prompt content remain out of relay-visible plaintext.
+
+If a locally estimated `8k-fast` request lands on an 8K node and the compute node returns the exact
+`compute_node_context_window_exceeded` error with a retryable 64K recommendation, DSPACE retries
+once on `64k-full`. The retry reuses the unchanged sanitized `messages` payload, preserves
+`contextSources`, reselects a fresh 64K-capable node, re-encrypts for that node's public key, and
+uses a new request ID and cancel token. DSPACE does not retry 64K overflows, malformed responses,
+policy errors, request-too-large errors, invalid requests, unsupported models, generic provider
+errors, or 8K requests that already spilled over to a 64K node.
+
+Prompts estimated over the 64K tier fail locally before relay selection with a clear context-budget
+message. Operators should verify staging with a healthy 8K node, a healthy 64K node, a forced 8K
+context-window overflow, a deliberate 8K-to-64K spillover scenario, and an over-64K local failure.
+Confirm token.place relay logs remain ciphertext-only plus safe routing metadata.
 
 API v1 remains non-streaming inside the encrypted envelope. Responses may appear after the full
 completion is ready rather than as a streaming token-by-token transcript.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -13,13 +13,16 @@ import {
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
 } from './tokenPlaceErrors.js';
+import { estimateTokenPlaceContextForSanitizedMessages } from './tokenPlaceContextEstimator.js';
 
 const DEFAULT_ORIGIN = 'https://token.place';
 const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_FAST_TIER_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_FULL_TIER_TIMEOUT_MS = 120_000;
+const DEFAULT_RELAY_TIMEOUT_MS = TOKEN_PLACE_FAST_TIER_TIMEOUT_MS;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 export {
     sanitizeTokenPlaceMessages,
@@ -383,9 +386,46 @@ const fetchJson = async (url, init, unavailableMessage) => {
     }
 };
 
+const CONTEXT_TIER_ORDER = Object.freeze({ '8k-fast': 0, '64k-full': 1 });
+const normalizeContextTier = (value) => {
+    const tier = String(value || '').trim();
+    return Object.prototype.hasOwnProperty.call(CONTEXT_TIER_ORDER, tier) ? tier : null;
+};
+const tierSatisfies = (selectedTier, requestedTier) =>
+    normalizeContextTier(selectedTier) !== null &&
+    normalizeContextTier(requestedTier) !== null &&
+    CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier];
+const getSelectedContextTier = (server) =>
+    normalizeContextTier(
+        server?.selected_context_tier ||
+            server?.selectedContextTier ||
+            server?.context_tier ||
+            server?.contextTier ||
+            server?.profile?.context_tier ||
+            server?.profile?.contextTier ||
+            server?.selected_profile?.context_tier ||
+            server?.selectedProfile?.contextTier
+    );
+const getSelectedProfileEcho = (server) =>
+    server?.selected_profile_id ||
+    server?.selectedProfileId ||
+    server?.profile_id ||
+    server?.profileId ||
+    server?.selected_profile?.id ||
+    server?.selectedProfile?.id ||
+    null;
+const buildServersNextUrl = (baseUrl, options = {}) => {
+    const url = new URL(`${baseUrl}/api/v1/relay/servers/next`);
+    if (options.model) url.searchParams.set('model', options.model);
+    if (options.contextTier) url.searchParams.set('context_tier', options.contextTier);
+    url.searchParams.set('client_supports_context_tiers', 'true');
+    return url.toString();
+};
+
 export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
+    const requestedTier = normalizeContextTier(options.contextTier);
     const data = await fetchJson(
-        `${baseUrl}/api/v1/relay/servers/next`,
+        buildServersNextUrl(baseUrl, options),
         { method: 'GET', signal: options.signal },
         'token.place relay is unavailable.'
     );
@@ -393,7 +433,20 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     if (!rawKey)
         throw createMalformedTokenPlaceResponseError('No token.place compute node is available.');
     const normalized = normalizeTokenPlacePublicKey(rawKey);
-    return { ...data, server_public_key: normalized.base64, serverPublicKeyPem: normalized.pem };
+    const selectedTier = getSelectedContextTier(data) || requestedTier;
+    if (requestedTier && !tierSatisfies(selectedTier, requestedTier)) {
+        throw createMalformedTokenPlaceResponseError(
+            'token.place selected compute node cannot satisfy the requested context tier.'
+        );
+    }
+    return {
+        ...data,
+        server_public_key: normalized.base64,
+        serverPublicKeyPem: normalized.pem,
+        selectedContextTier: selectedTier,
+        selectedProfileEcho: getSelectedProfileEcho(data),
+        spillover: Boolean(requestedTier && selectedTier && selectedTier !== requestedTier),
+    };
 };
 
 export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
@@ -552,13 +605,45 @@ const resolveTokenPlacePromptPayload = async (messages, options = {}) => {
     return buildChatPrompt(messages, options);
 };
 
-const buildApiV1Request = (promptPayload, options = {}) => ({
-    model: getTokenPlaceChatModel(options),
-    messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
-    options: {},
-});
+const buildApiV1Request = (sanitizedMessages, options = {}) => {
+    const request = {
+        model: getTokenPlaceChatModel(options),
+        messages: sanitizedMessages,
+        options: {},
+        routing: { context_tier: options.contextTier },
+    };
+    if (options.selectedProfileEcho)
+        request.routing.selected_profile_id = options.selectedProfileEcho;
+    return request;
+};
 
-const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
+const classifySanitizedTokenPlacePrompt = (sanitizedMessages, options = {}) => {
+    const estimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, options);
+    if (estimate.overLimit) {
+        const error = createMalformedTokenPlaceResponseError(
+            'This chat prompt is over token.place’s 64K context budget. Please shorten the request or reduce context and try again.'
+        );
+        error.code = 'token_place_context_over_limit';
+        error.context = {
+            estimatedPromptTokens: estimate.estimatedPromptTokens,
+            reservedOutputTokens: estimate.reservedOutputTokens,
+            selectedTier: null,
+            estimatorVersion: estimate.estimatorVersion,
+        };
+        throw error;
+    }
+    return estimate;
+};
+
+const getTimeoutClassForTier = (tier) => (tier === '64k-full' ? '64k-full' : '8k-fast');
+const getTimeoutMsForTier = (tier, options = {}) => {
+    if (options.timeoutMs !== undefined) return options.timeoutMs;
+    return getTimeoutClassForTier(tier) === '64k-full'
+        ? TOKEN_PLACE_FULL_TIER_TIMEOUT_MS
+        : TOKEN_PLACE_FAST_TIER_TIMEOUT_MS;
+};
+
+const runRelayAttempt = async (baseUrl, sanitizedMessages, options = {}) => {
     const server = await selectTokenPlaceRelayServer(baseUrl, options);
     const clientKeys = options.clientKeys || (await generateTokenPlaceClientKeypair());
     const requestId = options.requestId || randomBase64Url();
@@ -568,7 +653,10 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         version: RELAY_VERSION,
         request_id: requestId,
         client_public_key: clientKeys.publicKeyBase64,
-        api_v1_request: buildApiV1Request(promptPayload, options),
+        api_v1_request: buildApiV1Request(sanitizedMessages, {
+            ...options,
+            selectedProfileEcho: server.selectedProfileEcho,
+        }),
     };
     const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
     const dispatched = await dispatchTokenPlaceRelayRequest(
@@ -590,7 +678,14 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     const encryptedResponse = await pollTokenPlaceRelayResponse(
         baseUrl,
         { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
-        { ...options, cancelToken }
+        {
+            ...options,
+            cancelToken,
+            timeoutMs: getTimeoutMsForTier(
+                server.selectedContextTier || options.contextTier,
+                options
+            ),
+        }
     );
     if (encryptedResponse?.terminalSelectedServerFailure) return encryptedResponse;
     let responseEnvelope;
@@ -602,10 +697,19 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     } catch (error) {
         throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
     }
-    return validateTokenPlaceResponseEnvelope(responseEnvelope, {
+    const apiResponse = validateTokenPlaceResponseEnvelope(responseEnvelope, {
         requestId,
         clientPublicKey: clientKeys.publicKeyBase64,
     });
+    return {
+        apiResponse,
+        diagnostics: {
+            requestedTier: options.contextTier,
+            selectedTier: server.selectedContextTier,
+            spillover: server.spillover,
+            timeoutClass: getTimeoutClassForTier(server.selectedContextTier || options.contextTier),
+        },
+    };
 };
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
@@ -620,18 +724,58 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         runtimeUrl: options.runtimeUrl,
     });
 
-    let data = await runRelayAttempt(baseUrl, promptPayload, options);
-    if (data?.terminalSelectedServerFailure) {
-        data = await runRelayAttempt(baseUrl, promptPayload, {
+    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+    const estimate = classifySanitizedTokenPlacePrompt(sanitizedMessages, options);
+    const model = getTokenPlaceChatModel(options);
+    const runAttempt = (contextTier, attemptOptions = {}) =>
+        runRelayAttempt(baseUrl, sanitizedMessages, {
             ...options,
+            ...attemptOptions,
+            model,
+            contextTier,
+        });
+
+    let result = await runAttempt(estimate.selectedTier);
+    if (result?.terminalSelectedServerFailure) {
+        result = await runAttempt(estimate.selectedTier, {
             requestId: undefined,
             cancelToken: undefined,
         });
-        if (data?.terminalSelectedServerFailure) {
+        if (result?.terminalSelectedServerFailure) {
             throw createMalformedTokenPlaceResponseError(
                 'No token.place compute node is available.'
             );
         }
+    }
+
+    let data = result.apiResponse;
+    let diagnostics = {
+        ...result.diagnostics,
+        estimatedTier: estimate.selectedTier,
+        estimatorVersion: estimate.estimatorVersion,
+        estimatedPromptTokens: estimate.estimatedPromptTokens,
+        reservedOutputTokens: estimate.reservedOutputTokens,
+        escalationRetry: false,
+    };
+    if (
+        estimate.selectedTier === '8k-fast' &&
+        result.diagnostics?.selectedTier !== '64k-full' &&
+        data?.error?.code === 'compute_node_context_window_exceeded' &&
+        (data.error.retryable === true ||
+            data.error.recommended_context_tier === '64k-full' ||
+            data.error.recommended_tier === '64k-full')
+    ) {
+        const retryResult = await runAttempt('64k-full', {
+            requestId: undefined,
+            cancelToken: undefined,
+        });
+        data = retryResult.apiResponse;
+        diagnostics = {
+            ...diagnostics,
+            ...retryResult.diagnostics,
+            requestedTier: '64k-full',
+            escalationRetry: true,
+        };
     }
 
     throwStructuredTokenPlaceApiError(data);
@@ -642,7 +786,10 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         text,
         contextSources,
         usage: data?.usage,
-        metadata: data?.metadata,
+        metadata: {
+            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+            tokenPlaceContext: diagnostics,
+        },
     };
 };
 


### PR DESCRIPTION
### Motivation
- Route full-fat DSPACE chat through token.place with automatic local tier selection (8k-fast vs 64k-full), preserve relay E2EE, and provide a bounded safe escalation path for exact compute-side overflow.
- Ensure routing metadata and diagnostics are privacy-safe while allowing token.place P12 spillover to larger tiers when necessary.

### Description
- Integrate the local estimator into the token.place flow by classifying the sanitized API v1 `messages` payload and failing locally when the payload exceeds the 64K budget. 
- Pass `context_tier` and model to `/api/v1/relay/servers/next`, validate the relay-selected tier, accept larger selected tiers as controlled spillover, and include an optional selected-profile echo inside the encrypted envelope.
- Embed `api_v1_request.routing.context_tier` in the encrypted request and add tier-aware, testable timeout constants (`TOKEN_PLACE_FAST_TIER_TIMEOUT_MS`, `TOKEN_PLACE_FULL_TIER_TIMEOUT_MS`).
- Implement a single bounded retry: when a request initially classified/requested as `8k-fast` overflows with `compute_node_context_window_exceeded` and the error recommends/retryable to `64k-full`, reselect a fresh 64K node and retry once re-encrypting the exact same sanitized payload with a new request id and cancel token.
- Preserve token-lite behavior, API v1 response parsing, and relay blindness/E2EE while exposing safe diagnostics (requested/selected tier, spillover, estimator version, estimate tokens, timeout class, escalation flag) attached to returned metadata.

### Testing
- Ran focused unit/integration suite: `cd frontend && npm test -- tokenPlace.test.js` and all token.place tests passed (62 passed). 
- Ran repository checks and build: `cd frontend && npm run check && npm run build` both completed successfully with formatting/lint and Astro build passing. 
- Produced estimator benchmark: `npm run benchmark:token-place-context` which wrote artifacts under `artifacts/benchmarks/token-place-context/`.
- Updated/added focused tests that exercise: `/servers/next` model & context_tier query, encrypted `routing.context_tier`, 8K/64K selection and over-limit behavior, spillover acceptance/failure, single 8K→64K retry semantics, and timeout/cancel behavior; all test assertions passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de4316168832f8b1813d45e8f9ccb)