### PR TITLE
Conservative chat context planner + persona-preserving minimal prompt with NPC voice samples

### DIFF
--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -1,0 +1,73 @@
+const fullPlan = (reasonCodes) => ({
+    mode: 'full',
+    includePlayerState: true,
+    includeKnowledgePack: true,
+    includeDocsRag: true,
+    includePersonaVoiceSamples: false,
+    reasonCodes: [...new Set(reasonCodes)],
+    confidence: 'conservative',
+});
+
+const minimalPlan = () => ({
+    mode: 'minimal',
+    includePlayerState: false,
+    includeKnowledgePack: false,
+    includeDocsRag: false,
+    includePersonaVoiceSamples: true,
+    reasonCodes: ['no-grounding-signals'],
+    confidence: 'high',
+});
+
+const latestUserContent = (messages) =>
+    [...(Array.isArray(messages) ? messages : [])]
+        .reverse()
+        .find((message) => message?.role === 'user' && `${message.content || ''}`.trim())
+        ?.content || '';
+
+const longMessageGroundingThreshold = 2000;
+
+const patterns = [
+    [
+        'player-state-progress',
+        /\b(inventory|do i have|can i afford|enough|missing|remaining|left|what next|what should i (?:do|build|make|print|craft).*next|what should i do|unlock|unlocks|reward|rewards|completed quests?|active processes?|running processes?|balances?|resources?|status)\b/i,
+    ],
+    [
+        'game-data',
+        /\b(quests?|items?|process(?:es)?|achievements?|requirements?|requires?|consumes?|creates?|duration|recipes?|gates?|preflight check|green pla|solar tracker)\b/i,
+    ],
+    [
+        'docs-navigation',
+        /(?:\/docs|\/quests|\/inventory|\/processes|\/settings|\/gamesaves)|\b(docs?|routes?|pages?|settings|gamesaves?|changelog|release notes|import|export|where do i|how do i get to)\b/i,
+    ],
+    [
+        'vague-followup',
+        /\b(what about (?:that|the|this)|what about the second option|tell me more|continue|next step|that one|the other one|second option)\b/i,
+    ],
+    [
+        'dspace-entity',
+        /\b(token\.place|benchy|dusd|dbi|dwatt|dsolar|dprint|dlaunch|phone stand|bed leveling|print bed|hydroponics tub|stevia)\b/i,
+    ],
+];
+
+export const getChatGroundingReasonCodes = (content) => {
+    const text = `${content || ''}`.trim();
+    if (!text) {
+        return ['empty-latest-user-message'];
+    }
+    const reasonCodes = patterns
+        .filter(([, pattern]) => pattern.test(text))
+        .map(([reason]) => reason);
+    if (text.length > longMessageGroundingThreshold) {
+        reasonCodes.push('long-message-uncertain');
+    }
+    return reasonCodes;
+};
+
+export const planChatContext = (messages, options = {}) => {
+    if (options.contextPlan) {
+        return options.contextPlan;
+    }
+    const content = latestUserContent(messages);
+    const reasonCodes = getChatGroundingReasonCodes(content);
+    return reasonCodes.length > 0 ? fullPlan(reasonCodes) : minimalPlan();
+};

