### PR TITLE
Gate chat docs RAG by intent (skip docs RAG for player-state-only full prompts)

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -374,7 +374,7 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('metadata');
     });
 
-    test('default token.place mode uses the full dChat prompt path', async () => {
+    test('default token.place mode uses the full dChat prompt path without docs for player-state-only questions', async () => {
         loadGameState.mockReturnValue({
             settings: { tokenPlaceTokenLite: false },
             inventory: [{ id: 'solar-panel', quantity: 1 }],
@@ -386,11 +386,29 @@ describe('token.place API v1 client', () => {
 
         await TokenPlaceChatV2([{ role: 'user', content: 'What should I build next?' }]);
 
-        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        expect(searchDocsRag).not.toHaveBeenCalled();
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+    });
+
+    test('default token.place mode includes docs RAG for route questions', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: false },
+            inventory: [{ id: 'solar-panel', quantity: 1 }],
+        });
+        searchDocsRag.mockResolvedValue({
+            excerptsText: 'Docs grounding: gamesave import route.',
+            sources: [{ type: 'doc', id: '/docs/backups', label: 'Backups', url: '/docs/backups' }],
+        });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'where do I import a gamesave?' }]);
+
+        expect(searchDocsRag).toHaveBeenCalledTimes(1);
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        expect(JSON.stringify(decrypted.api_v1_request.messages)).toContain('Docs grounding');
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -2,11 +2,11 @@ import items from '../pages/inventory/json/items';
 import processes from '../generated/processes.json';
 import quests from '../generated/quests/listManifest.json';
 
-const fullPlan = (reasonCodes) => ({
+const fullPlan = (reasonCodes, includeDocsRag = true) => ({
     mode: 'full',
     includePlayerState: true,
     includeKnowledgePack: true,
-    includeDocsRag: true,
+    includeDocsRag,
     includePersonaVoiceSamples: false,
     reasonCodes: [...new Set(reasonCodes)],
     confidence: 'conservative',
@@ -52,6 +52,36 @@ export const latestUserContent = (messages) =>
 const regexHits = (text, checks) =>
     checks.filter(({ pattern }) => pattern.test(text)).map(({ reasonCode }) => reasonCode);
 
+const docsRagIntentChecks = [
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /(?:\/docs|\bdocs?\b|\broutes?\b|\bpages?\b|\bwhere do i\b|\bhow do i get to\b|\bsettings\b|\/settings|\/quests|\/inventory|\/processes)/i,
+    },
+    {
+        reasonCode: 'route-docs',
+        pattern:
+            /(?:\/gamesaves|\bgamesaves?\b|\bimport save\b|\bexport save\b|\bbackup\b|\bcontent backup\b)/i,
+    },
+    {
+        reasonCode: 'custom-content-docs',
+        pattern:
+            /\b(custom content|custom quests?|custom items?|custom processes?|quest submission|content bundles?|custom content bundles?|content editor|add custom content to dspace|submit a custom quest)\b/i,
+    },
+    {
+        reasonCode: 'changelog-version-docs',
+        pattern:
+            /\b(token\.place integration docs|token\.place|tokenplace|changelog|release notes?|versions?|v[23](?:\.\d+)?|drift|deprecated|current release state|what changed)\b/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern:
+            /\bprocess\b(?=.*\b(consumes?|creates?|requires?|duration)\b)|\bquest\b(?=.*\b(requirements?|rewards?|gates?|dialogue options?|authoring|schema|how-to)\b)|\brewards?\b(?=.*\bgive\b)|\bschema\b|\bauthoring guidance\b/i,
+    },
+];
+
+export const getDocsRagIntentReasonCodes = (text) => regexHits(text, docsRagIntentChecks);
+
 const groundingChecks = [
     {
         reasonCode: 'player-state-progress',
@@ -61,7 +91,7 @@ const groundingChecks = [
     {
         reasonCode: 'game-data',
         pattern:
-            /\b(token\.place|quests?|achievements?|rewards?|requirements?|gates?|unlocks?|balances?)\b/i,
+            /\b(token\.place|quests?|achievements?|rewards?|requirements?|gates?|unlocks?|balances?|v[23](?:\.\d+)?)\b/i,
     },
     {
         reasonCode: 'process-data',
@@ -154,5 +184,11 @@ export const planChatContext = (messages, options = {}) => {
 
     const reasonCodes = hasGroundingSignal(latest);
 
-    return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
+    if (!reasonCodes.length) return minimalPlan();
+
+    const docsReasonCodes = getDocsRagIntentReasonCodes(latest);
+    const includeDocsRag = docsReasonCodes.length > 0;
+    const docsDecisionReasonCodes = includeDocsRag ? docsReasonCodes : ['docs-rag-not-needed'];
+
+    return fullPlan([...reasonCodes, ...docsDecisionReasonCodes], includeDocsRag);
 };

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -787,11 +787,28 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
-    const docsRagStartedAt = performance.now();
-    const docsRagPayload = latestUserMessage
+    const forceDocsRag = options.forceDocsRag === true || options.docsRagOptions?.force === true;
+    const shouldIncludeDocsRag = Boolean(
+        latestUserMessage && (contextPlan.includeDocsRag || forceDocsRag)
+    );
+    const docsRagStatus = shouldIncludeDocsRag
+        ? 'included'
+        : latestUserMessage
+          ? 'skipped'
+          : 'not-applicable';
+    const docsRagStartedAt = shouldIncludeDocsRag ? performance.now() : 0;
+    const docsRagPayload = shouldIncludeDocsRag
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
-    const ragDurationMs = performance.now() - docsRagStartedAt;
+    const ragDurationMs = shouldIncludeDocsRag ? performance.now() - docsRagStartedAt : 0;
+    const contextPlanMetadata = {
+        ...contextPlan,
+        includeDocsRag: Boolean(contextPlan.includeDocsRag || forceDocsRag),
+        docsRagStatus,
+        docsRagReasonCodes: (contextPlan.reasonCodes || []).filter((reasonCode) =>
+            /docs|rag|route/.test(reasonCode)
+        ),
+    };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -852,7 +869,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
-        contextPlan,
+        contextPlan: contextPlanMetadata,
     };
 
     if (options.includePromptMetrics) {
@@ -880,7 +897,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
-            contextPlan,
+            contextPlan: contextPlanMetadata,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -26,31 +26,38 @@ describe('planChatContext', () => {
     });
 
     it.each([
-        'what should I do next?',
         'what quest do I have left?',
-        'How am I progressing?',
+        'what should I do next?',
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
+        'what is my inventory?',
+        'how many quests have I completed?',
+    ])('uses full mode without docs RAG for player-state turn: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.reasonCodes).toContain('docs-rag-not-needed');
+    });
+
+    it.each([
         'where do I import a gamesave?',
+        'how do I get to settings?',
         'How do I add custom content to DSPACE?',
         'how do I submit a custom quest?',
-        'where are content bundles documented?',
-        'how do I get to settings?',
+        'where is the content backup page?',
+        'what changed in v3.1 chat?',
         'what does this process consume?',
         'what rewards does preflight check give?',
-        'what about the second option?',
-        'Benchy',
-        'dSolar',
         '/gamesaves',
-        'what does this process create?',
-        'custom item for a DSPACE quest',
-    ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
+    ])('uses full mode with docs RAG for docs-like turn: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');
         expect(plan.includePlayerState).toBe(true);
         expect(plan.includeKnowledgePack).toBe(true);
         expect(plan.includeDocsRag).toBe(true);
-        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+        expect(plan.reasonCodes.some((code) => /docs|route/.test(code))).toBe(true);
     });
 });
 

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -699,7 +699,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -735,7 +735,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -759,7 +759,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -769,7 +769,7 @@ describe('buildChatPrompt', () => {
     it('passes expanded docs RAG options to searchDocsRag', async () => {
         const messages = [{ role: 'user', content: 'Tell me about quests.' }];
 
-        await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
+        await buildChatPrompt(messages, { docsRagBudgetChars: 1000000, forceDocsRag: true });
 
         const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
 
@@ -785,7 +785,7 @@ describe('buildChatPrompt', () => {
     it('clamps docs RAG maxChars when the prompt budget is exhausted', async () => {
         const messages = [{ role: 'user', content: 'Need docs.' }];
 
-        await buildChatPrompt(messages, { docsRagBudgetChars: 0 });
+        await buildChatPrompt(messages, { docsRagBudgetChars: 0, forceDocsRag: true });
 
         const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
 

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -143,6 +143,73 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('Use the PlayerState block when present.');
         expect(prompt).toContain('If PlayerState is missing');
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.contextPlan.docsRagStatus).toBe('skipped');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('skips docs RAG for full player-state-only questions', async () => {
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            {
+                includePromptMetrics: true,
+            }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.contextPlan.docsRagStatus).toBe('skipped');
+        expect(prompt).toContain('PlayerState');
+        expect(prompt).toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(payload.contextSources).toEqual([]);
+        expect(payload.promptMetrics.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.promptMetrics.contextPlan.docsRagStatus).toBe('skipped');
+        expect(searchDocsRag).not.toHaveBeenCalled();
+    });
+
+    it('includes docs RAG for gamesave route questions', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding: /gamesaves import details',
+            sources: [{ type: 'doc', id: '/docs/backups', label: 'Backups', url: '/docs/backups' }],
+        });
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'where do I import a gamesave?' },
+        ]);
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(payload.contextPlan.docsRagStatus).toBe('included');
         expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding');
+        expect(payload.contextSources.some((source) => source.url === '/docs/backups')).toBe(true);
+    });
+
+    it('includes docs RAG for custom content questions', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding: custom content bundle and quest submission guidance',
+            sources: [
+                {
+                    type: 'doc',
+                    id: '/docs/quest-submission',
+                    label: 'Quest Submission',
+                    url: '/docs/quest-submission',
+                },
+            ],
+        });
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'How do I add custom content to DSPACE?' },
+        ]);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(payload.contextPlan.docsRagStatus).toBe('included');
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(
+            payload.contextSources.some((source) => source.url === '/docs/quest-submission')
+        ).toBe(true);
     });
 });


