### PR TITLE
Add conservative chat context planner and persona-preserving minimal prompt path with NPC voice samples

### DIFF
--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -1,0 +1,81 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+import questManifest from '../generated/quests/listManifest.json' assert { type: 'json' };
+
+const fullPlan = (reasonCodes, confidence = 'conservative') => ({
+    mode: 'full',
+    includePlayerState: true,
+    includeKnowledgePack: true,
+    includeDocsRag: true,
+    includePersonaVoiceSamples: false,
+    reasonCodes: [...new Set(reasonCodes)],
+    confidence,
+});
+
+const minimalPlan = () => ({
+    mode: 'minimal',
+    includePlayerState: false,
+    includeKnowledgePack: false,
+    includeDocsRag: false,
+    includePersonaVoiceSamples: true,
+    reasonCodes: ['no-grounding-signals'],
+    confidence: 'high',
+});
+
+const latestUserContent = (messages) =>
+    [...(Array.isArray(messages) ? messages : [])]
+        .reverse()
+        .find((message) => message?.role === 'user' && String(message.content || '').trim())
+        ?.content || '';
+
+const normalize = (text) => String(text || '').toLowerCase();
+const has = (text, pattern) => pattern.test(text);
+
+const resourcePattern =
+    /\b(dusd|dbi|dwatt|dsolar|dprint|dlaunch|dwater|dchem|dwood|doxygen|dstevia)\b/i;
+const statePattern =
+    /\b(inventory|do i have|can i afford|afford|enough|missing|remaining|left|what next|what should i do|what should i .* next|unlock|unlocks|reward|rewards|completed quest|active process|running process|balance|balances|resources?|status)\b/i;
+const gameDataPattern =
+    /\b(quests?|items?|process(?:es)?|achievements?|requirements?|requires|consume|consumes|creates?|duration|recipes?|gates?|preflight check|changelog|release notes?|version|guardrails?)\b/i;
+const navigationPattern =
+    /(?:token\.place|\/docs|\/quests|\/inventory|\/processes|\/settings|\/gamesaves|\bdocs?\b|\broutes?\b|\bpages?\b|\bsettings\b|\bgamesaves?\b|\bimport\b|\bexport\b|\bwhere do i\b|\bhow do i get to\b)/i;
+const followUpPattern =
+    /\b(what about that|what about the second option|what about the second step|tell me more|continue|next step|that one|the other one)\b/i;
+
+const importantEntityPattern = /\b(benchy|green pla|solar tracker|preflight check)\b/i;
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const compactEntityValues = [
+    ...items.flatMap((item) => [item.id, item.name, item.title]).filter(Boolean),
+    ...processes.flatMap((process) => [process.id, process.title]).filter(Boolean),
+    ...questManifest.flatMap((quest) => [quest.id, quest.title, quest.route]).filter(Boolean),
+]
+    .filter((value) => typeof value === 'string' && value.length >= 4)
+    .sort((a, b) => b.length - a.length)
+    .slice(0, 1500);
+
+export const hasKnownDspaceEntityHit = (message) => {
+    const text = normalize(message);
+    if (has(text, importantEntityPattern) || has(text, resourcePattern)) return true;
+    return compactEntityValues.some((entity) => {
+        const normalizedEntity = normalize(entity).trim();
+        if (!normalizedEntity) return false;
+        if (normalizedEntity.includes('/')) return text.includes(normalizedEntity);
+        return new RegExp(`\\b${escapeRegExp(normalizedEntity)}\\b`, 'i').test(text);
+    });
+};
+
+export const planChatContext = (messages, _options = {}) => {
+    const latest = latestUserContent(messages);
+    const reasonCodes = [];
+
+    if (!latest.trim()) return fullPlan(['no-latest-user-message']);
+    if (latest.length > 2000) return fullPlan(['long-user-message']);
+    if (has(latest, statePattern)) reasonCodes.push('player-state-or-progress');
+    if (has(latest, gameDataPattern)) reasonCodes.push('game-data');
+    if (has(latest, navigationPattern)) reasonCodes.push('docs-or-navigation');
+    if (has(latest, followUpPattern)) reasonCodes.push('vague-follow-up');
+    if (hasKnownDspaceEntityHit(latest)) reasonCodes.push('known-dspace-entity');
+
+    return reasonCodes.length > 0 ? fullPlan(reasonCodes) : minimalPlan();
+};