--- a/frontend/src/utils/npcDialogueSamples.js
+++ b/frontend/src/utils/npcDialogueSamples.js
@@ -1,0 +1,58 @@
+export const DEFAULT_VOICE_SAMPLE_LIMIT = 3;
+export const DEFAULT_VOICE_SAMPLE_CHAR_LIMIT = 650;
+
+export const npcDialogueSamples = {
+    dchat: [
+        "Greetings, adventurer! I'm dChat, an advanced AI sidekick crafted by the grand codemancers of this realm.",
+        'Well, a friendly delivery robot dropped me off after you ordered me online.',
+        "No worries! I'm low-maintenance and won't hog your power supply.",
+    ],
+    sydney: [
+        "I'm Sydney—FDM rigs are my playground.",
+        'Bed off-kilter? Slide paper under the nozzle and level it.',
+        "Claim your printer and we'll tune it together.",
+    ],
+    nova: [
+        "Hey friend! I'm Nova! I'm sure you've met some of my colleagues!",
+        "Luckily I've already launched this exact rocket before! I estimate around 35 meters in perfect conditions.",
+        'Before launch, check the wind; even a breeze can skew the trajectory.',
+    ],
+    hydro: [
+        "Hey there! I'm Hydro, your local hydroponics expert!",
+        'Oh I could talk for hours, but the short version? Roots bathe in nutrient-rich water.',
+        "Let's try stevia next. Its leaves are unbelievably sweet!",
+    ],
+};
+
+export const getNpcDialogueSamples = (personaId, options = {}) => {
+    const limit = Number.isFinite(options.limit) ? options.limit : DEFAULT_VOICE_SAMPLE_LIMIT;
+    const samples = npcDialogueSamples[personaId] || [];
+    return samples.slice(0, Math.max(limit, 0));
+};
+
+export const renderNpcVoiceSamples = (persona, options = {}) => {
+    const charLimit = Number.isFinite(options.charLimit)
+        ? options.charLimit
+        : DEFAULT_VOICE_SAMPLE_CHAR_LIMIT;
+    const samples = getNpcDialogueSamples(persona?.id, options);
+    if (!persona?.name || samples.length === 0 || charLimit <= 0) {
+        return { text: '', count: 0, charCount: 0 };
+    }
+
+    const header = `Persona voice examples for ${persona.name}; use these only as tone/style cues, not as factual grounding:`;
+    const lines = [header];
+    let included = 0;
+
+    for (const sample of samples) {
+        const nextLine = `- "${sample}"`;
+        const candidate = [...lines, nextLine].join('\n');
+        if (candidate.length > charLimit) {
+            break;
+        }
+        lines.push(nextLine);
+        included += 1;
+    }
+
+    const text = included > 0 ? lines.join('\n') : '';
+    return { text, count: included, charCount: text.length };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -7,6 +7,8 @@ import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
 import { buildPromptMetrics } from './promptMetrics.js';
+import { planChatContext } from './chatContextPlanner.js';
+import { renderNpcVoiceSamples } from './npcDialogueSamples.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -118,6 +120,7 @@ const docsRagOptions = {
     maxExcerptChars: 8500,
 };
 const docsRagPromptBudgetChars = 80000;
+const minimalChatTailCharLimit = 1200;
 
 const readEnvValue = (key) => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
@@ -604,6 +607,45 @@ async function createChatResponse(openai, input) {
     }
 }
 