### PR DESCRIPTION
### Motivation

- Full-mode prompts were still always including the docs RAG block, which added noisy docs context for ordinary player-state questions and inflated token usage. 
- The goal is to keep P16 minimal/no-grounding behavior unchanged while allowing full-mode to skip docs RAG unless the user intent clearly requires docs/navigation/custom-content/version/mechanics grounding.

### Description

- Added a small docs-RAG intent detector and exported `getDocsRagIntentReasonCodes` in `frontend/src/utils/chatContextPlanner.js` and extended `fullPlan` so `includeDocsRag` can be false while preserving `includePlayerState` and `includeKnowledgePack`.
- Updated `planChatContext()` to merge grounding reason codes with docs-intent reason codes, emit safe reason codes (e.g. `docs-navigation`, `custom-content-docs`, `changelog-version-docs`, `mechanics-docs`, `docs-rag-not-needed`), and return a full plan with `includeDocsRag` set accordingly.
- Wired `buildChatPrompt()` in `frontend/src/utils/openAI.js` to call `searchDocsRag()` only when `contextPlan.includeDocsRag === true` (or when a `forceDocsRag` test/dev option is set), to produce an empty docs payload and zero duration when skipped, and to avoid inserting any `Docs grounding` system text when skipped.
- Added prompt metadata (`contextPlan.includeDocsRag`, `docsRagStatus`, `docsRagReasonCodes`) and wired those into `promptMetrics` while ensuring no sensitive content (excerpts/PlayerState/etc.) is logged; updated tests to cover both docs-skipped and docs-included full-mode paths and token.place behavior.

### Testing

- Ran the focused test set: `cd frontend && npm test -- chatContextPlanner` and it passed (all planner unit tests green).
- Ran prompt/integration tests: `cd frontend && npm test -- openAI` and the modified `buildChatPrompt` tests (including forced-RAG variants) passed.
- Ran token.place coverage: `cd frontend && npm test -- tokenPlace.test.js` and token.place tests passed, including checks that full-mode can skip docs RAG for player-state-only prompts and include docs RAG for route/custom-content prompts.
- Ran broader checks: `cd frontend && npm run check` and `cd frontend && npm run build` and both formatting/lint/build completed successfully.
- Notes/follow-ups: this PR only gates when docs RAG runs; future work should compact PlayerState and tune focused data retrieval and RAG caps to further reduce token usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f834ef4832f81b079648b54ce06)