### PR TITLE
Shrink chat docs RAG budgets

### DIFF
--- a/frontend/src/utils/docsRag.js
+++ b/frontend/src/utils/docsRag.js
@@ -617,7 +617,7 @@ export const searchDocsRag = async (queryText, options = {}) => {
 
         for (const chunk of orderedSelected) {
             const routeExcerptChars = wantsRouteChunk
-                ? Math.max(maxExcerptChars, 2500)
+                ? Math.min(Math.max(maxExcerptChars, 2000), 2500)
                 : maxExcerptChars;
             const chunkMaxExcerptChars =
                 chunk.kind === 'route' && wantsRouteChunk ? routeExcerptChars : maxExcerptChars;

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -114,12 +114,12 @@ const vagueFollowupPattern =
 const retrievalContextLimit = 800;
 const retrievalQueryLimit = 1000;
 const MAX_PLAYER_STATE_ITEMS = 50;
-const docsRagOptions = {
-    maxResults: 50,
-    maxChars: 50000,
-    maxExcerptChars: 8500,
-};
-const docsRagPromptBudgetChars = 80000;
+export const CHAT_DOCS_RAG_OPTIONS = Object.freeze({
+    maxResults: 6,
+    maxChars: 8000,
+    maxExcerptChars: 1200,
+});
+export const CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS = 12000;
 
 const readEnvValue = (key) => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.[key]) {
@@ -406,16 +406,24 @@ export const getPlayerStateSummary = (gameState = loadGameState()) => {
 };
 
 const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {
+    const baseOptions = { ...CHAT_DOCS_RAG_OPTIONS, ...(options || {}) };
+    const explicitMaxChars =
+        typeof options?.maxChars === 'number' && Number.isFinite(options.maxChars)
+            ? Math.max(0, options.maxChars)
+            : null;
+    const basePromptChars = countPromptChars(baseMessages);
     const budget =
         typeof promptBudgetChars === 'number' && Number.isFinite(promptBudgetChars)
             ? Math.max(0, promptBudgetChars)
-            : docsRagPromptBudgetChars;
-    const baseOptions = { ...docsRagOptions, ...(options || {}) };
-    const remainingBudget = Math.max(0, budget - countPromptChars(baseMessages));
+            : explicitMaxChars !== null
+              ? basePromptChars + explicitMaxChars
+              : CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS;
+    const remainingBudget = Math.max(0, budget - basePromptChars);
 
     return {
         ...baseOptions,
         maxChars: Math.min(baseOptions.maxChars, remainingBudget),
+        promptBudgetChars: budget,
     };
 };
 
@@ -815,6 +823,20 @@ export const buildChatPrompt = async (messages, options = {}) => {
         includeDocsRag: shouldIncludeDocsRag,
         docsRagStatus,
         docsRagReasonCodes,
+        docsRagResultCount: Array.isArray(docsRagPayload.sourcesMeta?.results)
+            ? docsRagPayload.sourcesMeta.results.length
+            : Array.isArray(docsRagPayload.sources)
+              ? docsRagPayload.sources.length
+              : 0,
+        docsRagRenderedChars: String(docsRagPayload.excerptsText || '').length,
+        docsRagBudget: docsRagRequestOptions
+            ? {
+                  maxResults: docsRagRequestOptions.maxResults,
+                  maxChars: docsRagRequestOptions.maxChars,
+                  maxExcerptChars: docsRagRequestOptions.maxExcerptChars,
+                  promptBudgetChars: docsRagRequestOptions.promptBudgetChars,
+              }
+            : null,
     };
     const docsRagMessage =
         !knowledgeMessage && docsRagPayload.excerptsText

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -87,6 +87,17 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                           ? metadata.contextPlan.docsRagReasonCodes
                           : [],
                       durationMs: status === 'included' ? Number(metadata.ragDurationMs || 0) : 0,
+                      resultCount: Number(metadata.contextPlan.docsRagResultCount || 0),
+                      renderedChars: Number(metadata.contextPlan.docsRagRenderedChars || 0),
+                      budget: metadata.contextPlan.docsRagBudget
+                          ? {
+                                maxResults: metadata.contextPlan.docsRagBudget.maxResults,
+                                maxChars: metadata.contextPlan.docsRagBudget.maxChars,
+                                maxExcerptChars: metadata.contextPlan.docsRagBudget.maxExcerptChars,
+                                promptBudgetChars:
+                                    metadata.contextPlan.docsRagBudget.promptBudgetChars,
+                            }
+                          : null,
                   };
               })()
             : null,

