### PR TITLE
Add persona-preserving chat context planner

### DIFF
--- a/frontend/e2e/chat-message-flow.spec.ts
+++ b/frontend/e2e/chat-message-flow.spec.ts
@@ -81,7 +81,7 @@ const installChatStub = async (page: Page, mode: StubMode) => {
     await page.addInitScript(
         ({ reply, stubMode }) => {
             const createResponse = async () => {
-                await new Promise((resolve) => setTimeout(resolve, 150));
+                await new Promise((resolve) => setTimeout(resolve, 750));
 
                 if (stubMode === 'network-error') {
                     const error = new TypeError('');

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -22,11 +22,32 @@ const minimalPlan = () => ({
     confidence: 'high',
 });
 
-const latestUserContent = (messages) =>
+const stringifyContent = (content) => {
+    if (typeof content === 'string') return content;
+    if (content === null || content === undefined) return '';
+    if (Array.isArray(content)) {
+        return content
+            .map((entry) => {
+                if (typeof entry === 'string') return entry;
+                if (entry && typeof entry === 'object') {
+                    return stringifyContent(entry.text ?? entry.content ?? entry.value ?? '');
+                }
+                return stringifyContent(entry);
+            })
+            .filter(Boolean)
+            .join(' ');
+    }
+    if (typeof content === 'object') {
+        return stringifyContent(content.text ?? content.content ?? content.value ?? '');
+    }
+    return String(content);
+};
+
+export const latestUserContent = (messages) =>
     [...(Array.isArray(messages) ? messages : [])]
         .reverse()
-        .find((message) => message?.role === 'user' && String(message.content || '').trim())
-        ?.content || '';
+        .map((message) => (message?.role === 'user' ? stringifyContent(message.content) : ''))
+        .find((content) => content.trim()) || '';
 
 const regexHits = (text, checks) =>
     checks.filter(({ pattern }) => pattern.test(text)).map(({ reasonCode }) => reasonCode);
@@ -40,7 +61,22 @@ const groundingChecks = [
     {
         reasonCode: 'game-data',
         pattern:
-            /\b(token\.place|quests?|items?|process(?:es)?|achievements?|rewards?|requirements?|requires?|consumes?|creates?|duration|recipes?|gates?)\b/i,
+            /\b(token\.place|quests?|achievements?|rewards?|requirements?|gates?|unlocks?|balances?)\b/i,
+    },
+    {
+        reasonCode: 'process-data',
+        pattern:
+            /\bprocess(?:es)?\b(?=.*\b(consumes?|creates?|duration|requires?|requirements?|quest|inventory|dspace|custom|crafting|materials)\b)|\b(consumes?|duration)\b/i,
+    },
+    {
+        reasonCode: 'item-data',
+        pattern:
+            /\bitems?\b(?=.*\b(inventory|quest|dspace|custom|requirements?|rewards?|gates?)\b)/i,
+    },
+    {
+        reasonCode: 'custom-content',
+        pattern:
+            /\b(custom content|custom quests?|custom items?|custom processes?|quest submission|content bundles?|custom content bundles?|content backup|add custom content to dspace)\b/i,
     },
     {
         reasonCode: 'docs-navigation',
@@ -54,7 +90,7 @@ const groundingChecks = [
     },
 ];
 
-const resourcePattern = /\bd(?:USD|BI|Watt|Solar|Print|Launch|Fuel|Oxygen|Water|Food)\b/;
+const resourcePattern = /\bd(?:USD|BI|Watt|Solar|Print|Launch|Fuel|Oxygen|Water|Food)\b/i;
 
 const normalize = (value) =>
     String(value || '')
@@ -88,15 +124,27 @@ const strongEntityTerms = (() => {
     return [...terms].sort((a, b) => b.length - a.length);
 })();
 
-const hasStrongEntityHit = (text) => {
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const strongEntityMatchers = strongEntityTerms.map((term) =>
+    term.includes('/')
+        ? (text) => text.includes(term)
+        : new RegExp(`(^|\\s)${escapeRegExp(term)}(\\s|$)`)
+);
+
+export const hasStrongEntityHit = (text) => {
     const normalizedText = normalize(text);
     if (!normalizedText) return false;
-    return strongEntityTerms.some((term) => {
-        if (term.includes('/')) return normalizedText.includes(term);
-        return new RegExp(`(^|\\s)${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\s|$)`).test(
-            normalizedText
-        );
-    });
+    return strongEntityMatchers.some((matcher) =>
+        typeof matcher === 'function' ? matcher(normalizedText) : matcher.test(normalizedText)
+    );
+};
+
+export const hasGroundingSignal = (text) => {
+    const reasonCodes = regexHits(text, groundingChecks);
+    if (resourcePattern.test(text)) reasonCodes.push('resource-token');
+    if (hasStrongEntityHit(text)) reasonCodes.push('entity-hit');
+    return reasonCodes;
 };
 
 export const planChatContext = (messages, options = {}) => {
@@ -104,9 +152,7 @@ export const planChatContext = (messages, options = {}) => {
     const latest = latestUserContent(messages);
     if (!latest.trim()) return fullPlan(['no-latest-user-message']);
 
-    const reasonCodes = regexHits(latest, groundingChecks);
-    if (resourcePattern.test(latest)) reasonCodes.push('resource-token');
-    if (hasStrongEntityHit(latest)) reasonCodes.push('entity-hit');
+    const reasonCodes = hasGroundingSignal(latest);
 
     return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
 };

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -1,0 +1,112 @@
+import items from '../pages/inventory/json/items';
+import processes from '../generated/processes.json';
+import quests from '../generated/quests/listManifest.json';
+
+const fullPlan = (reasonCodes) => ({
+    mode: 'full',
+    includePlayerState: true,
+    includeKnowledgePack: true,
+    includeDocsRag: true,
+    includePersonaVoiceSamples: false,
+    reasonCodes: [...new Set(reasonCodes)],
+    confidence: 'conservative',
+});
+
+const minimalPlan = () => ({
+    mode: 'minimal',
+    includePlayerState: false,
+    includeKnowledgePack: false,
+    includeDocsRag: false,
+    includePersonaVoiceSamples: true,
+    reasonCodes: ['no-grounding-signals'],
+    confidence: 'high',
+});
+
+const latestUserContent = (messages) =>
+    [...(Array.isArray(messages) ? messages : [])]
+        .reverse()
+        .find((message) => message?.role === 'user' && String(message.content || '').trim())
+        ?.content || '';
+
+const regexHits = (text, checks) =>
+    checks.filter(({ pattern }) => pattern.test(text)).map(({ reasonCode }) => reasonCode);
+
+const groundingChecks = [
+    {
+        reasonCode: 'player-state-progress',
+        pattern:
+            /\b(status|guardrails?|inventory|do i have|can i afford|enough|missing|remaining|left|what next|what should i do|what should i build|unlock(?:s|ed)?|rewards?|completed quests?|active process(?:es)?|running process(?:es)?|balances?|resources?)\b/i,
+    },
+    {
+        reasonCode: 'game-data',
+        pattern:
+            /\b(token\.place|quests?|items?|process(?:es)?|achievements?|rewards?|requirements?|requires?|consumes?|creates?|duration|recipes?|gates?)\b/i,
+    },
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /(?:\/docs|\/quests|\/inventory|\/processes|\/settings|\/gamesaves|\bdocs?\b|\broutes?\b|\bpages?\b|\bsettings\b|\bgamesaves?\b|\bimport\b|\bexport\b|\bwhere do i\b|\bhow do i get to\b)/i,
+    },
+    {
+        reasonCode: 'vague-followup',
+        pattern:
+            /\b(what about (?:that|the|this)|what about the second option|tell me more|continue|next step|that one|the other one)\b/i,
+    },
+];
+
+const resourcePattern = /\bd(?:USD|BI|Watt|Solar|Print|Launch|Fuel|Oxygen|Water|Food)\b/;
+
+const normalize = (value) =>
+    String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9/ -]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const strongEntityTerms = (() => {
+    const terms = new Set(['benchy', 'green pla', 'solar tracker']);
+    for (const item of items || []) {
+        for (const value of [item?.id, item?.name]) {
+            const normalized = normalize(value);
+            if (normalized && (normalized.length >= 5 || /^[0-9a-f-]{8,}$/i.test(String(value)))) {
+                terms.add(normalized);
+            }
+        }
+    }
+    for (const quest of quests || []) {
+        for (const value of [quest?.id, quest?.title, quest?.slug]) {
+            const normalized = normalize(value);
+            if (normalized && normalized.length >= 5) terms.add(normalized);
+        }
+    }
+    for (const process of processes || []) {
+        for (const value of [process?.id, process?.title]) {
+            const normalized = normalize(value);
+            if (normalized && normalized.length >= 5) terms.add(normalized);
+        }
+    }
+    return [...terms].sort((a, b) => b.length - a.length);
+})();
+
+const hasStrongEntityHit = (text) => {
+    const normalizedText = normalize(text);
+    if (!normalizedText) return false;
+    return strongEntityTerms.some((term) => {
+        if (term.includes('/')) return normalizedText.includes(term);
+        return new RegExp(`(^|\\s)${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\s|$)`).test(
+            normalizedText
+        );
+    });
+};
+
+export const planChatContext = (messages, options = {}) => {
+    if (options.contextPlan) return options.contextPlan;
+    const latest = latestUserContent(messages);
+    if (!latest.trim()) return fullPlan(['no-latest-user-message']);
+
+    const reasonCodes = regexHits(latest, groundingChecks);
+    if (resourcePattern.test(latest)) reasonCodes.push('resource-token');
+    if (hasStrongEntityHit(latest)) reasonCodes.push('entity-hit');
+
+    return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
+};

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -56,7 +56,7 @@ const groundingChecks = [
     {
         reasonCode: 'player-state-progress',
         pattern:
-            /\b(status|guardrails?|inventory|do i have|can i afford|enough|missing|remaining|left|what next|what should i do|what should i build|unlock(?:s|ed)?|rewards?|completed quests?|active process(?:es)?|running process(?:es)?|balances?|resources?)\b/i,
+            /\b(status|progress(?:ing)?|guardrails?|inventory|do i have|can i afford|enough|missing|remaining|left|what next|what should i do|what should i build|unlock(?:s|ed)?|rewards?|completed quests?|active process(?:es)?|running process(?:es)?|balances?|resources?)\b/i,
     },
     {
         reasonCode: 'game-data',

--- a/frontend/src/utils/npcDialogueSamples.js
+++ b/frontend/src/utils/npcDialogueSamples.js
@@ -1,0 +1,61 @@
+export const PERSONA_VOICE_SAMPLE_CHAR_LIMIT = 650;
+export const DEFAULT_PERSONA_VOICE_SAMPLE_COUNT = 3;
+
+export const npcDialogueSamples = {
+    dchat: [
+        "Greetings, adventurer! I'm dChat, an advanced AI sidekick crafted by the grand codemancers of this realm.",
+        "No worries! I'm low-maintenance and won't hog your power supply.",
+        'Your quest, dear player, is to master the ancient art of ... questing.',
+    ],
+    sydney: [
+        "I'm Sydney—FDM rigs are my playground.",
+        'Bed off-kilter? Slide paper under the nozzle and level it.',
+        "Claim your printer and we'll tune it together.",
+    ],
+    nova: [
+        "Hey friend! I'm Nova! I'm sure you've met some of my colleagues!",
+        "Nahhh, you're good! According to the FAA, without additional paperwork, the rocket may weigh no more than 1500 grams.",
+        'Before launch, check the wind; even a breeze can skew the trajectory.',
+    ],
+    hydro: [
+        "Hey there! I'm Hydro, your local hydroponics expert!",
+        'Oh I could talk for hours, but the short version? Roots bathe in nutrient-rich water.',
+        "Let's try stevia next. Its leaves are unbelievably sweet!",
+    ],
+};
+
+export const getPersonaVoiceSamples = (
+    personaId,
+    { limit = DEFAULT_PERSONA_VOICE_SAMPLE_COUNT } = {}
+) => {
+    const samples = npcDialogueSamples[String(personaId || '').toLowerCase()] || [];
+    return samples.slice(0, limit);
+};
+
+export const renderPersonaVoiceSamples = (
+    persona,
+    { count = DEFAULT_PERSONA_VOICE_SAMPLE_COUNT, charLimit = PERSONA_VOICE_SAMPLE_CHAR_LIMIT } = {}
+) => {
+    const samples = getPersonaVoiceSamples(persona?.id, { limit: count });
+    if (!samples.length) {
+        return { block: '', count: 0, characters: 0 };
+    }
+
+    const header = `Persona voice examples for ${persona?.name || persona?.id}; use these only as tone/style cues, not as factual grounding:`;
+    const rendered = [];
+    let block = header;
+
+    for (const sample of samples) {
+        const line = `- "${sample}"`;
+        const nextBlock = `${block}\n${line}`;
+        if (nextBlock.length > charLimit) break;
+        rendered.push(sample);
+        block = nextBlock;
+    }
+
+    if (!rendered.length) {
+        return { block: '', count: 0, characters: 0 };
+    }
+
+    return { block, count: rendered.length, characters: block.length };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -7,6 +7,8 @@ import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
 import { buildPromptMetrics } from './promptMetrics.js';
+import { planChatContext } from './chatContextPlanner.js';
+import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -604,6 +606,30 @@ async function createChatResponse(openai, input) {
     }
 }
 
+const buildMinimalChatTail = (messages, latestUserMessage, maxChars = 1200) => {
+    const safeMessages = (Array.isArray(messages) ? messages : [])
+        .filter(
+            (message) =>
+                message &&
+                message !== latestUserMessage &&
+                (message.role === 'user' || message.role === 'assistant') &&
+                typeof message.content === 'string' &&
+                message.content.trim()
+        )
+        .slice(-4);
+    const tail = [];
+    let usedChars = 0;
+
+    for (const message of safeMessages.reverse()) {
+        const content = message.content.trim().slice(0, 500);
+        if (usedChars + content.length > maxChars) break;
+        tail.unshift({ role: message.role, content });
+        usedChars += content.length;
+    }
+
+    return tail;
+};
+
 export const buildChatPrompt = async (messages, options = {}) => {
     const promptBuildStartedAt = performance.now();
     await ready;
@@ -611,6 +637,112 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const rawGameState = loadGameState();
     const hasGameState = rawGameState && typeof rawGameState === 'object';
     const gameState = hasGameState ? rawGameState : {};
+
+    const persona = options.persona || defaultPersona;
+    const basePersonaPrompt = persona?.systemPrompt || fallbackSystemPrompt;
+    const fullSystemPrompt = applySystemPolicyVersion(
+        applyProviderRealityLine(applySystemGuardrail(basePersonaPrompt))
+    );
+    const latestUserMessage = [...normalizedMessages]
+        .reverse()
+        .find((message) => message.role === 'user' && message.content?.trim());
+    const contextPlan = options.contextPlan || planChatContext(normalizedMessages, options);
+
+    if (contextPlan.mode === 'minimal') {
+        const minimalSystemPrompt = applySystemPolicyVersion(
+            applyProviderRealityLine(basePersonaPrompt)
+        );
+        const systemMessage = {
+            role: 'system',
+            content: `Prompt version: v3:${getPromptVersionSha()}\n${minimalSystemPrompt}`,
+        };
+        const voiceSamples = renderPersonaVoiceSamples(persona);
+        const voiceSampleMessage = voiceSamples.block
+            ? {
+                  role: 'system',
+                  content: voiceSamples.block,
+              }
+            : null;
+        const recentTail = buildMinimalChatTail(normalizedMessages, latestUserMessage);
+        const combinedMessages = [systemMessage];
+        if (voiceSampleMessage) combinedMessages.push(voiceSampleMessage);
+        combinedMessages.push(...recentTail);
+        if (latestUserMessage) combinedMessages.push(latestUserMessage);
+        if (!latestUserMessage && combinedMessages.length === (voiceSampleMessage ? 2 : 1)) {
+            combinedMessages.push({
+                role: 'assistant',
+                content: persona?.welcomeMessage || fallbackWelcomeMessage,
+            });
+        }
+
+        const debugMessages = combinedMessages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            kind: 'main',
+        }));
+        const contextPlanMetadata = {
+            ...contextPlan,
+            selectedPersonaId: persona?.id || null,
+            selectedPersonaName: persona?.name || null,
+            personaVoiceSampleCount: voiceSamples.count,
+            personaVoiceSampleCharacters: voiceSamples.characters,
+            includePersonaVoiceSamples: voiceSamples.count > 0,
+        };
+        const promptPayload = {
+            combinedMessages,
+            debugMessages,
+            gameState,
+            contextSources: [],
+            playerStateSummary: {
+                included: false,
+                inventoryIncludedCount: 0,
+                inventoryTotalCount: 0,
+                inventoryTruncated: false,
+            },
+            contextPlan: contextPlanMetadata,
+        };
+
+        if (options.includePromptMetrics) {
+            const latestUserMessageIndex = latestUserMessage
+                ? combinedMessages.lastIndexOf(latestUserMessage)
+                : -1;
+            const voiceSampleMessageIndex = voiceSampleMessage
+                ? combinedMessages.indexOf(voiceSampleMessage)
+                : -1;
+            const chatHistoryIndexes = combinedMessages
+                .map((message, index) => ({ message, index }))
+                .filter(
+                    ({ message, index }) =>
+                        index !== latestUserMessageIndex &&
+                        recentTail.includes(message) &&
+                        message.role !== 'system'
+                )
+                .map(({ index }) => index);
+
+            promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
+                promptBuildDurationMs: performance.now() - promptBuildStartedAt,
+                ragDurationMs: 0,
+                contextPlan: contextPlanMetadata,
+                componentMessageIndexes: {
+                    systemInstructions: [
+                        combinedMessages.indexOf(systemMessage),
+                        voiceSampleMessageIndex,
+                    ].filter((index) => index !== -1),
+                    rag: [],
+                    playerState: -1,
+                    chatHistory: chatHistoryIndexes,
+                    latestUserMessage: latestUserMessageIndex,
+                },
+            });
+        }
+
+        return promptPayload;
+    }
+
+    const systemMessage = {
+        role: 'system',
+        content: `Prompt version: v3:${getPromptVersionSha()}\n${fullSystemPrompt}`,
+    };
     const playerStateSnapshot = buildPlayerStateSnapshot(hasGameState ? rawGameState : null);
     const playerStateMessage = playerStateSnapshot.block
         ? {
@@ -618,17 +750,6 @@ export const buildChatPrompt = async (messages, options = {}) => {
               content: playerStateSnapshot.block,
           }
         : null;
-
-    const persona = options.persona || defaultPersona;
-    const systemPrompt = applySystemPolicyVersion(
-        applyProviderRealityLine(
-            applySystemGuardrail(persona?.systemPrompt || fallbackSystemPrompt)
-        )
-    );
-    const systemMessage = {
-        role: 'system',
-        content: `Prompt version: v3:${getPromptVersionSha()}\n${systemPrompt}`,
-    };
 
     const knowledgePack = buildDchatKnowledgePack(gameState);
     const knowledgeSummary = knowledgePack.summary;
@@ -648,9 +769,6 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ...normalizedMessages,
         ],
     });
-    const latestUserMessage = [...normalizedMessages]
-        .reverse()
-        .find((message) => message.role === 'user' && message.content?.trim());
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
@@ -719,6 +837,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
+        contextPlan,
     };
 
     if (options.includePromptMetrics) {
@@ -746,6 +865,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
+            contextPlan,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -260,10 +260,10 @@ const applyProviderRealityLine = (prompt) => {
     return `${providerRealityLine}\n\n${basePrompt}`;
 };
 
-const applySystemGuardrail = (prompt) => {
-    if (!prompt) return sharedSystemGuardrail;
+const applySystemGuardrail = (prompt, rules = guardrailRules) => {
+    if (!prompt) return rules.map((rule) => rule.line).join('\n');
     const normalizedPrompt = prompt.toLowerCase();
-    const missingRules = guardrailRules.filter((rule) => !rule.pattern.test(normalizedPrompt));
+    const missingRules = rules.filter((rule) => !rule.pattern.test(normalizedPrompt));
     if (missingRules.length === 0) return prompt;
     const missingGuardrail = missingRules.map((rule) => rule.line).join('\n');
     return `${prompt}\n\n${missingGuardrail}`;
@@ -274,6 +274,25 @@ const applySystemPolicyVersion = (prompt) => {
     if (prompt.includes(SYSTEM_POLICY_VERSION_LINE)) return prompt;
     return `${SYSTEM_POLICY_VERSION_LINE}\n${prompt}`;
 };
+
+const minimalSafeGuardrailRules = guardrailRules.filter(
+    (rule) =>
+        ![
+            'Use the PlayerState block when present.',
+            'If PlayerState is missing, ask for a save snapshot via /gamesaves and cite /docs/routes and /docs/backups.',
+        ].includes(rule.line)
+);
+
+const applyMinimalSafeSystemGuardrail = (prompt) =>
+    applySystemGuardrail(prompt, minimalSafeGuardrailRules);
+
+const buildMinimalSystemPrompt = (basePersonaPrompt) =>
+    applySystemPolicyVersion(
+        applyProviderRealityLine(applyMinimalSafeSystemGuardrail(basePersonaPrompt))
+    );
+
+const buildFullSystemPrompt = (basePersonaPrompt) =>
+    applySystemPolicyVersion(applyProviderRealityLine(applySystemGuardrail(basePersonaPrompt)));
 
 const toNumericStatus = (status) => {
     if (typeof status === 'string') {
@@ -640,18 +659,13 @@ export const buildChatPrompt = async (messages, options = {}) => {
 
     const persona = options.persona || defaultPersona;
     const basePersonaPrompt = persona?.systemPrompt || fallbackSystemPrompt;
-    const fullSystemPrompt = applySystemPolicyVersion(
-        applyProviderRealityLine(applySystemGuardrail(basePersonaPrompt))
-    );
     const latestUserMessage = [...normalizedMessages]
         .reverse()
-        .find((message) => message.role === 'user' && message.content?.trim());
+        .find((message) => message.role === 'user' && String(message.content || '').trim());
     const contextPlan = options.contextPlan || planChatContext(normalizedMessages, options);
 
     if (contextPlan.mode === 'minimal') {
-        const minimalSystemPrompt = applySystemPolicyVersion(
-            applyProviderRealityLine(basePersonaPrompt)
-        );
+        const minimalSystemPrompt = buildMinimalSystemPrompt(basePersonaPrompt);
         const systemMessage = {
             role: 'system',
             content: `Prompt version: v3:${getPromptVersionSha()}\n${minimalSystemPrompt}`,
@@ -739,6 +753,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         return promptPayload;
     }
 
+    const fullSystemPrompt = buildFullSystemPrompt(basePersonaPrompt);
     const systemMessage = {
         role: 'system',
         content: `Prompt version: v3:${getPromptVersionSha()}\n${fullSystemPrompt}`,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,5 +73,6 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        contextPlan: metadata.contextPlan || null,
     };
 };

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { planChatContext } from '../src/utils/chatContextPlanner.js';
+import { latestUserContent, planChatContext } from '../src/utils/chatContextPlanner.js';
 
 const planFor = (content: string) => planChatContext([{ role: 'user', content }]);
 
@@ -10,6 +10,9 @@ describe('planChatContext', () => {
         'thanks',
         'tell me a joke',
         'write a rocket haiku',
+        'create a haiku',
+        "what's the process for signing up?",
+        'what item would you recommend for dinner?',
         'what are you?',
         'explain Kubernetes',
     ])('uses minimal mode for no-grounding turn: %s', (content) => {
@@ -28,6 +31,9 @@ describe('planChatContext', () => {
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
         'where do I import a gamesave?',
+        'How do I add custom content to DSPACE?',
+        'how do I submit a custom quest?',
+        'where are content bundles documented?',
         'how do I get to settings?',
         'what does this process consume?',
         'what rewards does preflight check give?',
@@ -35,6 +41,8 @@ describe('planChatContext', () => {
         'Benchy',
         'dSolar',
         '/gamesaves',
+        'what does this process create?',
+        'custom item for a DSPACE quest',
     ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');
@@ -43,4 +51,14 @@ describe('planChatContext', () => {
         expect(plan.includeDocsRag).toBe(true);
         expect(plan.reasonCodes.length).toBeGreaterThan(0);
     });
+});
+
+it('stringifies structured latest user content without throwing', () => {
+    const content = latestUserContent([
+        { role: 'user', content: [{ type: 'input_text', text: 'dSolar' }] },
+    ]);
+
+    expect(content).toBe('dSolar');
+    expect(() => planChatContext([{ role: 'user', content: { text: 'hello' } }])).not.toThrow();
+    expect(planChatContext([{ role: 'user', content: [{ text: 'dSolar' }] }]).mode).toBe('full');
 });

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -28,6 +28,7 @@ describe('planChatContext', () => {
     it.each([
         'what should I do next?',
         'what quest do I have left?',
+        'How am I progressing?',
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
         'where do I import a gamesave?',

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { planChatContext } from '../src/utils/chatContextPlanner.js';
+
+const planFor = (content: string) => planChatContext([{ role: 'user', content }]);
+
+describe('planChatContext', () => {
+    it.each([
+        'hi',
+        'hello',
+        'thanks',
+        'tell me a joke',
+        'write a rocket haiku',
+        'what are you?',
+        'explain Kubernetes',
+    ])('uses minimal mode for no-grounding turn: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('minimal');
+        expect(plan.includePlayerState).toBe(false);
+        expect(plan.includeKnowledgePack).toBe(false);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.includePersonaVoiceSamples).toBe(true);
+        expect(plan.reasonCodes).toContain('no-grounding-signals');
+    });
+
+    it.each([
+        'what should I do next?',
+        'what quest do I have left?',
+        'do I have enough green PLA?',
+        'can I afford a solar tracker?',
+        'where do I import a gamesave?',
+        'how do I get to settings?',
+        'what does this process consume?',
+        'what rewards does preflight check give?',
+        'what about the second option?',
+        'Benchy',
+        'dSolar',
+        '/gamesaves',
+    ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(true);
+        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+    });
+});

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -211,7 +211,7 @@ describe('GPT5Chat', () => {
                 content: [
                     {
                         type: 'input_text',
-                        text: expect.stringContaining('Persona voice examples for dchat'),
+                        text: expect.stringMatching(/Persona voice examples for dChat/i),
                     },
                 ],
             }),

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -211,16 +211,7 @@ describe('GPT5Chat', () => {
                 content: [
                     {
                         type: 'input_text',
-                        text: expect.stringContaining('PlayerState v'),
-                    },
-                ],
-            }),
-            expect.objectContaining({
-                role: 'system',
-                content: [
-                    {
-                        type: 'input_text',
-                        text: expect.stringContaining('DSPACE knowledge base:\nknowledge'),
+                        text: expect.stringContaining('Persona voice examples for dchat'),
                     },
                 ],
             }),
@@ -234,6 +225,8 @@ describe('GPT5Chat', () => {
                 ],
             },
         ]);
+        expect(JSON.stringify(payload.input)).not.toContain('PlayerState v');
+        expect(JSON.stringify(payload.input)).not.toContain('DSPACE knowledge base');
         expect(result).toBe('ok');
     });
 

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { npcPersonas } from '../src/data/npcPersonas.js';
+import {
+    npcDialogueSamples,
+    PERSONA_VOICE_SAMPLE_CHAR_LIMIT,
+} from '../src/utils/npcDialogueSamples.js';
+
+vi.mock('../src/utils/gameState/common.js', () => ({
+    ready: Promise.resolve(),
+    loadGameState: vi.fn(() => ({ inventory: {}, quests: {}, versionNumberString: '3' })),
+}));
+
+vi.mock('../src/utils/dchatKnowledge.js', () => ({
+    buildDchatKnowledgePack: vi.fn(() => ({ summary: 'knowledge', sources: [] })),
+}));
+
+vi.mock('../src/utils/docsRag.js', () => ({
+    searchDocsRag: vi.fn(async () => ({ excerptsText: 'Docs grounding', sources: [] })),
+}));
+
+const { buildChatPrompt } = await import('../src/utils/openAI.js');
+const { buildDchatKnowledgePack } = await import('../src/utils/dchatKnowledge.js');
+const { searchDocsRag } = await import('../src/utils/docsRag.js');
+
+const persona = (id: string) => npcPersonas.find((entry) => entry.id === id)!;
+const joinedPrompt = (payload: { combinedMessages: Array<{ content: string }> }) =>
+    payload.combinedMessages.map((message) => message.content).join('\n\n');
+
+describe('buildChatPrompt context planning', () => {
+    beforeEach(() => {
+        vi.mocked(buildDchatKnowledgePack).mockClear();
+        vi.mocked(searchDocsRag).mockClear();
+    });
+
+    it('builds a small minimal prompt for hi without full grounding', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            includePromptMetrics: true,
+        });
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(payload.contextSources).toEqual([]);
+        expect(prompt).not.toContain('PlayerState');
+        expect(prompt).not.toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(prompt).not.toContain('inventory highlights');
+        expect(prompt.length).toBeLessThan(3500);
+        expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
+        expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('preserves Sydney persona and includes only Sydney voice samples in minimal mode', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            persona: persona('sydney'),
+            includePromptMetrics: true,
+        });
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(prompt).toContain('You are Sydney');
+        expect(prompt).toContain('additive manufacturing');
+        expect(prompt).toContain('Persona voice examples for Sydney');
+        expect(prompt).toContain(npcDialogueSamples.sydney[0]);
+        expect(prompt).not.toContain('You are dChat, a helpful assistant in the game DSPACE');
+        expect(prompt).not.toContain(npcDialogueSamples.nova[0]);
+        expect(prompt).not.toContain(npcDialogueSamples.hydro[0]);
+        expect(prompt).not.toContain(npcDialogueSamples.dchat[0]);
+        expect(prompt).not.toContain('PlayerState');
+        expect(prompt).not.toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(payload.contextSources).toEqual([]);
+        expect(payload.promptMetrics.contextPlan.personaVoiceSampleCount).toBeGreaterThan(0);
+        expect(JSON.stringify(payload.contextSources)).not.toContain(npcDialogueSamples.sydney[0]);
+        expect(JSON.stringify(payload.promptMetrics.contextPlan)).not.toContain(
+            npcDialogueSamples.sydney[0]
+        );
+        expect(payload.promptMetrics.contextPlan.personaVoiceSampleCharacters).toBeLessThanOrEqual(
+            PERSONA_VOICE_SAMPLE_CHAR_LIMIT
+        );
+    });
+
+    it('preserves Nova persona and isolates Nova samples in minimal mode', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            persona: persona('nova'),
+            includePromptMetrics: true,
+        });
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(prompt).toContain('You are Nova');
+        expect(prompt).toContain('resident rocketry expert');
+        expect(prompt).toContain('Persona voice examples for Nova');
+        expect(prompt).toContain(npcDialogueSamples.nova[0]);
+        expect(prompt).not.toContain(npcDialogueSamples.sydney[0]);
+        expect(prompt).not.toContain(npcDialogueSamples.hydro[0]);
+        expect(prompt).not.toContain(npcDialogueSamples.dchat[0]);
+        expect(payload.contextSources).toEqual([]);
+    });
+
+    it('preserves Hydro persona and full grounding when planner selects full', async () => {
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            { persona: persona('hydro'), includePromptMetrics: true }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.reasonCodes).toContain('player-state-progress');
+        expect(prompt).toContain('You are Hydro');
+        expect(prompt).toContain('hydroponics steward');
+        expect(prompt).toContain('PlayerState');
+        expect(prompt).toContain('DSPACE knowledge base');
+        expect(buildDchatKnowledgePack).toHaveBeenCalled();
+        expect(searchDocsRag).toHaveBeenCalled();
+    });
+});

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -44,7 +44,11 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).not.toContain('DSPACE knowledge base');
         expect(prompt).not.toContain('Docs grounding');
         expect(prompt).not.toContain('inventory highlights');
