### PR TITLE
Shrink chat docs RAG payload budgets

### DIFF
--- a/frontend/src/utils/docsRag.js
+++ b/frontend/src/utils/docsRag.js
@@ -3,6 +3,7 @@ import MiniSearch from 'minisearch';
 const DEFAULT_MAX_RESULTS = 5;
 const DEFAULT_MAX_CHARS = 5000;
 const DEFAULT_MAX_EXCERPT_CHARS = 850;
+const ROUTE_DETAIL_MAX_EXCERPT_CHARS = 1800;
 const ROUTES_INTENT =
     /\b(route|routes|url|urls|path|page|menu|navigate|navigation|where is|link|sitemap|site[-\s]?map)\b/i;
 const CHANGELOG_INTENT =
@@ -617,7 +618,7 @@ export const searchDocsRag = async (queryText, options = {}) => {
 
         for (const chunk of orderedSelected) {
             const routeExcerptChars = wantsRouteChunk
-                ? Math.max(maxExcerptChars, 2500)
+                ? Math.min(Math.max(maxExcerptChars, ROUTE_DETAIL_MAX_EXCERPT_CHARS), maxChars)
                 : maxExcerptChars;
             const chunkMaxExcerptChars =
                 chunk.kind === 'route' && wantsRouteChunk ? routeExcerptChars : maxExcerptChars;

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -114,12 +114,12 @@ const vagueFollowupPattern =
 const retrievalContextLimit = 800;
 const retrievalQueryLimit = 1000;
 const MAX_PLAYER_STATE_ITEMS = 50;
-const docsRagOptions = {
-    maxResults: 50,
-    maxChars: 50000,
-    maxExcerptChars: 8500,
-};
-const docsRagPromptBudgetChars = 80000;
+export const CHAT_DOCS_RAG_DEFAULT_OPTIONS = Object.freeze({
+    maxResults: 6,
+    maxChars: 8000,
+    maxExcerptChars: 1200,
+});
+export const CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS = 16000;
 
 const readEnvValue = (key) => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
@@ -409,8 +409,8 @@ const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {
     const budget =
         typeof promptBudgetChars === 'number' && Number.isFinite(promptBudgetChars)
             ? Math.max(0, promptBudgetChars)
-            : docsRagPromptBudgetChars;
-    const baseOptions = { ...docsRagOptions, ...(options || {}) };
+            : CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS;
+    const baseOptions = { ...CHAT_DOCS_RAG_DEFAULT_OPTIONS, ...(options || {}) };
     const remainingBudget = Math.max(0, budget - countPromptChars(baseMessages));
 
     return {
@@ -815,6 +815,26 @@ export const buildChatPrompt = async (messages, options = {}) => {
         includeDocsRag: shouldIncludeDocsRag,
         docsRagStatus,
         docsRagReasonCodes,
+        docsRagMetrics: {
+            status: docsRagStatus,
+            resultCount: Array.isArray(docsRagPayload.sourcesMeta?.results)
+                ? docsRagPayload.sourcesMeta.results.length
+                : Array.isArray(docsRagPayload.sources)
+                  ? docsRagPayload.sources.length
+                  : 0,
+            renderedChars: String(docsRagPayload.excerptsText || '').length,
+            budget: docsRagRequestOptions
+                ? {
+                      maxResults: docsRagRequestOptions.maxResults,
+                      maxChars: docsRagRequestOptions.maxChars,
+                      maxExcerptChars: docsRagRequestOptions.maxExcerptChars,
+                  }
+                : {
+                      maxResults: 0,
+                      maxChars: 0,
+                      maxExcerptChars: 0,
+                  },
+        },
     };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -87,6 +87,21 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                           ? metadata.contextPlan.docsRagReasonCodes
                           : [],
                       durationMs: status === 'included' ? Number(metadata.ragDurationMs || 0) : 0,
+                      resultCount: Number(metadata.contextPlan.docsRagMetrics?.resultCount || 0),
+                      renderedChars: Number(
+                          metadata.contextPlan.docsRagMetrics?.renderedChars || 0
+                      ),
+                      budget: {
+                          maxResults: Number(
+                              metadata.contextPlan.docsRagMetrics?.budget?.maxResults || 0
+                          ),
+                          maxChars: Number(
+                              metadata.contextPlan.docsRagMetrics?.budget?.maxChars || 0
+                          ),
+                          maxExcerptChars: Number(
+                              metadata.contextPlan.docsRagMetrics?.budget?.maxExcerptChars || 0
+                          ),
+                      },
                   };
               })()
             : null,

--- a/frontend/tests/docsRag.test.ts
+++ b/frontend/tests/docsRag.test.ts
@@ -294,4 +294,55 @@ describe('docs RAG search', () => {
             )
         ).toBe(false);
     });