--- a/frontend/tests/docsRag.test.ts
+++ b/frontend/tests/docsRag.test.ts
@@ -294,4 +294,45 @@ describe('docs RAG search', () => {
             )
         ).toBe(false);
     });
+    it('keeps gamesave route grounding under the compact chat budget', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sources } = await searchDocsRag(
+            'where do I import a gamesave?',
+            compactBudget
+        );
+
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(sources.length).toBeGreaterThan(0);
+        expect(
+            sources.some((entry) => /gamesaves|backup|route/i.test(`${entry.label} ${entry.url}`))
+        ).toBe(true);
+    });
+
+    it('keeps custom-content grounding useful under the compact chat budget', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sources } = await searchDocsRag(
+            'How do I add custom content to DSPACE?',
+            compactBudget
+        );
+        const sourceText = sources.map((entry) => `${entry.label} ${entry.url}`).join(' ');
+
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(`${excerptsText} ${sourceText}`).toMatch(
+            /custom content|quest submission|content bundle/i
+        );
+    });
+
+    it('keeps changelog version grounding under the compact chat budget', async () => {
+        const compactBudget = { maxResults: 6, maxChars: 8000, maxExcerptChars: 1200 };
+        const { excerptsText, sourcesMeta } = await searchDocsRag(
+            'what changed in v3.1 chat?',
+            compactBudget
+        );
+
+        expect(excerptsText).toContain('Docs grounding');
+        expect(excerptsText.length).toBeLessThanOrEqual(compactBudget.maxChars);
+        expect(sourcesMeta.results.some((entry) => entry.kind === 'changelog')).toBe(true);
+    });
 });

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -34,6 +34,8 @@ import {
     defaultOpenAIErrorMessage,
     describeOpenAIError,
     buildChatPrompt,
+    CHAT_DOCS_RAG_OPTIONS,
+    CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS,
     getOpenAIErrorSummary,
     GPT5Chat,
     GPT5ChatV2,
@@ -692,12 +694,15 @@ Docs grounding (gitSha: test):
         vi.mocked(searchDocsRag).mockResolvedValueOnce({
             excerptsText: `---\nDocs grounding (gitSha: test):\n- [route] Backups — /docs/backups#top\n  import saves\n---`,
             sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups#top' }],
-            sourcesMeta: { results: [] },
+            sourcesMeta: {
+                results: [{ id: 'backups', kind: 'doc', title: 'Backups', slug: '/docs/backups' }],
+            },
         });
 
-        const payload = await buildChatPrompt([
-            { role: 'user', content: 'where do I import a gamesave?' },
-        ]);
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'where do I import a gamesave?' }],
+            { includePromptMetrics: true }
+        );
         const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
 
         expect(payload.contextPlan.mode).toBe('full');
@@ -705,6 +710,11 @@ Docs grounding (gitSha: test):
         expect(searchDocsRag).toHaveBeenCalled();
         expect(prompt).toContain('Docs grounding');
         expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+        expect(payload.promptMetrics.docsRag.resultCount).toBe(1);
+        expect(payload.promptMetrics.docsRag.renderedChars).toBeLessThanOrEqual(
+            payload.promptMetrics.docsRag.budget.maxChars
+        );
+        expect(JSON.stringify(payload.promptMetrics.docsRag)).not.toContain('import saves');
     });
 
     it('does not duplicate docs excerpts when knowledge summary exists', async () => {
@@ -828,18 +838,39 @@ Docs grounding (gitSha: test):
         expect(retrievalQuery).toBe(latestMessage);
     });
 
