### PR TITLE
Gate docs RAG by chat intent

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -374,23 +374,44 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('metadata');
     });
 
-    test('default token.place mode uses the full dChat prompt path', async () => {
+    test('default token.place mode uses the docs-skipped full dChat prompt path for player-state questions', async () => {
         loadGameState.mockReturnValue({
             settings: { tokenPlaceTokenLite: false },
             inventory: [{ id: 'solar-panel', quantity: 1 }],
         });
         searchDocsRag.mockResolvedValue({
-            excerptsText: 'RAG excerpt canary for normal mode.',
+            excerptsText: 'RAG excerpt should be skipped for player-state-only normal mode.',
             sources: [{ title: 'DSPACE docs', url: '/docs/about' }],
         });
 
         await TokenPlaceChatV2([{ role: 'user', content: 'What should I build next?' }]);
 
-        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        expect(searchDocsRag).not.toHaveBeenCalled();
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+    });
+
+    test('default token.place mode includes docs RAG for route and docs questions', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: false },
+            inventory: [{ id: 'solar-panel', quantity: 1 }],
+        });
+        searchDocsRag.mockResolvedValue({
+            excerptsText: 'RAG excerpt canary for gamesaves route.',
+            sources: [{ title: 'Backups', url: '/docs/backups' }],
+        });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'Where do I import a gamesave?' }]);
+
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const promptText = decrypted.api_v1_request.messages
+            .map((message) => message.content)
+            .join('\\n');
+        expect(promptText).toContain('RAG excerpt canary for gamesaves route.');
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -2,13 +2,16 @@ import items from '../pages/inventory/json/items';
 import processes from '../generated/processes.json';
 import quests from '../generated/quests/listManifest.json';
 