+const buildMinimalChatTail = (messages) => {
+    const selected = [];
+    let remaining = minimalChatTailCharLimit;
+
+    for (const message of [...messages].reverse()) {
+        if (!['user', 'assistant'].includes(message?.role)) {
+            continue;
+        }
+        const content = `${message.content || ''}`.trim();
+        if (!content || remaining <= 0) {
+            continue;
+        }
+        const clipped =
+            content.length > remaining ? content.slice(content.length - remaining) : content;
+        selected.unshift({ role: message.role, content: clipped });
+        remaining -= clipped.length;
+    }
+
+    return selected;
+};
+
+const buildContextPlanMetadata = (
+    contextPlan,
+    persona,
+    voiceSamples = { count: 0, charCount: 0 }
+) => ({
+    mode: contextPlan.mode,
+    reasonCodes: contextPlan.reasonCodes,
+    confidence: contextPlan.confidence,
+    includePlayerState: contextPlan.includePlayerState,
+    includeKnowledgePack: contextPlan.includeKnowledgePack,
+    includeDocsRag: contextPlan.includeDocsRag,
+    includePersonaVoiceSamples: contextPlan.includePersonaVoiceSamples,
+    selectedPersonaId: persona?.id || null,
+    selectedPersonaName: persona?.name || null,
+    personaVoiceSampleCount: voiceSamples.count || 0,
+    personaVoiceSampleCharCount: voiceSamples.charCount || 0,
+});
+
 export const buildChatPrompt = async (messages, options = {}) => {
     const promptBuildStartedAt = performance.now();
     await ready;
@@ -611,6 +653,83 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const rawGameState = loadGameState();
     const hasGameState = rawGameState && typeof rawGameState === 'object';
     const gameState = hasGameState ? rawGameState : {};
+    const persona = options.persona || defaultPersona;
+    const contextPlan = options.contextPlan || planChatContext(normalizedMessages, options);
+    const personaSystemPrompt = persona?.systemPrompt || fallbackSystemPrompt;
+    const minimalSystemPrompt = applySystemPolicyVersion(
+        applyProviderRealityLine(personaSystemPrompt)
+    );
+    const fullSystemPrompt = applySystemPolicyVersion(
+        applyProviderRealityLine(applySystemGuardrail(personaSystemPrompt))
+    );
+    const systemMessage = {
+        role: 'system',
+        content: `Prompt version: v3:${getPromptVersionSha()}
+${minimalSystemPrompt}`,
+    };
+
+    if (contextPlan.mode === 'minimal') {
+        const voiceSamples = renderNpcVoiceSamples(persona);
+        const voiceSampleMessage = voiceSamples.text
+            ? {
+                  role: 'system',
+                  content: voiceSamples.text,
+              }
+            : null;
+        const combinedMessages = [
+            systemMessage,
+            ...(voiceSampleMessage ? [voiceSampleMessage] : []),
+            ...buildMinimalChatTail(normalizedMessages),
+        ];
+        const debugMessages = combinedMessages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            kind: 'main',
+        }));
+        const minimalPlayerStateSummary = { included: false, reason: 'context-plan-minimal' };
+        const promptPayload = {
+            combinedMessages,
+            debugMessages,
+            gameState,
+            contextSources: [],
+            playerStateSummary: minimalPlayerStateSummary,
+            contextPlan: buildContextPlanMetadata(contextPlan, persona, voiceSamples),
+        };
+
+        if (options.includePromptMetrics) {
+            const latestUserMessage = [...combinedMessages]
+                .reverse()
+                .find((message) => message.role === 'user' && message.content?.trim());
+            const latestUserMessageIndex = latestUserMessage
+                ? combinedMessages.lastIndexOf(latestUserMessage)
+                : -1;
+            promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
+                promptBuildDurationMs: performance.now() - promptBuildStartedAt,
+                ragDurationMs: 0,
+                componentMessageIndexes: {
+                    systemInstructions: 0,
+                    rag: [],
+                    playerState: -1,
+                    chatHistory: combinedMessages
+                        .map((message, index) => ({ message, index }))
+                        .filter(
+                            ({ message, index }) =>
+                                index !== latestUserMessageIndex && message.role !== 'system'
+                        )
+                        .map(({ index }) => index),
+                    latestUserMessage: latestUserMessageIndex,
+                },
+                contextPlan: promptPayload.contextPlan,
+            });
+            promptPayload.promptMetrics.contextPlan = promptPayload.contextPlan;
+        }
+
+        return promptPayload;
+    }
+
+    systemMessage.content = `Prompt version: v3:${getPromptVersionSha()}
+${fullSystemPrompt}`;
+
     const playerStateSnapshot = buildPlayerStateSnapshot(hasGameState ? rawGameState : null);
     const playerStateMessage = playerStateSnapshot.block
         ? {
@@ -618,17 +737,6 @@ export const buildChatPrompt = async (messages, options = {}) => {
               content: playerStateSnapshot.block,
           }
         : null;
-
-    const persona = options.persona || defaultPersona;
-    const systemPrompt = applySystemPolicyVersion(
-        applyProviderRealityLine(
-            applySystemGuardrail(persona?.systemPrompt || fallbackSystemPrompt)
-        )
-    );
-    const systemMessage = {
-        role: 'system',
-        content: `Prompt version: v3:${getPromptVersionSha()}\n${systemPrompt}`,
-    };
 
     const knowledgePack = buildDchatKnowledgePack(gameState);
     const knowledgeSummary = knowledgePack.summary;
@@ -719,6 +827,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
+        contextPlan: buildContextPlanMetadata(contextPlan, persona),
     };
 
     if (options.includePromptMetrics) {
@@ -754,6 +863,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 latestUserMessage: latestUserMessageIndex,
             },
         });