+    it('keeps gamesave docs grounding under compact chat budgets with route sources', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sources } = await searchDocsRag(
+            'where do I import a gamesave?',
+            compactBudget
+        );
+
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(sources.length).toBeGreaterThan(0);
+        expect(
+            sources.some((entry) =>
+                /gamesaves|backup|routes/i.test(`${entry.label || ''} ${entry.url || ''}`)
+            )
+        ).toBe(true);
+    });
+
+    it('keeps custom content docs grounding under compact chat budgets with useful sources', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sources } = await searchDocsRag(
+            'How do I add custom content to DSPACE?',
+            compactBudget
+        );
+
+        const sourceText = sources
+            .map((entry) => `${entry.label || ''} ${entry.url || ''}`)
+            .join(' ');
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(`${excerptsText} ${sourceText}`).toMatch(
+            /custom content|quest submission|content bundle/i
+        );
+    });
+
+    it('keeps changelog version docs grounding bounded under compact chat budgets', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sources } = await searchDocsRag(
+            'what changed in v3.1 chat?',
+            compactBudget
+        );
+
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(
+            sources.some(
+                (entry) =>
+                    entry.type === 'changelog' ||
+                    /v3|changelog|token.place/i.test(`${entry.label || ''} ${entry.url || ''}`)
+            )
+        ).toBe(true);
+    });
 });

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -31,6 +31,8 @@ vi.mock('../src/data/npcPersonas.js', () => ({
 }));
 
 import {
+    CHAT_DOCS_RAG_DEFAULT_OPTIONS,
+    CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS,
     defaultOpenAIErrorMessage,
     describeOpenAIError,
     buildChatPrompt,
@@ -671,7 +673,7 @@ Docs grounding (gitSha: test):
 - [doc] Forced docs
 ---`,
             sources: [{ type: 'doc', id: 'forced', label: 'Forced docs', url: '/docs/forced#top' }],
-            sourcesMeta: { results: [] },
+            sourcesMeta: { results: [{ id: 'forced' }] },
         });
 
         const payload = await buildChatPrompt(
@@ -686,6 +688,12 @@ Docs grounding (gitSha: test):
         expect(payload.contextPlan.docsRagReasonCodes).not.toEqual(['docs-rag-not-needed']);
         expect(payload.promptMetrics.docsRag.includeDocsRag).toBe(true);
         expect(payload.promptMetrics.docsRag.status).toBe('included');
+        expect(payload.promptMetrics.docsRag.resultCount).toBe(1);
+        expect(payload.promptMetrics.docsRag.renderedChars).toBeGreaterThan(0);
+        expect(payload.promptMetrics.docsRag.budget).toEqual(
+            expect.objectContaining(CHAT_DOCS_RAG_DEFAULT_OPTIONS)
+        );
+        expect(JSON.stringify(payload.promptMetrics.docsRag)).not.toContain('Forced docs');
     });
 
     it('includes docs RAG for gamesave route prompts', async () => {
@@ -828,18 +836,40 @@ Docs grounding (gitSha: test):
         expect(retrievalQuery).toBe(latestMessage);
     });
 
-    it('passes expanded docs RAG options to searchDocsRag', async () => {
+    it('uses compact named default docs RAG options for chat prompts', async () => {
         const messages = [{ role: 'user', content: 'Where is /docs/routes?' }];
 
         await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
 
         const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
 
+        expect(CHAT_DOCS_RAG_DEFAULT_OPTIONS).toEqual({
+            maxResults: 6,
+            maxChars: 8000,
+            maxExcerptChars: 1200,
+        });
+        expect(CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS).toBe(16000);
+        expect(options).toEqual(expect.objectContaining(CHAT_DOCS_RAG_DEFAULT_OPTIONS));
+        expect(options.maxResults).toBeLessThan(50);
+        expect(options.maxChars).toBeLessThan(50000);
+        expect(options.maxExcerptChars).toBeLessThan(8500);
+    });
+
+    it('preserves explicit docs RAG option overrides', async () => {
+        const messages = [{ role: 'user', content: 'Where is /docs/routes?' }];
+
+        await buildChatPrompt(messages, {
+            docsRagBudgetChars: 1000000,
+            docsRagOptions: { maxResults: 12, maxChars: 24000, maxExcerptChars: 3000 },
+        });
+
+        const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
+
         expect(options).toEqual(
             expect.objectContaining({
-                maxResults: 50,
-                maxChars: 50000,
-                maxExcerptChars: 8500,
+                maxResults: 12,
+                maxChars: 24000,
+                maxExcerptChars: 3000,
             })
         );
     });


### PR DESCRIPTION
### Motivation
- Reduce the size of docs RAG payloads included in normal chat prompts so local/smaller models (e.g. Llama 3.1 8B) receive useful grounding without huge docs excerpts. 

### Description
- Introduced named compact chat defaults `CHAT_DOCS_RAG_DEFAULT_OPTIONS` and `CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS` and used them when building docs RAG request options, preserving explicit overrides via `options.docsRagOptions` and `options.docsRagBudgetChars`. (edited `frontend/src/utils/openAI.js`)
- Added bounded route-detail excerpt handling via `ROUTE_DETAIL_MAX_EXCERPT_CHARS` and limited the route excerpt boost so navigation/custom-content chunks cannot consume the entire docs block. (edited `frontend/src/utils/docsRag.js`)
- Emit safe docs RAG metadata into the context plan (`docsRagMetrics`) and surfaced result/budget/size fields in prompt metrics without including any docs excerpt text. (edited `frontend/src/utils/openAI.js` and `frontend/src/utils/promptMetrics.js`)
- Added and updated focused tests to assert compact defaults, override preservation, bounded docs rendering for routes/custom-content/changelog, and safe docs RAG metrics. (edited `frontend/tests/docsRag.test.ts` and `frontend/tests/openAI.test.ts`)

### Testing
- Ran unit/test targets: `cd frontend && npm test -- docsRag openAIContextPlanner openAI.test.ts`, and the suite passed. (✅)
- Ran context and provider tests: `cd frontend && npm test -- chatContextPlanner` and `cd frontend && npm test -- tokenPlace.test.js`, and both passed. (✅)
- Verified lint/format and build with `cd frontend && npm run check && npm run build`, and both completed successfully. (✅)
- Verified full OpenAI-related tests with `cd frontend && npm test -- openAI`, which passed. (✅)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f65ae00b4832fb2e098494f9de39f)