-const fullPlan = (reasonCodes) => ({
+const fullPlan = (reasonCodes, docsRagReasonCodes = []) => ({
     mode: 'full',
     includePlayerState: true,
     includeKnowledgePack: true,
-    includeDocsRag: true,
+    includeDocsRag: docsRagReasonCodes.length > 0,
     includePersonaVoiceSamples: false,
-    reasonCodes: [...new Set(reasonCodes)],
+    reasonCodes: [...new Set([...reasonCodes, ...docsRagReasonCodes])],
+    docsRagReasonCodes: docsRagReasonCodes.length
+        ? [...new Set(docsRagReasonCodes)]
+        : ['docs-rag-not-needed'],
     confidence: 'conservative',
 });
 
@@ -19,6 +22,7 @@ const minimalPlan = () => ({
     includeDocsRag: false,
     includePersonaVoiceSamples: true,
     reasonCodes: ['no-grounding-signals'],
+    docsRagReasonCodes: ['not-applicable'],
     confidence: 'high',
 });
 
@@ -51,6 +55,36 @@ export const latestUserContent = (messages) =>
 
 const regexHits = (text, checks) =>
     checks.filter(({ pattern }) => pattern.test(text)).map(({ reasonCode }) => reasonCode);
+
+const docsRagIntentChecks = [
+    {
+        reasonCode: 'route-docs',
+        pattern:
+            /(?:\/docs|\/quests|\/inventory|\/processes|\/settings|\/gamesaves|\broutes?\b|\bpages?\b|\bsettings\b|\bwhere do i\b|\bhow do i get to\b)/i,
+    },
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /\b(docs?|documentation|gamesaves?|import save|export save|backup|content backup)\b/i,
+    },
+    {
+        reasonCode: 'custom-content-docs',
+        pattern:
+            /\b(custom content|custom quests?|custom items?|custom processes?|quest submission|content bundles?|custom content bundles?|content editor|add custom content to dspace)\b/i,
+    },
+    {
+        reasonCode: 'changelog-version-docs',
+        pattern:
+            /\b(changelog|release notes|token\.place(?: integration docs)?|versions?|v\d+(?:\.\d+)?|v2|v3|drift|deprecated|current release state)\b/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern:
+            /\bprocess(?:es)?\b(?=.*\b(consumes?|creates?|duration|requires?|requirements?)\b)|\bquest(?:s)?\b(?=.*\b(requirements?|rewards?|gates?|dialogue options?|schema|authoring)\b)|\b(rewards?|gates?|dialogue options?|schema|authoring)\b/i,
+    },
+];
+
+export const hasDocsRagIntent = (text) => regexHits(text, docsRagIntentChecks);
 
 const groundingChecks = [
     {
@@ -153,6 +187,8 @@ export const planChatContext = (messages, options = {}) => {
     if (!latest.trim()) return fullPlan(['no-latest-user-message']);
 
     const reasonCodes = hasGroundingSignal(latest);
+    const docsRagReasonCodes = hasDocsRagIntent(latest);
+    const fullReasonCodes = reasonCodes.length ? reasonCodes : docsRagReasonCodes;
 
-    return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
+    return fullReasonCodes.length ? fullPlan(fullReasonCodes, docsRagReasonCodes) : minimalPlan();
 };

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -736,6 +736,8 @@ export const buildChatPrompt = async (messages, options = {}) => {
             promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
                 promptBuildDurationMs: performance.now() - promptBuildStartedAt,
                 ragDurationMs: 0,
+                docsRagStatus: 'not-applicable',
+                docsRagReasonCodes: contextPlanMetadata.docsRagReasonCodes || [],
                 contextPlan: contextPlanMetadata,
                 componentMessageIndexes: {
                     systemInstructions: [
@@ -774,24 +776,34 @@ export const buildChatPrompt = async (messages, options = {}) => {
               content: `DSPACE knowledge base:\n${knowledgeSummary}`,
           }
         : null;
-    const docsRagRequestOptions = buildDocsRagOptions({
-        promptBudgetChars: options.docsRagBudgetChars,
-        options: options.docsRagOptions,
-        baseMessages: [
-            systemMessage,
-            ...(playerStateMessage ? [playerStateMessage] : []),
-            ...(knowledgeMessage ? [knowledgeMessage] : []),
-            ...normalizedMessages,
-        ],
-    });
+    const shouldIncludeDocsRag = Boolean(
+        latestUserMessage && (contextPlan.includeDocsRag || options.forceDocsRag)
+    );
+    const docsRagRequestOptions = shouldIncludeDocsRag
+        ? buildDocsRagOptions({
+              promptBudgetChars: options.docsRagBudgetChars,
+              options: options.docsRagOptions,
+              baseMessages: [
+                  systemMessage,
+                  ...(playerStateMessage ? [playerStateMessage] : []),
+                  ...(knowledgeMessage ? [knowledgeMessage] : []),
+                  ...normalizedMessages,
+              ],
+          })
+        : null;
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
-    const docsRagStartedAt = performance.now();
-    const docsRagPayload = latestUserMessage
+    const docsRagStartedAt = shouldIncludeDocsRag ? performance.now() : 0;
+    const docsRagPayload = shouldIncludeDocsRag
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
-    const ragDurationMs = performance.now() - docsRagStartedAt;
+    const ragDurationMs = shouldIncludeDocsRag ? performance.now() - docsRagStartedAt : 0;
+    const docsRagStatus = shouldIncludeDocsRag
+        ? 'included'
+        : latestUserMessage && contextPlan.mode === 'full'
+          ? 'skipped'
+          : 'not-applicable';
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -880,6 +892,8 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
+            docsRagStatus,
+            docsRagReasonCodes: contextPlan.docsRagReasonCodes || [],
             contextPlan,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,6 +73,10 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        docsRagStatus: metadata.docsRagStatus || 'not-applicable',
+        docsRagReasonCodes: Array.isArray(metadata.docsRagReasonCodes)
+            ? [...new Set(metadata.docsRagReasonCodes)]
+            : [],
         contextPlan: metadata.contextPlan || null,
     };
 };

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -26,30 +26,47 @@ describe('planChatContext', () => {
     });
 
     it.each([
-        'what should I do next?',
         'what quest do I have left?',
-        'How am I progressing?',
+        'what should I do next?',
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
-        'where do I import a gamesave?',
-        'How do I add custom content to DSPACE?',
-        'how do I submit a custom quest?',
-        'where are content bundles documented?',
-        'how do I get to settings?',
-        'what does this process consume?',
-        'what rewards does preflight check give?',
+        'what is my inventory?',
+        'how many quests have I completed?',
+        'How am I progressing?',
         'what about the second option?',
         'Benchy',
         'dSolar',
+    ])('uses full mode without docs RAG for player-state-only turn: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.docsRagReasonCodes).toEqual(['docs-rag-not-needed']);
+        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+    });
+
+    it.each([
+        'where do I import a gamesave?',
+        'how do I get to settings?',
+        'How do I add custom content to DSPACE?',
+        'how do I submit a custom quest?',
+        'where is the content backup page?',
+        'what changed in v3.1 chat?',
+        'what does this process consume?',
+        'what rewards does preflight check give?',
         '/gamesaves',
+        'where are content bundles documented?',
         'what does this process create?',
         'custom item for a DSPACE quest',
-    ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
+    ])('uses full mode with docs RAG for docs-like turn: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');
         expect(plan.includePlayerState).toBe(true);
         expect(plan.includeKnowledgePack).toBe(true);
         expect(plan.includeDocsRag).toBe(true);
+        expect(plan.docsRagReasonCodes.length).toBeGreaterThan(0);
+        expect(plan.docsRagReasonCodes).not.toContain('docs-rag-not-needed');
         expect(plan.reasonCodes.length).toBeGreaterThan(0);
     });
 });

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -699,7 +699,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -735,7 +735,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -769,7 +769,7 @@ describe('buildChatPrompt', () => {
     it('passes expanded docs RAG options to searchDocsRag', async () => {
         const messages = [{ role: 'user', content: 'Tell me about quests.' }];
 
-        await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
+        await buildChatPrompt(messages, { docsRagBudgetChars: 1000000, forceDocsRag: true });
 
         const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
 

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -32,6 +32,55 @@ describe('buildChatPrompt context planning', () => {
         vi.mocked(searchDocsRag).mockClear();
     });
 
+    it('includes docs RAG for gamesave import navigation', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding',
+            sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups' }],
+        });
+
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'where do I import a gamesave?' }],
+            { includePromptMetrics: true }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding');
+        expect(payload.contextSources.some((source) => source.url === '/docs/backups')).toBe(true);
+        expect(payload.promptMetrics.docsRagStatus).toBe('included');
+    });
+
+    it('includes docs RAG for custom content guidance', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding custom content bundles quest submission',
+            sources: [
+                {
+                    type: 'doc',
+                    id: 'quest-submission',
+                    label: 'Quest submission',
+                    url: '/docs/quest-submission',
+                },
+            ],
+        });
+
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'How do I add custom content to DSPACE?' }],
+            { includePromptMetrics: true }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding custom content bundles quest submission');
+        expect(
+            payload.contextSources.some((source) => source.url === '/docs/quest-submission')
+        ).toBe(true);
+        expect(payload.promptMetrics.docsRagStatus).toBe('included');
+    });
+
     it('builds a small minimal prompt for hi without full grounding', async () => {
         const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
             includePromptMetrics: true,
@@ -143,6 +192,10 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('Use the PlayerState block when present.');
         expect(prompt).toContain('If PlayerState is missing');
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
-        expect(searchDocsRag).toHaveBeenCalled();
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        expect(prompt).not.toContain('Docs grounding');
+        expect(payload.contextSources).toEqual([]);
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.promptMetrics.docsRagStatus).toBe('skipped');
     });
 });