-        expect(prompt.length).toBeLessThan(3500);
+        expect(prompt).toContain('Never invent game facts or player state.');
+        expect(prompt).toContain('Only give exact counts/durations/rates');
+        expect(prompt).not.toContain('Use the PlayerState block when present.');
+        expect(prompt).not.toContain('If PlayerState is missing');
+        expect(prompt.length).toBeLessThan(5000);
         expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
         expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
         expect(searchDocsRag).not.toHaveBeenCalled();
@@ -75,6 +79,9 @@ describe('buildChatPrompt context planning', () => {
         expect(JSON.stringify(payload.promptMetrics.contextPlan)).not.toContain(
             npcDialogueSamples.sydney[0]
         );
+        expect(prompt).toContain('Never invent game facts or player state.');
+        expect(prompt).not.toContain('Use the PlayerState block when present.');
+        expect(prompt).not.toContain('If PlayerState is missing');
         expect(payload.promptMetrics.contextPlan.personaVoiceSampleCharacters).toBeLessThanOrEqual(
             PERSONA_VOICE_SAMPLE_CHAR_LIMIT
         );
@@ -95,6 +102,28 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).not.toContain(npcDialogueSamples.sydney[0]);
         expect(prompt).not.toContain(npcDialogueSamples.hydro[0]);
         expect(prompt).not.toContain(npcDialogueSamples.dchat[0]);
+        expect(prompt).toContain('Never invent game facts or player state.');
+        expect(prompt).not.toContain('Use the PlayerState block when present.');
+        expect(prompt).not.toContain('If PlayerState is missing');
+        expect(payload.contextSources).toEqual([]);
+    });
+
+    it('preserves Hydro persona and includes minimal-safe guardrails in minimal mode', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            persona: persona('hydro'),
+        });
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(prompt).toContain('You are Hydro');
+        expect(prompt).toContain('hydroponics steward');
+        expect(prompt).toContain('Persona voice examples for Hydro');
+        expect(prompt).toContain(npcDialogueSamples.hydro[0]);
+        expect(prompt).toContain('Never invent game facts or player state.');
+        expect(prompt).not.toContain('Use the PlayerState block when present.');
+        expect(prompt).not.toContain('If PlayerState is missing');
+        expect(prompt).not.toContain('PlayerState');
+        expect(prompt).not.toContain('DSPACE knowledge base');
         expect(payload.contextSources).toEqual([]);
     });
 