--- a/frontend/src/utils/npcDialogueSamples.js
+++ b/frontend/src/utils/npcDialogueSamples.js
@@ -1,0 +1,71 @@
+export const PERSONA_VOICE_SAMPLE_MAX_CHARS = 650;
+export const PERSONA_VOICE_SAMPLE_DEFAULT_LIMIT = 3;
+
+export const npcDialogueSamples = {
+    dchat: [
+        "Greetings, adventurer! I'm dChat, an advanced AI sidekick crafted by the grand codemancers of this realm.",
+        "No worries! I'm low-maintenance and won't hog your power supply.",
+        'Your quest, dear player, is to master the ancient art of ... questing.',
+    ],
+    sydney: [
+        "I'm Sydney—FDM rigs are my playground.",
+        'Bed off-kilter? Slide paper under the nozzle and level it.',
+        "Claim your printer and we'll tune it together.",
+    ],
+    nova: [
+        "Hey friend! I'm Nova! I'm sure you've met some of my colleagues!",
+        "Luckily I've already launched this exact rocket before! I estimate around 35 meters in perfect conditions.",
+        'Before launch, check the wind; even a breeze can skew the trajectory.',
+    ],
+    hydro: [
+        "Hey there! I'm Hydro, your local hydroponics expert!",
+        'Oh I could talk for hours, but the short version? Roots bathe in nutrient-rich water.',
+        "Let's try stevia next. Its leaves are unbelievably sweet!",
+    ],
+};
+
+const normalizePersonaId = (persona) => {
+    if (typeof persona === 'string') return persona;
+    return typeof persona?.id === 'string' ? persona.id : '';
+};
+
+export const getPersonaVoiceSamples = (
+    persona,
+    { limit = PERSONA_VOICE_SAMPLE_DEFAULT_LIMIT } = {}
+) => {
+    const personaId = normalizePersonaId(persona);
+    const samples = npcDialogueSamples[personaId] || [];
+    return samples.slice(0, Math.max(0, limit));
+};
+
+export const renderPersonaVoiceSamples = (
+    persona,
+    { limit = PERSONA_VOICE_SAMPLE_DEFAULT_LIMIT, maxChars = PERSONA_VOICE_SAMPLE_MAX_CHARS } = {}
+) => {
+    const samples = getPersonaVoiceSamples(persona, { limit });
+    if (samples.length === 0) {
+        return { block: '', count: 0, characters: 0 };
+    }
+
+    const personaName = persona?.name || persona?.id || 'selected persona';
+    const header =
+        `Persona voice examples for ${personaName}; use these only as tone/style cues, ` +
+        'not as factual grounding:';
+    const lines = [header];
+    let included = 0;
+
+    for (const sample of samples) {
+        const line = `- "${sample}"`;
+        const nextBlock = [...lines, line].join('\n');
+        if (nextBlock.length > maxChars) break;
+        lines.push(line);
+        included += 1;
+    }
+
+    if (included === 0) {
+        return { block: '', count: 0, characters: 0 };
+    }
+
+    const block = lines.join('\n');
+    return { block, count: included, characters: block.length };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -7,6 +7,8 @@ import { npcPersonas } from '../data/npcPersonas.js';
 import OpenAI from 'openai';
 import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
 import { buildPromptMetrics } from './promptMetrics.js';
+import { planChatContext } from './chatContextPlanner.js';
+import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -608,6 +610,97 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const promptBuildStartedAt = performance.now();
     await ready;
     const normalizedMessages = Array.isArray(messages) ? messages : [];
+    const contextPlan = options.contextPlan || planChatContext(normalizedMessages, options);
+    const persona = options.persona || defaultPersona;
+    const fullSystemPrompt = applySystemPolicyVersion(
+        applyProviderRealityLine(
+            applySystemGuardrail(persona?.systemPrompt || fallbackSystemPrompt)
+        )
+    );
+    const minimalSystemPrompt = applySystemPolicyVersion(
+        applyProviderRealityLine(persona?.systemPrompt || fallbackSystemPrompt)
+    );
+    const systemMessage = {
+        role: 'system',
+        content: `Prompt version: v3:${getPromptVersionSha()}
+${contextPlan.mode === 'minimal' ? minimalSystemPrompt : fullSystemPrompt}`,
+    };
+    const latestUserMessage = [...normalizedMessages]
+        .reverse()
+        .find((message) => message.role === 'user' && message.content?.trim());
+
+    if (contextPlan.mode === 'minimal') {
+        const rawGameState = loadGameState();
+        const hasGameState = rawGameState && typeof rawGameState === 'object';
+        const gameState = hasGameState ? rawGameState : {};
+        const voiceSamplePayload = contextPlan.includePersonaVoiceSamples
+            ? renderPersonaVoiceSamples(persona)
+            : { block: '', count: 0, characters: 0 };
+        const voiceSampleMessage = voiceSamplePayload.block
+            ? {
+                  role: 'system',
+                  content: voiceSamplePayload.block,
+              }
+            : null;
+        const minimalMessages = normalizedMessages
+            .filter((message) => message?.role !== 'system')
+            .slice(-4)
+            .reduceRight((selected, message) => {
+                const currentCharacters = selected.reduce(
+                    (sum, entry) => sum + String(entry.content || '').length,
+                    0
+                );
+                if (currentCharacters + String(message.content || '').length > 1000) {
+                    return selected;
+                }
+                return [message, ...selected];
+            }, []);
+        const combinedMessages = [
+            systemMessage,
+            ...(voiceSampleMessage ? [voiceSampleMessage] : []),
+            ...minimalMessages,
+        ];
+        const debugMessages = combinedMessages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            kind: 'main',
+        }));
+        const promptPayload = {
+            combinedMessages,
+            debugMessages,
+            gameState,
+            contextSources: [],
+            playerStateSummary: { included: false, reason: 'context-plan-minimal' },
+            contextPlan: {
+                ...contextPlan,
+                selectedPersonaId: persona?.id || null,
+                selectedPersonaName: persona?.name || null,
+                personaVoiceSampleCount: voiceSamplePayload.count,
+                personaVoiceSampleCharacters: voiceSamplePayload.characters,
+            },
+        };
+
+        if (options.includePromptMetrics) {
+            const latestUserMessageIndex = latestUserMessage
+                ? combinedMessages.lastIndexOf(latestUserMessage)
+                : -1;
+            promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
+                promptBuildDurationMs: performance.now() - promptBuildStartedAt,
+                ragDurationMs: 0,
+                contextPlan: promptPayload.contextPlan,
+                componentMessageIndexes: {
+                    systemInstructions: 0,
+                    rag: [],
+                    playerState: -1,
+                    chatHistory: [],
+                    latestUserMessage: latestUserMessageIndex,
+                },
+            });
+        }
+
+        return promptPayload;
+    }
+
     const rawGameState = loadGameState();
     const hasGameState = rawGameState && typeof rawGameState === 'object';
     const gameState = hasGameState ? rawGameState : {};
