### PR TITLE
Wire token.place context-tier routing and bounded 8K→64K retry

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -55,11 +55,11 @@ const makeRelayFetch = ({
 } = {}) => {
     let retrieveCount = 0;
     return jest.fn(async (url, init = {}) => {
-        if (url.endsWith('/api/v1/relay/servers/next')) {
+        if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
             const key =
                 serverFailureOnce &&
                 fetch.mock.calls.filter(([calledUrl]) =>
-                    calledUrl.endsWith('/api/v1/relay/servers/next')
+                    new URL(calledUrl).pathname.endsWith('/api/v1/relay/servers/next')
                 ).length === 1
                     ? relayServerKeys[1]
                     : relayServerKeys[0];
@@ -109,7 +109,8 @@ const getFetchCalls = () =>
         init,
         body: init.body ? JSON.parse(init.body) : undefined,
     }));
-const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+const getFetchCallByPath = (path) =>
+    getFetchCalls().find((call) => new URL(call.url).pathname.endsWith(path));
 
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
@@ -183,17 +184,19 @@ describe('token.place API v1 client', () => {
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('VITE_TOKEN_PLACE_URL production override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://token.place/api/v1/relay/servers/next');
     });
 
     test('explicit url overrides state and runtime compatibility values', async () => {
@@ -203,18 +206,20 @@ describe('token.place API v1 client', () => {
             url: 'https://explicit.token.place/api/v1',
             runtimeUrl: 'https://runtime.token.place',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://explicit.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://explicit.token.place/api/v1/relay/servers/next');
     });
 
     test('state tokenPlace url compatibility override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
         loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://state.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://state.token.place/api/v1/relay/servers/next');
     });
 
     test('runtime url is used before saved state and VITE fallback', async () => {
@@ -223,9 +228,10 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             runtimeUrl: 'https://staging.token.place/api',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('legacy /api base normalizes without /api/api duplication', () => {
@@ -694,6 +700,178 @@ ${ragExcerpt.repeat(4000)}`,
         expectValidApiV1Messages(messages);
     });
 
+    test('server selection receives model and estimated context tier and encrypted routing echoes tier', async () => {
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello tier routing' }], {
+            model: 'tier-test-model',
+        });
+
+        const selectionUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+        expect(selectionUrl.searchParams.get('model')).toBe('tier-test-model');
+        expect(selectionUrl.searchParams.get('context_tier')).toBe('8k-fast');
+        expect(selectionUrl.searchParams.get('client_context_tiers')).toBe('1');
+
+        const decrypted = await decryptFirstRelayRequest();
+        expect(decrypted.api_v1_request.routing).toEqual({ context_tier: '8k-fast' });
+        expect(JSON.stringify(getFetchCallByPath('/api/v1/relay/requests').body)).not.toContain(
+            'hello tier routing'
+        );
+    });
+
+    test('large full-fat prompt selects 64k-full and over-64k prompt fails locally', async () => {
+        await TokenPlaceChatV2([], {
+            promptPayload: {
+                combinedMessages: [{ role: 'user', content: 'large context '.repeat(2500) }],
+                contextSources: [],
+                gameState: {},
+            },
+        });
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).searchParams.get(
+                'context_tier'
+            )
+        ).toBe('64k-full');
+
+        fetch.mockClear();
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [{ role: 'user', content: '🚀'.repeat(70_000) }],
+                    contextSources: [],
+                    gameState: {},
+                },
+            })
+        ).rejects.toMatchObject({ code: 'token_place_context_over_limit' });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('accepts larger selected tier as spillover and rejects smaller selected tier', async () => {
+        global.fetch = makeRelayFetch();
+        global.fetch.mockImplementation(async (url, init = {}) => {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key: relayServerKeys[0].publicKeyBase64,
+                            selected_context_tier: '64k-full',
+                            selected_profile_id: 'profile-64k',
+                        }),
+                };
+            }
+            return makeRelayFetch()(url, init);
+        });
+
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'small spillover' }]);
+        expect(result.metadata.tokenPlaceContext.spillover).toBe(true);
+        expect(result.metadata.tokenPlaceContext.selectedTier).toBe('64k-full');
+        const decrypted = await decryptFirstRelayRequest();
+        expect(decrypted.api_v1_request.routing).toEqual({
+            context_tier: '8k-fast',
+            selected_profile_id: 'profile-64k',
+        });
+
+        global.fetch = jest.fn(async (url) => {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key: relayServerKeys[0].publicKeyBase64,
+                            selected_context_tier: '8k-fast',
+                        }),
+                };
+            }
+            throw new Error(`Unexpected URL ${url}`);
+        });
+        await expect(
+            TokenPlaceChatV2([], {
+                promptPayload: {
+                    combinedMessages: [{ role: 'user', content: 'large context '.repeat(2500) }],
+                    contextSources: [],
+                    gameState: {},
+                },
+            })
+        ).rejects.toThrow(/insufficient context tier/i);
+    });
+
+    test('8k exact overflow retries once on 64k with unchanged messages and fresh request', async () => {
+        const seen = [];
+        global.fetch = jest.fn(async (url, init = {}) => {
+            const pathname = new URL(url).pathname;
+            if (pathname.endsWith('/api/v1/relay/servers/next')) {
+                const requestedTier = new URL(url).searchParams.get('context_tier');
+                const key = requestedTier === '64k-full' ? relayServerKeys[1] : relayServerKeys[0];
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({
+                            server_public_key: key.publicKeyBase64,
+                            selected_context_tier: requestedTier,
+                        }),
+                };
+            }
+            if (pathname.endsWith('/api/v1/relay/requests')) {
+                const body = JSON.parse(init.body);
+                const privateKey =
+                    seen.length === 0
+                        ? relayServerKeys[0].privateKey
+                        : relayServerKeys[1].privateKey;
+                const decrypted = await decryptTokenPlaceEnvelope(body, privateKey);
+                seen.push({
+                    body,
+                    messages: decrypted.api_v1_request.messages,
+                    routing: decrypted.api_v1_request.routing,
+                });
+                return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
+            }
+            if (pathname.endsWith('/api/v1/relay/responses/retrieve')) {
+                const body = JSON.parse(init.body);
+                const isRetry = seen.length > 1;
+                const clientPublicPem = decodeBase64Text(body.client_public_key);
+                const encrypted = await encryptTokenPlaceEnvelope(
+                    {
+                        protocol: 'tokenplace_api_v1_relay_e2ee',
+                        version: 1,
+                        request_id: body.request_id,
+                        client_public_key: body.client_public_key,
+                        api_v1_response: isRetry
+                            ? { choices: [{ message: { content: 'retry reply' } }] }
+                            : {
+                                  error: {
+                                      code: 'compute_node_context_window_exceeded',
+                                      message: 'too large for 8k',
+                                      retryable: true,
+                                      recommended_context_tier: '64k-full',
+                                  },
+                              },
+                    },
+                    clientPublicPem
+                );
+                return {
+                    ok: true,
+                    status: 200,
+                    json: () =>
+                        Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
+                };
+            }
+            throw new Error(`Unexpected URL ${url}`);
+        });
+
+        const result = await TokenPlaceChatV2([{ role: 'user', content: 'retry same payload' }]);
+        expect(result.text).toBe('retry reply');
+        expect(seen).toHaveLength(2);
+        expect(seen[0].messages).toEqual(seen[1].messages);
+        expect(seen[0].routing.context_tier).toBe('8k-fast');
+        expect(seen[1].routing.context_tier).toBe('64k-full');
+        expect(seen[0].body.request_id).not.toBe(seen[1].body.request_id);
+        expect(seen[0].body.cancel_token).not.toBe(seen[1].body.cancel_token);
+        expect(seen[0].body.server_public_key).not.toBe(seen[1].body.server_public_key);
+        expect(result.metadata.tokenPlaceContext.escalatedRetry).toBe(true);
+    });
+
     test('decryption accepts chat_history as the response ciphertext', async () => {
         const encrypted = await encryptTokenPlaceEnvelope(
             { ok: true, source: 'chat_history' },
@@ -998,7 +1176,14 @@ ${ragExcerpt.repeat(4000)}`,
             text: 'mocked reply',
             contextSources: dspaceSources,
             usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
-            metadata: { client: 'dspace', conversation_id: 'conv-42' },
+            metadata: expect.objectContaining({
+                client: 'dspace',
+                conversation_id: 'conv-42',
+                tokenPlaceContext: expect.objectContaining({
+                    requestedTier: '8k-fast',
+                    estimatorVersion: 'dspace-token-context-estimator-v1',
+                }),
+            }),
         });
     });
 
@@ -1221,7 +1406,7 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const serverSelections = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/servers/next')
+            new URL(url).pathname.endsWith('/api/v1/relay/servers/next')
         );
         const dispatches = fetch.mock.calls.filter(([url]) =>
             url.endsWith('/api/v1/relay/requests')
@@ -1285,7 +1470,7 @@ ${ragExcerpt.repeat(4000)}`,
 
     test('no available compute node, relay unavailable, malformed encrypted response, and disconnected server classify safely', async () => {
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({}) };
             }
             throw new Error(`Unexpected URL ${url}`);
@@ -1293,7 +1478,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
 
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: false,
                     status: 503,
@@ -1306,7 +1491,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ status: 503 });
 
         global.fetch = jest.fn(async (url, init = {}) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (new URL(url).pathname.endsWith('/api/v1/relay/servers/next')) {
                 return {
                     ok: true,
                     status: 200,

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -38,17 +38,10 @@ default.
 
 ## v3.1 / P8 relay E2EE implementation target
 
-The relay E2EE flow below is the v3.1 / P8 implementation target and the production/staging
-promotion gate for P8b. Until that client implementation lands, the shipped DSPACE Chat client is
-being corrected from its legacy plaintext token.place API v1 request path. Operators should not use
-the relay-route sequence below as evidence that today's shipped `/chat` client already dispatches
-relay-blind requests; use it as the required target for the P8b implementation PR and release
-sign-off.
-
 DSPACE v3.1 / P8 requires token.place API v1 relay E2EE routes for the default Chat path. The
 browser must generate a DSPACE `/chat` client keypair, fetch a compute node with
 `GET /api/v1/relay/servers/next`, build a `tokenplace_api_v1_relay_e2ee` envelope with
-`client_public_key`, encrypt that API v1 chat request envelope for the compute node, dispatch
+`client_public_key`, include the requested `routing.context_tier` inside the encrypted API v1 request, encrypt that API v1 chat request envelope for the compute node, dispatch
 ciphertext with `POST /api/v1/relay/requests`, poll
 `POST /api/v1/relay/responses/retrieve`, then decrypt and validate the response client-side
 before reading `api_v1_response.choices[0].message.content`.
@@ -80,3 +73,29 @@ one immutable image can move between staging and production without rebuilding. 
 compatibility fallbacks only. Runtime `DSPACE_TOKEN_PLACE_URL` takes precedence over legacy saved
 `state.tokenPlace.url` values so an old browser save cannot keep a staging deployment pointed at a
 production token.place origin.
+
+## Context-tier routing and bounded retry QA
+
+DSPACE estimates the sanitized token.place API v1 message payload locally before relay selection.
+Small token-lite and full-fat prompts request `8k-fast`; larger full-fat/RAG prompts request
+`64k-full`; prompts estimated beyond the 64K budget fail locally with a context-budget message
+before any relay call. The estimator records content-free diagnostics such as the requested tier,
+estimator version, estimated prompt tokens, and reserved output tokens.
+
+Server selection calls `/api/v1/relay/servers/next` with the selected model and requested context
+tier. DSPACE validates the selected compute profile can satisfy that tier, accepts deliberate
+spillover from `8k-fast` to a `64k-full` node, and records the spillover as safe metadata. The
+relay-visible dispatch body remains ciphertext-only; prompt text, RAG snippets, player state,
+private keys, ciphertext contents, and decrypted responses must not appear in relay logs.
+
+If an `8k-fast` request lands on an 8K node and the encrypted compute response reports
+`compute_node_context_window_exceeded` with a retryable 64K recommendation, DSPACE retries exactly
+once on `64k-full`. The retry reuses the exact same sanitized message payload, selects a fresh
+64K-capable node, re-encrypts for the new public key, and uses a new request ID and cancel token.
+DSPACE does not retry 64K overflows, spillover-to-64K overflows, malformed responses,
+request-too-large errors, invalid requests, policy errors, unsupported models, provider errors, or
+network errors beyond existing safe client behavior.
+
+Staging validation should cover: token-lite on a healthy 8K node, small full-fat on 8K, large
+full-fat/RAG on 64K, forced 8K overflow escalating once to 64K, 8K spillover accepted on a 64K node,
+over-64K local failure, and relay logs containing no plaintext DSPACE prompt/RAG/player-state data.

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -9,6 +9,10 @@ import {
     TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from './tokenPlaceMessages.js';
 import {
+    estimateTokenPlaceContextForSanitizedMessages,
+    TOKEN_PLACE_CONTEXT_TIERS,
+} from './tokenPlaceContextEstimator.js';
+import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
@@ -19,7 +23,9 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_RELAY_TIMEOUT_8K_FAST_MS = 30_000;
+export const TOKEN_PLACE_RELAY_TIMEOUT_64K_FULL_MS = 120_000;
+const DEFAULT_RELAY_TIMEOUT_MS = TOKEN_PLACE_RELAY_TIMEOUT_8K_FAST_MS;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 export {
     sanitizeTokenPlaceMessages,
@@ -104,11 +110,16 @@ const getStructuredApiErrorStatus = (apiResponse) => {
     return status ?? 400;
 };
 
-const throwStructuredTokenPlaceApiError = (apiResponse) => {
-    if (!apiResponse?.error || typeof apiResponse.error !== 'object') return;
-    throw createTokenPlaceHttpError(getStructuredApiErrorStatus(apiResponse), {
+const createStructuredTokenPlaceApiError = (apiResponse) => {
+    if (!apiResponse?.error || typeof apiResponse.error !== 'object') return null;
+    return createTokenPlaceHttpError(getStructuredApiErrorStatus(apiResponse), {
         error: apiResponse.error,
     });
+};
+
+const throwStructuredTokenPlaceApiError = (apiResponse) => {
+    const error = createStructuredTokenPlaceApiError(apiResponse);
+    if (error) throw error;
 };
 
 const parseErrorPayload = async (response) => {
@@ -383,9 +394,41 @@ const fetchJson = async (url, init, unavailableMessage) => {
     }
 };
 
+const TIER_ORDER = ['8k-fast', '64k-full'];
+const tierRank = (tier) => TIER_ORDER.indexOf(String(tier || ''));
+const tierSatisfies = (selectedTier, requestedTier) =>
+    tierRank(selectedTier) >= 0 &&
+    tierRank(requestedTier) >= 0 &&
+    tierRank(selectedTier) >= tierRank(requestedTier);
+
+const extractSelectedContextTier = (data) =>
+    data?.selected_context_tier ||
+    data?.selectedContextTier ||
+    data?.context_tier ||
+    data?.contextTier ||
+    data?.profile?.context_tier ||
+    data?.profile?.contextTier ||
+    data?.selected_profile?.context_tier ||
+    data?.selectedProfile?.contextTier;
+
+const extractSelectedProfileId = (data) =>
+    data?.selected_profile_id ||
+    data?.selectedProfileId ||
+    data?.profile_id ||
+    data?.profileId ||
+    data?.profile?.id ||
+    data?.selected_profile?.id ||
+    data?.selectedProfile?.id;
+
 export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
+    const model = getTokenPlaceChatModel(options);
+    const params = new URLSearchParams();
+    if (model) params.set('model', model);
+    if (options.contextTier) params.set('context_tier', options.contextTier);
+    if (options.contextTier) params.set('client_context_tiers', '1');
+    const path = `/api/v1/relay/servers/next${params.toString() ? `?${params}` : ''}`;
     const data = await fetchJson(
-        `${baseUrl}/api/v1/relay/servers/next`,
+        `${baseUrl}${path}`,
         { method: 'GET', signal: options.signal },
         'token.place relay is unavailable.'
     );
@@ -393,7 +436,22 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     if (!rawKey)
         throw createMalformedTokenPlaceResponseError('No token.place compute node is available.');
     const normalized = normalizeTokenPlacePublicKey(rawKey);
-    return { ...data, server_public_key: normalized.base64, serverPublicKeyPem: normalized.pem };
+    const selectedContextTier =
+        extractSelectedContextTier(data) || options.contextTier || '8k-fast';
+    if (options.contextTier && !tierSatisfies(selectedContextTier, options.contextTier)) {
+        throw createMalformedTokenPlaceResponseError(
+            'token.place selected a compute node with insufficient context tier.'
+        );
+    }
+    const selectedProfileId = extractSelectedProfileId(data);
+    return {
+        ...data,
+        server_public_key: normalized.base64,
+        serverPublicKeyPem: normalized.pem,
+        selectedContextTier,
+        selectedProfileId,
+        spillover: Boolean(options.contextTier && selectedContextTier !== options.contextTier),
+    };
 };
 
 export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
@@ -554,9 +612,48 @@ const resolveTokenPlacePromptPayload = async (messages, options = {}) => {
 
 const buildApiV1Request = (promptPayload, options = {}) => ({
     model: getTokenPlaceChatModel(options),
-    messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
+    messages:
+        options.sanitizedMessages || sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
     options: {},
+    routing: {
+        context_tier: options.contextTier || '8k-fast',
+        ...(options.selectedProfileId ? { selected_profile_id: options.selectedProfileId } : {}),
+    },
 });
+
+const classifyTokenPlacePrompt = (sanitizedMessages, options = {}) => {
+    const estimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, options);
+    if (estimate.overLimit) {
+        const error = createMalformedTokenPlaceResponseError(
+            'Your message and DSPACE context exceed the 64K token.place context budget. Try a shorter request or disable some context.'
+        );
+        error.code = 'token_place_context_over_limit';
+        error.context = {
+            estimatedPromptTokens: estimate.estimatedPromptTokens,
+            reservedOutputTokens: estimate.reservedOutputTokens,
+            selectedTier: null,
+            estimatorVersion: estimate.estimatorVersion,
+        };
+        throw error;
+    }
+    return estimate;
+};
+
+const timeoutForTier = (tier) =>
+    tier === TOKEN_PLACE_CONTEXT_TIERS['64k-full'].id
+        ? TOKEN_PLACE_RELAY_TIMEOUT_64K_FULL_MS
+        : TOKEN_PLACE_RELAY_TIMEOUT_8K_FAST_MS;
+
+const isRetryableContextOverflow = (errorResponse) => {
+    const error = errorResponse?.error;
+    if (!error || typeof error !== 'object') return false;
+    return (
+        error.code === 'compute_node_context_window_exceeded' &&
+        (error.retryable === true ||
+            error.recommended_context_tier === '64k-full' ||
+            error.recommendedContextTier === '64k-full')
+    );
+};
 
 const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     const server = await selectTokenPlaceRelayServer(baseUrl, options);
@@ -568,7 +665,10 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         version: RELAY_VERSION,
         request_id: requestId,
         client_public_key: clientKeys.publicKeyBase64,
-        api_v1_request: buildApiV1Request(promptPayload, options),
+        api_v1_request: buildApiV1Request(promptPayload, {
+            ...options,
+            selectedProfileId: server.selectedProfileId,
+        }),
     };
     const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
     const dispatched = await dispatchTokenPlaceRelayRequest(
@@ -590,7 +690,13 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     const encryptedResponse = await pollTokenPlaceRelayResponse(
         baseUrl,
         { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
-        { ...options, cancelToken }
+        {
+            ...options,
+            cancelToken,
+            timeoutMs:
+                options.timeoutMs ??
+                timeoutForTier(server.selectedContextTier || options.contextTier),
+        }
     );
     if (encryptedResponse?.terminalSelectedServerFailure) return encryptedResponse;
     let responseEnvelope;
@@ -602,15 +708,29 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     } catch (error) {
         throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
     }
-    return validateTokenPlaceResponseEnvelope(responseEnvelope, {
+    const apiResponse = validateTokenPlaceResponseEnvelope(responseEnvelope, {
         requestId,
         clientPublicKey: clientKeys.publicKeyBase64,
     });
+    return {
+        apiResponse,
+        diagnostics: {
+            requestedTier: options.contextTier,
+            selectedTier: server.selectedContextTier,
+            spillover: server.spillover,
+            timeoutClass:
+                (server.selectedContextTier || options.contextTier) === '64k-full'
+                    ? '64k-full'
+                    : '8k-fast',
+        },
+    };
 };
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
     await ready;
     const promptPayload = await resolveTokenPlacePromptPayload(messages, options);
+    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+    const estimate = classifyTokenPlacePrompt(sanitizedMessages, options);
     const contextSources = Array.isArray(promptPayload.contextSources)
         ? promptPayload.contextSources
         : [];
@@ -620,18 +740,45 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         runtimeUrl: options.runtimeUrl,
     });
 
-    let data = await runRelayAttempt(baseUrl, promptPayload, options);
-    if (data?.terminalSelectedServerFailure) {
-        data = await runRelayAttempt(baseUrl, promptPayload, {
-            ...options,
+    const baseAttemptOptions = {
+        ...options,
+        sanitizedMessages,
+        contextTier: estimate.selectedTier,
+    };
+    let attempt = await runRelayAttempt(baseUrl, promptPayload, baseAttemptOptions);
+    if (attempt?.terminalSelectedServerFailure) {
+        attempt = await runRelayAttempt(baseUrl, promptPayload, {
+            ...baseAttemptOptions,
             requestId: undefined,
             cancelToken: undefined,
         });
-        if (data?.terminalSelectedServerFailure) {
+        if (attempt?.terminalSelectedServerFailure) {
             throw createMalformedTokenPlaceResponseError(
                 'No token.place compute node is available.'
             );
         }
+    }
+
+    let data = attempt.apiResponse;
+    const firstError = createStructuredTokenPlaceApiError(data);
+    const shouldRetry64k =
+        firstError &&
+        estimate.selectedTier === '8k-fast' &&
+        attempt.diagnostics?.selectedTier !== '64k-full' &&
+        isRetryableContextOverflow(data);
+    let retryDiagnostics = null;
+    if (shouldRetry64k) {
+        const retryAttempt = await runRelayAttempt(baseUrl, promptPayload, {
+            ...baseAttemptOptions,
+            contextTier: '64k-full',
+            requestId: undefined,
+            cancelToken: undefined,
+            clientKeys: undefined,
+        });
+        data = retryAttempt.apiResponse;
+        retryDiagnostics = { escalatedRetry: true, firstErrorCode: firstError.code };
+    } else if (firstError) {
+        throw firstError;
     }
 
     throwStructuredTokenPlaceApiError(data);
@@ -642,7 +789,17 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         text,
         contextSources,
         usage: data?.usage,
-        metadata: data?.metadata,
+        metadata: {
+            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+            tokenPlaceContext: {
+                requestedTier: estimate.selectedTier,
+                estimatorVersion: estimate.estimatorVersion,
+                estimatedPromptTokens: estimate.estimatedPromptTokens,
+                reservedOutputTokens: estimate.reservedOutputTokens,
+                ...(attempt.diagnostics || {}),
+                ...(retryDiagnostics || {}),
+            },
+        },
     };
 };
 


### PR DESCRIPTION
### Motivation
- Integrate DSPACE's local P7 estimator to choose token.place context tiers (`8k-fast` vs `64k-full`) and fail early for over‑64K payloads. 
- Preserve relay blindness/E2EE while surfacing safe routing metadata and accepting controlled spillover from smaller to larger compute tiers. 
- Provide a single, bounded escalation path for exact compute-side 8K overflows and choose context-aware timeouts. 

### Description
- Classify the sanitized API v1 payload with the local estimator before relay selection and fail locally if the estimate exceeds 64K. 
- Send model and the requested `context_tier` to `/api/v1/relay/servers/next`, validate the relay's selected-tier metadata, accept larger selected tiers as spillover, and record spillover diagnostics. 
- Embed `api_v1_request.routing.context_tier` (and selected-profile echo when present) inside the encrypted API v1 envelope while keeping the outer relay body ciphertext-only. 
- Add named timeout constants `TOKEN_PLACE_RELAY_TIMEOUT_8K_FAST_MS` and `TOKEN_PLACE_RELAY_TIMEOUT_64K_FULL_MS`, and choose the safer timeout based on the selected/active tier. 
- Implement one bounded retry: if first attempt requested `8k-fast`, the selected node was not already `64k-full`, and the decrypted error is a retryable `compute_node_context_window_exceeded`, retry exactly once on a fresh `64k-full` node reusing the exact sanitized payload but with a new request id/cancel token and new server public key. 
- Preserve token-lite behavior and existing API v1 response parsing; add privacy-safe diagnostics to returned `metadata.tokenPlaceContext` without including any prompt text, RAG snippets, player state, keys, ciphertext, or decrypted content. 
- Tests: extend and adjust `frontend/__tests__/tokenPlace.test.js` to cover estimator selection, server selection query params, encrypted routing field, local over-limit, spillover acceptance, insufficient-tier rejection, and the bounded retry flow. 
- Docs: update `frontend/src/pages/docs/md/token-place.md` with context-tier routing, bounded retry, spillover, over-budget behavior, and staging QA notes. 

### Testing
- Ran focused unit tests with `cd frontend && npm test -- tokenPlace.test.js` and the file passed (62 tests passed). 
- Ran lint/format checks with `cd frontend && npm run check` and the check completed successfully. 
- Built the frontend with `cd frontend && npm run build` and the build completed successfully. 
- Generated estimator benchmarks with `npm run benchmark:token-place-context` and artifacts were written to `artifacts/benchmarks/token-place-context/*.json` and `*.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de43831a4832f877966c09107cca4)