### PR TITLE
Compact live PlayerState and bounded inventory highlights

### DIFF
--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -2,6 +2,7 @@ import items from '../pages/inventory/json/items/index.js';
 import processes from '../generated/processes.json' assert { type: 'json' };
 import { evaluateAchievements } from './achievements.js';
 import { mergeSources } from './contextSources.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 
 const MAX_ITEMS = 25;
 const MAX_PROCESSES = 20;
@@ -112,13 +113,15 @@ function prioritizeQuests(allQuests) {
     return prioritized.concat(remaining);
 }
 
-function formatInventory(inventory = {}) {
+function formatInventory(inventory = {}, options = {}) {
     if (!inventory || typeof inventory !== 'object') {
         return [];
     }
 
+    const maxEntries = Number.isInteger(options.maxEntries) ? options.maxEntries : 8;
     return Object.entries(inventory)
         .filter(([, count]) => typeof count === 'number' && count > 0)
+        .slice(0, maxEntries)
         .map(([id, count]) => {
             const item = items.find((entry) => entry.id === id);
             const name = item ? item.name : id;
@@ -288,17 +291,30 @@ function summarizeProcessProgress(gameState = {}) {
         .sort((a, b) => a.localeCompare(b));
 }
 
-export function buildDchatKnowledgePack(gameState = {}) {
+export function buildDchatKnowledgePack(gameState = {}, options = {}) {
     const knowledgeSections = [];
     const sources = [];
     const stateDetails = [];
 
-    const inventorySummary = formatInventory(gameState.inventory);
-    if (inventorySummary.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.inventoryHighlights}: ${inventorySummary.join('; ')}`
+    const stateSummary =
+        options.playerStateSummary ||
+        buildPlayerStatePromptSummary(gameState, {
+            latestUserMessage: options.latestUserMessage || '',
+        });
+    const compactInventorySummary = [
+        ...(stateSummary.slices?.resourceBalances || []),
+        ...(stateSummary.slices?.relevantInventory || []),
+    ]
+        .slice(0, 10)
+        .map(
+            (entry) =>
+                `${entry.name || entry.id} (x${Number.isInteger(entry.count) ? entry.count : entry.count.toFixed(2)})`
         );
-        stateDetails.push('inventory');
+    if (compactInventorySummary.length > 0) {
+        knowledgeSections.push(
+            `${dchatKnowledgeScaffolding.inventoryHighlights}: compact bounded live-state highlights; ${compactInventorySummary.join('; ')}`
+        );
+        stateDetails.push('inventory highlights');
     }
 
     const itemEntries = getItemsForKnowledge();

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -301,10 +301,20 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
         buildPlayerStatePromptSummary(gameState, {
             latestUserMessage: options.latestUserMessage || '',
         });
-    const compactInventorySummary = [
+    const compactInventoryEntries = [
         ...(stateSummary.slices?.resourceBalances || []),
         ...(stateSummary.slices?.relevantInventory || []),
-    ]
+    ];
+    if (compactInventoryEntries.length === 0 && gameState?.inventory) {
+        const fallbackSummary = buildPlayerStatePromptSummary(gameState, {
+            latestUserMessage: `${options.latestUserMessage || ''} inventory items`,
+        });
+        compactInventoryEntries.push(
+            ...(fallbackSummary.slices?.resourceBalances || []),
+            ...(fallbackSummary.slices?.relevantInventory || [])
+        );
+    }
+    const compactInventorySummary = compactInventoryEntries
         .slice(0, 10)
         .map(
             (entry) =>

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -1,5 +1,4 @@
 import { loadGameState, ready } from './gameState/common.js';
-import { getOfficialQuestStats } from './gameState/questStats.js';
 import { buildDchatKnowledgePack } from './dchatKnowledge.js';
 import { mergeSources } from './contextSources.js';
 import { searchDocsRag } from './docsRag.js';
@@ -9,6 +8,7 @@ import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
 import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -113,7 +113,6 @@ const vagueFollowupPattern =
     /^\s*(what about|and then|that step|the second step|next step|step 2)\b/i;
 const retrievalContextLimit = 800;
 const retrievalQueryLimit = 1000;
-const MAX_PLAYER_STATE_ITEMS = 50;
 export const CHAT_DOCS_RAG_DEFAULTS = Object.freeze({
     maxResults: 6,
     maxChars: 8000,
@@ -317,94 +316,9 @@ const countPromptChars = (messages) => {
     return messages.reduce((total, message) => total + (message?.content?.length || 0), 0);
 };
 
-const normalizeVersionNumberString = (value) => {
-    if (typeof value === 'string' && value.trim()) {
-        return value.trim();
-    }
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return String(value);
-    }
-    return '3';
-};
-
-const buildPlayerStateSnapshot = (gameState, options = {}) => {
-    const { maxInventoryEntries = MAX_PLAYER_STATE_ITEMS } = options;
-    if (!gameState || typeof gameState !== 'object') {
-        const questStats = getOfficialQuestStats(null);
-        return {
-            block: null,
-            meta: {
-                included: false,
-                questsFinishedCount: 0,
-                completedQuestCount: questStats.completedQuestCount,
-                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-                inventoryIncludedCount: 0,
-                inventoryTotalCount: 0,
-                inventoryTruncated: false,
-            },
-        };
-    }
-
-    const questsFinished = Object.entries(gameState.quests || {})
-        .filter(([, questState]) => questState?.finished)
-        .map(([questId]) => questId)
-        .sort((a, b) => a.localeCompare(b));
-
-    const inventoryEntries = Object.entries(gameState.inventory || {})
-        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
-        .map(([id, count]) => ({ id, count }))
-        .sort((a, b) => {
-            if (b.count !== a.count) {
-                return b.count - a.count;
-            }
-            return a.id.localeCompare(b.id);
-        });
-
-    const totalItems = inventoryEntries.length;
-    const truncated = totalItems > maxInventoryEntries;
-    const includedInventory = truncated
-        ? inventoryEntries.slice(0, maxInventoryEntries)
-        : inventoryEntries;
-
-    const versionNumberString = normalizeVersionNumberString(gameState.versionNumberString);
-    const questStats = getOfficialQuestStats(gameState);
-    const snapshot = {
-        versionNumberString,
-        questsFinished,
-        inventory: includedInventory,
-    };
-
-    if (truncated) {
-        snapshot.truncated = true;
-        snapshot.totalItems = totalItems;
-    }
-
-    const statsBlock = `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}`;
-    const block = `${statsBlock}\nPlayerState v${versionNumberString} (authoritative; do not infer beyond this):\n${JSON.stringify(
-        snapshot,
-        null,
-        2
-    )}`;
-
-    return {
-        block,
-        meta: {
-            included: true,
-            questsFinishedCount: questsFinished.length,
-            completedQuestCount: questStats.completedQuestCount,
-            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-            inventoryIncludedCount: includedInventory.length,
-            inventoryTotalCount: totalItems,
-            inventoryTruncated: truncated,
-        },
-    };
-};
-
 export const getPlayerStateSummary = (gameState = loadGameState()) => {
     const hasGameState = gameState && typeof gameState === 'object';
-    return buildPlayerStateSnapshot(hasGameState ? gameState : null).meta;
+    return buildPlayerStatePromptSummary(hasGameState ? gameState : null).meta;
 };
 
 const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {
@@ -751,6 +665,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 promptBuildDurationMs: performance.now() - promptBuildStartedAt,
                 ragDurationMs: 0,
                 contextPlan: contextPlanMetadata,
+                playerStateSummary: promptPayload.playerStateSummary,
                 componentMessageIndexes: {
                     systemInstructions: [
                         combinedMessages.indexOf(systemMessage),
@@ -772,7 +687,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
         role: 'system',
         content: `Prompt version: v3:${getPromptVersionSha()}\n${fullSystemPrompt}`,
     };
-    const playerStateSnapshot = buildPlayerStateSnapshot(hasGameState ? rawGameState : null);
+    const playerStateSnapshot = buildPlayerStatePromptSummary(hasGameState ? rawGameState : null, {
+        playerStatePromptMode: options.playerStatePromptMode,
+        includeRawPlayerState: options.includeRawPlayerState,
+        latestUserMessage: latestUserMessage?.content || '',
+    });
     const playerStateMessage = playerStateSnapshot.block
         ? {
               role: 'system',
@@ -780,7 +699,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
           }
         : null;
 
-    const knowledgePack = buildDchatKnowledgePack(gameState);
+    const knowledgePack = buildDchatKnowledgePack(gameState, {
+        latestUserMessage: latestUserMessage?.content || '',
+        playerStateSummary: playerStateSnapshot,
+    });
     const knowledgeSummary = knowledgePack.summary;
     const knowledgeMessage = knowledgeSummary
         ? {
@@ -931,6 +853,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
             contextPlan: contextPlanMetadata,
+            playerStateSummary: playerStateSnapshot.meta,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -318,7 +318,15 @@ const countPromptChars = (messages) => {
 
 export const getPlayerStateSummary = (gameState = loadGameState()) => {
     const hasGameState = gameState && typeof gameState === 'object';
-    return buildPlayerStatePromptSummary(hasGameState ? gameState : null).meta;
+    const meta = buildPlayerStatePromptSummary(hasGameState ? gameState : null).meta;
+    return {
+        ...meta,
+        // Backward-compatible debug UI semantics: this field historically meant
+        // owned inventory entries in the loaded PlayerState, not the compact
+        // prompt's bounded inventory slice. Prompt metrics continue to use the
+        // compact summary metadata directly.
+        inventoryIncludedCount: meta.inventoryTotalCount,
+    };
 };
 
 const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -10,7 +10,7 @@ export const PLAYER_STATE_PROMPT_DEFAULTS = Object.freeze({
     activeProcessCap: 6,
 });
 
-const RESOURCE_IDS = ['dUSD', 'dBI', 'dWatt', 'dSolar', 'dPrint', 'dLaunch', 'dWind'];
+const RESOURCE_NAMES = ['dUSD', 'dBI', 'dWatt', 'dSolar', 'dPrint', 'dLaunch', 'dWind'];
 
 const itemById = new Map(items.map((item) => [item.id, item]));
 const processById = new Map(processes.map((process) => [process.id, process]));
@@ -45,8 +45,7 @@ const inventoryEntries = (inventory = {}) =>
         .map(([id, count]) => ({ id, name: itemLabel(id), count }))
         .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
 
-const isResourceEntry = (entry) =>
-    RESOURCE_IDS.includes(entry.id) || RESOURCE_IDS.includes(entry.name);
+const isResourceEntry = (entry) => RESOURCE_NAMES.includes(entry.name);
 
 const entryMatchesQuery = (entry, queryTokens, queryText) => {
     if (!queryText || queryTokens.size === 0) return false;
@@ -77,16 +76,47 @@ const buildRemainingQuests = (gameState, cap) => {
         });
 };
 
-const buildActiveProcesses = (gameState, cap) =>
-    Object.entries(gameState?.processes || {})
-        .filter(([, state]) => state && state.startedAt && !state.finished)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .slice(0, cap)
-        .map(([id, state]) => ({
+const isProcessFinishedByElapsedTime = (state, now = Date.now()) => {
+    if (state?.finished) return true;
+    if (
+        !state ||
+        !Number.isFinite(state.startedAt) ||
+        !Number.isFinite(state.duration) ||
+        state.duration <= 0
+    ) {
+        return false;
+    }
+
+    const elapsedBeforePause = Number(state.elapsedBeforePause ?? 0);
+    const isPaused = state.pausedAt !== null && state.pausedAt !== undefined;
+    const hasLegacyPauseModel = !state.pauseModelVersion;
+    let segmentElapsed = 0;
+
+    if (isPaused) {
+        if (!hasLegacyPauseModel) {
+            segmentElapsed = Math.max(0, state.pausedAt - state.startedAt);
+        }
+    } else {
+        segmentElapsed = Math.max(0, now - state.startedAt);
+    }
+
+    return elapsedBeforePause + segmentElapsed >= state.duration;
+};
+
+const buildActiveProcesses = (gameState, cap) => {
+    const activeEntries = Object.entries(gameState?.processes || {})
+        .filter(([, state]) => state && state.startedAt && !isProcessFinishedByElapsedTime(state))
+        .sort(([a], [b]) => a.localeCompare(b));
+
+    return {
+        total: activeEntries.length,
+        shown: activeEntries.slice(0, cap).map(([id, state]) => ({
             id,
             title: processById.get(id)?.title || id,
             status: state.pausedAt ? 'paused' : 'running',
-        }));
+        })),
+    };
+};
 
 const buildRawPlayerStateBlock = (gameState, maxInventoryEntries = 50) => {
     const questStats = getOfficialQuestStats(gameState);
@@ -118,6 +148,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             meta: {
                 included: false,
                 mode: 'none',
+                questsFinishedCount: 0,
                 completedQuestCount: questStats.completedQuestCount,
                 totalOfficialQuestCount: questStats.totalOfficialQuestCount,
                 remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
@@ -177,7 +208,6 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             (entry) => !isResourceEntry(entry) && entryMatchesQuery(entry, queryTokens, queryText)
         )
         .slice(0, caps.inventoryRelevantCap);
-    const remainingRelevantSlots = Math.max(0, caps.inventoryRelevantCap - queryRelevant.length);
     const inventorySample = wantsInventorySummary(queryText)
         ? entries
               .filter(
@@ -185,11 +215,12 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
                       !isResourceEntry(entry) &&
                       !queryRelevant.some((match) => match.id === entry.id)
               )
-              .slice(0, Math.min(caps.inventorySampleCap, remainingRelevantSlots))
+              .slice(0, caps.inventorySampleCap)
         : [];
     const relevantInventory = [...queryRelevant, ...inventorySample];
     const remainingQuests = buildRemainingQuests(gameState, caps.remainingQuestCap);
-    const activeProcesses = buildActiveProcesses(gameState, caps.activeProcessCap);
+    const activeProcessSummary = buildActiveProcesses(gameState, caps.activeProcessCap);
+    const activeProcesses = activeProcessSummary.shown;
     const inventoryIncludedCount = resourceBalances.length + relevantInventory.length;
     const inventoryTruncated = entries.length > inventoryIncludedCount;
 
@@ -210,11 +241,11 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
     }
     if (relevantInventory.length > 0) {
         lines.push(
-            `Query-relevant owned inventory shown (cap ${caps.inventoryRelevantCap}): ${relevantInventory.map((entry) => `${entry.name} [${entry.id}]=${formatCount(entry.count)}`).join('; ')}.`
+            `Query-relevant/sample owned inventory shown (relevant cap ${caps.inventoryRelevantCap}, sample cap ${caps.inventorySampleCap}): ${relevantInventory.map((entry) => `${entry.name} [${entry.id}]=${formatCount(entry.count)}`).join('; ')}.`
         );
     }
     lines.push(
-        `Active processes: ${Object.values(gameState.processes || {}).filter((state) => state?.startedAt && !state?.finished).length} total${activeProcesses.length ? `; shown: ${activeProcesses.map((process) => `${process.title} [${process.id}] ${process.status}`).join('; ')}` : ''}.`
+        `Active processes: ${activeProcessSummary.total} total${activeProcesses.length ? `; shown: ${activeProcesses.map((process) => `${process.title} [${process.id}] ${process.status}`).join('; ')}` : ''}.`
     );
     if (inventoryTruncated || questStats.remainingOfficialQuestCount > remainingQuests.length) {
         lines.push(
@@ -228,6 +259,9 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
         meta: {
             included: true,
             mode: 'compact',
+            questsFinishedCount: Object.values(gameState.quests || {}).filter(
+                (quest) => quest?.finished
+            ).length,
             completedQuestCount: questStats.completedQuestCount,
             totalOfficialQuestCount: questStats.totalOfficialQuestCount,
             remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -65,6 +65,21 @@ const entryMatchesQuery = (entry, queryTokens, queryText) => {
 const wantsInventorySummary = (queryText) =>
     /\binventory\b|\bitems?\b|\bwhat do i have\b/i.test(queryText);
 
+const wantsCompletedQuestSummary = (queryText) =>
+    /\b(completed|finished|done)\b.*\bquests?\b|\bquests?\b.*\b(completed|finished|done)\b/i.test(
+        queryText
+    );
+
+const buildCompletedQuests = (gameState, cap) =>
+    Object.entries(gameState?.quests || {})
+        .filter(([, questState]) => questState?.finished)
+        .map(([questId]) => {
+            const quest = getBuiltInQuest(questId);
+            return { id: questId, title: quest?.title || questId };
+        })
+        .sort((a, b) => a.id.localeCompare(b.id))
+        .slice(0, cap);
+
 const buildRemainingQuests = (gameState, cap) => {
     const officialQuestIds = listBuiltInQuestIds().sort((a, b) => a.localeCompare(b));
     return officialQuestIds
@@ -218,6 +233,9 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
               .slice(0, caps.inventorySampleCap)
         : [];
     const relevantInventory = [...queryRelevant, ...inventorySample];
+    const completedQuests = wantsCompletedQuestSummary(queryText)
+        ? buildCompletedQuests(gameState, caps.remainingQuestCap)
+        : [];
     const remainingQuests = buildRemainingQuests(gameState, caps.remainingQuestCap);
     const activeProcessSummary = buildActiveProcesses(gameState, caps.activeProcessCap);
     const activeProcesses = activeProcessSummary.shown;
@@ -228,6 +246,11 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
         `PlayerStateCompact v${normalizeVersionNumberString(gameState.versionNumberString)} (authoritative for fields shown).`,
         `Official quests: completed ${questStats.completedQuestCount}/${questStats.totalOfficialQuestCount}; remaining ${questStats.remainingOfficialQuestCount}.`,
     ];
+    if (completedQuests.length > 0) {
+        lines.push(
+            `Completed quests shown (cap ${caps.remainingQuestCap}): ${completedQuests.map((quest) => `${quest.id} — ${quest.title}`).join(' | ')}.`
+        );
+    }
     if (remainingQuests.length > 0) {
         lines.push(
             `Remaining official quests shown (cap ${caps.remainingQuestCap}): ${remainingQuests.map((quest) => `${quest.id} — ${quest.title}`).join(' | ')}.`

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -1,0 +1,243 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+import { getBuiltInQuest, listBuiltInQuestIds } from './builtInQuests.js';
+import { getOfficialQuestStats } from './gameState/questStats.js';
+
+export const PLAYER_STATE_PROMPT_DEFAULTS = Object.freeze({
+    remainingQuestCap: 12,
+    inventoryRelevantCap: 8,
+    inventorySampleCap: 8,
+    activeProcessCap: 6,
+});
+
+const RESOURCE_IDS = ['dUSD', 'dBI', 'dWatt', 'dSolar', 'dPrint', 'dLaunch', 'dWind'];
+
+const itemById = new Map(items.map((item) => [item.id, item]));
+const processById = new Map(processes.map((process) => [process.id, process]));
+
+const normalizeVersionNumberString = (value) => {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+    return '3';
+};
+
+const formatCount = (count) =>
+    Number.isInteger(count) ? String(count) : String(Number(count.toFixed(4)));
+
+const normalizeText = (value) =>
+    String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+
+const tokenSet = (value) =>
+    new Set(
+        normalizeText(value)
+            .split(/\s+/)
+            .filter((token) => token.length >= 2)
+    );
+
+const itemLabel = (id) => itemById.get(id)?.name || id;
+
+const inventoryEntries = (inventory = {}) =>
+    Object.entries(inventory || {})
+        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
+        .map(([id, count]) => ({ id, name: itemLabel(id), count }))
+        .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
+const isResourceEntry = (entry) =>
+    RESOURCE_IDS.includes(entry.id) || RESOURCE_IDS.includes(entry.name);
+
+const entryMatchesQuery = (entry, queryTokens, queryText) => {
+    if (!queryText || queryTokens.size === 0) return false;
+    const haystack = normalizeText(
+        `${entry.id} ${entry.name} ${itemById.get(entry.id)?.description || ''}`
+    );
+    const entryTokens = tokenSet(haystack);
+    if (normalizeText(entry.name) && queryText.includes(normalizeText(entry.name))) return true;
+    if (normalizeText(entry.id) && queryText.includes(normalizeText(entry.id))) return true;
+    let hits = 0;
+    for (const token of queryTokens) {
+        if (entryTokens.has(token)) hits += 1;
+    }
+    return hits >= Math.min(2, queryTokens.size);
+};
+
+const wantsInventorySummary = (queryText) =>
+    /\binventory\b|\bitems?\b|\bwhat do i have\b/i.test(queryText);
+
+const buildRemainingQuests = (gameState, cap) => {
+    const officialQuestIds = listBuiltInQuestIds().sort((a, b) => a.localeCompare(b));
+    return officialQuestIds
+        .filter((questId) => !gameState?.quests?.[questId]?.finished)
+        .slice(0, cap)
+        .map((questId) => {
+            const quest = getBuiltInQuest(questId);
+            return { id: questId, title: quest?.title || questId };
+        });
+};
+
+const buildActiveProcesses = (gameState, cap) =>
+    Object.entries(gameState?.processes || {})
+        .filter(([, state]) => state && state.startedAt && !state.finished)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .slice(0, cap)
+        .map(([id, state]) => ({
+            id,
+            title: processById.get(id)?.title || id,
+            status: state.pausedAt ? 'paused' : 'running',
+        }));
+
+const buildRawPlayerStateBlock = (gameState, maxInventoryEntries = 50) => {
+    const questStats = getOfficialQuestStats(gameState);
+    const finished = Object.entries(gameState?.quests || {})
+        .filter(([, questState]) => questState?.finished)
+        .map(([questId]) => questId)
+        .sort((a, b) => a.localeCompare(b));
+    const inventory = inventoryEntries(gameState?.inventory)
+        .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id))
+        .slice(0, maxInventoryEntries)
+        .map(({ id, count }) => ({ id, count }));
+    const snapshot = {
+        versionNumberString: normalizeVersionNumberString(gameState?.versionNumberString),
+        questsFinished: finished,
+        inventory,
+    };
+    return `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}\nPlayerState v${snapshot.versionNumberString} (raw debug; authoritative; do not infer beyond this):\n${JSON.stringify(snapshot, null, 2)}`;
+};
+
+export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
+    const mode =
+        options.playerStatePromptMode === 'raw' || options.includeRawPlayerState
+            ? 'raw'
+            : 'compact';
+    const questStats = getOfficialQuestStats(gameState || null);
+    if (!gameState || typeof gameState !== 'object') {
+        return {
+            block: null,
+            meta: {
+                included: false,
+                mode: 'none',
+                completedQuestCount: questStats.completedQuestCount,
+                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+                remainingQuestIncludedCount: 0,
+                inventoryTotalCount: 0,
+                inventoryIncludedCount: 0,
+                inventoryTruncated: false,
+                activeProcessIncludedCount: 0,
+                blockCharCount: 0,
+            },
+            slices: {
+                resourceBalances: [],
+                relevantInventory: [],
+                remainingQuests: [],
+                activeProcesses: [],
+            },
+        };
+    }
+
+    if (mode === 'raw') {
+        const block = buildRawPlayerStateBlock(gameState, options.maxInventoryEntries);
+        const entries = inventoryEntries(gameState.inventory);
+        return {
+            block,
+            meta: {
+                included: true,
+                mode: 'raw',
+                questsFinishedCount: Object.values(gameState.quests || {}).filter(
+                    (quest) => quest?.finished
+                ).length,
+                completedQuestCount: questStats.completedQuestCount,
+                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+                remainingQuestIncludedCount: 0,
+                inventoryTotalCount: entries.length,
+                inventoryIncludedCount: Math.min(entries.length, options.maxInventoryEntries || 50),
+                inventoryTruncated: entries.length > (options.maxInventoryEntries || 50),
+                activeProcessIncludedCount: 0,
+                blockCharCount: block.length,
+            },
+            slices: {
+                resourceBalances: [],
+                relevantInventory: [],
+                remainingQuests: [],
+                activeProcesses: [],
+            },
+        };
+    }
+
+    const caps = { ...PLAYER_STATE_PROMPT_DEFAULTS, ...options };
+    const queryText = normalizeText(options.latestUserMessage || options.query || '');
+    const queryTokens = tokenSet(queryText);
+    const entries = inventoryEntries(gameState.inventory);
+    const resourceBalances = entries.filter(isResourceEntry);
+    const queryRelevant = entries
+        .filter(
+            (entry) => !isResourceEntry(entry) && entryMatchesQuery(entry, queryTokens, queryText)
+        )
+        .slice(0, caps.inventoryRelevantCap);
+    const remainingRelevantSlots = Math.max(0, caps.inventoryRelevantCap - queryRelevant.length);
+    const inventorySample = wantsInventorySummary(queryText)
+        ? entries
+              .filter(
+                  (entry) =>
+                      !isResourceEntry(entry) &&
+                      !queryRelevant.some((match) => match.id === entry.id)
+              )
+              .slice(0, Math.min(caps.inventorySampleCap, remainingRelevantSlots))
+        : [];
+    const relevantInventory = [...queryRelevant, ...inventorySample];
+    const remainingQuests = buildRemainingQuests(gameState, caps.remainingQuestCap);
+    const activeProcesses = buildActiveProcesses(gameState, caps.activeProcessCap);
+    const inventoryIncludedCount = resourceBalances.length + relevantInventory.length;
+    const inventoryTruncated = entries.length > inventoryIncludedCount;
+
+    const lines = [
+        `PlayerStateCompact v${normalizeVersionNumberString(gameState.versionNumberString)} (authoritative for fields shown).`,
+        `Official quests: completed ${questStats.completedQuestCount}/${questStats.totalOfficialQuestCount}; remaining ${questStats.remainingOfficialQuestCount}.`,
+    ];
+    if (remainingQuests.length > 0) {
+        lines.push(
+            `Remaining official quests shown (cap ${caps.remainingQuestCap}): ${remainingQuests.map((quest) => `${quest.id} — ${quest.title}`).join(' | ')}.`
+        );
+    }
+    lines.push(`Inventory: ${entries.length} owned item/resource types total.`);
+    if (resourceBalances.length > 0) {
+        lines.push(
+            `Notable balances: ${resourceBalances.map((entry) => `${entry.name}=${formatCount(entry.count)}`).join(', ')}.`
+        );
+    }
+    if (relevantInventory.length > 0) {
+        lines.push(
+            `Query-relevant owned inventory shown (cap ${caps.inventoryRelevantCap}): ${relevantInventory.map((entry) => `${entry.name} [${entry.id}]=${formatCount(entry.count)}`).join('; ')}.`
+        );
+    }
+    lines.push(
+        `Active processes: ${Object.values(gameState.processes || {}).filter((state) => state?.startedAt && !state?.finished).length} total${activeProcesses.length ? `; shown: ${activeProcesses.map((process) => `${process.title} [${process.id}] ${process.status}`).join('; ')}` : ''}.`
+    );
+    if (inventoryTruncated || questStats.remainingOfficialQuestCount > remainingQuests.length) {
+        lines.push(
+            'Omitted inventory/quest details are not evidence that the player lacks them; ask a clarifying question or suggest checking the relevant DSPACE page for exact missing details.'
+        );
+    }
+    const block = lines.join('\n');
+
+    return {
+        block,
+        meta: {
+            included: true,
+            mode: 'compact',
+            completedQuestCount: questStats.completedQuestCount,
+            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+            remainingQuestIncludedCount: remainingQuests.length,
+            inventoryTotalCount: entries.length,
+            inventoryIncludedCount,
+            inventoryTruncated,
+            activeProcessIncludedCount: activeProcesses.length,
+            blockCharCount: block.length,
+        },
+        slices: { resourceBalances, relevantInventory, remainingQuests, activeProcesses },
+    };
+};

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -27,6 +27,37 @@ const normalizeIndexes = (value) => {
     return [];
 };
 
+const numberOrZero = (value) => (Number.isFinite(value) ? Number(value) : 0);
+
+const sanitizePlayerStateSummary = (summary) => {
+    if (!summary || typeof summary !== 'object') return null;
+
+    const safeSummary = {
+        mode: typeof summary.mode === 'string' ? summary.mode : 'unknown',
+        playerStatePromptMode:
+            typeof summary.playerStatePromptMode === 'string'
+                ? summary.playerStatePromptMode
+                : typeof summary.mode === 'string'
+                  ? summary.mode
+                  : 'unknown',
+        completedQuestCount: numberOrZero(summary.completedQuestCount),
+        totalOfficialQuestCount: numberOrZero(summary.totalOfficialQuestCount),
+        remainingOfficialQuestCount: numberOrZero(summary.remainingOfficialQuestCount),
+        remainingQuestIncludedCount: numberOrZero(summary.remainingQuestIncludedCount),
+        inventoryTotalCount: numberOrZero(summary.inventoryTotalCount),
+        inventoryIncludedCount: numberOrZero(summary.inventoryIncludedCount),
+        inventoryTruncated: Boolean(summary.inventoryTruncated),
+        activeProcessIncludedCount: numberOrZero(summary.activeProcessIncludedCount),
+        blockCharCount: numberOrZero(summary.blockCharCount),
+    };
+
+    if (Number.isFinite(summary.questsFinishedCount)) {
+        safeSummary.questsFinishedCount = Number(summary.questsFinishedCount);
+    }
+
+    return safeSummary;
+};
+
 export const buildPromptMetrics = (promptPayload, metadata = {}) => {
     const messages = Array.isArray(promptPayload?.combinedMessages)
         ? promptPayload.combinedMessages
@@ -102,6 +133,6 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
               })()
             : null,
         contextPlan: metadata.contextPlan || null,
-        playerStateSummary: metadata.playerStateSummary || null,
+        playerStateSummary: sanitizePlayerStateSummary(metadata.playerStateSummary),
     };
 };

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -102,5 +102,6 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
               })()
             : null,
         contextPlan: metadata.contextPlan || null,
+        playerStateSummary: metadata.playerStateSummary || null,
     };
 };

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -89,6 +89,17 @@ describe('buildDchatKnowledgePack', () => {
         expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
     });
 
+    it('keeps bounded live inventory highlights for broad progress questions', () => {
+        const pack = buildDchatKnowledgePack(
+            { inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 2 } },
+            { latestUserMessage: 'How am I progressing?' }
+        );
+
+        expect(pack.summary).toContain('Inventory highlights: compact bounded');
+        expect(pack.summary).toContain('white PLA filament');
+        expect(pack.summary).toContain('x2');
+    });
+
     it('keeps query-relevant live inventory in compact highlights', () => {
         const pack = buildDchatKnowledgePack(
             { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -28,9 +28,10 @@ describe('buildDchatKnowledgePack', () => {
 
     it('adds a state source when game state context is used', () => {
         const sampleItemId = items[0]?.id;
-        const pack = buildDchatKnowledgePack({
-            inventory: sampleItemId ? { [sampleItemId]: 1 } : {},
-        });
+        const pack = buildDchatKnowledgePack(
+            { inventory: sampleItemId ? { [sampleItemId]: 1 } : {} },
+            { latestUserMessage: 'what is my inventory?' }
+        );
 
         expect(pack.sources.some((entry) => entry.type === 'state')).toBe(true);
     });
@@ -69,5 +70,33 @@ describe('buildDchatKnowledgePack', () => {
         expect(achievementSources.length).toBe(6);
         expect(achievementSources.map((entry) => entry.id)).toEqual(sortedAchievementIds);
         expect(new Set(achievementSources.map((entry) => entry.id))).toEqual(new Set(expectedIds));
+    });
+
+    it('bounds live-state inventory highlights instead of dumping all owned inventory', () => {
+        const inventory = Object.fromEntries(
+            Array.from({ length: 150 }, (_, index) => [`raw-owned-${index}`, index + 1])
+        );
+        const pack = buildDchatKnowledgePack(
+            { inventory },
+            { latestUserMessage: 'what is my inventory?' }
+        );
+        const highlights = pack.summary
+            .split('\n\n')
+            .find((section) => section.startsWith('Inventory highlights:'));
+
+        expect(highlights).toContain('compact bounded live-state highlights');
+        expect((highlights?.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
+        expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
+    });
+
+    it('keeps query-relevant live inventory in compact highlights', () => {
+        const pack = buildDchatKnowledgePack(
+            { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },
+            { latestUserMessage: 'do I have enough green PLA?' }
+        );
+
+        expect(pack.summary).toContain('Inventory highlights: compact bounded');
+        expect(pack.summary).toContain('green PLA filament');
+        expect(pack.summary).toContain('x13');
     });
 });

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -557,7 +557,7 @@ describe('buildChatPrompt', () => {
         expect(content).toContain('/docs/routes');
     });
 
-    it('injects PlayerState with finished quests and inventory entries', async () => {
+    it('injects compact PlayerState with quest counts and query-relevant inventory', async () => {
         vi.mocked(loadGameState).mockReturnValueOnce({
             openAI: {},
             versionNumberString: '3',
@@ -567,58 +567,33 @@ describe('buildChatPrompt', () => {
                 '3dprinter/start': { finished: true },
             },
             inventory: {
-                'item-alpha': 12,
+                'd3590107-25ff-4de5-af3a-46e2497bfc52': 12,
                 'item-beta': 0,
                 'item-gamma': 5.5,
             },
         });
 
-        const payload = await buildChatPrompt([{ role: 'user', content: 'Status?' }]);
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'do I have enough green PLA?' },
+        ]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerState v3')
+            message.content?.includes('PlayerStateCompact v3')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
-        );
-        const jsonStart = content.indexOf('{');
-        const jsonBody = jsonStart >= 0 ? content.slice(jsonStart) : '';
-        const snapshot = jsonBody ? JSON.parse(jsonBody) : null;
 
-        expect(snapshot?.versionNumberString).toBe('3');
-        expect(statsMatch).not.toBeNull();
-        expect(snapshot?.questsFinished).toEqual(
-            expect.arrayContaining(['welcome/howtodoquests', '3dprinter/start'])
-        );
-        expect(snapshot?.questsFinished).not.toEqual(
-            expect.arrayContaining(['welcome/intro-inventory'])
-        );
-        expect(snapshot?.inventory).toEqual(
-            expect.arrayContaining([
-                { id: 'item-alpha', count: 12 },
-                { id: 'item-gamma', count: 5.5 },
-            ])
-        );
+        expect(content).toContain('Official quests: completed');
+        expect(content).toContain('green PLA filament');
+        expect(content).toContain('=12');
+        expect(content).not.toContain('questsFinished');
+        expect(content).not.toContain('item-gamma');
         expect(payload.playerStateSummary).toEqual(
             expect.objectContaining({
                 included: true,
-                questsFinishedCount: 2,
-                completedQuestCount: Number(statsMatch?.[1]),
-                totalOfficialQuestCount: Number(statsMatch?.[2]),
-                remainingOfficialQuestCount: Number(statsMatch?.[3]),
-                inventoryIncludedCount: 2,
-                inventoryTruncated: false,
+                mode: 'compact',
+                completedQuestCount: 1,
+                inventoryIncludedCount: 1,
+                inventoryTruncated: true,
             })
-        );
-        // '3dprinter/start' is intentionally non-canonical (real ID is '3dprinting/start').
-        // This verifies only official quest IDs count toward completedQuestCount.
-        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
-        expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
-            Math.max(
-                payload.playerStateSummary.totalOfficialQuestCount -
-                    payload.playerStateSummary.completedQuestCount,
-                0
-            )
         );
     });
 
@@ -635,17 +610,16 @@ describe('buildChatPrompt', () => {
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Quest totals?' }]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerStateStats:')
+            message.content?.includes('PlayerStateCompact')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
-        );
 
-        expect(statsMatch).not.toBeNull();
-        expect(Number(statsMatch?.[1])).toBe(1);
-        expect(Number(statsMatch?.[2])).toBeGreaterThan(1);
-        expect(Number(statsMatch?.[3])).toBe(Number(statsMatch?.[2]) - Number(statsMatch?.[1]));
+        expect(content).toContain('Official quests: completed 1/');
+        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
+        expect(payload.playerStateSummary.totalOfficialQuestCount).toBeGreaterThan(1);
+        expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
+            payload.playerStateSummary.totalOfficialQuestCount - 1
+        );
     });
 
     it('skips docs RAG for player-state-only full prompts', async () => {

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -590,6 +590,7 @@ describe('buildChatPrompt', () => {
             expect.objectContaining({
                 included: true,
                 mode: 'compact',
+                questsFinishedCount: 2,
                 completedQuestCount: 1,
                 inventoryIncludedCount: 1,
                 inventoryTruncated: true,
@@ -639,6 +640,45 @@ describe('buildChatPrompt', () => {
         expect(searchDocsRag).not.toHaveBeenCalled();
         expect(payload.contextSources.every((source) => source.type !== 'doc')).toBe(true);
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
+    });
+
+    it('exposes only safe PlayerState summary fields in prompt metrics', async () => {
+        vi.mocked(loadGameState).mockReturnValueOnce({
+            openAI: {},
+            versionNumberString: '3',
+            quests: {
+                'welcome/howtodoquests': { finished: true },
+                'custom/non-official': { finished: true },
+            },
+            inventory: {
+                'd3590107-25ff-4de5-af3a-46e2497bfc52': 12,
+                'secret-item-id': 99,
+            },
+        });
+
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'do I have enough green PLA?' }],
+            { includePromptMetrics: true }
+        );
+        const summary = payload.promptMetrics.playerStateSummary;
+
+        expect(summary).toEqual({
+            mode: 'compact',
+            playerStatePromptMode: 'compact',
+            completedQuestCount: 1,
+            totalOfficialQuestCount: expect.any(Number),
+            remainingOfficialQuestCount: expect.any(Number),
+            remainingQuestIncludedCount: expect.any(Number),
+            inventoryTotalCount: 2,
+            inventoryIncludedCount: 1,
+            inventoryTruncated: true,
+            activeProcessIncludedCount: 0,
+            blockCharCount: expect.any(Number),
+            questsFinishedCount: 2,
+        });
+        expect(JSON.stringify(summary)).not.toContain('secret-item-id');
+        expect(JSON.stringify(summary)).not.toContain('green PLA filament');
+        expect(JSON.stringify(summary)).not.toContain('welcome/howtodoquests');
     });
 
     it('reports forced docs RAG consistently in plan metadata and prompt metrics', async () => {

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayerStatePromptSummary } from '../src/utils/playerStatePromptSummary.js';
+
+const GREEN_PLA_ID = 'd3590107-25ff-4de5-af3a-46e2497bfc52';
+const DSOLAR_ID = 'b02ecff5-1f7d-4247-a09d-7d6cd6bb218a';
+
+const makeState = (inventory = {}) => ({
+    versionNumberString: '3',
+    quests: {
+        'welcome/howtodoquests': { finished: true },
+        'welcome/intro-inventory': { finished: true },
+        'custom/not-official': { finished: true },
+    },
+    inventory,
+    processes: {},
+});
+
+describe('buildPlayerStatePromptSummary', () => {
+    it('summarizes many finished quests with counts instead of a full questsFinished array', () => {
+        const result = buildPlayerStatePromptSummary(makeState());
+
+        expect(result.block).toContain('PlayerStateCompact v3');
+        expect(result.block).toContain('Official quests: completed');
+        expect(result.block).not.toContain('questsFinished');
+        expect(result.block).not.toContain('custom/not-official');
+        expect(result.meta.completedQuestCount).toBe(2);
+        expect(result.meta.remainingQuestIncludedCount).toBeGreaterThan(0);
+    });
+
+    it('bounds remaining official quests and includes omission guidance', () => {
+        const result = buildPlayerStatePromptSummary(makeState(), { remainingQuestCap: 2 });
+
+        expect(result.meta.remainingQuestIncludedCount).toBeLessThanOrEqual(2);
+        expect(result.block).toContain('Remaining official quests shown (cap 2)');
+        expect(result.block).toContain('Omitted inventory/quest details are not evidence');
+    });
+
+    it('does not dump UUID-heavy inventory by default', () => {
+        const inventory = Object.fromEntries(
+            Array.from({ length: 60 }, (_, index) => [
+                `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+                index + 1,
+            ])
+        );
+        const result = buildPlayerStatePromptSummary(makeState(inventory), {
+            latestUserMessage: 'what quest do I have left?',
+        });
+
+        expect(result.meta.inventoryTotalCount).toBe(60);
+        expect(result.meta.inventoryIncludedCount).toBe(0);
+        expect(result.meta.inventoryTruncated).toBe(true);
+        expect((result.block.match(/00000000-0000-4000-8000/g) || []).length).toBe(0);
+    });
+
+    it('includes query-relevant green PLA when asked', () => {
+        const result = buildPlayerStatePromptSummary(makeState({ [GREEN_PLA_ID]: 42 }), {
+            latestUserMessage: 'do I have enough green PLA?',
+        });
+
+        expect(result.block).toContain('green PLA filament');
+        expect(result.block).toContain('42');
+        expect(result.meta.inventoryIncludedCount).toBe(1);
+    });
+
+    it('includes notable dSolar balances when present', () => {
+        const result = buildPlayerStatePromptSummary(makeState({ [DSOLAR_ID]: 7 }), {
+            latestUserMessage: 'dSolar',
+        });
+
+        expect(result.block).toContain('dSolar=7');
+        expect(result.meta.inventoryIncludedCount).toBe(1);
+    });
+
+    it('shows a bounded inventory sample for broad inventory questions', () => {
+        const inventory = Object.fromEntries(
+            Array.from({ length: 20 }, (_, index) => [`item-${index}`, index + 1])
+        );
+        const result = buildPlayerStatePromptSummary(makeState(inventory), {
+            latestUserMessage: 'what is my inventory?',
+            inventorySampleCap: 4,
+            inventoryRelevantCap: 4,
+        });
+
+        expect(result.meta.inventoryTotalCount).toBe(20);
+        expect(result.meta.inventoryIncludedCount).toBe(4);
+        expect(result.meta.inventoryTruncated).toBe(true);
+        expect(result.slices.relevantInventory).toHaveLength(4);
+    });
+});

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -16,6 +16,61 @@ const makeState = (inventory = {}) => ({
 });
 
 describe('buildPlayerStatePromptSummary', () => {
+    it('keeps questsFinishedCount in compact and missing-state metadata for debug consumers', () => {
+        const compact = buildPlayerStatePromptSummary(makeState());
+        const missing = buildPlayerStatePromptSummary(null);
+
+        expect(compact.meta.questsFinishedCount).toBe(3);
+        expect(missing.meta.questsFinishedCount).toBe(0);
+    });
+
+    it('excludes elapsed completed processes from active process counts', () => {
+        const result = buildPlayerStatePromptSummary({
+            ...makeState(),
+            processes: {
+                elapsed: {
+                    startedAt: Date.now() - 2_000,
+                    duration: 1_000,
+                    finished: false,
+                    pausedAt: null,
+                    elapsedBeforePause: 0,
+                    pauseModelVersion: 2,
+                },
+                running: {
+                    startedAt: Date.now(),
+                    duration: 60_000,
+                    finished: false,
+                    pausedAt: null,
+                    elapsedBeforePause: 0,
+                    pauseModelVersion: 2,
+                },
+            },
+        });
+
+        expect(result.block).toContain('Active processes: 1 total');
+        expect(result.slices.activeProcesses).toEqual([
+            expect.objectContaining({ id: 'running', status: 'running' }),
+        ]);
+        expect(result.meta.activeProcessIncludedCount).toBe(1);
+    });
+
+    it('keeps broad inventory samples independent from query relevance slots', () => {
+        const inventory = {
+            [GREEN_PLA_ID]: 42,
+            'item-1': 1,
+            'item-2': 2,
+        };
+        const result = buildPlayerStatePromptSummary(makeState(inventory), {
+            latestUserMessage: 'what items do I have with green PLA?',
+            inventoryRelevantCap: 1,
+            inventorySampleCap: 2,
+        });
+
+        expect(result.slices.relevantInventory).toHaveLength(3);
+        expect(result.slices.relevantInventory[0].id).toBe(GREEN_PLA_ID);
+        expect(result.meta.inventoryIncludedCount).toBe(3);
+    });
+
     it('summarizes many finished quests with counts instead of a full questsFinished array', () => {
         const result = buildPlayerStatePromptSummary(makeState());
 

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -18,10 +18,14 @@ const makeState = (inventory = {}) => ({
 describe('buildPlayerStatePromptSummary', () => {
     it('keeps questsFinishedCount in compact and missing-state metadata for debug consumers', () => {
         const compact = buildPlayerStatePromptSummary(makeState());
+        const raw = buildPlayerStatePromptSummary(makeState(), { playerStatePromptMode: 'raw' });
         const missing = buildPlayerStatePromptSummary(null);
 
         expect(compact.meta.questsFinishedCount).toBe(3);
+        expect(raw.meta.questsFinishedCount).toBe(3);
         expect(missing.meta.questsFinishedCount).toBe(0);
+        expect(compact.block).not.toContain('questsFinished');
+        expect(raw.block).toContain('questsFinished');
     });
 
     it('excludes elapsed completed processes from active process counts', () => {

--- a/tests/chatNonReasoningRegression.test.ts
+++ b/tests/chatNonReasoningRegression.test.ts
@@ -147,20 +147,18 @@ describe('chat non-reasoning regression probes', () => {
             const playerStateMessage = messages.find(
                 (message) =>
                     message.role === 'system' &&
-                    message.content?.[0]?.text?.includes('PlayerState v3')
+                    message.content?.[0]?.text?.includes('PlayerStateCompact v3')
             );
             const text = playerStateMessage?.content?.[0]?.text ?? '';
-            const jsonStart = text.indexOf('{');
-            const snapshot = JSON.parse(text.slice(jsonStart));
+            expect(text).toContain('Completed quests shown');
+            expect(text).not.toContain('questsFinished');
             return {
-                output_text: `Completed quests: ${snapshot.questsFinished.join(', ')}`,
+                output_text: `Completed quests: ${text}`,
             };
         });
 
         const { GPT5Chat } = await import('../frontend/src/utils/openAI.js');
-        const reply = await GPT5Chat([
-            { role: 'user', content: 'What quests have I completed?' },
-        ]);
+        const reply = await GPT5Chat([{ role: 'user', content: 'What quests have I completed?' }]);
 
         expect(reply).toContain('welcome/howtodoquests');
         expect(reply).toContain('3dprinter/start');
@@ -188,9 +186,7 @@ describe('chat non-reasoning regression probes', () => {
         });
 
         const { GPT5Chat } = await import('../frontend/src/utils/openAI.js');
-        const reply = await GPT5Chat([
-            { role: 'user', content: 'What quests have I completed?' },
-        ]);
+        const reply = await GPT5Chat([{ role: 'user', content: 'What quests have I completed?' }]);
 
         expect(reply).toMatch(/\/gamesaves/);
         expect(reply).toMatch(/\/docs\/backups|\/docs\/routes/);


### PR DESCRIPTION
### Motivation
- Full-mode chat was sending bulky live PlayerState payloads (long `questsFinished` arrays, raw UUID inventory dumps, and unbounded dChat inventory highlights) that wasted tokens and hurt local model performance.
- The goal is to preserve authoritative grounding for progress/inventory queries while drastically reducing prompt size and avoiding accidental exposure of full save JSON.

### Description
- Add `buildPlayerStatePromptSummary(gameState, options)` in `frontend/src/utils/playerStatePromptSummary.js` which returns a deterministic compact `block`, safe `meta` summary, and `slices` (resource balances, relevant inventory, remaining quests, active processes) and supports an opt-in `raw` mode for tests/dev tools.
- Replace the previous raw PlayerState insertion with the compact summary by default in `frontend/src/utils/openAI.js`, passing the latest user message for query-aware selection and exposing safe `playerStateSummary` to `promptMetrics` (no raw state or prompt text is logged).
- Compact dChat live-state inventory highlights in `frontend/src/utils/dchatKnowledge.js` to use bounded resource/relevant inventory slices from the new helper while leaving static item/quest/process catalog summaries unchanged.
- Update `frontend/src/utils/promptMetrics.js` to include safe state-summary metadata (mode, counts, included/omitted flags, block char count) without exposing raw arrays or full JSON.
- Add focused tests: `frontend/tests/playerStatePromptSummary.test.ts` for unit behavior, tweaks to `frontend/tests/dchatKnowledgePack.test.ts` and `frontend/tests/openAI.test.ts` to validate integration and query-aware inclusion.

### Testing
- Ran compact focused suites with: `cd frontend && npm test -- openAI` and the suite passed successfully.
- Ran `cd frontend && npm test -- dchatKnowledge` and `cd frontend && npm test -- playerStatePromptSummary` and both suites passed successfully.
- Ran `cd frontend && npm test -- chatContextPlanner` and `cd frontend && npm test -- tokenPlace.test.js` and both suites passed successfully, verifying provider/token.place paths and P16/P17/P18 regressions.
- Performed broader checks `cd frontend && npm run check` and `cd frontend && npm run build` and both succeeded, confirming lint/format and build pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f829855a8832f811984a7a4008676)