@@ -619,23 +712,13 @@ export const buildChatPrompt = async (messages, options = {}) => {
           }
         : null;
 
-    const persona = options.persona || defaultPersona;
-    const systemPrompt = applySystemPolicyVersion(
-        applyProviderRealityLine(
-            applySystemGuardrail(persona?.systemPrompt || fallbackSystemPrompt)
-        )
-    );
-    const systemMessage = {
-        role: 'system',
-        content: `Prompt version: v3:${getPromptVersionSha()}\n${systemPrompt}`,
-    };
-
     const knowledgePack = buildDchatKnowledgePack(gameState);
     const knowledgeSummary = knowledgePack.summary;
     const knowledgeMessage = knowledgeSummary
         ? {
               role: 'system',
-              content: `DSPACE knowledge base:\n${knowledgeSummary}`,
+              content: `DSPACE knowledge base:
+${knowledgeSummary}`,
           }
         : null;
     const docsRagRequestOptions = buildDocsRagOptions({
@@ -648,9 +731,6 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ...normalizedMessages,
         ],
     });
-    const latestUserMessage = [...normalizedMessages]
-        .reverse()
-        .find((message) => message.role === 'user' && message.content?.trim());
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
@@ -668,7 +748,9 @@ export const buildChatPrompt = async (messages, options = {}) => {
             : null;
 
     if (knowledgeMessage && docsRagPayload.excerptsText) {
-        knowledgeMessage.content = `${knowledgeMessage.content}\n\n${docsRagPayload.excerptsText}`;
+        knowledgeMessage.content = `${knowledgeMessage.content}
+
+${docsRagPayload.excerptsText}`;
     }
 
     const openingMessage = {
@@ -719,6 +801,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
+        contextPlan,
     };
 
     if (options.includePromptMetrics) {
@@ -746,6 +829,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
+            contextPlan,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,5 +73,6 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        contextPlan: metadata.contextPlan || promptPayload?.contextPlan || null,
     };
 };

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { planChatContext } from '../src/utils/chatContextPlanner.js';
+
+const planFor = (content: string) => planChatContext([{ role: 'user', content }]);
+
+describe('planChatContext', () => {
+    it.each([
+        'hi',
+        'hello',
+        'thanks',
+        'tell me a joke',
+        'write a rocket haiku',
+        'what are you?',
+        'explain Kubernetes',
+    ])('chooses minimal for no-grounding turn: %s', (message) => {
+        const plan = planFor(message);
+        expect(plan.mode).toBe('minimal');
+        expect(plan.includePlayerState).toBe(false);
+        expect(plan.includeKnowledgePack).toBe(false);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.includePersonaVoiceSamples).toBe(true);
+    });
+
+    it.each([
+        'what should I do next?',
+        'what quest do I have left?',
+        'do I have enough green PLA?',
+        'can I afford a solar tracker?',
+        'where do I import a gamesave?',
+        'how do I get to settings?',
+        'what does this process consume?',
+        'what rewards does preflight check give?',
+        'what about the second option?',
+        'Benchy',
+        'dSolar',
+        '/gamesaves',
+    ])('chooses full for grounded turn: %s', (message) => {
+        const plan = planFor(message);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(true);
+        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+    });
+});

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -24,8 +24,29 @@ vi.mock('../src/data/npcPersonas.js', () => ({
     npcPersonas: [
         {
             id: 'dchat',
+            name: 'dChat',
             systemPrompt: 'system prompt',
             welcomeMessage: 'hello',
+        },
+        {
+            id: 'sydney',
+            name: 'Sydney',
+            systemPrompt:
+                'You are Sydney, the additive manufacturing lead. Speak with practical 3D printing mentor energy.',
+            welcomeMessage: 'Sydney here—FDM rigs are my playground.',
+        },
+        {
+            id: 'nova',
+            name: 'Nova',
+            systemPrompt:
+                'You are Nova, the resident rocketry expert. Use launch-ready checklist energy.',
+            welcomeMessage: "Hey friend! I'm Nova—ready to prep another launch?",
+        },
+        {
+            id: 'hydro',
+            name: 'Hydro',
+            systemPrompt: 'You are Hydro, the hydroponics steward focused on nutrient balance.',
+            welcomeMessage: "Hey there! I'm Hydro—let's keep those nutrient baths dialed in.",
         },
     ],
 }));