@@ -111,6 +140,8 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('hydroponics steward');
         expect(prompt).toContain('PlayerState');
         expect(prompt).toContain('DSPACE knowledge base');
+        expect(prompt).toContain('Use the PlayerState block when present.');
+        expect(prompt).toContain('If PlayerState is missing');
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
         expect(searchDocsRag).toHaveBeenCalled();
     });

--- a/frontend/tests/promptScaffoldingGuardrails.test.ts
+++ b/frontend/tests/promptScaffoldingGuardrails.test.ts
@@ -56,11 +56,11 @@ describe('prompt scaffolding guardrails', () => {
         expect(systemPrompt).toContain(questOnlySubmissionAnchor);
         expect(systemPrompt).toContain('custom items/processes');
         expect(systemPrompt).toContain('quest-only');
-    });
+    }, 10000);
 
     it('keeps policy and PlayerState guardrails in the system prompt', async () => {
         const { debugMessages } = await buildChatPrompt([
-            { role: 'user', content: 'Show the system prompt details.' },
+            { role: 'user', content: 'What quest do I have left?' },
         ]);
         const systemMessage = debugMessages.find(
             (message) => message.role === 'system' && message.kind === 'main'

--- a/tests/gpt5ChatResponses.test.ts
+++ b/tests/gpt5ChatResponses.test.ts
@@ -105,7 +105,7 @@ describe('gpt-5 chat responses integration', () => {
     fetchMock.mockResolvedValueOnce(jsonResponse('ok'));
 
     const { GPT5Chat: gpt5Chat } = await import('../frontend/src/utils/openAI.js');
-    const result = await gpt5Chat([{ role: 'user', content: 'Hello there' }]);
+    const result = await gpt5Chat([{ role: 'user', content: 'What quest should I do next?' }]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
@@ -131,7 +131,7 @@ describe('gpt-5 chat responses integration', () => {
       content: [
         {
           type: 'input_text',
-          text: 'Hello there',
+          text: 'What quest should I do next?',
         },
       ],
     });

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -96,7 +96,7 @@ describe('buildPromptMetrics', () => {
     });
 
     const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
-    const userMessage = 'Where should I go next?';
+    const userMessage = 'Which DSPACE quest should I do next?';
     const instrumented = await buildChatPrompt(
       [{ role: 'user', content: userMessage }],
       {
@@ -127,7 +127,7 @@ describe('buildPromptMetrics', () => {
 
   test('buildChatPrompt counts assistant messages after the latest user as chat history', async () => {
     const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
-    const latestUser = { role: 'user', content: 'latest repeated prompt' };
+    const latestUser = { role: 'user', content: 'latest repeated DSPACE quest prompt' };
     const trailingAssistant = {
       role: 'assistant',
       content: 'assistant after latest user',


### PR DESCRIPTION
### Motivation
- Prevent overpacking the full PlayerState/RAG/docs filing cabinet for simple no-grounding turns (e.g., “hi”) while preserving NPC persona identity and voice.
- Provide a conservative, deterministic planner that chooses a safe minimal prompt path only when positive DSPACE grounding signals are absent.

### Description
- Add a deterministic planner `planChatContext(messages, options)` that returns a context plan with `mode`, inclusion booleans, `reasonCodes`, and `confidence`. (new file: `frontend/src/utils/chatContextPlanner.js`).
- Add a small structured persona voice-sample helper (`npcDialogueSamples.js`) with 2–3 short examples per persona and a capped renderer used only for the selected persona (new file: `frontend/src/utils/npcDialogueSamples.js`).
- Wire the planner into `buildChatPrompt()` so when `contextPlan.mode === 'minimal'` the prompt: includes the selected persona system instructions, a small persona-only voice-sample block, the latest user message, an optional tiny recent chat tail, and explicitly omits PlayerState, dChat knowledge pack, docs RAG, and `contextSources` (modified: `frontend/src/utils/openAI.js`).
- Preserve full-mode behavior exactly when grounding signals exist, and leave token-lite behavior unchanged.
- Expose safe context-plan metadata in prompt metrics (counts/booleans and persona id/name only when safe) without logging prompt text, PlayerState, or sample text (modified: `frontend/src/utils/promptMetrics.js`).
- Add unit and integration tests covering planner heuristics, minimal prompt payload shape, persona-preserving behavior, isolation of voice samples, and provider/token.place integration (new/updated tests: `frontend/tests/chatContextPlanner.test.ts`, `frontend/tests/openAIContextPlanner.test.ts`, and adjustments to `frontend/tests/openAI.test.ts`).

### Testing
- Ran focused planner and integration suites: `cd frontend && npm test -- chatContextPlanner` — passed.
- Ran OpenAI/chat prompt tests: `cd frontend && npm test -- openAI` — passed (tests updated to expect persona-sample minimal prompts where appropriate).
- Ran token.place integration tests: `cd frontend && npm test -- tokenPlace.test.js` — passed and verified that token-lite is unchanged while default token.place uses the full path for grounded turns.
- Ran repo checks and build: `cd frontend && npm run check` and `cd frontend && npm run build` — both passed.

All automated tests mentioned above passed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec003a7d4832f83649f8b7305da56)