### PR DESCRIPTION
### Motivation

- Reduce noisy docs RAG in `full` prompts by only running docs retrieval for turns that explicitly need docs/navigation/custom-content/version/mechanics grounding while preserving PlayerState and dChat knowledge inclusion. 
- Preserve the conservative P16 minimal-mode behavior for no-grounding turns and keep planner compatibility metadata for downstream telemetry. 

### Description

- Add docs-RAG intent detection and metadata to the planner by exporting `hasDocsRagIntent` and wiring `docsRagReasonCodes` into `planChatContext()` so `includeDocsRag` can be false even when `mode === 'full'` (`frontend/src/utils/chatContextPlanner.js`).
- Make `buildChatPrompt()` conditionally call `searchDocsRag()` only when `contextPlan.includeDocsRag === true` or `options.forceDocsRag` is set, set a safe skipped payload when not included, and avoid inserting any "Docs grounding" system text when skipped (`frontend/src/utils/openAI.js`).
- Add docs-RAG status and reason codes to prompt metrics and preserve privacy-safe sizing (no excerpts or sensitive content) via `buildPromptMetrics()` (`frontend/src/utils/promptMetrics.js`).
- Update and add focused tests to verify planner decisions, prompt building, and token.place behavior for player-state-only vs docs/navigation/custom-content queries (`frontend/tests/*`, `frontend/__tests__/tokenPlace.test.js`).

### Testing

- Ran planner/unit and integration tests: `npm test --prefix frontend -- chatContextPlanner openAI tokenPlace.test.js`, and all targeted tests passed (final run: 163 tests passed across suites that include the modified areas). 
- Ran repository checks and build: `cd frontend && npm run check` and `cd frontend && npm run build`, both completed successfully with no formatting or build failures. 
- Notes: unit test files updated/added to cover both docs-skipped full-mode player-state queries and docs-included route/custom-content queries, and token.place tests confirm the docs-skipped full prompt path for player-state-only questions and docs-included path for navigation/custom-content questions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f7a2d88832fb6681277a378e82f)