-    it('passes expanded docs RAG options to searchDocsRag', async () => {
+    it('passes compact named docs RAG options to searchDocsRag by default', async () => {
         const messages = [{ role: 'user', content: 'Where is /docs/routes?' }];
 
         await buildChatPrompt(messages, { docsRagBudgetChars: 1000000 });
 
         const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
 
+        expect(CHAT_DOCS_RAG_OPTIONS).toEqual({
+            maxResults: 6,
+            maxChars: 8000,
+            maxExcerptChars: 1200,
+        });
+        expect(CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS).toBe(12000);
+        expect(options).toEqual(expect.objectContaining(CHAT_DOCS_RAG_OPTIONS));
+        expect(options.maxResults).toBeLessThan(50);
+        expect(options.maxChars).toBeLessThan(50000);
+        expect(options.maxExcerptChars).toBeLessThan(8500);
+    });
+
+    it('preserves explicit docs RAG option overrides', async () => {
+        const messages = [{ role: 'user', content: 'Where is /docs/routes?' }];
+
+        await buildChatPrompt(messages, {
+            docsRagOptions: { maxResults: 12, maxChars: 20000, maxExcerptChars: 3000 },
+        });
+
+        const [, options] = vi.mocked(searchDocsRag).mock.calls[0];
+
         expect(options).toEqual(
             expect.objectContaining({
-                maxResults: 50,
-                maxChars: 50000,
-                maxExcerptChars: 8500,
+                maxResults: 12,
+                maxChars: 20000,
+                maxExcerptChars: 3000,
             })
         );
     });


### PR DESCRIPTION
### Motivation

- Docs RAG grounding is intent-gated but the prior chat rendering budget was sized for high-recall debugging and can produce payloads too large for local/smaller LLMs; we need a much smaller default chat budget while preserving route/custom-content/version/changelog grounding and explicit overrides.

### Description

- Introduced compact, named chat defaults in `frontend/src/utils/openAI.js` as `CHAT_DOCS_RAG_OPTIONS` (`maxResults: 6`, `maxChars: 8000`, `maxExcerptChars: 1200`) and `CHAT_DOCS_RAG_PROMPT_BUDGET_CHARS` (`12000`).
- Reworked `buildDocsRagOptions` to merge caller `options` with the compact defaults, compute remaining budget relative to base messages, preserve explicit `docsRagOptions`/`docsRagBudgetChars` overrides, and return a `promptBudgetChars` value for metrics.
- Bounded route excerpt boosting in `frontend/src/utils/docsRag.js` so route-oriented chunks can be useful without letting a single excerpt consume unbounded budget (route excerpt sizing clamped between ~2000–2500 but still constrained by the overall budget).
- Added safe docs-RAG metadata into the planning payload and metrics (no excerpts or text): `docsRagResultCount`, `docsRagRenderedChars`, and `docsRagBudget` are attached to `contextPlan` and surfaced in `promptMetrics` (budget values, counts, and sizes only).
- Tests updated/added in `frontend/tests/openAI.test.ts` and `frontend/tests/docsRag.test.ts` to assert compact defaults, explicit override behavior, bounded route/custom-content/gamesave/changelog behavior, safe prompt metrics exposure, and that the clamping behavior respects prompt budgets.
- Preserved P16 minimal routing and P17 docs gating and retained explicit override/backdoor behavior for debug/dev flows; no changes to token.place routing, PlayerState shape, knowledge packs, retrieval or embeddings.

### Testing

- Focused tests executed:
  - `cd frontend && npm test -- docsRag` — passed (docs RAG unit tests).
  - `cd frontend && npm test -- openAI` — passed (openAI/prompt integration tests; an earlier assertion mismatch was fixed by adjusting budget math and all tests now pass).
  - `cd frontend && npm test -- chatContextPlanner` — passed.
  - `cd frontend && npm test -- tokenPlace.test.js` — passed (token.place behavior unchanged).
- Broad checks executed:
  - `cd frontend && npm run check` — passed (lint + format check).
  - `cd frontend && npm run build` — passed (Astro build completed).

All automated tests mentioned above passed in the final run; no test regressions remain for the touched areas. Follow-ups: monitor real-world prompt sizes on token.place paths and consider future compaction of PlayerState and knowledge packs in a separate PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f65b44bc0832fab484c9a8cc2f89e)