### PR TITLE
Wire token.place 8K/64K routing, estimator integration, and bounded 8K→64K retry

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1338-L1351))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1559-L1573))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1559-L1573))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1595-L1609))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -48,31 +48,45 @@ let relayReply = {
     choices: [{ message: { content: 'mocked reply' } }],
 };
 
+const urlPathEndsWith = (url, path) => new URL(url).pathname.endsWith(path);
+
 const makeRelayFetch = ({
     retrieveStatuses = [200],
     serverFailureOnce = false,
     accepted = true,
+    selectedTier = ({ url }) => new URL(url).searchParams.get('context_tier') || '8k-fast',
+    replyForRetrieve = null,
 } = {}) => {
     let retrieveCount = 0;
+    let selectionCount = 0;
     return jest.fn(async (url, init = {}) => {
-        if (url.endsWith('/api/v1/relay/servers/next')) {
+        if (urlPathEndsWith(url, '/api/v1/relay/servers/next')) {
+            selectionCount += 1;
             const key =
                 serverFailureOnce &&
                 fetch.mock.calls.filter(([calledUrl]) =>
-                    calledUrl.endsWith('/api/v1/relay/servers/next')
+                    urlPathEndsWith(calledUrl, '/api/v1/relay/servers/next')
                 ).length === 1
                     ? relayServerKeys[1]
                     : relayServerKeys[0];
             return {
                 ok: true,
                 status: 200,
-                json: () => Promise.resolve({ server_public_key: key.publicKeyBase64 }),
+                json: () =>
+                    Promise.resolve({
+                        server_public_key: key.publicKeyBase64,
+                        context_tier:
+                            typeof selectedTier === 'function'
+                                ? selectedTier({ url, selectionCount })
+                                : selectedTier,
+                        selected_profile_id: 'test-8k',
+                    }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests')) {
+        if (urlPathEndsWith(url, '/api/v1/relay/requests')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ accepted }) };
         }
-        if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+        if (urlPathEndsWith(url, '/api/v1/relay/responses/retrieve')) {
             const status = retrieveStatuses[Math.min(retrieveCount, retrieveStatuses.length - 1)];
             retrieveCount += 1;
             if (status === 202) return { ok: false, status: 202, json: () => Promise.resolve({}) };
@@ -86,7 +100,9 @@ const makeRelayFetch = ({
                     version: 1,
                     request_id: body.request_id,
                     client_public_key: body.client_public_key,
-                    api_v1_response: relayReply,
+                    api_v1_response: replyForRetrieve
+                        ? replyForRetrieve({ requestBody: body })
+                        : relayReply,
                 },
                 clientPublicPem
             );
@@ -96,7 +112,7 @@ const makeRelayFetch = ({
                 json: () => Promise.resolve({ ...encrypted, chat_history: encrypted.ciphertext }),
             };
         }
-        if (url.endsWith('/api/v1/relay/requests/cancel')) {
+        if (urlPathEndsWith(url, '/api/v1/relay/requests/cancel')) {
             return { ok: true, status: 200, json: () => Promise.resolve({ canceled: true }) };
         }
         throw new Error(`Unexpected fetch URL ${url}`);
@@ -109,7 +125,8 @@ const getFetchCalls = () =>
         init,
         body: init.body ? JSON.parse(init.body) : undefined,
     }));
-const getFetchCallByPath = (path) => getFetchCalls().find((call) => call.url.endsWith(path));
+const getFetchCallByPath = (path) =>
+    getFetchCalls().find((call) => urlPathEndsWith(call.url, path));
 
 const getFetchCall = () => {
     const [url, init] = fetch.mock.calls[0];
@@ -162,9 +179,9 @@ describe('token.place API v1 client', () => {
         expect(getFetchCallByPath('/api/v1/relay/servers/next')?.init.method).toBe('GET');
         expect(getFetchCallByPath('/api/v1/relay/requests')?.init.method).toBe('POST');
         expect(getFetchCallByPath('/api/v1/relay/responses/retrieve')?.init.method).toBe('POST');
-        expect(fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/chat/completions'))).toBe(
-            false
-        );
+        expect(
+            fetch.mock.calls.some(([url]) => urlPathEndsWith(url, '/api/v1/chat/completions'))
+        ).toBe(false);
     });
 
     test('legacy enabled flags do not disable default token.place chat', async () => {
@@ -183,17 +200,19 @@ describe('token.place API v1 client', () => {
     test('VITE_TOKEN_PLACE_URL staging override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://staging.token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('VITE_TOKEN_PLACE_URL production override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://token.place/';
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://token.place/api/v1/relay/servers/next');
     });
 
     test('explicit url overrides state and runtime compatibility values', async () => {
@@ -203,18 +222,20 @@ describe('token.place API v1 client', () => {
             url: 'https://explicit.token.place/api/v1',
             runtimeUrl: 'https://runtime.token.place',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://explicit.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://explicit.token.place/api/v1/relay/servers/next');
     });
 
     test('state tokenPlace url compatibility override works', async () => {
         process.env.VITE_TOKEN_PLACE_URL = 'https://env.token.place';
         loadGameState.mockReturnValue({ tokenPlace: { url: 'https://state.token.place/' } });
         await tokenPlaceChat([{ role: 'user', content: 'hello' }]);
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://state.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://state.token.place/api/v1/relay/servers/next');
     });
 
     test('runtime url is used before saved state and VITE fallback', async () => {
@@ -223,9 +244,10 @@ describe('token.place API v1 client', () => {
         await TokenPlaceChatV2([{ role: 'user', content: 'hello' }], {
             runtimeUrl: 'https://staging.token.place/api',
         });
-        expect(getFetchCallByPath('/api/v1/relay/servers/next').url).toBe(
-            'https://staging.token.place/api/v1/relay/servers/next'
-        );
+        expect(
+            new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).origin +
+                new URL(getFetchCallByPath('/api/v1/relay/servers/next').url).pathname
+        ).toBe('https://staging.token.place/api/v1/relay/servers/next');
     });
 
     test('legacy /api base normalizes without /api/api duplication', () => {
@@ -994,7 +1016,7 @@ ${ragExcerpt.repeat(4000)}`,
                 gameState: {},
             },
         });
-        expect(result).toEqual({
+        expect(result).toMatchObject({
             text: 'mocked reply',
             contextSources: dspaceSources,
             usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
@@ -1210,7 +1232,7 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const retrieveCalls = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/responses/retrieve')
+            urlPathEndsWith(url, '/api/v1/relay/responses/retrieve')
         );
         expect(retrieveCalls).toHaveLength(3);
     });
@@ -1221,10 +1243,10 @@ ${ragExcerpt.repeat(4000)}`,
             tokenPlaceChat([{ role: 'user', content: 'hello' }], { pollIntervalMs: 1 })
         ).resolves.toBe('mocked reply');
         const serverSelections = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/servers/next')
+            urlPathEndsWith(url, '/api/v1/relay/servers/next')
         );
         const dispatches = fetch.mock.calls.filter(([url]) =>
-            url.endsWith('/api/v1/relay/requests')
+            urlPathEndsWith(url, '/api/v1/relay/requests')
         );
         expect(serverSelections).toHaveLength(2);
         expect(dispatches).toHaveLength(2);
@@ -1239,7 +1261,7 @@ ${ragExcerpt.repeat(4000)}`,
             })
         ).rejects.toMatchObject({ status: 408 });
         expect(
-            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/requests/cancel'))
+            fetch.mock.calls.some(([url]) => urlPathEndsWith(url, '/api/v1/relay/requests/cancel'))
         ).toBe(true);
     });
 
@@ -1251,7 +1273,9 @@ ${ragExcerpt.repeat(4000)}`,
             message: 'token.place relay rejected the request.',
         });
         expect(
-            fetch.mock.calls.some(([url]) => url.endsWith('/api/v1/relay/responses/retrieve'))
+            fetch.mock.calls.some(([url]) =>
+                urlPathEndsWith(url, '/api/v1/relay/responses/retrieve')
+            )
         ).toBe(false);
     });
 
@@ -1285,7 +1309,7 @@ ${ragExcerpt.repeat(4000)}`,
 
     test('no available compute node, relay unavailable, malformed encrypted response, and disconnected server classify safely', async () => {
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPathEndsWith(url, '/api/v1/relay/servers/next')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({}) };
             }
             throw new Error(`Unexpected URL ${url}`);
@@ -1293,7 +1317,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ type: 'malformed' });
 
         global.fetch = jest.fn(async (url) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPathEndsWith(url, '/api/v1/relay/servers/next')) {
                 return {
                     ok: false,
                     status: 503,
@@ -1306,7 +1330,7 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(tokenPlaceChat([])).rejects.toMatchObject({ status: 503 });
 
         global.fetch = jest.fn(async (url, init = {}) => {
-            if (url.endsWith('/api/v1/relay/servers/next')) {
+            if (urlPathEndsWith(url, '/api/v1/relay/servers/next')) {
                 return {
                     ok: true,
                     status: 200,
@@ -1314,10 +1338,10 @@ ${ragExcerpt.repeat(4000)}`,
                         Promise.resolve({ server_public_key: relayServerKeys[0].publicKeyBase64 }),
                 };
             }
-            if (url.endsWith('/api/v1/relay/requests')) {
+            if (urlPathEndsWith(url, '/api/v1/relay/requests')) {
                 return { ok: true, status: 200, json: () => Promise.resolve({ accepted: true }) };
             }
-            if (url.endsWith('/api/v1/relay/responses/retrieve')) {
+            if (urlPathEndsWith(url, '/api/v1/relay/responses/retrieve')) {
                 return {
                     ok: true,
                     status: 200,
@@ -1335,6 +1359,83 @@ ${ragExcerpt.repeat(4000)}`,
         });
     });
 
+    test('requests estimated context tier, encrypts routing metadata, and records spillover diagnostics', async () => {
+        global.fetch = makeRelayFetch();
+        await TokenPlaceChatV2([{ role: 'user', content: 'hello' }]);
+
+        const selectionUrl = new URL(getFetchCallByPath('/api/v1/relay/servers/next').url);
+        expect(selectionUrl.searchParams.get('model')).toBe('llama-3.1-8b-instruct');
+        expect(selectionUrl.searchParams.get('context_tier')).toBe('8k-fast');
+
+        const encryptedRequest = await decryptFirstRelayRequest();
+        expect(encryptedRequest.api_v1_request.routing).toMatchObject({
+            context_tier: '8k-fast',
+            selected_profile_id: 'test-8k',
+        });
+        expect(JSON.stringify(getFetchCallByPath('/api/v1/relay/requests').body)).not.toContain(
+            'hello'
+        );
+    });
+
+    test('accepts larger selected context tier as spillover and rejects smaller selected tier', async () => {
+        global.fetch = makeRelayFetch({ selectedTier: '64k-full' });
+        await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).resolves.toMatchObject(
+            {
+                metadata: { tokenPlaceContext: { spillover: true, relaySelectedTier: '64k-full' } },
+            }
+        );
+
+        global.fetch = makeRelayFetch({ selectedTier: '8k-fast' });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'x'.repeat(25_000) }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+    });
+
+    test('retries one exact 8K overflow on 64K with unchanged message payload', async () => {
+        let retrieveCount = 0;
+        global.fetch = makeRelayFetch({
+            selectedTier: ({ selectionCount }) => (selectionCount === 1 ? '8k-fast' : '64k-full'),
+            replyForRetrieve: ({ requestBody }) => {
+                retrieveCount += 1;
+                if (retrieveCount === 1) {
+                    return {
+                        error: {
+                            code: 'compute_node_context_window_exceeded',
+                            message: 'too large for active context',
+                            retryable: true,
+                            recommended_context_tier: '64k-full',
+                        },
+                    };
+                }
+                return { choices: [{ message: { content: 'retried reply' } }] };
+            },
+        });
+
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello retry' }])
+        ).resolves.toMatchObject({
+            text: 'retried reply',
+            metadata: { tokenPlaceContext: { escalationRetry: true } },
+        });
+
+        const selections = fetch.mock.calls
+            .filter(([url]) => urlPathEndsWith(url, '/api/v1/relay/servers/next'))
+            .map(([url]) => new URL(url).searchParams.get('context_tier'));
+        expect(selections).toEqual(['8k-fast', '64k-full']);
+        const requestBodies = fetch.mock.calls
+            .filter(([url]) => urlPathEndsWith(url, '/api/v1/relay/requests'))
+            .map(([, init]) => JSON.parse(init.body));
+        expect(requestBodies[0].request_id).not.toBe(requestBodies[1].request_id);
+        const first = await decryptTokenPlaceEnvelope(
+            requestBodies[0],
+            relayServerKeys[0].privateKey
+        );
+        const second = await decryptTokenPlaceEnvelope(
+            requestBodies[1],
+            relayServerKeys[0].privateKey
+        );
+        expect(first.api_v1_request.messages).toEqual(second.api_v1_request.messages);
+    });
     test('shared prompt and token.place payload omit stale provider guidance', async () => {
         const promptPayload = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
         const serializedPrompt = JSON.stringify({

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1441,6 +1441,42 @@ ${ragExcerpt.repeat(4000)}`,
         expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
     });
 
+    test('validates selected context window metadata against exact tier budgets', async () => {
+        global.fetch = makeRelayFetch({
+            selectedTier: '8k-fast',
+            selectedWindowTokens: 8_191,
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello just under 8k window' }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
+
+        global.fetch = makeRelayFetch({
+            selectedTier: '8k-fast',
+            selectedWindowTokens: 8_192,
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello exact 8k window' }])
+        ).resolves.toMatchObject({ text: 'mocked reply' });
+
+        global.fetch = makeRelayFetch({
+            selectedTier: '64k-full',
+            selectedWindowTokens: 65_535,
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'x'.repeat(25_000) }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
+
+        global.fetch = makeRelayFetch({
+            selectedTier: '64k-full',
+            selectedWindowTokens: 65_536,
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'x'.repeat(25_000) }])
+        ).resolves.toMatchObject({ text: 'mocked reply' });
+    });
+
     test('retries one exact 8K overflow on 64K with unchanged message payload', async () => {
         let retrieveCount = 0;
         global.fetch = makeRelayFetch({

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -54,7 +54,10 @@ const makeRelayFetch = ({
     retrieveStatuses = [200],
     serverFailureOnce = false,
     accepted = true,
+    omitSelectedTier = false,
     selectedTier = ({ url }) => new URL(url).searchParams.get('context_tier') || '8k-fast',
+    selectedWindowTokens,
+    selectedModelSupport,
     replyForRetrieve = null,
 } = {}) => {
     let retrieveCount = 0;
@@ -69,16 +72,24 @@ const makeRelayFetch = ({
                 ).length === 1
                     ? relayServerKeys[1]
                     : relayServerKeys[0];
+            const tier = omitSelectedTier
+                ? undefined
+                : typeof selectedTier === 'function'
+                  ? selectedTier({ url, selectionCount })
+                  : selectedTier;
             return {
                 ok: true,
                 status: 200,
                 json: () =>
                     Promise.resolve({
                         server_public_key: key.publicKeyBase64,
-                        context_tier:
-                            typeof selectedTier === 'function'
-                                ? selectedTier({ url, selectionCount })
-                                : selectedTier,
+                        ...(tier ? { context_tier: tier } : {}),
+                        ...(selectedWindowTokens
+                            ? { selected_context_window_tokens: selectedWindowTokens }
+                            : {}),
+                        ...(selectedModelSupport
+                            ? { selected_model_support: selectedModelSupport }
+                            : {}),
                         selected_profile_id: 'test-8k',
                     }),
             };
@@ -1335,7 +1346,10 @@ ${ragExcerpt.repeat(4000)}`,
                     ok: true,
                     status: 200,
                     json: () =>
-                        Promise.resolve({ server_public_key: relayServerKeys[0].publicKeyBase64 }),
+                        Promise.resolve({
+                            server_public_key: relayServerKeys[0].publicKeyBase64,
+                            context_tier: '8k-fast',
+                        }),
                 };
             }
             if (urlPathEndsWith(url, '/api/v1/relay/requests')) {
@@ -1377,22 +1391,16 @@ ${ragExcerpt.repeat(4000)}`,
         );
     });
 
-    test('allows legacy relay selection responses without context tier echo', async () => {
-        global.fetch = makeRelayFetch({ selectedTier: undefined });
+    test('missing selected tier metadata fails before dispatch', async () => {
+        global.fetch = makeRelayFetch({ omitSelectedTier: true });
 
         await expect(
-            TokenPlaceChatV2([{ role: 'user', content: 'hello legacy relay' }])
-        ).resolves.toMatchObject({
-            metadata: {
-                tokenPlaceContext: {
-                    requestedTier: '8k-fast',
-                    spillover: false,
-                },
-            },
-        });
+            TokenPlaceChatV2([{ role: 'user', content: 'hello missing relay tier' }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
     });
 
-    test('accepts larger selected context tier as spillover and rejects smaller selected tier', async () => {
+    test('accepts larger selected context tier as spillover and rejects incompatible tiers', async () => {
         global.fetch = makeRelayFetch({ selectedTier: '64k-full' });
         await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).resolves.toMatchObject(
             {
@@ -1404,6 +1412,33 @@ ${ragExcerpt.repeat(4000)}`,
         await expect(
             TokenPlaceChatV2([{ role: 'user', content: 'x'.repeat(25_000) }])
         ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
+
+        global.fetch = makeRelayFetch({ selectedTier: 'bogus-tier' });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello invalid relay tier' }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
+    });
+
+    test('rejects incoherent selected context window and model support metadata before dispatch', async () => {
+        global.fetch = makeRelayFetch({
+            selectedTier: '64k-full',
+            selectedWindowTokens: 8_000,
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello small relay window' }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
+
+        global.fetch = makeRelayFetch({
+            selectedTier: '8k-fast',
+            selectedModelSupport: ['other-model'],
+        });
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello unsupported relay model' }])
+        ).rejects.toMatchObject({ type: 'malformed' });
+        expect(getFetchCallByPath('/api/v1/relay/requests')).toBeUndefined();
     });
 
     test('retries one exact 8K overflow on 64K with unchanged message payload', async () => {
@@ -1491,6 +1526,34 @@ ${ragExcerpt.repeat(4000)}`,
             .filter(([url]) => urlPathEndsWith(url, '/api/v1/relay/servers/next'))
             .map(([url]) => new URL(url).searchParams.get('context_tier'));
         expect(selections).toEqual(['8k-fast', '64k-full', '64k-full']);
+    });
+
+    test('does not retry 8K overflow when encrypted error reports active 64K tier', async () => {
+        global.fetch = makeRelayFetch({
+            selectedTier: '8k-fast',
+            replyForRetrieve: () => ({
+                error: {
+                    code: 'compute_node_context_window_exceeded',
+                    message: 'too large for active context',
+                    retryable: true,
+                    recommended_context_tier: '64k-full',
+                    active_context_tier: '64k-full',
+                },
+            }),
+        });
+
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello no retry active 64k' }])
+        ).rejects.toMatchObject({ status: 400 });
+
+        const selections = fetch.mock.calls.filter(([url]) =>
+            urlPathEndsWith(url, '/api/v1/relay/servers/next')
+        );
+        const dispatches = fetch.mock.calls.filter(([url]) =>
+            urlPathEndsWith(url, '/api/v1/relay/requests')
+        );
+        expect(selections).toHaveLength(1);
+        expect(dispatches).toHaveLength(1);
     });
 
     test('shared prompt and token.place payload omit stale provider guidance', async () => {

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1377,6 +1377,21 @@ ${ragExcerpt.repeat(4000)}`,
         );
     });
 
+    test('allows legacy relay selection responses without context tier echo', async () => {
+        global.fetch = makeRelayFetch({ selectedTier: undefined });
+
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello legacy relay' }])
+        ).resolves.toMatchObject({
+            metadata: {
+                tokenPlaceContext: {
+                    requestedTier: '8k-fast',
+                    spillover: false,
+                },
+            },
+        });
+    });
+
     test('accepts larger selected context tier as spillover and rejects smaller selected tier', async () => {
         global.fetch = makeRelayFetch({ selectedTier: '64k-full' });
         await expect(TokenPlaceChatV2([{ role: 'user', content: 'hello' }])).resolves.toMatchObject(
@@ -1436,6 +1451,48 @@ ${ragExcerpt.repeat(4000)}`,
         );
         expect(first.api_v1_request.messages).toEqual(second.api_v1_request.messages);
     });
+
+    test('reselects once when the 64K overflow retry selected server disconnects', async () => {
+        let retrieveCount = 0;
+        global.fetch = makeRelayFetch({
+            selectedTier: ({ selectionCount }) => (selectionCount === 1 ? '8k-fast' : '64k-full'),
+            retrieveStatuses: [200, 404, 200],
+            replyForRetrieve: () => {
+                retrieveCount += 1;
+                if (retrieveCount === 1) {
+                    return {
+                        error: {
+                            code: 'compute_node_context_window_exceeded',
+                            message: 'too large for active context',
+                            retryable: true,
+                            recommended_context_tier: '64k-full',
+                        },
+                    };
+                }
+                return { choices: [{ message: { content: 'retried after disconnect' } }] };
+            },
+        });
+
+        await expect(
+            TokenPlaceChatV2([{ role: 'user', content: 'hello retry disconnect' }], {
+                pollIntervalMs: 1,
+            })
+        ).resolves.toMatchObject({
+            text: 'retried after disconnect',
+            metadata: {
+                tokenPlaceContext: {
+                    requestedTier: '64k-full',
+                    escalationRetry: true,
+                },
+            },
+        });
+
+        const selections = fetch.mock.calls
+            .filter(([url]) => urlPathEndsWith(url, '/api/v1/relay/servers/next'))
+            .map(([url]) => new URL(url).searchParams.get('context_tier'));
+        expect(selections).toEqual(['8k-fast', '64k-full', '64k-full']);
+    });
+
     test('shared prompt and token.place payload omit stale provider guidance', async () => {
         const promptPayload = await buildChatPrompt([{ role: 'user', content: 'hello' }]);
         const serializedPrompt = JSON.stringify({

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -359,7 +359,7 @@ test.describe('Chat provider routing', () => {
         }> = [];
         const legacyRequests: string[] = [];
         const serverKey = await generateRelayKeypair();
-        await page.route('https://token.place/api/v1/relay/servers/next', async (route) => {
+        await page.route('https://token.place/api/v1/relay/servers/next**', async (route) => {
             const request = route.request();
             tokenPlaceRequests.push({
                 url: request.url(),
@@ -369,7 +369,11 @@ test.describe('Chat provider routing', () => {
             await route.fulfill({
                 status: 200,
                 contentType: 'application/json',
-                body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+                body: JSON.stringify({
+                    server_public_key: serverKey.publicKeyBase64,
+                    context_tier: '8k-fast',
+                    selected_profile_id: 'e2e-8k',
+                }),
             });
         });
         await page.route('https://token.place/api/v1/relay/requests', async (route) => {
@@ -439,11 +443,13 @@ test.describe('Chat provider routing', () => {
         await chatPanel.getByRole('button', { name: 'Send' }).click();
 
         await expect(chatPanel.getByText('token.place grounded reply')).toBeVisible();
-        expect(tokenPlaceRequests.map((request) => request.url)).toEqual([
+        const tokenPlaceUrls = tokenPlaceRequests.map((request) => new URL(request.url));
+        expect(tokenPlaceUrls.map((url) => `${url.origin}${url.pathname}`)).toEqual([
             'https://token.place/api/v1/relay/servers/next',
             'https://token.place/api/v1/relay/requests',
             'https://token.place/api/v1/relay/responses/retrieve',
         ]);
+        expect(tokenPlaceUrls[0].searchParams.get('context_tier')).toBe('8k-fast');
         expect(legacyRequests).toEqual([]);
         const { body, headers } = tokenPlaceRequests[1];
         expect(headers.authorization).toBeUndefined();

--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -366,13 +366,15 @@ test.describe('Chat provider routing', () => {
                 body: {},
                 headers: request.headers(),
             });
+            const requestedTier =
+                new URL(request.url()).searchParams.get('context_tier') || '8k-fast';
             await route.fulfill({
                 status: 200,
                 contentType: 'application/json',
                 body: JSON.stringify({
                     server_public_key: serverKey.publicKeyBase64,
-                    context_tier: '8k-fast',
-                    selected_profile_id: 'e2e-8k',
+                    context_tier: requestedTier,
+                    selected_profile_id: `e2e-${requestedTier}`,
                 }),
             });
         });
@@ -449,7 +451,7 @@ test.describe('Chat provider routing', () => {
             'https://token.place/api/v1/relay/requests',
             'https://token.place/api/v1/relay/responses/retrieve',
         ]);
-        expect(tokenPlaceUrls[0].searchParams.get('context_tier')).toBe('8k-fast');
+        expect(tokenPlaceUrls[0].searchParams.get('context_tier')).toMatch(/^(8k-fast|64k-full)$/);
         expect(legacyRequests).toEqual([]);
         const { body, headers } = tokenPlaceRequests[1];
         expect(headers.authorization).toBeUndefined();

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -81,13 +81,15 @@ async function routeTokenPlaceSuccess(page: Page, origin = 'https://token.place'
             headers: route.request().headers(),
             body: {},
         });
+        const requestedTier =
+            new URL(route.request().url()).searchParams.get('context_tier') || '8k-fast';
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
                 server_public_key: serverKey.publicKeyBase64,
-                context_tier: '8k-fast',
-                selected_profile_id: 'e2e-8k',
+                context_tier: requestedTier,
+                selected_profile_id: `e2e-${requestedTier}`,
             }),
         });
     });
@@ -191,7 +193,7 @@ test.describe('Chat provider routing', () => {
             'https://token.place/api/v1/relay/requests',
             'https://token.place/api/v1/relay/responses/retrieve',
         ]);
-        expect(requestUrls[0].searchParams.get('context_tier')).toBe('8k-fast');
+        expect(requestUrls[0].searchParams.get('context_tier')).toMatch(/^(8k-fast|64k-full)$/);
         const request = requests[1];
         expect(request.method).toBe('POST');
         expect(request.headers.authorization).toBeUndefined();
@@ -233,7 +235,7 @@ test.describe('Chat provider routing', () => {
         expect(`${selectionUrl.origin}${selectionUrl.pathname}`).toBe(
             'https://token.place/api/v1/relay/servers/next'
         );
-        expect(selectionUrl.searchParams.get('context_tier')).toBe('8k-fast');
+        expect(selectionUrl.searchParams.get('context_tier')).toMatch(/^(8k-fast|64k-full)$/);
         expect(requests[0].url).not.toContain('/api/api/v1/relay');
     });
 

--- a/frontend/e2e/chat-provider-routing.spec.ts
+++ b/frontend/e2e/chat-provider-routing.spec.ts
@@ -74,7 +74,7 @@ const tokenPlacePayload = (content = 'token.place assistant reply') => ({
 async function routeTokenPlaceSuccess(page: Page, origin = 'https://token.place') {
     const requests: CapturedRequest[] = [];
     const serverKey = await generateRelayKeypair();
-    await page.route(`${origin}/api/v1/relay/servers/next`, async (route) => {
+    await page.route(`${origin}/api/v1/relay/servers/next**`, async (route) => {
         requests.push({
             method: route.request().method(),
             url: route.request().url(),
@@ -84,7 +84,11 @@ async function routeTokenPlaceSuccess(page: Page, origin = 'https://token.place'
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+            body: JSON.stringify({
+                server_public_key: serverKey.publicKeyBase64,
+                context_tier: '8k-fast',
+                selected_profile_id: 'e2e-8k',
+            }),
         });
     });
     await page.route(`${origin}/api/v1/relay/requests`, async (route) => {
@@ -181,11 +185,13 @@ test.describe('Chat provider routing', () => {
         await sendFromPanel(chatPanel, 'Route my fresh profile through token.place');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
 
-        expect(requests.map((request) => request.url)).toEqual([
+        const requestUrls = requests.map((request) => new URL(request.url));
+        expect(requestUrls.map((url) => `${url.origin}${url.pathname}`)).toEqual([
             'https://token.place/api/v1/relay/servers/next',
             'https://token.place/api/v1/relay/requests',
             'https://token.place/api/v1/relay/responses/retrieve',
         ]);
+        expect(requestUrls[0].searchParams.get('context_tier')).toBe('8k-fast');
         const request = requests[1];
         expect(request.method).toBe('POST');
         expect(request.headers.authorization).toBeUndefined();
@@ -223,7 +229,11 @@ test.describe('Chat provider routing', () => {
         await sendFromPanel(chatPanel, 'Use runtime token.place');
         await expect(chatPanel.getByText('token.place assistant reply')).toBeVisible();
 
-        expect(requests[0].url).toBe('https://token.place/api/v1/relay/servers/next');
+        const selectionUrl = new URL(requests[0].url);
+        expect(`${selectionUrl.origin}${selectionUrl.pathname}`).toBe(
+            'https://token.place/api/v1/relay/servers/next'
+        );
+        expect(selectionUrl.searchParams.get('context_tier')).toBe('8k-fast');
         expect(requests[0].url).not.toContain('/api/api/v1/relay');
     });
 

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -99,7 +99,7 @@ async function encryptRelayEnvelope(
 const installTokenPlaceStub = async (page: Page, mode: TokenPlaceStubMode) => {
     const serverKey = await generateRelayKeypair();
 
-    await page.route('https://token.place/api/v1/relay/servers/next', async (route) => {
+    await page.route('https://token.place/api/v1/relay/servers/next**', async (route) => {
         if (mode === 'network-error') {
             await route.abort('failed');
             return;
@@ -108,7 +108,11 @@ const installTokenPlaceStub = async (page: Page, mode: TokenPlaceStubMode) => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify({ server_public_key: serverKey.publicKeyBase64 }),
+            body: JSON.stringify({
+                server_public_key: serverKey.publicKeyBase64,
+                context_tier: '8k-fast',
+                selected_profile_id: 'e2e-8k',
+            }),
         });
     });
 

--- a/frontend/e2e/token-place-chat-banners.spec.ts
+++ b/frontend/e2e/token-place-chat-banners.spec.ts
@@ -105,13 +105,15 @@ const installTokenPlaceStub = async (page: Page, mode: TokenPlaceStubMode) => {
             return;
         }
 
+        const requestedTier =
+            new URL(route.request().url()).searchParams.get('context_tier') || '8k-fast';
         await route.fulfill({
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
                 server_public_key: serverKey.publicKeyBase64,
-                context_tier: '8k-fast',
-                selected_profile_id: 'e2e-8k',
+                context_tier: requestedTier,
+                selected_profile_id: `e2e-${requestedTier}`,
             }),
         });
     });

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -38,20 +38,38 @@ default.
 
 ## v3.1 / P8 relay E2EE implementation target
 
-The relay E2EE flow below is the v3.1 / P8 implementation target and the production/staging
-promotion gate for P8b. Until that client implementation lands, the shipped DSPACE Chat client is
-being corrected from its legacy plaintext token.place API v1 request path. Operators should not use
-the relay-route sequence below as evidence that today's shipped `/chat` client already dispatches
-relay-blind requests; use it as the required target for the P8b implementation PR and release
-sign-off.
+DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The browser
+generates a DSPACE `/chat` client keypair, estimates the sanitized API v1 message payload locally,
+requests the selected context tier with `GET /api/v1/relay/servers/next?model=...&context_tier=...`,
+builds a `tokenplace_api_v1_relay_e2ee` envelope with `client_public_key`, encrypts that API v1
+chat request envelope for the compute node, dispatches ciphertext with
+`POST /api/v1/relay/requests`, polls `POST /api/v1/relay/responses/retrieve`, then decrypts and
+validates the response client-side before reading `api_v1_response.message.content` or
+`api_v1_response.choices[0].message.content`.
 
-DSPACE v3.1 / P8 requires token.place API v1 relay E2EE routes for the default Chat path. The
-browser must generate a DSPACE `/chat` client keypair, fetch a compute node with
-`GET /api/v1/relay/servers/next`, build a `tokenplace_api_v1_relay_e2ee` envelope with
-`client_public_key`, encrypt that API v1 chat request envelope for the compute node, dispatch
-ciphertext with `POST /api/v1/relay/requests`, poll
-`POST /api/v1/relay/responses/retrieve`, then decrypt and validate the response client-side
-before reading `api_v1_response.choices[0].message.content`.
+## Context tiers and bounded retry
+
+DSPACE estimates the complete sanitized token.place API v1 messages in the browser before relay
+selection. The estimator chooses `8k-fast` when the prompt estimate plus output reservation and
+safety margin fits 8,192 tokens, chooses `64k-full` when it needs the larger 65,536-token tier, and
+fails locally with a context-budget message when the request is estimated above 64K. The estimate is
+only a routing hint; the compute node remains authoritative.
+
+The encrypted API v1 request includes `routing.context_tier` with the requested tier. The
+relay-visible request remains ciphertext-only plus the existing public routing envelope and does not
+include exact token counts, prompt text, docs/RAG snippets, player state, private keys, ciphertext in
+logs, or decrypted content. DSPACE validates the relay-selected node metadata, accepts controlled
+spillover from an `8k-fast` request to a `64k-full` node, and records safe diagnostics such as
+requested tier, selected tier, spillover, estimator version, token estimates, timeout class, and safe
+error code.
+
+If an `8k-fast` attempt lands on an 8K node and the encrypted compute response reports
+`compute_node_context_window_exceeded` as retryable or recommends `64k-full`, DSPACE retries exactly
+once on `64k-full`. The retry reuses the unchanged sanitized message payload, reselects a fresh
+64K-capable node, re-encrypts for the new public key, and uses a new request ID and cancel token.
+DSPACE does not retry 64K overflows, request-too-large errors, invalid requests, malformed responses,
+policy errors, model unsupported errors, provider errors, or network errors beyond existing safe
+behavior.
 
 The relay request payload must be ciphertext-only plus safe routing metadata. token.place
 relay-owned state and logs must not receive plaintext DSPACE prompt messages, player state, docs

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -36,9 +36,9 @@ If OpenAI is selected without a saved key, Chat should guide you back to Setting
 an empty-key request. Switch the provider back to token.place in Settings to return to the no-key
 default.
 
-## v3.1 / P8 relay E2EE implementation target
+## v3.1 / P8 implementation target: relay E2EE
 
-DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The browser
+Until that client implementation lands, P8 QA treats the relay E2EE route sequence and ciphertext-only invariant as the implementation target. DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The browser
 generates a DSPACE `/chat` client keypair, estimates the sanitized API v1 message payload locally,
 requests the selected context tier with `GET /api/v1/relay/servers/next?model=...&context_tier=...`,
 builds a `tokenplace_api_v1_relay_e2ee` envelope with `client_public_key`, encrypts that API v1

--- a/frontend/src/pages/docs/md/token-place.md
+++ b/frontend/src/pages/docs/md/token-place.md
@@ -36,9 +36,9 @@ If OpenAI is selected without a saved key, Chat should guide you back to Setting
 an empty-key request. Switch the provider back to token.place in Settings to return to the no-key
 default.
 
-## v3.1 / P8 implementation target: relay E2EE
+## v3.1 relay E2EE implementation target
 
-Until that client implementation lands, P8 QA treats the relay E2EE route sequence and ciphertext-only invariant as the implementation target. DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The browser
+DSPACE v3.1 uses token.place API v1 relay E2EE routes for the default Chat path. The browser
 generates a DSPACE `/chat` client keypair, estimates the sanitized API v1 message payload locally,
 requests the selected context tier with `GET /api/v1/relay/servers/next?model=...&context_tier=...`,
 builds a `tokenplace_api_v1_relay_e2ee` envelope with `client_public_key`, encrypts that API v1

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -95,14 +95,14 @@ export const extractTokenPlaceAssistantText = (response) => {
 };
 
 const CONTEXT_TIER_ORDER = { '8k-fast': 1, '64k-full': 2 };
+const CONTEXT_TIER_MIN_WINDOW_TOKENS = { '8k-fast': 8_000, '64k-full': 64_000 };
 
 const isValidContextTier = (tier) => Object.hasOwn(CONTEXT_TIER_ORDER, tier);
 
 const canSatisfyContextTier = (selectedTier, requestedTier) =>
-    !selectedTier ||
-    (isValidContextTier(selectedTier) &&
-        isValidContextTier(requestedTier) &&
-        CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier]);
+    isValidContextTier(selectedTier) &&
+    isValidContextTier(requestedTier) &&
+    CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier];
 
 const getStructuredApiErrorStatus = (apiResponse) => {
     const candidates = [
@@ -154,8 +154,14 @@ const getApiErrorActiveTier = (apiResponse) =>
     apiResponse?.error?.activeContextTier ||
     apiResponse?.error?.selected_context_tier ||
     apiResponse?.error?.selectedContextTier ||
+    apiResponse?.error?.context_tier ||
+    apiResponse?.error?.contextTier ||
     apiResponse?.error?.metadata?.active_context_tier ||
-    apiResponse?.error?.metadata?.selected_context_tier;
+    apiResponse?.error?.metadata?.activeContextTier ||
+    apiResponse?.error?.metadata?.selected_context_tier ||
+    apiResponse?.error?.metadata?.selectedContextTier ||
+    apiResponse?.error?.metadata?.context_tier ||
+    apiResponse?.error?.metadata?.contextTier;
 
 const shouldRetryContextOverflow = (apiResponse, attempt) => {
     const error = apiResponse?.error;
@@ -165,10 +171,13 @@ const shouldRetryContextOverflow = (apiResponse, attempt) => {
     const recommends64k =
         error.recommended_context_tier === '64k-full' ||
         error.recommendedContextTier === '64k-full' ||
-        error.metadata?.recommended_context_tier === '64k-full';
+        error.metadata?.recommended_context_tier === '64k-full' ||
+        error.metadata?.recommendedContextTier === '64k-full';
+    const activeTier = getApiErrorActiveTier(apiResponse);
     return (
         attempt?.requestedTier === '8k-fast' &&
         attempt?.relaySelectedTier !== '64k-full' &&
+        activeTier !== '64k-full' &&
         (error.retryable === true || recommends64k)
     );
 };
@@ -464,6 +473,67 @@ const getRelayProfileEcho = (data) =>
     data?.selectedProfile?.id ||
     data?.profile?.id;
 
+const getRelaySelectedContextWindowTokens = (data) => {
+    const value =
+        data?.selected_context_window_tokens ??
+        data?.selectedContextWindowTokens ??
+        data?.context_window_tokens ??
+        data?.contextWindowTokens ??
+        data?.profile?.selected_context_window_tokens ??
+        data?.profile?.selectedContextWindowTokens ??
+        data?.profile?.context_window_tokens ??
+        data?.profile?.contextWindowTokens ??
+        data?.selected_profile?.selected_context_window_tokens ??
+        data?.selected_profile?.context_window_tokens ??
+        data?.selectedProfile?.selectedContextWindowTokens ??
+        data?.selectedProfile?.contextWindowTokens;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric > 0 ? numeric : undefined;
+};
+
+const getRelaySelectedModelSupport = (data) =>
+    data?.selected_model_support ??
+    data?.selectedModelSupport ??
+    data?.model_support ??
+    data?.modelSupport ??
+    data?.models ??
+    data?.profile?.selected_model_support ??
+    data?.profile?.selectedModelSupport ??
+    data?.profile?.model_support ??
+    data?.profile?.modelSupport ??
+    data?.profile?.models ??
+    data?.selected_profile?.selected_model_support ??
+    data?.selected_profile?.model_support ??
+    data?.selected_profile?.models ??
+    data?.selectedProfile?.selectedModelSupport ??
+    data?.selectedProfile?.modelSupport ??
+    data?.selectedProfile?.models;
+
+const relayModelSupportIncludes = (modelSupport, requestedModel) => {
+    if (!modelSupport || !requestedModel) return true;
+    if (Array.isArray(modelSupport)) return modelSupport.includes(requestedModel);
+    if (typeof modelSupport === 'string') return modelSupport === requestedModel;
+    if (typeof modelSupport === 'object') {
+        if (Array.isArray(modelSupport.models)) return modelSupport.models.includes(requestedModel);
+        if (Array.isArray(modelSupport.supported_models)) {
+            return modelSupport.supported_models.includes(requestedModel);
+        }
+        if (Array.isArray(modelSupport.supportedModels)) {
+            return modelSupport.supportedModels.includes(requestedModel);
+        }
+        if (typeof modelSupport[requestedModel] === 'boolean') return modelSupport[requestedModel];
+    }
+    return false;
+};
+
+const relayContextWindowSatisfiesTier = (windowTokens, selectedTier, requestedTier) => {
+    if (!windowTokens) return true;
+    return (
+        windowTokens >= CONTEXT_TIER_MIN_WINDOW_TOKENS[selectedTier] &&
+        windowTokens >= CONTEXT_TIER_MIN_WINDOW_TOKENS[requestedTier]
+    );
+};
+
 export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     const params = new URLSearchParams();
     if (options.model) params.set('model', options.model);
@@ -480,9 +550,27 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     const normalized = normalizeTokenPlacePublicKey(rawKey);
     const selectedTier = getRelaySelectedContextTier(data);
     if (options.contextTier) {
-        if (!canSatisfyContextTier(selectedTier, options.contextTier)) {
+        if (!selectedTier || !canSatisfyContextTier(selectedTier, options.contextTier)) {
             throw createMalformedTokenPlaceResponseError(
                 'token.place relay selected incompatible context tier metadata.'
+            );
+        }
+        const selectedWindowTokens = getRelaySelectedContextWindowTokens(data);
+        if (
+            !relayContextWindowSatisfiesTier(
+                selectedWindowTokens,
+                selectedTier,
+                options.contextTier
+            )
+        ) {
+            throw createMalformedTokenPlaceResponseError(
+                'token.place relay selected incompatible context window metadata.'
+            );
+        }
+        const selectedModelSupport = getRelaySelectedModelSupport(data);
+        if (!relayModelSupportIncludes(selectedModelSupport, options.model)) {
+            throw createMalformedTokenPlaceResponseError(
+                'token.place relay selected incompatible model metadata.'
             );
         }
     }

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -8,6 +8,7 @@ import {
     TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
     TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from './tokenPlaceMessages.js';
+import { estimateTokenPlaceContextForSanitizedMessages } from './tokenPlaceContextEstimator.js';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -19,7 +20,9 @@ const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
 const RELAY_PROTOCOL = 'tokenplace_api_v1_relay_e2ee';
 const RELAY_VERSION = 1;
 const DEFAULT_CHAT_MODEL = 'llama-3.1-8b-instruct';
-const DEFAULT_RELAY_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_FAST_TIER_TIMEOUT_MS = 30_000;
+export const TOKEN_PLACE_FULL_TIER_TIMEOUT_MS = 120_000;
+const DEFAULT_RELAY_TIMEOUT_MS = TOKEN_PLACE_FAST_TIER_TIMEOUT_MS;
 const DEFAULT_RELAY_POLL_INTERVAL_MS = 500;
 export {
     sanitizeTokenPlaceMessages,
@@ -91,6 +94,15 @@ export const extractTokenPlaceAssistantText = (response) => {
     return content;
 };
 
+const CONTEXT_TIER_ORDER = { '8k-fast': 1, '64k-full': 2 };
+
+const isValidContextTier = (tier) => Object.hasOwn(CONTEXT_TIER_ORDER, tier);
+
+const canSatisfyContextTier = (selectedTier, requestedTier) =>
+    isValidContextTier(selectedTier) &&
+    isValidContextTier(requestedTier) &&
+    CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier];
+
 const getStructuredApiErrorStatus = (apiResponse) => {
     const candidates = [
         apiResponse?.error?.status,
@@ -109,6 +121,55 @@ const throwStructuredTokenPlaceApiError = (apiResponse) => {
     throw createTokenPlaceHttpError(getStructuredApiErrorStatus(apiResponse), {
         error: apiResponse.error,
     });
+};
+
+const createTokenPlaceContextBudgetError = (contextEstimate) => {
+    const metadata = {
+        estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
+        reservedOutputTokens: contextEstimate.reservedOutputTokens,
+        failedTier: '64k-full',
+        estimatorVersion: contextEstimate.estimatorVersion,
+    };
+    const error = createTokenPlaceHttpError(413, {
+        error: {
+            code: 'dspace_context_budget_exceeded',
+            message:
+                'This chat request is too large for token.place 64K context. Reduce the message or disable extra context and try again.',
+            type: 'validation',
+            metadata,
+        },
+    });
+    error.safeMetadata = metadata;
+    return error;
+};
+
+const getApiErrorCode = (apiResponse) =>
+    apiResponse?.error && typeof apiResponse.error === 'object'
+        ? apiResponse.error.code
+        : undefined;
+
+const getApiErrorActiveTier = (apiResponse) =>
+    apiResponse?.error?.active_context_tier ||
+    apiResponse?.error?.activeContextTier ||
+    apiResponse?.error?.selected_context_tier ||
+    apiResponse?.error?.selectedContextTier ||
+    apiResponse?.error?.metadata?.active_context_tier ||
+    apiResponse?.error?.metadata?.selected_context_tier;
+
+const shouldRetryContextOverflow = (apiResponse, attempt) => {
+    const error = apiResponse?.error;
+    if (!error || getApiErrorCode(apiResponse) !== 'compute_node_context_window_exceeded') {
+        return false;
+    }
+    const recommends64k =
+        error.recommended_context_tier === '64k-full' ||
+        error.recommendedContextTier === '64k-full' ||
+        error.metadata?.recommended_context_tier === '64k-full';
+    return (
+        attempt?.requestedTier === '8k-fast' &&
+        attempt?.relaySelectedTier !== '64k-full' &&
+        (error.retryable === true || recommends64k)
+    );
 };
 
 const parseErrorPayload = async (response) => {
@@ -383,9 +444,32 @@ const fetchJson = async (url, init, unavailableMessage) => {
     }
 };
 
+const getRelaySelectedContextTier = (data) =>
+    data?.selected_context_tier ||
+    data?.selectedContextTier ||
+    data?.context_tier ||
+    data?.contextTier ||
+    data?.profile?.context_tier ||
+    data?.profile?.contextTier ||
+    data?.selected_profile?.context_tier ||
+    data?.selectedProfile?.contextTier;
+
+const getRelayProfileEcho = (data) =>
+    data?.selected_profile_id ||
+    data?.selectedProfileId ||
+    data?.profile_id ||
+    data?.profileId ||
+    data?.selected_profile?.id ||
+    data?.selectedProfile?.id ||
+    data?.profile?.id;
+
 export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
+    const params = new URLSearchParams();
+    if (options.model) params.set('model', options.model);
+    if (options.contextTier) params.set('context_tier', options.contextTier);
+    const suffix = params.toString() ? `?${params}` : '';
     const data = await fetchJson(
-        `${baseUrl}/api/v1/relay/servers/next`,
+        `${baseUrl}/api/v1/relay/servers/next${suffix}`,
         { method: 'GET', signal: options.signal },
         'token.place relay is unavailable.'
     );
@@ -393,7 +477,24 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     if (!rawKey)
         throw createMalformedTokenPlaceResponseError('No token.place compute node is available.');
     const normalized = normalizeTokenPlacePublicKey(rawKey);
-    return { ...data, server_public_key: normalized.base64, serverPublicKeyPem: normalized.pem };
+    const selectedTier = getRelaySelectedContextTier(data);
+    if (options.contextTier) {
+        if (!canSatisfyContextTier(selectedTier, options.contextTier)) {
+            throw createMalformedTokenPlaceResponseError(
+                'token.place relay selected incompatible context tier metadata.'
+            );
+        }
+    }
+    return {
+        ...data,
+        server_public_key: normalized.base64,
+        serverPublicKeyPem: normalized.pem,
+        selectedContextTier: selectedTier,
+        selectedProfileId: getRelayProfileEcho(data),
+        spillover: Boolean(
+            options.contextTier && selectedTier && selectedTier !== options.contextTier
+        ),
+    };
 };
 
 export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
@@ -552,13 +653,24 @@ const resolveTokenPlacePromptPayload = async (messages, options = {}) => {
     return buildChatPrompt(messages, options);
 };
 
-const buildApiV1Request = (promptPayload, options = {}) => ({
-    model: getTokenPlaceChatModel(options),
-    messages: sanitizeTokenPlaceMessages(promptPayload.combinedMessages),
+const buildApiV1Request = (messages, options = {}) => ({
+    model: options.model || getTokenPlaceChatModel(options),
+    messages,
     options: {},
+    routing: {
+        context_tier: options.contextTier,
+        ...(options.selectedProfileId ? { selected_profile_id: options.selectedProfileId } : {}),
+    },
 });
 
-const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
+const getTimeoutClassForTier = (tier) => (tier === '64k-full' ? '64k-full' : '8k-fast');
+const getTimeoutForTier = (tier, options = {}) =>
+    options.timeoutMs ??
+    (getTimeoutClassForTier(tier) === '64k-full'
+        ? TOKEN_PLACE_FULL_TIER_TIMEOUT_MS
+        : TOKEN_PLACE_FAST_TIER_TIMEOUT_MS);
+
+const runRelayAttempt = async (baseUrl, messages, options = {}) => {
     const server = await selectTokenPlaceRelayServer(baseUrl, options);
     const clientKeys = options.clientKeys || (await generateTokenPlaceClientKeypair());
     const requestId = options.requestId || randomBase64Url();
@@ -568,7 +680,10 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
         version: RELAY_VERSION,
         request_id: requestId,
         client_public_key: clientKeys.publicKeyBase64,
-        api_v1_request: buildApiV1Request(promptPayload, options),
+        api_v1_request: buildApiV1Request(messages, {
+            ...options,
+            selectedProfileId: server.selectedProfileId,
+        }),
     };
     const encrypted = await encryptTokenPlaceEnvelope(envelope, server.serverPublicKeyPem);
     const dispatched = await dispatchTokenPlaceRelayRequest(
@@ -590,7 +705,14 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     const encryptedResponse = await pollTokenPlaceRelayResponse(
         baseUrl,
         { client_public_key: clientKeys.publicKeyBase64, request_id: requestId },
-        { ...options, cancelToken }
+        {
+            ...options,
+            cancelToken,
+            timeoutMs: getTimeoutForTier(
+                server.selectedContextTier || options.contextTier,
+                options
+            ),
+        }
     );
     if (encryptedResponse?.terminalSelectedServerFailure) return encryptedResponse;
     let responseEnvelope;
@@ -602,10 +724,20 @@ const runRelayAttempt = async (baseUrl, promptPayload, options = {}) => {
     } catch (error) {
         throw createMalformedTokenPlaceResponseError('Malformed encrypted token.place response.');
     }
-    return validateTokenPlaceResponseEnvelope(responseEnvelope, {
+    const apiResponse = validateTokenPlaceResponseEnvelope(responseEnvelope, {
         requestId,
         clientPublicKey: clientKeys.publicKeyBase64,
     });
+    return {
+        apiResponse,
+        diagnostics: {
+            requestedTier: options.contextTier,
+            relaySelectedTier: server.selectedContextTier,
+            spillover: server.spillover,
+            timeoutClass: getTimeoutClassForTier(server.selectedContextTier || options.contextTier),
+            requestId,
+        },
+    };
 };
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
@@ -620,18 +752,42 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         runtimeUrl: options.runtimeUrl,
     });
 
-    let data = await runRelayAttempt(baseUrl, promptPayload, options);
-    if (data?.terminalSelectedServerFailure) {
-        data = await runRelayAttempt(baseUrl, promptPayload, {
-            ...options,
+    const model = getTokenPlaceChatModel(options);
+    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+    const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
+        reservedOutputTokens: options.reservedOutputTokens,
+        safetyMarginTokens: options.safetyMarginTokens,
+    });
+    if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
+
+    const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
+    let attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
+    if (attempt?.terminalSelectedServerFailure) {
+        attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
+            ...baseAttemptOptions,
             requestId: undefined,
             cancelToken: undefined,
         });
-        if (data?.terminalSelectedServerFailure) {
+        if (attempt?.terminalSelectedServerFailure) {
             throw createMalformedTokenPlaceResponseError(
                 'No token.place compute node is available.'
             );
         }
+    }
+
+    let data = attempt.apiResponse;
+    if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
+        const retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
+            ...baseAttemptOptions,
+            contextTier: '64k-full',
+            requestId: undefined,
+            cancelToken: undefined,
+        });
+        attempt = {
+            ...retry,
+            diagnostics: { ...retry.diagnostics, escalationRetry: true },
+        };
+        data = retry.apiResponse;
     }
 
     throwStructuredTokenPlaceApiError(data);
@@ -642,7 +798,21 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         text,
         contextSources,
         usage: data?.usage,
-        metadata: data?.metadata,
+        metadata: {
+            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+            tokenPlaceContext: {
+                requestedTier: contextEstimate.selectedTier,
+                relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
+                finalActiveTier: getApiErrorActiveTier(data),
+                spillover: Boolean(attempt.diagnostics?.spillover),
+                escalationRetry: Boolean(attempt.diagnostics?.escalationRetry),
+                estimatorVersion: contextEstimate.estimatorVersion,
+                estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
+                reservedOutputTokens: contextEstimate.reservedOutputTokens,
+                timeoutClass: attempt.diagnostics?.timeoutClass,
+                safeErrorCode: getApiErrorCode(data),
+            },
+        },
     };
 };
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -99,9 +99,10 @@ const CONTEXT_TIER_ORDER = { '8k-fast': 1, '64k-full': 2 };
 const isValidContextTier = (tier) => Object.hasOwn(CONTEXT_TIER_ORDER, tier);
 
 const canSatisfyContextTier = (selectedTier, requestedTier) =>
-    isValidContextTier(selectedTier) &&
-    isValidContextTier(requestedTier) &&
-    CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier];
+    !selectedTier ||
+    (isValidContextTier(selectedTier) &&
+        isValidContextTier(requestedTier) &&
+        CONTEXT_TIER_ORDER[selectedTier] >= CONTEXT_TIER_ORDER[requestedTier]);
 
 const getStructuredApiErrorStatus = (apiResponse) => {
     const candidates = [
@@ -777,12 +778,25 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
 
     let data = attempt.apiResponse;
     if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
-        const retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
+        const retryAttemptOptions = {
             ...baseAttemptOptions,
             contextTier: '64k-full',
             requestId: undefined,
             cancelToken: undefined,
-        });
+        };
+        let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
+        if (retry?.terminalSelectedServerFailure) {
+            retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
+                ...retryAttemptOptions,
+                requestId: undefined,
+                cancelToken: undefined,
+            });
+            if (retry?.terminalSelectedServerFailure) {
+                throw createMalformedTokenPlaceResponseError(
+                    'No token.place compute node is available.'
+                );
+            }
+        }
         attempt = {
             ...retry,
             diagnostics: { ...retry.diagnostics, escalationRetry: true },
@@ -801,7 +815,7 @@ export const TokenPlaceChatV2 = async (messages, options = {}) => {
         metadata: {
             ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
             tokenPlaceContext: {
-                requestedTier: contextEstimate.selectedTier,
+                requestedTier: attempt.diagnostics?.requestedTier || contextEstimate.selectedTier,
                 relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
                 finalActiveTier: getApiErrorActiveTier(data),
                 spillover: Boolean(attempt.diagnostics?.spillover),

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -8,7 +8,10 @@ import {
     TOKEN_PLACE_API_V1_MAX_MESSAGE_CONTENT_CHARS,
     TOKEN_PLACE_API_V1_MAX_TOTAL_CONTENT_CHARS,
 } from './tokenPlaceMessages.js';
-import { estimateTokenPlaceContextForSanitizedMessages } from './tokenPlaceContextEstimator.js';
+import {
+    estimateTokenPlaceContextForSanitizedMessages,
+    TOKEN_PLACE_CONTEXT_TIERS,
+} from './tokenPlaceContextEstimator.js';
 import {
     createMalformedTokenPlaceResponseError,
     createTokenPlaceHttpError,
@@ -95,7 +98,12 @@ export const extractTokenPlaceAssistantText = (response) => {
 };
 
 const CONTEXT_TIER_ORDER = { '8k-fast': 1, '64k-full': 2 };
-const CONTEXT_TIER_MIN_WINDOW_TOKENS = { '8k-fast': 8_000, '64k-full': 64_000 };
+const CONTEXT_TIER_MIN_WINDOW_TOKENS = Object.fromEntries(
+    Object.entries(TOKEN_PLACE_CONTEXT_TIERS).map(([tier, config]) => [
+        tier,
+        config.totalContextTokens,
+    ])
+);
 
 const isValidContextTier = (tier) => Object.hasOwn(CONTEXT_TIER_ORDER, tier);
 
@@ -550,6 +558,8 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     const normalized = normalizeTokenPlacePublicKey(rawKey);
     const selectedTier = getRelaySelectedContextTier(data);
     if (options.contextTier) {
+        // Missing selected tier metadata fails safely before dispatch rather than
+        // silently degrading to an unvalidated compute node.
         if (!selectedTier || !canSatisfyContextTier(selectedTier, options.contextTier)) {
             throw createMalformedTokenPlaceResponseError(
                 'token.place relay selected incompatible context tier metadata.'

--- a/tests/qaDocsContentAlignment.test.ts
+++ b/tests/qaDocsContentAlignment.test.ts
@@ -113,8 +113,7 @@ describe('token.place doc alignment', () => {
       expect(publicDoc).not.toMatch(claim);
     }
 
-    expect(publicDoc).toMatch(/P8 implementation target/i);
-    expect(publicDoc).toMatch(/Until that client implementation lands/i);
+    expect(publicDoc).toMatch(/relay E2EE implementation target/i);
     expect(publicDoc).toMatch(/https:\/\/token\.place/);
     expect(publicDoc).toMatch(/default provider/i);
     expect(publicDoc).toMatch(/OpenAI/i);


### PR DESCRIPTION
### Motivation
- Route full-fat DSPACE chat through token.place using the local P7 estimator so requests are routed to the smallest capable context tier (`8k-fast` or `64k-full`).
- Preserve relay blindness and E2EE while passing safe, relay-visible routing hints and validating relay-selected tier metadata.
- Provide a single controlled escalation path when a compute node reports exact 8K overflow and recommend/allow a 64K retry.

### Description
- Use the existing sanitized API v1 message payload and call the local estimator (`estimateTokenPlaceContextForSanitizedMessages`) to select `context_tier` (`8k-fast` or `64k-full`) and fail locally if over 64K; estimator metadata is preserved as diagnostics.
- Query the relay `GET /api/v1/relay/servers/next` with `model` and `context_tier` parameters, validate the relay-selected tier/public key/profile echo, accept larger selected tiers (spillover) and record `spillover` diagnostics, and reject incompatible smaller selected tiers safely.
- Include `api_v1_request.routing.context_tier` (and selected-profile echo when present) inside the encrypted envelope; do not include token counts, prompt text, RAG, or player state in plaintext.
- Add named, testable timeouts: `TOKEN_PLACE_FAST_TIER_TIMEOUT_MS` and `TOKEN_PLACE_FULL_TIER_TIMEOUT_MS`, and choose the safer timeout based on the selected tier (or spillover) when dispatching/polling.
- Implement a single bounded retry path: only retry once from an initial `8k-fast` request to `64k-full` when the compute node returns an encrypted `compute_node_context_window_exceeded` (and the error is retryable or recommends `64k-full`); the retry reselects a fresh 64K-capable node, re-encrypts the unchanged message payload, and uses a new request id and cancel token while preserving user-visible flow.
- Preserve token-lite behavior and API v1 response parsing (accept `response.message.content`, `response.choices[0].message.content`, and structured `response.error` only).
- Add privacy-safe diagnostics into `metadata.tokenPlaceContext` (requested/relay-selected tier, final active tier when available, spillover, estimator version, estimated tokens/reservation, timeout class, safe error code, escalationRetry, timing breakdown) and ensure no prompt/RAG/player state is logged.
- Tests and docs: expanded `frontend/__tests__/tokenPlace.test.js` with coverage for context-tier query, encrypted routing metadata, spillover behavior, and the bounded retry case, and updated `frontend/src/pages/docs/md/token-place.md` to document tiers and retry behavior.

### Testing
- Ran unit tests: `cd frontend && npm test -- tokenPlace.test.js` and the token.place test suite passed (61 tests passed). 
- Ran static checks: `cd frontend && npm run check` (ESLint + Prettier format check) which succeeded. 
- Built the frontend: `cd frontend && npm run build` which completed successfully. 
- Benchmarked estimator outputs: `npm run benchmark:token-place-context` which wrote artifacts into `artifacts/benchmarks/token-place-context/`.
- Result: focused tests and checks exercised the new estimator → relay selection → envelope encryption → retry flow and all automated checks above completed successfully.

Residual notes: this change expects token.place P12 best-fit routing to be staged so 8K requests normally land on 8K nodes; manual staging validation per QA checklist is recommended before releasing to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de43ec750832f89706015debcce87)