### PR TITLE
Gate docs RAG by chat intent

### DIFF
--- a/docs/qa/v3.md
+++ b/docs/qa/v3.md
@@ -1088,7 +1088,7 @@ Local-mode validation status (March 20, 2026):
       ([<gpt5ChatResponses.test.ts:calls the Responses API with knowledge context and returns text output>](../../tests/gpt5ChatResponses.test.ts#L35-L126))
 - [x] Confirm docs match reality (no “docs say token.place but app uses OpenAI” drift) ([<qaDocsContentAlignment.test.ts:guards relay E2EE route sequence, ciphertext-only invariant, and opt-in guidance>](../../tests/qaDocsContentAlignment.test.ts#L81-L125))
 - [x] UI labels token.place as future/experimental or hides toggles until v3.1
-      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1595-L1609))
+      ([<tokenPlace.test.js:shared prompt and token.place payload omit stale provider guidance>](../../frontend/__tests__/tokenPlace.test.js#L1615-L1629))
 
 ### 9.3 token.place follow-up (v3 deferral tracked for v3.1)
 

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -374,7 +374,7 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('metadata');
     });
 
-    test('default token.place mode uses the full dChat prompt path', async () => {
+    test('default token.place mode uses docs-skipped full dChat prompt path for player-state questions', async () => {
         loadGameState.mockReturnValue({
             settings: { tokenPlaceTokenLite: false },
             inventory: [{ id: 'solar-panel', quantity: 1 }],
@@ -386,10 +386,30 @@ describe('token.place API v1 client', () => {
 
         await TokenPlaceChatV2([{ role: 'user', content: 'What should I build next?' }]);
 
-        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        expect(searchDocsRag).not.toHaveBeenCalled();
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
+        expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+    });
+
+    test('default token.place mode includes docs RAG for route questions', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: false },
+            inventory: [{ id: 'solar-panel', quantity: 1 }],
+        });
+        searchDocsRag.mockResolvedValue({
+            excerptsText: 'Docs grounding canary for gamesaves.',
+            sources: [{ title: 'Backups', url: '/docs/backups' }],
+        });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'where do I import a gamesave?' }]);
+
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const serializedMessages = JSON.stringify(decrypted.api_v1_request.messages);
+        expect(serializedMessages).toContain('Docs grounding canary for gamesaves.');
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
     });
 

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -118,7 +118,7 @@ const docsRagIntentChecks = [
     {
         reasonCode: 'changelog-version-docs',
         pattern:
-            /\b(?:changelog|release notes?|token\.place integration|version|v\d+(?:\.\d+)?|drift|deprecated|current release state)\b/i,
+            /\b(?:changelog|release notes?|token\.place integration|v\d+(?:\.\d+)?|drift|deprecated|current release state)\b|\bversion\b(?=.*\b(?:changelog|release|docs?|integration)\b)/i,
     },
     {
         reasonCode: 'changelog-version-docs',
@@ -195,10 +195,10 @@ export const hasStrongEntityHit = (text) => {
     );
 };
 
-export const hasGroundingSignal = (text) => {
+export const hasGroundingSignal = (text, docsRagReasonCodes = detectDocsRagIntent(text)) => {
     const reasonCodes = regexHits(text, groundingChecks);
     if (resourcePattern.test(text)) reasonCodes.push('resource-token');
-    if (!detectDocsRagIntent(text).includes('docs-rag-not-needed')) {
+    if (!docsRagReasonCodes.includes('docs-rag-not-needed')) {
         reasonCodes.push('docs-rag-intent');
     }
     if (hasStrongEntityHit(text)) reasonCodes.push('entity-hit');
@@ -210,7 +210,8 @@ export const planChatContext = (messages, options = {}) => {
     const latest = latestUserContent(messages);
     if (!latest.trim()) return fullPlan(['no-latest-user-message']);
 
-    const reasonCodes = hasGroundingSignal(latest);
+    const docsRagReasonCodes = detectDocsRagIntent(latest);
+    const reasonCodes = hasGroundingSignal(latest, docsRagReasonCodes);
 
-    return reasonCodes.length ? fullPlan(reasonCodes, detectDocsRagIntent(latest)) : minimalPlan();
+    return reasonCodes.length ? fullPlan(reasonCodes, docsRagReasonCodes) : minimalPlan();
 };

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -2,15 +2,24 @@ import items from '../pages/inventory/json/items';
 import processes from '../generated/processes.json';
 import quests from '../generated/quests/listManifest.json';
 
-const fullPlan = (reasonCodes) => ({
-    mode: 'full',
-    includePlayerState: true,
-    includeKnowledgePack: true,
-    includeDocsRag: true,
-    includePersonaVoiceSamples: false,
-    reasonCodes: [...new Set(reasonCodes)],
-    confidence: 'conservative',
-});
+const fullPlan = (reasonCodes, docsRagReasonCodes = []) => {
+    const uniqueDocsReasonCodes = [...new Set(docsRagReasonCodes)];
+
+    return {
+        mode: 'full',
+        includePlayerState: true,
+        includeKnowledgePack: true,
+        includeDocsRag: uniqueDocsReasonCodes.some(
+            (reasonCode) => reasonCode !== 'docs-rag-not-needed'
+        ),
+        includePersonaVoiceSamples: false,
+        reasonCodes: [...new Set(reasonCodes)],
+        docsRagReasonCodes: uniqueDocsReasonCodes.length
+            ? uniqueDocsReasonCodes
+            : ['docs-rag-not-needed'],
+        confidence: 'conservative',
+    };
+};
 
 const minimalPlan = () => ({
     mode: 'minimal',
@@ -90,6 +99,52 @@ const groundingChecks = [
     },
 ];
 
+const docsRagIntentChecks = [
+    {
+        reasonCode: 'route-docs',
+        pattern:
+            /(?:\/docs|\/quests|\/inventory|\/processes|\/settings|\/gamesaves|\broutes?\b|\bpages?\b)/i,
+    },
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /\b(?:docs?|documentation|where do i|how do i get to|settings|gamesaves?|import(?: a)? save|export(?: a)? save|backup|content backup)\b/i,
+    },
+    {
+        reasonCode: 'custom-content-docs',
+        pattern:
+            /\b(?:custom content|custom quests?|custom items?|custom processes?|quest submission|submit a custom quest|content bundles?|content editor|add custom content to dspace)\b/i,
+    },
+    {
+        reasonCode: 'changelog-version-docs',
+        pattern:
+            /\b(?:changelog|release notes?|token\.place integration|version|v\d+(?:\.\d+)?|drift|deprecated|current release state)\b/i,
+    },
+    {
+        reasonCode: 'changelog-version-docs',
+        pattern: /\btoken\.place\b(?=.*\b(?:active|current|release|version|docs?|integration)\b)/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern:
+            /\bprocess(?:es)?\b(?=.*\b(?:consumes?|creates?|requires?|requirements?|duration)\b)|\b(?:consumes?|creates?|requires?|duration)\b(?=.*\bprocess(?:es)?\b)/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern:
+            /\bquest(?:s)?\b(?=.*\b(?:requirements?|rewards?|gates?|dialogue options?|schema|authoring|how-to)\b)|\b(?:requirements?|rewards?|gates?|dialogue options?)\b(?=.*\b(?:quest|give|grant|preflight check)\b)/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern: /\b(?:schema|authoring|how-to authoring)\b/i,
+    },
+];
+
+export const detectDocsRagIntent = (text) => {
+    const reasonCodes = regexHits(text, docsRagIntentChecks);
+    return reasonCodes.length ? [...new Set(reasonCodes)] : ['docs-rag-not-needed'];
+};
+
 const resourcePattern = /\bd(?:USD|BI|Watt|Solar|Print|Launch|Fuel|Oxygen|Water|Food)\b/i;
 
 const normalize = (value) =>
@@ -143,6 +198,9 @@ export const hasStrongEntityHit = (text) => {
 export const hasGroundingSignal = (text) => {
     const reasonCodes = regexHits(text, groundingChecks);
     if (resourcePattern.test(text)) reasonCodes.push('resource-token');
+    if (!detectDocsRagIntent(text).includes('docs-rag-not-needed')) {
+        reasonCodes.push('docs-rag-intent');
+    }
     if (hasStrongEntityHit(text)) reasonCodes.push('entity-hit');
     return reasonCodes;
 };
@@ -154,5 +212,5 @@ export const planChatContext = (messages, options = {}) => {
 
     const reasonCodes = hasGroundingSignal(latest);
 
-    return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
+    return reasonCodes.length ? fullPlan(reasonCodes, detectDocsRagIntent(latest)) : minimalPlan();
 };

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -108,7 +108,7 @@ const docsRagIntentChecks = [
     {
         reasonCode: 'docs-navigation',
         pattern:
-            /\b(?:docs?|documentation|where do i|how do i get to|settings|gamesaves?|import(?: a)? save|export(?: a)? save|backup|content backup)\b/i,
+            /\b(?:docs?|documentation|where do i|how do i get to|settings|gamesaves?|import(?: a)? save|export(?: a)? save|back up|backup|content backup)\b/i,
     },
     {
         reasonCode: 'custom-content-docs',
@@ -127,7 +127,7 @@ const docsRagIntentChecks = [
     {
         reasonCode: 'mechanics-docs',
         pattern:
-            /\bprocess(?:es)?\b(?=.*\b(?:consumes?|creates?|requires?|requirements?|duration)\b)|\b(?:consumes?|creates?|requires?|duration)\b(?=.*\bprocess(?:es)?\b)/i,
+            /\bprocess(?:es)?\b(?=.*\b(?:consumes?|creates?|requires?|requirements?|duration)\b)|\b(?:consumes?|creates?|requires?|duration)\b(?=.*\bprocess(?:es)?\b)|\brequires?\b(?=.*\bconsumes?\b)(?=.*\bcreates?\b)(?=.*\bduration\b)/i,
     },
     {
         reasonCode: 'mechanics-docs',

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -774,24 +774,41 @@ export const buildChatPrompt = async (messages, options = {}) => {
               content: `DSPACE knowledge base:\n${knowledgeSummary}`,
           }
         : null;
-    const docsRagRequestOptions = buildDocsRagOptions({
-        promptBudgetChars: options.docsRagBudgetChars,
-        options: options.docsRagOptions,
-        baseMessages: [
-            systemMessage,
-            ...(playerStateMessage ? [playerStateMessage] : []),
-            ...(knowledgeMessage ? [knowledgeMessage] : []),
-            ...normalizedMessages,
-        ],
-    });
+    const shouldIncludeDocsRag = Boolean(
+        latestUserMessage && (contextPlan.includeDocsRag || options.forceDocsRag)
+    );
+    const docsRagRequestOptions = shouldIncludeDocsRag
+        ? buildDocsRagOptions({
+              promptBudgetChars: options.docsRagBudgetChars,
+              options: options.docsRagOptions,
+              baseMessages: [
+                  systemMessage,
+                  ...(playerStateMessage ? [playerStateMessage] : []),
+                  ...(knowledgeMessage ? [knowledgeMessage] : []),
+                  ...normalizedMessages,
+              ],
+          })
+        : null;
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
-    const docsRagStartedAt = performance.now();
-    const docsRagPayload = latestUserMessage
+    const docsRagStartedAt = shouldIncludeDocsRag ? performance.now() : 0;
+    const docsRagPayload = shouldIncludeDocsRag
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
-    const ragDurationMs = performance.now() - docsRagStartedAt;
+    const ragDurationMs = shouldIncludeDocsRag ? performance.now() - docsRagStartedAt : 0;
+    const docsRagStatus = shouldIncludeDocsRag
+        ? 'included'
+        : latestUserMessage
+          ? 'skipped'
+          : 'not-applicable';
+    const contextPlanMetadata = {
+        ...contextPlan,
+        docsRagStatus,
+        docsRagReasonCodes: contextPlan.docsRagReasonCodes || [
+            shouldIncludeDocsRag ? 'docs-rag-included' : 'docs-rag-not-needed',
+        ],
+    };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -852,7 +869,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
-        contextPlan,
+        contextPlan: contextPlanMetadata,
     };
 
     if (options.includePromptMetrics) {
@@ -880,7 +897,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
-            contextPlan,
+            contextPlan: contextPlanMetadata,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -802,12 +802,19 @@ export const buildChatPrompt = async (messages, options = {}) => {
         : latestUserMessage
           ? 'skipped'
           : 'not-applicable';
+    const contextPlanDocsRagReasonCodes = Array.isArray(contextPlan.docsRagReasonCodes)
+        ? contextPlan.docsRagReasonCodes
+        : [];
+    const docsRagReasonCodes = options.forceDocsRag
+        ? [...new Set([...contextPlanDocsRagReasonCodes, 'docs-rag-forced'])]
+        : contextPlanDocsRagReasonCodes.length
+          ? contextPlanDocsRagReasonCodes
+          : [shouldIncludeDocsRag ? 'docs-rag-included' : 'docs-rag-not-needed'];
     const contextPlanMetadata = {
         ...contextPlan,
+        includeDocsRag: shouldIncludeDocsRag,
         docsRagStatus,
-        docsRagReasonCodes: contextPlan.docsRagReasonCodes || [
-            shouldIncludeDocsRag ? 'docs-rag-included' : 'docs-rag-not-needed',
-        ],
+        docsRagReasonCodes,
     };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,6 +73,21 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        docsRag: metadata.contextPlan
+            ? {
+                  includeDocsRag: Boolean(metadata.contextPlan.includeDocsRag),
+                  status:
+                      metadata.contextPlan.docsRagStatus ||
+                      (metadata.contextPlan.mode === 'minimal' ? 'not-applicable' : 'skipped'),
+                  reasonCodes: Array.isArray(metadata.contextPlan.docsRagReasonCodes)
+                      ? metadata.contextPlan.docsRagReasonCodes
+                      : [],
+                  durationMs:
+                      metadata.contextPlan.docsRagStatus === 'included'
+                          ? Number(metadata.ragDurationMs || 0)
+                          : 0,
+              }
+            : null,
         contextPlan: metadata.contextPlan || null,
     };
 };

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -74,19 +74,21 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                 ? null
                 : Number(metadata.ragDurationMs),
         docsRag: metadata.contextPlan
-            ? {
-                  includeDocsRag: Boolean(metadata.contextPlan.includeDocsRag),
-                  status:
+            ? (() => {
+                  const status =
                       metadata.contextPlan.docsRagStatus ||
-                      (metadata.contextPlan.mode === 'minimal' ? 'not-applicable' : 'skipped'),
-                  reasonCodes: Array.isArray(metadata.contextPlan.docsRagReasonCodes)
-                      ? metadata.contextPlan.docsRagReasonCodes
-                      : [],
-                  durationMs:
-                      metadata.contextPlan.docsRagStatus === 'included'
-                          ? Number(metadata.ragDurationMs || 0)
-                          : 0,
-              }
+                      (metadata.contextPlan.mode === 'minimal' ? 'not-applicable' : 'skipped');
+                  return {
+                      includeDocsRag:
+                          status === 'included' ||
+                          (status !== 'skipped' && Boolean(metadata.contextPlan.includeDocsRag)),
+                      status,
+                      reasonCodes: Array.isArray(metadata.contextPlan.docsRagReasonCodes)
+                          ? metadata.contextPlan.docsRagReasonCodes
+                          : [],
+                      durationMs: status === 'included' ? Number(metadata.ragDurationMs || 0) : 0,
+                  };
+              })()
             : null,
         contextPlan: metadata.contextPlan || null,
     };

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -26,30 +26,46 @@ describe('planChatContext', () => {
     });
 
     it.each([
-        'what should I do next?',
         'what quest do I have left?',
-        'How am I progressing?',
+        'what should I do next?',
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
-        'where do I import a gamesave?',
-        'How do I add custom content to DSPACE?',
-        'how do I submit a custom quest?',
-        'where are content bundles documented?',
-        'how do I get to settings?',
-        'what does this process consume?',
-        'what rewards does preflight check give?',
+        'what is my inventory?',
+        'how many quests have I completed?',
+        'How am I progressing?',
         'what about the second option?',
         'Benchy',
         'dSolar',
+    ])('uses full mode without docs RAG for player-state turns: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.docsRagReasonCodes).toContain('docs-rag-not-needed');
+        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+    });
+
+    it.each([
+        'where do I import a gamesave?',
+        'how do I get to settings?',
+        'How do I add custom content to DSPACE?',
+        'how do I submit a custom quest?',
+        'where is the content backup page?',
+        'what changed in v3.1 chat?',
+        'what does this process consume?',
+        'what rewards does preflight check give?',
         '/gamesaves',
+        'where are content bundles documented?',
         'what does this process create?',
         'custom item for a DSPACE quest',
-    ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
+    ])('uses full mode with docs RAG for docs-like turns: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');
         expect(plan.includePlayerState).toBe(true);
         expect(plan.includeKnowledgePack).toBe(true);
         expect(plan.includeDocsRag).toBe(true);
+        expect(plan.docsRagReasonCodes).not.toContain('docs-rag-not-needed');
         expect(plan.reasonCodes.length).toBeGreaterThan(0);
     });
 });

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -59,6 +59,9 @@ describe('planChatContext', () => {
         '/gamesaves',
         'where are content bundles documented?',
         'what does this process create?',
+        'What can I back up or export?',
+        'Explain requires vs consumes vs creates and duration semantics',
+        'what do processes consume?',
         'custom item for a DSPACE quest',
     ])('uses full mode with docs RAG for docs-like turns: %s', (content) => {
         const plan = planFor(content);

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -36,6 +36,7 @@ describe('planChatContext', () => {
         'what about the second option?',
         'Benchy',
         'dSolar',
+        'what version of the solar tracker blueprint do I have?',
     ])('uses full mode without docs RAG for player-state turns: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -683,6 +683,7 @@ Docs grounding (gitSha: test):
         expect(payload.contextPlan.includeDocsRag).toBe(true);
         expect(payload.contextPlan.docsRagStatus).toBe('included');
         expect(payload.contextPlan.docsRagReasonCodes).toContain('docs-rag-forced');
+        expect(payload.contextPlan.docsRagReasonCodes).not.toEqual(['docs-rag-not-needed']);
         expect(payload.promptMetrics.docsRag.includeDocsRag).toBe(true);
         expect(payload.promptMetrics.docsRag.status).toBe('included');
     });

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -664,6 +664,29 @@ describe('buildChatPrompt', () => {
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
     });
 
+    it('reports forced docs RAG consistently in plan metadata and prompt metrics', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: `---
+Docs grounding (gitSha: test):
+- [doc] Forced docs
+---`,
+            sources: [{ type: 'doc', id: 'forced', label: 'Forced docs', url: '/docs/forced#top' }],
+            sourcesMeta: { results: [] },
+        });
+
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            { forceDocsRag: true, includePromptMetrics: true }
+        );
+
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(payload.contextPlan.docsRagStatus).toBe('included');
+        expect(payload.contextPlan.docsRagReasonCodes).toContain('docs-rag-forced');
+        expect(payload.promptMetrics.docsRag.includeDocsRag).toBe(true);
+        expect(payload.promptMetrics.docsRag.status).toBe('included');
+    });
+
     it('includes docs RAG for gamesave route prompts', async () => {
         vi.mocked(searchDocsRag).mockResolvedValueOnce({
             excerptsText: `---\nDocs grounding (gitSha: test):\n- [route] Backups — /docs/backups#top\n  import saves\n---`,

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -645,6 +645,44 @@ describe('buildChatPrompt', () => {
         expect(Number(statsMatch?.[3])).toBe(Number(statsMatch?.[2]) - Number(statsMatch?.[1]));
     });
 
+    it('skips docs RAG for player-state-only full prompts', async () => {
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            {
+                includePromptMetrics: true,
+            }
+        );
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(prompt).toContain('PlayerState');
+        expect(prompt).toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        expect(payload.contextSources.every((source) => source.type !== 'doc')).toBe(true);
+        expect(payload.promptMetrics.docsRag.status).toBe('skipped');
+    });
+
+    it('includes docs RAG for gamesave route prompts', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: `---\nDocs grounding (gitSha: test):\n- [route] Backups — /docs/backups#top\n  import saves\n---`,
+            sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups#top' }],
+            sourcesMeta: { results: [] },
+        });
+
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'where do I import a gamesave?' },
+        ]);
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding');
+        expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+    });
+
     it('does not duplicate docs excerpts when knowledge summary exists', async () => {
         vi.mocked(buildDchatKnowledgePack).mockReturnValueOnce({
             summary: 'Summary entry',
@@ -699,7 +737,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -735,7 +773,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -759,7 +797,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -767,7 +805,7 @@ describe('buildChatPrompt', () => {
     });
 
     it('passes expanded docs RAG options to searchDocsRag', async () => {
-        const messages = [{ role: 'user', content: 'Tell me about quests.' }];
+        const messages = [{ role: 'user', content: 'Where is /docs/routes?' }];
 
         await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
 

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -136,6 +136,8 @@ describe('buildChatPrompt context planning', () => {
 
         expect(payload.contextPlan.mode).toBe('full');
         expect(payload.contextPlan.reasonCodes).toContain('player-state-progress');
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.promptMetrics.docsRag.status).toBe('skipped');
         expect(prompt).toContain('You are Hydro');
         expect(prompt).toContain('hydroponics steward');
         expect(prompt).toContain('PlayerState');
@@ -143,6 +145,30 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('Use the PlayerState block when present.');
         expect(prompt).toContain('If PlayerState is missing');
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
-        expect(searchDocsRag).toHaveBeenCalled();
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('includes docs RAG for route and custom-content full prompts', async () => {
+        const routePayload = await buildChatPrompt(
+            [{ role: 'user', content: 'where do I import a gamesave?' }],
+            { includePromptMetrics: true }
+        );
+
+        expect(routePayload.contextPlan.mode).toBe('full');
+        expect(routePayload.contextPlan.includeDocsRag).toBe(true);
+        expect(routePayload.promptMetrics.docsRag.status).toBe('included');
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+
+        vi.mocked(searchDocsRag).mockClear();
+
+        const customPayload = await buildChatPrompt(
+            [{ role: 'user', content: 'How do I add custom content to DSPACE?' }],
+            { includePromptMetrics: true }
+        );
+
+        expect(customPayload.contextPlan.mode).toBe('full');
+        expect(customPayload.contextPlan.includeDocsRag).toBe(true);
+        expect(customPayload.contextPlan.docsRagReasonCodes).toContain('custom-content-docs');
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/promptMetrics.test.ts
+++ b/tests/promptMetrics.test.ts
@@ -101,6 +101,7 @@ describe('buildPromptMetrics', () => {
       [{ role: 'user', content: userMessage }],
       {
         includePromptMetrics: true,
+        forceDocsRag: true,
       }
     );
     const ragMessages = instrumented.combinedMessages.filter((message) =>
@@ -127,7 +128,10 @@ describe('buildPromptMetrics', () => {
 
   test('buildChatPrompt counts assistant messages after the latest user as chat history', async () => {
     const { buildChatPrompt } = await import('../frontend/src/utils/openAI.js');
-    const latestUser = { role: 'user', content: 'latest repeated DSPACE quest prompt' };
+    const latestUser = {
+      role: 'user',
+      content: 'latest repeated DSPACE quest prompt',
+    };
     const trailingAssistant = {
       role: 'assistant',
       content: 'assistant after latest user',


### PR DESCRIPTION
### Motivation
- Reduce unnecessary docs RAG noise in full-mode prompts by making docs retrieval conditional on explicit docs/navigation/custom-content/version/mechanics intent while preserving full PlayerState and dChat knowledge inclusion. 
- Preserve the P16 minimal/no-grounding behavior unchanged so short conversational turns still avoid heavy grounding.
- Provide safe telemetry so callers can know whether docs RAG was included or skipped without leaking any prompt text or sensitive payloads.

### Description
- Add a small docs-RAG intent detector and reason codes in `frontend/src/utils/chatContextPlanner.js` and wire them into the full-mode plan so `includeDocsRag` can be false even when `mode === 'full'`, while keeping `includePlayerState` and `includeKnowledgePack` true.  New exported helper: `detectDocsRagIntent()` and planner metadata `docsRagReasonCodes`.  (file: `frontend/src/utils/chatContextPlanner.js`)
- Change `buildChatPrompt()` to only call `searchDocsRag()` when the context plan requests docs RAG or when `options.forceDocsRag` is set, and to produce an empty docs payload and no "Docs grounding" system text when skipped. Prompt building still includes PlayerState and the dChat knowledge pack for full-mode. (file: `frontend/src/utils/openAI.js`)
- Extend prompt metrics via `buildPromptMetrics()` to include a `docsRag` block with `includeDocsRag`, `status` (`included`/`skipped`/`not-applicable`), `reasonCodes`, and safe `durationMs`, without including any excerpts or prompt contents. (file: `frontend/src/utils/promptMetrics.js`)
- Update and add focused tests to validate planner and integration behavior for both player-state-only full prompts (docs RAG skipped) and docs/navigation/custom-content/mechanics prompts (docs RAG included). Tests touched/added: `frontend/tests/chatContextPlanner.test.ts`, `frontend/tests/openAI.test.ts`, `frontend/tests/openAIContextPlanner.test.ts`, and `frontend/__tests__/tokenPlace.test.js`.

### Testing
- Ran focused unit and integration suites and checks in the `frontend` workspace; all commands shown below completed successfully:
  - `cd frontend && npm test -- chatContextPlanner` — passed (planner unit tests updated to cover docs-skipped and docs-included cases).
  - `cd frontend && npm test -- openAI` — passed (integration tests exercising `buildChatPrompt()` updated; calls to `searchDocsRag()` asserted appropriately and `forceDocsRag` preserved test forcing behavior).
  - `cd frontend && npm test -- tokenPlace.test.js` — passed (token.place path tests updated to assert docs-skipped full prompts for player-state questions and docs-included for route/custom-content queries).
  - `cd frontend && npm test -- openAIContextPlanner` — passed (context-planning / prompt-metrics assertions).
  - `cd frontend && npm run check` — passed (lint/format checks).
  - `cd frontend && npm run build` — passed (Astro build completed).

All automated tests that exercise the changed behavior passed in the CI-local run; files changed are limited to the scoped utilities and tests described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f6c7f30832f9c63f5895d625ef4)