### PR TITLE
Gate docs RAG by intent (skip docs for player-state full prompts)

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -374,23 +374,53 @@ describe('token.place API v1 client', () => {
         expect(JSON.stringify(body)).not.toContain('metadata');
     });
 
-    test('default token.place mode uses the full dChat prompt path', async () => {
+    test('default token.place mode uses full dChat prompt path and skips docs for player-state questions', async () => {
         loadGameState.mockReturnValue({
             settings: { tokenPlaceTokenLite: false },
             inventory: [{ id: 'solar-panel', quantity: 1 }],
         });
         searchDocsRag.mockResolvedValue({
-            excerptsText: 'RAG excerpt canary for normal mode.',
-            sources: [{ title: 'DSPACE docs', url: '/docs/about' }],
+            excerptsText: 'RAG excerpt should be skipped for normal game-state mode.',
+            sources: [{ type: 'doc', id: 'about', label: 'DSPACE docs', url: '/docs/about' }],
         });
 
         await TokenPlaceChatV2([{ role: 'user', content: 'What should I build next?' }]);
 
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        const { body } = getFetchCallByPath('/api/v1/relay/requests');
+        const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
+        const promptText = decrypted.api_v1_request.messages
+            .map((message) => message.content)
+            .join('\\n');
+        // Verify full path produces more messages than token-lite's fixed [system, user] pair.
+        expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        expect(promptText).toContain('PlayerState');
+        expect(promptText).toContain('DSPACE knowledge base');
+        expect(promptText).not.toContain('RAG excerpt should be skipped');
+        expect(promptText).not.toContain('Docs grounding');
+    });
+
+    test('default token.place mode includes docs RAG for route and docs questions', async () => {
+        loadGameState.mockReturnValue({
+            settings: { tokenPlaceTokenLite: false },
+            inventory: [{ id: 'solar-panel', quantity: 1 }],
+        });
+        searchDocsRag.mockResolvedValue({
+            excerptsText: 'Docs grounding canary for gamesaves import route.',
+            sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups' }],
+        });
+
+        await TokenPlaceChatV2([{ role: 'user', content: 'where do I import a gamesave?' }]);
+
         expect(searchDocsRag).toHaveBeenCalledTimes(1);
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
-        // Verify full path produces more messages than token-lite's fixed [system, user] pair.
-        expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        const promptText = decrypted.api_v1_request.messages
+            .map((message) => message.content)
+            .join('\\n');
+        expect(promptText).toContain('PlayerState');
+        expect(promptText).toContain('DSPACE knowledge base');
+        expect(promptText).toContain('Docs grounding canary');
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {

--- a/frontend/src/utils/chatContextPlanner.js
+++ b/frontend/src/utils/chatContextPlanner.js
@@ -2,15 +2,26 @@ import items from '../pages/inventory/json/items';
 import processes from '../generated/processes.json';
 import quests from '../generated/quests/listManifest.json';
 
-const fullPlan = (reasonCodes) => ({
-    mode: 'full',
-    includePlayerState: true,
-    includeKnowledgePack: true,
-    includeDocsRag: true,
-    includePersonaVoiceSamples: false,
-    reasonCodes: [...new Set(reasonCodes)],
-    confidence: 'conservative',
-});
+const fullPlan = (reasonCodes, docsReasonCodes = []) => {
+    const includeDocsRag = docsReasonCodes.length > 0;
+    return {
+        mode: 'full',
+        includePlayerState: true,
+        includeKnowledgePack: true,
+        includeDocsRag,
+        includePersonaVoiceSamples: false,
+        reasonCodes: [
+            ...new Set([
+                ...reasonCodes,
+                ...(includeDocsRag ? docsReasonCodes : ['docs-rag-not-needed']),
+            ]),
+        ],
+        docsRagReasonCodes: [
+            ...new Set(includeDocsRag ? docsReasonCodes : ['docs-rag-not-needed']),
+        ],
+        confidence: 'conservative',
+    };
+};
 
 const minimalPlan = () => ({
     mode: 'minimal',
@@ -90,6 +101,41 @@ const groundingChecks = [
     },
 ];
 
+const docsIntentChecks = [
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /(?:\/docs|\bdocs?\b|\broutes?\b|\bpages?\b|\bwhere do i\b|\bwhere is\b|\bhow do i get to\b|\bsettings\b|\/settings|\/gamesaves|\/quests|\/inventory|\/processes)/i,
+    },
+    {
+        reasonCode: 'route-docs',
+        pattern:
+            /(?:\/settings|\/gamesaves|\/quests|\/inventory|\/processes|\/docs|\broute\b|\bpage\b)/i,
+    },
+    {
+        reasonCode: 'docs-navigation',
+        pattern:
+            /\b(gamesaves?|import save|import a gamesave|export save|backup|content backup)\b/i,
+    },
+    {
+        reasonCode: 'custom-content-docs',
+        pattern:
+            /\b(custom content|custom quests?|custom items?|custom processes?|quest submission|submit a custom quest|content bundles?|custom content bundles?|content editor|add custom content to dspace)\b/i,
+    },
+    {
+        reasonCode: 'changelog-version-docs',
+        pattern:
+            /\b(changelog|release notes?|token\.place(?: integration docs?)?|versions?|v\d+(?:\.\d+)?(?:\.\d+)?|v2|v3|drift|deprecated behavior|current release state|what changed)\b/i,
+    },
+    {
+        reasonCode: 'mechanics-docs',
+        pattern:
+            /\bprocess\b(?=.*\b(consumes?|creates?|requires?|requirements?|duration)\b)|\bquest\b(?=.*\b(requirements?|rewards?|gates?|dialogue options?)\b)|\b(requirements?|rewards?|gates?|dialogue options?)\b(?=.*\b(give|gives|preflight|quest)\b)|\b(schema|authoring guidance|how-to author|how to author)\b/i,
+    },
+];
+
+export const detectDocsRagIntent = (text) => regexHits(text, docsIntentChecks);
+
 const resourcePattern = /\bd(?:USD|BI|Watt|Solar|Print|Launch|Fuel|Oxygen|Water|Food)\b/i;
 
 const normalize = (value) =>
@@ -153,6 +199,9 @@ export const planChatContext = (messages, options = {}) => {
     if (!latest.trim()) return fullPlan(['no-latest-user-message']);
 
     const reasonCodes = hasGroundingSignal(latest);
+    const docsReasonCodes = detectDocsRagIntent(latest);
 
-    return reasonCodes.length ? fullPlan(reasonCodes) : minimalPlan();
+    if (!reasonCodes.length && !docsReasonCodes.length) return minimalPlan();
+
+    return fullPlan(reasonCodes, docsReasonCodes);
 };

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -787,11 +787,27 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const retrievalQuery = latestUserMessage
         ? buildRetrievalQuery(normalizedMessages, latestUserMessage)
         : '';
-    const docsRagStartedAt = performance.now();
-    const docsRagPayload = latestUserMessage
+    const shouldIncludeDocsRag =
+        Boolean(latestUserMessage) &&
+        (contextPlan.includeDocsRag === true || options.forceDocsRag === true);
+    const docsRagStartedAt = shouldIncludeDocsRag ? performance.now() : 0;
+    const docsRagPayload = shouldIncludeDocsRag
         ? await searchDocsRag(retrievalQuery, docsRagRequestOptions)
         : { excerptsText: '', sources: [] };
-    const ragDurationMs = performance.now() - docsRagStartedAt;
+    const ragDurationMs = shouldIncludeDocsRag ? performance.now() - docsRagStartedAt : 0;
+    const docsRagStatus = shouldIncludeDocsRag
+        ? 'included'
+        : latestUserMessage
+          ? 'skipped'
+          : 'not-applicable';
+    const contextPlanMetadata = {
+        ...contextPlan,
+        includeDocsRag: shouldIncludeDocsRag,
+        docsRagStatus,
+        docsRagReasonCodes:
+            contextPlan.docsRagReasonCodes ||
+            (shouldIncludeDocsRag ? ['docs-rag-forced'] : ['docs-rag-not-needed']),
+    };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText
             ? {
@@ -852,7 +868,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         gameState,
         contextSources,
         playerStateSummary: playerStateSnapshot.meta,
-        contextPlan,
+        contextPlan: contextPlanMetadata,
     };
 
     if (options.includePromptMetrics) {
@@ -880,7 +896,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         promptPayload.promptMetrics = buildPromptMetrics(promptPayload, {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
-            contextPlan,
+            contextPlan: contextPlanMetadata,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/tests/chatContextPlanner.test.ts
+++ b/frontend/tests/chatContextPlanner.test.ts
@@ -26,31 +26,45 @@ describe('planChatContext', () => {
     });
 
     it.each([
-        'what should I do next?',
         'what quest do I have left?',
-        'How am I progressing?',
+        'what should I do next?',
         'do I have enough green PLA?',
         'can I afford a solar tracker?',
-        'where do I import a gamesave?',
-        'How do I add custom content to DSPACE?',
-        'how do I submit a custom quest?',
-        'where are content bundles documented?',
-        'how do I get to settings?',
-        'what does this process consume?',
-        'what rewards does preflight check give?',
+        'what is my inventory?',
+        'how many quests have I completed?',
+        'How am I progressing?',
         'what about the second option?',
         'Benchy',
         'dSolar',
+    ])('uses full mode without docs RAG for game-state turn: %s', (content) => {
+        const plan = planFor(content);
+        expect(plan.mode).toBe('full');
+        expect(plan.includePlayerState).toBe(true);
+        expect(plan.includeKnowledgePack).toBe(true);
+        expect(plan.includeDocsRag).toBe(false);
+        expect(plan.reasonCodes).toContain('docs-rag-not-needed');
+    });
+
+    it.each([
+        'where do I import a gamesave?',
+        'how do I get to settings?',
+        'How do I add custom content to DSPACE?',
+        'how do I submit a custom quest?',
+        'where is the content backup page?',
+        'what changed in v3.1 chat?',
+        'what does this process consume?',
+        'what rewards does preflight check give?',
         '/gamesaves',
+        'where are content bundles documented?',
         'what does this process create?',
         'custom item for a DSPACE quest',
-    ])('uses full mode for grounded or ambiguous turn: %s', (content) => {
+    ])('uses full mode with docs RAG for docs/mechanics turn: %s', (content) => {
         const plan = planFor(content);
         expect(plan.mode).toBe('full');
         expect(plan.includePlayerState).toBe(true);
         expect(plan.includeKnowledgePack).toBe(true);
         expect(plan.includeDocsRag).toBe(true);
-        expect(plan.reasonCodes.length).toBeGreaterThan(0);
+        expect(plan.docsRagReasonCodes.length).toBeGreaterThan(0);
     });
 });
 

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -699,7 +699,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -735,7 +735,7 @@ describe('buildChatPrompt', () => {
             },
         ];
 
-        await buildChatPrompt(messages);
+        await buildChatPrompt(messages, { forceDocsRag: true });
 
         const retrievalQuery = vi.mocked(searchDocsRag).mock.calls[0][0];
 
@@ -767,7 +767,7 @@ describe('buildChatPrompt', () => {
     });
 
     it('passes expanded docs RAG options to searchDocsRag', async () => {
-        const messages = [{ role: 'user', content: 'Tell me about quests.' }];
+        const messages = [{ role: 'user', content: 'Need docs.' }];
 
         await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
 

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -127,6 +127,81 @@ describe('buildChatPrompt context planning', () => {
         expect(payload.contextSources).toEqual([]);
     });
 
+    it('skips docs RAG for player-state-only full prompt', async () => {
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            {
+                includePromptMetrics: true,
+            }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.contextPlan.docsRagStatus).toBe('skipped');
+        expect(prompt).toContain('PlayerState');
+        expect(prompt).toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(payload.contextSources.filter((source) => source.type === 'doc')).toEqual([]);
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        expect(payload.promptMetrics.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.promptMetrics.contextPlan.docsRagStatus).toBe('skipped');
+    });
+
+    it('includes docs RAG for gamesave navigation full prompt', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding: /gamesaves import instructions',
+            sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups' }],
+        });
+
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'where do I import a gamesave?' }],
+            {
+                includePromptMetrics: true,
+            }
+        );
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(payload.contextPlan.docsRagStatus).toBe('included');
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding');
+        expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+        expect(payload.promptMetrics.contextPlan.docsRagStatus).toBe('included');
+    });
+
+    it('includes docs RAG for custom content full prompt', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText: 'Docs grounding: custom content bundle and quest submission guidance',
+            sources: [
+                {
+                    type: 'doc',
+                    id: 'quest-submission',
+                    label: 'Quest Submission',
+                    url: '/docs/quest-submission',
+                },
+                {
+                    type: 'doc',
+                    id: 'custom-content-bundles',
+                    label: 'Custom Content Bundles',
+                    url: '/docs/custom-content-bundles',
+                },
+            ],
+        });
+
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'How do I add custom content to DSPACE?' },
+        ]);
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(searchDocsRag).toHaveBeenCalled();
+        expect(prompt).toContain('Docs grounding');
+        expect(JSON.stringify(payload.contextSources)).toMatch(/custom-content|quest-submission/i);
+    });
+
     it('preserves Hydro persona and full grounding when planner selects full', async () => {
         const payload = await buildChatPrompt(
             [{ role: 'user', content: 'what quest do I have left?' }],
@@ -143,6 +218,9 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('Use the PlayerState block when present.');
         expect(prompt).toContain('If PlayerState is missing');
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
-        expect(searchDocsRag).toHaveBeenCalled();
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(payload.contextPlan.docsRagStatus).toBe('skipped');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(searchDocsRag).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### Motivation
- Reduce prompt noise by decoupling the previous "full" plan from always including docs RAG so common PlayerState/game-state questions keep PlayerState and the dChat knowledge pack without pulling a large docs RAG block.
- Preserve P16 minimal no-grounding behavior and token.place routing while only running docs RAG when the user intent explicitly requests docs/navigation/custom-content/version/mechanics grounding.

### Description
- Add docs intent detection and per-plan docs gating: `detectDocsRagIntent` with targeted regexes for navigation/routes, gamesaves/import/export/backup, custom content, changelog/version/token.place, and mechanics/schema questions in `frontend/src/utils/chatContextPlanner.js` and expose `docsRagReasonCodes` and `docs-rag-not-needed` when appropriate.
- Make `fullPlan` accept docs reason codes and set `includeDocsRag` based on detected docs intent while preserving `includePlayerState` and `includeKnowledgePack` in full mode.
- Wire `buildChatPrompt()` in `frontend/src/utils/openAI.js` to only call `searchDocsRag()` when `contextPlan.includeDocsRag === true` or when `options.forceDocsRag === true`, and otherwise set `docsRagPayload` to empty `{ excerptsText: '', sources: [] }` with `ragDurationMs = 0` and `docsRagStatus` metadata (`included|skipped|not-applicable`).
- Surface safe docs-RAG metadata in the returned `contextPlan` and include `contextPlan` docs fields in prompt metrics without exposing any sensitive content or excerpts.
- Update tests to validate the new behavior and keep P16 minimal behavior unchanged: modified/added assertions in `frontend/tests/chatContextPlanner.test.ts`, `frontend/tests/openAIContextPlanner.test.ts`, `frontend/tests/openAI.test.ts`, and `frontend/__tests__/tokenPlace.test.js` to cover docs-skipped full prompts (player-state queries) and docs-included full prompts (gamesave/navigation/custom-content/mechanics queries).

### Testing
- Ran focused unit/test suites and CI checks in `frontend`.
  - `cd frontend && npm test -- chatContextPlanner` — passed (planner tests validate docs gating for game-state vs docs/mechanics queries).
  - `cd frontend && npm test -- openAI` — passed (prompt building tests updated to assert docs inclusion/skip and prompt metrics).
  - `cd frontend && npm test -- tokenPlace.test.js` — passed (token.place tests updated to ensure default full chat path skips docs for player-state-only queries and includes docs for gamesave/docs queries).
- Repo checks: `cd frontend && npm run check` and `cd frontend && npm run build` were executed and completed successfully.

All automated tests exercised for this change passed in the test runs; minimal-mode behavior and token-lite/token.place routing were preserved. Follow-ups: consider future PRs to compact PlayerState and reduce docs RAG caps as noted in the task scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4f8a17bc832f8ea5d859005d5d1b)