+        promptPayload.promptMetrics.contextPlan = promptPayload.contextPlan;
     }
 
     return promptPayload;

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { planChatContext } from '../src/utils/chatContextPlanner.js';
+
+const planFor = (content: string) => planChatContext([{ role: 'user', content }]);
+
+describe('planChatContext', () => {
+    it.each([
+        'hi',
+        'hello',
+        'thanks',
+        'tell me a joke',
+        'write a rocket haiku',
+        'what are you?',
+        'explain Kubernetes',
+    ])('uses minimal mode for ungrounded message: %s', (content) => {
+        expect(planFor(content)).toEqual(
+            expect.objectContaining({
+                mode: 'minimal',
+                includePlayerState: false,
+                includeKnowledgePack: false,
+                includeDocsRag: false,
+                includePersonaVoiceSamples: true,
+                confidence: 'high',
+            })
+        );
+    });
+
+    it.each([
+        ['what should I do next?', 'player-state-progress'],
+        ['what quest do I have left?', 'player-state-progress'],
+        ['do I have enough green PLA?', 'player-state-progress'],
+        ['can I afford a solar tracker?', 'player-state-progress'],
+        ['where do I import a gamesave?', 'docs-navigation'],
+        ['how do I get to settings?', 'docs-navigation'],
+        ['what does this process consume?', 'game-data'],
+        ['what rewards does preflight check give?', 'player-state-progress'],
+        ['what about the second option?', 'vague-followup'],
+        ['Benchy', 'dspace-entity'],
+        ['dSolar', 'dspace-entity'],
+        ['/gamesaves', 'docs-navigation'],
+    ])('uses full mode for grounded message: %s', (content, reasonCode) => {
+        expect(planFor(content)).toEqual(
+            expect.objectContaining({
+                mode: 'full',
+                includePlayerState: true,
+                includeKnowledgePack: true,
+                includeDocsRag: true,
+                includePersonaVoiceSamples: false,
+                confidence: 'conservative',
+                reasonCodes: expect.arrayContaining([reasonCode]),
+            })
+        );
+    });
+});

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -24,8 +24,27 @@ vi.mock('../src/data/npcPersonas.js', () => ({
     npcPersonas: [
         {
             id: 'dchat',
+            name: 'dChat',
             systemPrompt: 'system prompt',
             welcomeMessage: 'hello',
+        },
+        {
+            id: 'sydney',
+            name: 'Sydney',
+            systemPrompt: 'You are Sydney, the 3D-printing mentor.',
+            welcomeMessage: 'Sydney here.',
+        },
+        {
+            id: 'nova',
+            name: 'Nova',
+            systemPrompt: 'You are Nova, the rocketry expert.',
+            welcomeMessage: 'Nova here.',
+        },
+        {
+            id: 'hydro',
+            name: 'Hydro',
+            systemPrompt: 'You are Hydro, the hydroponics steward.',
+            welcomeMessage: 'Hydro here.',
         },
     ],
 }));
@@ -211,16 +230,7 @@ describe('GPT5Chat', () => {
                 content: [
                     {
                         type: 'input_text',
-                        text: expect.stringContaining('PlayerState v'),
-                    },
-                ],
-            }),
-            expect.objectContaining({
-                role: 'system',
-                content: [
-                    {
-                        type: 'input_text',
-                        text: expect.stringContaining('DSPACE knowledge base:\nknowledge'),
+                        text: expect.stringContaining('Persona voice examples for dChat'),
                     },
                 ],
             }),
@@ -234,6 +244,8 @@ describe('GPT5Chat', () => {
                 ],
             },
         ]);
+        expect(JSON.stringify(payload.input)).not.toContain('PlayerState v');
+        expect(JSON.stringify(payload.input)).not.toContain('DSPACE knowledge base');
         expect(result).toBe('ok');
     });
 
@@ -477,6 +489,88 @@ describe('buildChatPrompt', () => {
         vi.mocked(searchDocsRag).mockClear();
     });
 