@@ -211,16 +232,7 @@ describe('GPT5Chat', () => {
                 content: [
                     {
                         type: 'input_text',
-                        text: expect.stringContaining('PlayerState v'),
-                    },
-                ],
-            }),
-            expect.objectContaining({
-                role: 'system',
-                content: [
-                    {
-                        type: 'input_text',
-                        text: expect.stringContaining('DSPACE knowledge base:\nknowledge'),
+                        text: expect.stringContaining('Persona voice examples for dChat'),
                     },
                 ],
             }),
@@ -475,6 +487,93 @@ describe('buildChatPrompt', () => {
     beforeEach(() => {
         vi.mocked(buildDchatKnowledgePack).mockClear();
         vi.mocked(searchDocsRag).mockClear();
+    });
+
+    it('uses a small minimal prompt for no-grounding greetings', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            includePromptMetrics: true,
+        });
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
+        expect(promptText).not.toContain('PlayerState');
+        expect(promptText).not.toContain('DSPACE knowledge base');
+        expect(promptText).not.toContain('Docs grounding');
+        expect(payload.contextSources).toEqual([]);
+        expect(promptText.length).toBeLessThan(3500);
+        expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('preserves Sydney persona and isolates Sydney voice samples in minimal mode', async () => {
+        const persona = {
+            id: 'sydney',
+            name: 'Sydney',
+            systemPrompt:
+                'You are Sydney, the additive manufacturing lead. Speak with practical 3D printing mentor energy.',
+            welcomeMessage: 'Sydney here—FDM rigs are my playground.',
+        };
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            persona,
+            includePromptMetrics: true,
+        });
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(promptText).toContain('You are Sydney');
+        expect(promptText).toContain('Persona voice examples for Sydney');
+        expect(promptText).toContain("I'm Sydney—FDM rigs are my playground.");
+        expect(promptText).not.toContain('You are dChat');
+        expect(promptText).not.toContain("Hey friend! I'm Nova");
+        expect(promptText).not.toContain("Hey there! I'm Hydro");
+        expect(promptText).not.toContain('PlayerState');
+        expect(promptText).not.toContain('DSPACE knowledge base');
+        expect(promptText).not.toContain('Docs grounding');
+        expect(payload.contextSources).toEqual([]);
+        expect(payload.promptMetrics.contextPlan.personaVoiceSampleCount).toBeGreaterThan(0);
+        expect(JSON.stringify(payload.promptMetrics)).not.toContain('FDM rigs');
+    });
+
+    it('preserves Nova persona and isolates Nova voice samples in minimal mode', async () => {
+        const persona = {
+            id: 'nova',
+            name: 'Nova',
+            systemPrompt:
+                'You are Nova, the resident rocketry expert. Use launch-ready checklist energy.',
+            welcomeMessage: "Hey friend! I'm Nova—ready to prep another launch?",
+        };
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], { persona });
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(promptText).toContain('You are Nova');
+        expect(promptText).toContain('Persona voice examples for Nova');
+        expect(promptText).toContain("Hey friend! I'm Nova!");
+        expect(promptText).not.toContain("I'm Sydney—FDM rigs");
+        expect(promptText).not.toContain("Hey there! I'm Hydro");
+        expect(payload.contextSources).toEqual([]);
+    });
+
+    it('preserves full prompt behavior and persona for grounded questions', async () => {
+        const persona = {
+            id: 'hydro',
+            name: 'Hydro',
+            systemPrompt: 'You are Hydro, the hydroponics steward focused on nutrient balance.',
+            welcomeMessage: "Hey there! I'm Hydro—let's keep those nutrient baths dialed in.",
+        };
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            { persona }
+        );
+        const promptText = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.reasonCodes).toContain('player-state-or-progress');
+        expect(promptText).toContain('You are Hydro');
+        expect(promptText).toContain('PlayerState');
+        expect(promptText).toContain('DSPACE knowledge base');
+        expect(buildDchatKnowledgePack).toHaveBeenCalled();
     });
 
     it('adds guardrails for save snapshots, clarifying questions, and anti-precision', async () => {


### PR DESCRIPTION
### Motivation
- Prevent full PlayerState/RAG/docs payloads being sent for obvious no-grounding turns (e.g., “hi”) which bloats token.place/OpenAI prompts and breaks small-model workflows.
- Preserve selectable NPC persona identity/voice while offering a safe, compact minimal prompt path so short social turns remain persona-aware without game-state grounding.
- Keep behavior conservative and deterministic: only choose minimal when positive signals indicate no DSPACE grounding is needed, otherwise preserve the existing full-fat prompt behavior.

### Description
- Added a deterministic planner module `frontend/src/utils/chatContextPlanner.js` that exports `planChatContext(messages, options)` and returns a context plan object (`mode`, include booleans, `reasonCodes`, and `confidence`).
- Added compact persona voice sample support in `frontend/src/utils/npcDialogueSamples.js` with a small structured sample map and `renderPersonaVoiceSamples()` to produce a bounded style-only block for the selected persona.
- Wired the planner and persona-sample rendering into `buildChatPrompt()` (`frontend/src/utils/openAI.js`) so `contextPlan.mode === 'minimal'` produces a minimal prompt that includes system/persona instructions, a persona voice-sample block, the latest user message plus a tiny bounded chat tail, and explicitly excludes PlayerState, dChat knowledge pack, docs RAG, and `contextSources`.
- Preserved full mode exactly: when the planner selects `full` (or is uncertain) `buildChatPrompt()` follows the existing PlayerState/knowledge/RAG construction path unchanged.
- Added context-plan metadata into prompt metrics (`frontend/src/utils/promptMetrics.js`) and ensured diagnostics only expose safe counts/booleans (no prompt text or sample text is logged).
- Added unit and integration tests: `frontend/tests/chatContextPlanner.test.ts` and focused assertions in `frontend/tests/openAI.test.ts` to verify planner decisions, minimal-prompt composition, persona preservation, voice-sample isolation, and provider expectations.

### Testing
- Ran planner and OpenAI-focused tests: `cd frontend && npm test -- chatContextPlanner openAI` and all tests passed (combined run finished with 79/79 tests passing across the focused suites used during development).
- Verified token.place provider tests: `cd frontend && npm test -- tokenPlace.test.js` and the token.place test file passed (66/66 tests in that file passed in the run used to validate integration).
- Ran formatting and build checks: `cd frontend && npm run check` and `cd frontend && npm run build` and both succeeded after applying Prettier formatting changes; no lint/build regressions remain.
- Commands used:
  - `cd frontend && npm test -- chatContextPlanner openAI` — passed
  - `cd frontend && npm test -- tokenPlace.test.js` — passed
  - `cd frontend && npm run check` — passed (Prettier fixed during run)
  - `cd frontend && npm run build` — passed

Follow-ups / notes: voice samples were derived from existing NPC docs snippets and live NPC data (no markdown parsing at runtime); a human reviewer may tweek or expand persona examples later but no binary assets or docs markdown were changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec017c0f8832fbca4e80c575f799e)