+    it('uses a persona-preserving minimal prompt for ungrounded greetings', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            includePromptMetrics: true,
+            persona: {
+                id: 'sydney',
+                name: 'Sydney',
+                systemPrompt: 'You are Sydney, the 3D-printing mentor.',
+                welcomeMessage: 'Sydney here.',
+            },
+        });
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
+        expect(payload.contextSources).toEqual([]);
+        expect(promptText).toContain('You are Sydney');
+        expect(promptText).toContain('Persona voice examples for Sydney');
+        expect(promptText).toContain("I'm Sydney—FDM rigs are my playground.");
+        expect(promptText).not.toContain('You are dChat');
+        expect(promptText).not.toContain('PlayerState');
+        expect(promptText).not.toContain('DSPACE knowledge base');
+        expect(promptText).not.toContain('Docs grounding');
+        expect(promptText.length).toBeLessThan(3500);
+        expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('isolates selected persona voice samples in minimal prompts', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hello' }], {
+            includePromptMetrics: true,
+            persona: {
+                id: 'nova',
+                name: 'Nova',
+                systemPrompt: 'You are Nova, the rocketry expert.',
+                welcomeMessage: 'Nova here.',
+            },
+        });
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan).toEqual(
+            expect.objectContaining({
+                mode: 'minimal',
+                selectedPersonaId: 'nova',
+                personaVoiceSampleCount: 3,
+            })
+        );
+        expect(payload.contextPlan.personaVoiceSampleCharCount).toBeLessThanOrEqual(650);
+        expect(promptText).toContain('Persona voice examples for Nova');
+        expect(promptText).toContain("Hey friend! I'm Nova!");
+        expect(promptText).not.toContain("I'm Sydney—FDM rigs are my playground.");
+        expect(promptText).not.toContain("Hey there! I'm Hydro");
+        expect(promptText).not.toContain('Greetings, adventurer!');
+        expect(payload.contextSources).toEqual([]);
+        expect(JSON.stringify(payload.promptMetrics.contextPlan)).not.toContain(
+            "Hey friend! I'm Nova!"
+        );
+    });
+
+    it('preserves persona and full grounding for grounded questions', async () => {
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            {
+                persona: {
+                    id: 'hydro',
+                    name: 'Hydro',
+                    systemPrompt: 'You are Hydro, the hydroponics steward.',
+                    welcomeMessage: 'Hydro here.',
+                },
+            }
+        );
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.reasonCodes).toEqual(
+            expect.arrayContaining(['player-state-progress', 'game-data'])
+        );
+        expect(promptText).toContain('You are Hydro');
+        expect(promptText).toContain('DSPACE knowledge base');
+        expect(buildDchatKnowledgePack).toHaveBeenCalled();
+        expect(searchDocsRag).toHaveBeenCalled();
+    });
+
     it('adds guardrails for save snapshots, clarifying questions, and anti-precision', async () => {
         const payload = await buildChatPrompt([{ role: 'user', content: 'Status?' }]);
         const systemMessage = payload.debugMessages.find(
@@ -514,6 +608,15 @@ describe('buildChatPrompt', () => {
         ].join('\n');
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Check guardrails.' }], {
+            contextPlan: {
+                mode: 'full',
+                includePlayerState: true,
+                includeKnowledgePack: true,
+                includeDocsRag: true,
+                includePersonaVoiceSamples: false,
+                reasonCodes: ['test-forced-full'],
+                confidence: 'conservative',
+            },
             persona: {
                 id: 'custom',
                 systemPrompt,
@@ -543,6 +646,15 @@ describe('buildChatPrompt', () => {
         ].join('\n');
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Check guardrails.' }], {
+            contextPlan: {
+                mode: 'full',
+                includePlayerState: true,
+                includeKnowledgePack: true,
+                includeDocsRag: true,
+                includePersonaVoiceSamples: false,
+                reasonCodes: ['test-forced-full'],
+                confidence: 'conservative',
+            },
             persona: {
                 id: 'custom',
                 systemPrompt,


### PR DESCRIPTION
### Motivation
- Stop sending the full PlayerState / dChat knowledge / docs RAG filing cabinet for obvious no-grounding turns (e.g., "hi") while preserving selectable NPC persona identity and tone. 
- Provide a low-risk, deterministic planner that chooses a compact persona-preserving prompt only when positive grounding signals are absent.

### Description
- Add a deterministic planner `planChatContext(messages, options)` that returns a context plan object (`mode`, booleans for included components, `reasonCodes`, and `confidence`). (new file `frontend/src/utils/chatContextPlanner.js`)
- Add a small structured NPC voice-sample helper and renderer (`frontend/src/utils/npcDialogueSamples.js`) with per-persona samples for `dchat`, `sydney`, `nova`, and `hydro`, sample limits, and a character ceiling on the rendered block.
- Wire the planner into `buildChatPrompt()` (`frontend/src/utils/openAI.js`) so that when the plan is `minimal` the prompt payload omits PlayerState, knowledge pack, docs RAG, and `contextSources` and instead includes: the selected persona system prompt, a compact persona-only voice-sample `system` block (if available), a bounded recent chat tail, and safe `contextPlan`/metrics metadata; when the plan is `full` the existing full-fat prompt path is preserved unchanged.
- Implement a compact chat-tail builder and safe context-plan metadata exporter (counts/booleans only, not sample text) used for prompt metrics and diagnostics.
- Add unit tests for the planner (`frontend/tests/chatContextPlanner.test.ts`) and integration tests covering persona-preserving minimal prompts, voice-sample isolation, prompt metrics, and full-mode preservation (`frontend/tests/openAI.test.ts` updates).
- Keep token-lite and token.place routing/estimator behavior unchanged; token-lite still bypasses the planner as before.

### Testing
- Ran focused planner tests: `cd frontend && npm test -- chatContextPlanner` (19 tests passed).
- Ran OpenAI prompt tests: `cd frontend && npm test -- openAI` (59 tests passed after adjustments).
- Ran token.place provider tests: `cd frontend && npm test -- tokenPlace.test.js` (66 tests passed).
- Ran repository checks: `cd frontend && npm run check` (lint + format-check succeeded) and `cd frontend && npm run build` (Astro build succeeded).
- All executed automated tests listed above passed on this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec00f7a08832f8f64ef330b4186dc)