### PR TITLE
Compact live PlayerState prompts and bounded inventory highlights

### DIFF
--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -2,6 +2,7 @@ import items from '../pages/inventory/json/items/index.js';
 import processes from '../generated/processes.json' assert { type: 'json' };
 import { evaluateAchievements } from './achievements.js';
 import { mergeSources } from './contextSources.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 
 const MAX_ITEMS = 25;
 const MAX_PROCESSES = 20;
@@ -112,11 +113,12 @@ function prioritizeQuests(allQuests) {
     return prioritized.concat(remaining);
 }
 
-function formatInventory(inventory = {}) {
+function formatInventory(inventory = {}, options = {}) {
     if (!inventory || typeof inventory !== 'object') {
         return [];
     }
 
+    const maxEntries = options.maxEntries || 8;
     return Object.entries(inventory)
         .filter(([, count]) => typeof count === 'number' && count > 0)
         .map(([id, count]) => {
@@ -124,7 +126,8 @@ function formatInventory(inventory = {}) {
             const name = item ? item.name : id;
             return `${name} (x${Number.isInteger(count) ? count : count.toFixed(2)})`;
         })
-        .sort();
+        .sort()
+        .slice(0, maxEntries);
 }
 
 function summarizeItems() {
@@ -288,17 +291,36 @@ function summarizeProcessProgress(gameState = {}) {
         .sort((a, b) => a.localeCompare(b));
 }
 
-export function buildDchatKnowledgePack(gameState = {}) {
+export function buildDchatKnowledgePack(gameState = {}, options = {}) {
     const knowledgeSections = [];
     const sources = [];
     const stateDetails = [];
 
-    const inventorySummary = formatInventory(gameState.inventory);
+    const stateSummary =
+        options.playerStateSummary ||
+        buildPlayerStatePromptSummary(gameState, {
+            latestUserMessage: options.latestUserMessage || '',
+        });
+    const stateSlices = stateSummary.slices || {};
+    const compactInventoryEntries = Array.isArray(stateSlices.relevantInventory)
+        ? stateSlices.relevantInventory
+        : [];
+    const inventorySummary = compactInventoryEntries.map(
+        (entry) =>
+            `${entry.name || entry.id} (x${
+                Number.isInteger(entry.count) ? entry.count : entry.count.toFixed(2)
+            })`
+    );
     if (inventorySummary.length > 0) {
+        const omittedNote = stateSummary.meta?.inventoryTruncated
+            ? `; inventory omitted beyond compact cap (${stateSummary.meta.inventoryTotalCount} total)`
+            : '';
         knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.inventoryHighlights}: ${inventorySummary.join('; ')}`
+            `${dchatKnowledgeScaffolding.inventoryHighlights}: ${inventorySummary.join('; ')}${omittedNote}`
         );
-        stateDetails.push('inventory');
+        stateDetails.push('compact inventory');
+    } else if (stateSummary.meta?.inventoryTotalCount > 0) {
+        stateDetails.push('compact inventory omitted');
     }
 
     const itemEntries = getItemsForKnowledge();

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -1,5 +1,5 @@
 import { loadGameState, ready } from './gameState/common.js';
-import { getOfficialQuestStats } from './gameState/questStats.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 import { buildDchatKnowledgePack } from './dchatKnowledge.js';
 import { mergeSources } from './contextSources.js';
 import { searchDocsRag } from './docsRag.js';
@@ -113,7 +113,6 @@ const vagueFollowupPattern =
     /^\s*(what about|and then|that step|the second step|next step|step 2)\b/i;
 const retrievalContextLimit = 800;
 const retrievalQueryLimit = 1000;
-const MAX_PLAYER_STATE_ITEMS = 50;
 export const CHAT_DOCS_RAG_DEFAULTS = Object.freeze({
     maxResults: 6,
     maxChars: 8000,
@@ -317,94 +316,9 @@ const countPromptChars = (messages) => {
     return messages.reduce((total, message) => total + (message?.content?.length || 0), 0);
 };
 
-const normalizeVersionNumberString = (value) => {
-    if (typeof value === 'string' && value.trim()) {
-        return value.trim();
-    }
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return String(value);
-    }
-    return '3';
-};
-
-const buildPlayerStateSnapshot = (gameState, options = {}) => {
-    const { maxInventoryEntries = MAX_PLAYER_STATE_ITEMS } = options;
-    if (!gameState || typeof gameState !== 'object') {
-        const questStats = getOfficialQuestStats(null);
-        return {
-            block: null,
-            meta: {
-                included: false,
-                questsFinishedCount: 0,
-                completedQuestCount: questStats.completedQuestCount,
-                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-                inventoryIncludedCount: 0,
-                inventoryTotalCount: 0,
-                inventoryTruncated: false,
-            },
-        };
-    }
-
-    const questsFinished = Object.entries(gameState.quests || {})
-        .filter(([, questState]) => questState?.finished)
-        .map(([questId]) => questId)
-        .sort((a, b) => a.localeCompare(b));
-
-    const inventoryEntries = Object.entries(gameState.inventory || {})
-        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
-        .map(([id, count]) => ({ id, count }))
-        .sort((a, b) => {
-            if (b.count !== a.count) {
-                return b.count - a.count;
-            }
-            return a.id.localeCompare(b.id);
-        });
-
-    const totalItems = inventoryEntries.length;
-    const truncated = totalItems > maxInventoryEntries;
-    const includedInventory = truncated
-        ? inventoryEntries.slice(0, maxInventoryEntries)
-        : inventoryEntries;
-
-    const versionNumberString = normalizeVersionNumberString(gameState.versionNumberString);
-    const questStats = getOfficialQuestStats(gameState);
-    const snapshot = {
-        versionNumberString,
-        questsFinished,
-        inventory: includedInventory,
-    };
-
-    if (truncated) {
-        snapshot.truncated = true;
-        snapshot.totalItems = totalItems;
-    }
-
-    const statsBlock = `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}`;
-    const block = `${statsBlock}\nPlayerState v${versionNumberString} (authoritative; do not infer beyond this):\n${JSON.stringify(
-        snapshot,
-        null,
-        2
-    )}`;
-
-    return {
-        block,
-        meta: {
-            included: true,
-            questsFinishedCount: questsFinished.length,
-            completedQuestCount: questStats.completedQuestCount,
-            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-            inventoryIncludedCount: includedInventory.length,
-            inventoryTotalCount: totalItems,
-            inventoryTruncated: truncated,
-        },
-    };
-};
-
 export const getPlayerStateSummary = (gameState = loadGameState()) => {
     const hasGameState = gameState && typeof gameState === 'object';
-    return buildPlayerStateSnapshot(hasGameState ? gameState : null).meta;
+    return buildPlayerStatePromptSummary(hasGameState ? gameState : null).meta;
 };
 
 const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {
@@ -751,6 +665,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 promptBuildDurationMs: performance.now() - promptBuildStartedAt,
                 ragDurationMs: 0,
                 contextPlan: contextPlanMetadata,
+                playerStateSummary: promptPayload.playerStateSummary,
                 componentMessageIndexes: {
                     systemInstructions: [
                         combinedMessages.indexOf(systemMessage),
@@ -772,7 +687,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
         role: 'system',
         content: `Prompt version: v3:${getPromptVersionSha()}\n${fullSystemPrompt}`,
     };
-    const playerStateSnapshot = buildPlayerStateSnapshot(hasGameState ? rawGameState : null);
+    const playerStateSnapshot = buildPlayerStatePromptSummary(hasGameState ? rawGameState : null, {
+        latestUserMessage: latestUserMessage?.content || '',
+        playerStatePromptMode: options.playerStatePromptMode,
+        includeRawPlayerState: options.includeRawPlayerState,
+    });
     const playerStateMessage = playerStateSnapshot.block
         ? {
               role: 'system',
@@ -780,7 +699,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
           }
         : null;
 
-    const knowledgePack = buildDchatKnowledgePack(gameState);
+    const knowledgePack = buildDchatKnowledgePack(gameState, {
+        latestUserMessage: latestUserMessage?.content || '',
+        playerStateSummary: playerStateSnapshot,
+    });
     const knowledgeSummary = knowledgePack.summary;
     const knowledgeMessage = knowledgeSummary
         ? {
@@ -931,6 +853,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
             promptBuildDurationMs: performance.now() - promptBuildStartedAt,
             ragDurationMs,
             contextPlan: contextPlanMetadata,
+            playerStateSummary: playerStateSnapshot.meta,
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -1,0 +1,259 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+import { listBuiltInQuestIds } from './builtInQuests.js';
+import { getOfficialQuestStats } from './gameState/questStats.js';
+
+export const PLAYER_STATE_SUMMARY_LIMITS = Object.freeze({
+    remainingQuests: 12,
+    activeProcesses: 6,
+    relevantInventory: 8,
+    inventorySample: 8,
+});
+
+const NOTABLE_RESOURCE_IDS = [
+    'dUSD',
+    'dBI',
+    'dWatt',
+    'dSolar',
+    'dPrint',
+    'dLaunch',
+    'dWind',
+    'dHydro',
+    'dRocket',
+];
+
+const normalizeVersionNumberString = (value) => {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+    return '3';
+};
+
+const formatCount = (count) => (Number.isInteger(count) ? String(count) : count.toFixed(2));
+const normalizeText = (value) =>
+    String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+const tokensFor = (value) =>
+    normalizeText(value)
+        .split(/\s+/)
+        .filter((token) => token.length >= 2);
+
+function getQuestData() {
+    if (typeof import.meta === 'undefined' || typeof import.meta.glob !== 'function') return [];
+    const modules = import.meta.glob('../pages/quests/json/**/*.json', { eager: true });
+    return Object.values(modules)
+        .map((mod) => (mod?.default ? mod.default : mod))
+        .filter((quest) => quest && typeof quest.id === 'string')
+        .map((quest) => ({ id: quest.id, title: quest.title || quest.id }));
+}
+
+const questTitleById = new Map(getQuestData().map((quest) => [quest.id, quest.title]));
+const itemById = new Map(items.map((item) => [item.id, item]));
+const processById = new Map(processes.map((process) => [process.id, process]));
+
+const getInventoryEntries = (inventory = {}) =>
+    Object.entries(inventory || {})
+        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
+        .map(([id, count]) => ({ id, count, name: itemById.get(id)?.name || id }))
+        .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
+const matchesQuery = (entry, queryTokens, queryText) => {
+    if (!queryText || queryTokens.length === 0) return false;
+    const haystack = normalizeText(`${entry.id} ${entry.name}`);
+    if (haystack && queryText.includes(haystack)) return true;
+    const entryTokens = tokensFor(`${entry.id} ${entry.name}`);
+    return entryTokens.some((token) => queryTokens.includes(token));
+};
+
+const isInventoryBroadQuery = (queryText) =>
+    /\binventory\b|\bitems?\b|\bwhat do i have\b/i.test(queryText);
+
+const getActiveProcessEntries = (
+    gameState = {},
+    cap = PLAYER_STATE_SUMMARY_LIMITS.activeProcesses
+) =>
+    Object.entries(gameState.processes || {})
+        .filter(([, state]) => state && (state.startedAt || state.pausedAt || state.duration))
+        .sort(([a], [b]) => a.localeCompare(b))
+        .slice(0, cap)
+        .map(([id, state]) => {
+            const process = processById.get(id);
+            const title = process?.title || id;
+            const status = state.pausedAt ? 'paused' : 'running';
+            return `${title} [${id}] ${status}`;
+        });
+
+const buildRawPlayerState = (gameState, options = {}) => {
+    const inventoryEntries = getInventoryEntries(gameState.inventory);
+    const maxInventoryEntries = options.maxInventoryEntries || 50;
+    const includedInventory = inventoryEntries.slice(0, maxInventoryEntries);
+    const questsFinished = Object.entries(gameState.quests || {})
+        .filter(([, questState]) => questState?.finished)
+        .map(([questId]) => questId)
+        .sort((a, b) => a.localeCompare(b));
+    const questStats = getOfficialQuestStats(gameState);
+    const versionNumberString = normalizeVersionNumberString(gameState.versionNumberString);
+    const snapshot = {
+        versionNumberString,
+        questsFinished,
+        inventory: includedInventory.map(({ id, count }) => ({ id, count })),
+    };
+    const block = `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}\nPlayerState v${versionNumberString} (raw debug mode):\n${JSON.stringify(snapshot, null, 2)}`;
+    return {
+        block,
+        meta: {
+            included: true,
+            mode: 'raw',
+            playerStatePromptMode: 'raw',
+            completedQuestCount: questStats.completedQuestCount,
+            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+            remainingQuestIncludedCount: 0,
+            inventoryTotalCount: inventoryEntries.length,
+            inventoryIncludedCount: includedInventory.length,
+            inventoryTruncated: inventoryEntries.length > includedInventory.length,
+            activeProcessIncludedCount: 0,
+            compactStateBlockChars: block.length,
+        },
+        slices: { inventoryEntries: includedInventory },
+    };
+};
+
+export function buildPlayerStatePromptSummary(gameState, options = {}) {
+    const mode =
+        options.includeRawPlayerState || options.playerStatePromptMode === 'raw'
+            ? 'raw'
+            : 'compact';
+    if (!gameState || typeof gameState !== 'object') {
+        const questStats = getOfficialQuestStats(null);
+        return {
+            block: null,
+            meta: {
+                included: false,
+                mode: 'none',
+                playerStatePromptMode: 'none',
+                completedQuestCount: questStats.completedQuestCount,
+                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+                remainingQuestIncludedCount: 0,
+                inventoryTotalCount: 0,
+                inventoryIncludedCount: 0,
+                inventoryTruncated: false,
+                activeProcessIncludedCount: 0,
+                compactStateBlockChars: 0,
+            },
+            slices: {
+                resourceBalances: [],
+                relevantInventory: [],
+                remainingQuests: [],
+                activeProcesses: [],
+            },
+        };
+    }
+    if (mode === 'raw') return buildRawPlayerState(gameState, options);
+
+    const limits = { ...PLAYER_STATE_SUMMARY_LIMITS, ...(options.limits || {}) };
+    const latestUserMessage = options.latestUserMessage || options.query || '';
+    const queryText = normalizeText(latestUserMessage);
+    const queryTokens = tokensFor(latestUserMessage);
+    const inventoryEntries = getInventoryEntries(gameState.inventory);
+    const resourceBalances = inventoryEntries.filter(
+        (entry) =>
+            NOTABLE_RESOURCE_IDS.some((id) => id.toLowerCase() === entry.id.toLowerCase()) ||
+            /^d[A-Z]/.test(entry.id)
+    );
+    const relevantInventory = inventoryEntries.filter((entry) =>
+        matchesQuery(entry, queryTokens, queryText)
+    );
+    const inventorySample = isInventoryBroadQuery(latestUserMessage)
+        ? inventoryEntries
+              .filter((entry) => !resourceBalances.some((resource) => resource.id === entry.id))
+              .slice(0, limits.inventorySample)
+        : [];
+    const includedInventory = [
+        ...new Map(
+            [...resourceBalances, ...relevantInventory, ...inventorySample].map((entry) => [
+                entry.id,
+                entry,
+            ])
+        ).values(),
+    ].slice(0, limits.relevantInventory);
+
+    const officialQuestIds = listBuiltInQuestIds().sort((a, b) => a.localeCompare(b));
+    const finishedOfficial = new Set(
+        Object.entries(gameState.quests || {})
+            .filter(([, questState]) => questState?.finished)
+            .map(([questId]) => questId)
+    );
+    const remainingQuests = officialQuestIds
+        .filter((questId) => !finishedOfficial.has(questId))
+        .map((id) => ({ id, title: questTitleById.get(id) || id }));
+    const includedRemainingQuests = remainingQuests.slice(0, limits.remainingQuests);
+    const questStats = getOfficialQuestStats(gameState);
+    const activeProcesses = getActiveProcessEntries(gameState, limits.activeProcesses);
+    const activeProcessTotalCount = Object.values(gameState.processes || {}).filter(
+        (state) => state && (state.startedAt || state.pausedAt || state.duration)
+    ).length;
+    const versionNumberString = normalizeVersionNumberString(gameState.versionNumberString);
+    const inventoryOmitted = inventoryEntries.length > includedInventory.length;
+    const questOmitted = remainingQuests.length > includedRemainingQuests.length;
+
+    const lines = [
+        `PlayerState compact summary v${versionNumberString}:`,
+        'This compact PlayerState summary is authoritative for the fields shown.',
+        `Official quests: completed ${questStats.completedQuestCount}/${questStats.totalOfficialQuestCount}; remaining ${questStats.remainingOfficialQuestCount}.`,
+        includedRemainingQuests.length
+            ? `Remaining official quests shown (cap ${limits.remainingQuests}): ${includedRemainingQuests.map((quest) => `${quest.title} [${quest.id}]`).join('; ')}${questOmitted ? `; +${remainingQuests.length - includedRemainingQuests.length} more omitted` : ''}.`
+            : 'Remaining official quests shown: none.',
+        `Active/running processes: ${activeProcessTotalCount}${activeProcesses.length ? `; shown: ${activeProcesses.join('; ')}` : ''}.`,
+        `Inventory: ${inventoryEntries.length} owned item/resource entr${inventoryEntries.length === 1 ? 'y' : 'ies'}.`,
+    ];
+
+    if (resourceBalances.length) {
+        lines.push(
+            `Notable balances: ${resourceBalances.map((entry) => `${entry.name} [${entry.id}]=${formatCount(entry.count)}`).join('; ')}.`
+        );
+    }
+    if (includedInventory.length) {
+        lines.push(
+            `Inventory entries shown (query-relevant/resources, cap ${limits.relevantInventory}): ${includedInventory.map((entry) => `${entry.name} [${entry.id}]=${formatCount(entry.count)}`).join('; ')}.`
+        );
+    } else {
+        lines.push(
+            `Inventory entries shown: none selected for this query (cap ${limits.relevantInventory}).`
+        );
+    }
+    if (inventoryOmitted || questOmitted) {
+        lines.push(
+            'Omitted inventory/quest details are not evidence that the player lacks them; they are omitted from this prompt. For exact missing details, ask a clarifying question or suggest checking the relevant DSPACE page.'
+        );
+    }
+
+    const block = lines.join('\n');
+    return {
+        block,
+        meta: {
+            included: true,
+            mode: 'compact',
+            playerStatePromptMode: 'compact',
+            completedQuestCount: questStats.completedQuestCount,
+            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+            remainingQuestIncludedCount: includedRemainingQuests.length,
+            inventoryTotalCount: inventoryEntries.length,
+            inventoryIncludedCount: includedInventory.length,
+            inventoryTruncated: inventoryOmitted,
+            activeProcessIncludedCount: activeProcesses.length,
+            compactStateBlockChars: block.length,
+        },
+        slices: {
+            resourceBalances,
+            relevantInventory: includedInventory,
+            remainingQuests: includedRemainingQuests,
+            activeProcesses,
+            inventoryTotalCount: inventoryEntries.length,
+            inventoryTruncated: inventoryOmitted,
+        },
+    };
+}

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,6 +73,35 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        playerState: metadata.playerStateSummary
+            ? {
+                  mode:
+                      metadata.playerStateSummary.playerStatePromptMode ||
+                      metadata.playerStateSummary.mode ||
+                      (metadata.playerStateSummary.included ? 'compact' : 'none'),
+                  completedQuestCount: Number(metadata.playerStateSummary.completedQuestCount || 0),
+                  totalOfficialQuestCount: Number(
+                      metadata.playerStateSummary.totalOfficialQuestCount || 0
+                  ),
+                  remainingOfficialQuestCount: Number(
+                      metadata.playerStateSummary.remainingOfficialQuestCount || 0
+                  ),
+                  remainingQuestIncludedCount: Number(
+                      metadata.playerStateSummary.remainingQuestIncludedCount || 0
+                  ),
+                  inventoryTotalCount: Number(metadata.playerStateSummary.inventoryTotalCount || 0),
+                  inventoryIncludedCount: Number(
+                      metadata.playerStateSummary.inventoryIncludedCount || 0
+                  ),
+                  inventoryTruncated: Boolean(metadata.playerStateSummary.inventoryTruncated),
+                  activeProcessIncludedCount: Number(
+                      metadata.playerStateSummary.activeProcessIncludedCount || 0
+                  ),
+                  compactStateBlockChars: Number(
+                      metadata.playerStateSummary.compactStateBlockChars || 0
+                  ),
+              }
+            : null,
         docsRag: metadata.contextPlan
             ? (() => {
                   const status =

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -35,6 +35,25 @@ describe('buildDchatKnowledgePack', () => {
         expect(pack.sources.some((entry) => entry.type === 'state')).toBe(true);
     });
 
+    it('bounds compact inventory highlights instead of dumping hundreds of entries', () => {
+        const greenPlaId = 'd3590107-25ff-4de5-af3a-46e2497bfc52';
+        const inventory = Object.fromEntries(
+            Array.from({ length: 120 }, (_, index) => [`uuid-owned-${index}`, index + 1])
+        );
+        const pack = buildDchatKnowledgePack(
+            { inventory: { ...inventory, [greenPlaId]: 12 } },
+            { latestUserMessage: 'do I have enough green PLA?' }
+        );
+        const highlights = pack.summary
+            .split('\n\n')
+            .find((section) => section.startsWith('Inventory highlights:'));
+
+        expect(highlights).toContain('green PLA filament');
+        expect(highlights).toContain('inventory omitted beyond compact cap');
+        expect(highlights).not.toContain('uuid-owned-119');
+        expect((highlights?.match(/uuid-owned-/g) || []).length).toBeLessThan(10);
+    });
+
     it('caps achievement sources to the configured limit', () => {
         const unlocked = Array.from({ length: 4 }, (_, index) => ({
             id: `unlocked-${index + 1}`,

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -557,7 +557,7 @@ describe('buildChatPrompt', () => {
         expect(content).toContain('/docs/routes');
     });
 
-    it('injects PlayerState with finished quests and inventory entries', async () => {
+    it('injects compact PlayerState without raw finished quest or inventory dumps', async () => {
         vi.mocked(loadGameState).mockReturnValueOnce({
             openAI: {},
             versionNumberString: '3',
@@ -575,50 +575,24 @@ describe('buildChatPrompt', () => {
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Status?' }]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerState v3')
+            message.content?.includes('PlayerState compact summary v3')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
-        );
-        const jsonStart = content.indexOf('{');
-        const jsonBody = jsonStart >= 0 ? content.slice(jsonStart) : '';
-        const snapshot = jsonBody ? JSON.parse(jsonBody) : null;
 
-        expect(snapshot?.versionNumberString).toBe('3');
-        expect(statsMatch).not.toBeNull();
-        expect(snapshot?.questsFinished).toEqual(
-            expect.arrayContaining(['welcome/howtodoquests', '3dprinter/start'])
-        );
-        expect(snapshot?.questsFinished).not.toEqual(
-            expect.arrayContaining(['welcome/intro-inventory'])
-        );
-        expect(snapshot?.inventory).toEqual(
-            expect.arrayContaining([
-                { id: 'item-alpha', count: 12 },
-                { id: 'item-gamma', count: 5.5 },
-            ])
-        );
+        expect(content).toContain('Official quests: completed');
+        expect(content).toContain('remaining');
+        expect(content).not.toContain('questsFinished');
+        expect(content).not.toContain('item-alpha');
+        expect(content).toContain('Omitted inventory/quest details are not evidence');
         expect(payload.playerStateSummary).toEqual(
             expect.objectContaining({
                 included: true,
-                questsFinishedCount: 2,
-                completedQuestCount: Number(statsMatch?.[1]),
-                totalOfficialQuestCount: Number(statsMatch?.[2]),
-                remainingOfficialQuestCount: Number(statsMatch?.[3]),
-                inventoryIncludedCount: 2,
-                inventoryTruncated: false,
+                playerStatePromptMode: 'compact',
+                completedQuestCount: 1,
+                inventoryTotalCount: 2,
+                inventoryIncludedCount: 0,
+                inventoryTruncated: true,
             })
-        );
-        // '3dprinter/start' is intentionally non-canonical (real ID is '3dprinting/start').
-        // This verifies only official quest IDs count toward completedQuestCount.
-        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
-        expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
-            Math.max(
-                payload.playerStateSummary.totalOfficialQuestCount -
-                    payload.playerStateSummary.completedQuestCount,
-                0
-            )
         );
     });
 
@@ -635,17 +609,15 @@ describe('buildChatPrompt', () => {
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Quest totals?' }]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerStateStats:')
+            message.content?.includes('PlayerState compact summary')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
+        expect(content).toContain('Official quests: completed 1/');
+        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
+        expect(payload.playerStateSummary.totalOfficialQuestCount).toBeGreaterThan(1);
+        expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
+            payload.playerStateSummary.totalOfficialQuestCount - 1
         );
-
-        expect(statsMatch).not.toBeNull();
-        expect(Number(statsMatch?.[1])).toBe(1);
-        expect(Number(statsMatch?.[2])).toBeGreaterThan(1);
-        expect(Number(statsMatch?.[3])).toBe(Number(statsMatch?.[2]) - Number(statsMatch?.[1]));
     });
 
     it('skips docs RAG for player-state-only full prompts', async () => {
@@ -665,6 +637,30 @@ describe('buildChatPrompt', () => {
         expect(searchDocsRag).not.toHaveBeenCalled();
         expect(payload.contextSources.every((source) => source.type !== 'doc')).toBe(true);
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
+    });
+
+    it('includes query-relevant owned green PLA without dumping full inventory', async () => {
+        const greenPlaId = 'd3590107-25ff-4de5-af3a-46e2497bfc52';
+        const fillerInventory = Object.fromEntries(
+            Array.from({ length: 40 }, (_, index) => [`uuid-filler-${index}`, index + 1])
+        );
+        vi.mocked(loadGameState).mockReturnValueOnce({
+            openAI: {},
+            versionNumberString: '3',
+            quests: {},
+            inventory: { ...fillerInventory, [greenPlaId]: 30 },
+        });
+
+        const payload = await buildChatPrompt([
+            { role: 'user', content: 'do I have enough green PLA?' },
+        ]);
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(prompt).toContain('green PLA filament');
+        expect(prompt).toContain('30');
+        expect(prompt).not.toContain('uuid-filler-39');
+        expect(payload.playerStateSummary.playerStatePromptMode).toBe('compact');
     });
 
     it('reports forced docs RAG consistently in plan metadata and prompt metrics', async () => {

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayerStatePromptSummary } from '../src/utils/playerStatePromptSummary.js';
+
+const greenPlaId = 'd3590107-25ff-4de5-af3a-46e2497bfc52';
+const dSolarId = 'b02ecff5-1f7d-4247-a09d-7d6cd6bb218a';
+
+const manyInventory = Object.fromEntries(
+    Array.from({ length: 60 }, (_, index) => [
+        `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+        index + 1,
+    ])
+);
+
+const manyFinishedQuests = Object.fromEntries(
+    Array.from({ length: 40 }, (_, index) => [`custom/finished-${index}`, { finished: true }])
+);
+
+describe('buildPlayerStatePromptSummary', () => {
+    it('summarizes finished quests with counts instead of a raw questsFinished array', () => {
+        const summary = buildPlayerStatePromptSummary({
+            versionNumberString: '3',
+            quests: manyFinishedQuests,
+            inventory: {},
+        });
+
+        expect(summary.block).toContain('PlayerState compact summary v3');
+        expect(summary.block).toContain('Official quests: completed');
+        expect(summary.block).not.toContain('questsFinished');
+        expect(summary.block).not.toContain('custom/finished-39');
+        expect(summary.meta.remainingQuestIncludedCount).toBeLessThanOrEqual(12);
+        expect(summary.block).toContain('Omitted inventory/quest details are not evidence');
+    });
+
+    it('bounds inventory entries and reports truncation metadata', () => {
+        const summary = buildPlayerStatePromptSummary(
+            {
+                versionNumberString: '3',
+                quests: {},
+                inventory: { ...manyInventory, [greenPlaId]: 25 },
+            },
+            { latestUserMessage: 'what is my inventory?' }
+        );
+
+        expect(summary.meta.inventoryTotalCount).toBe(61);
+        expect(summary.meta.inventoryIncludedCount).toBeLessThanOrEqual(8);
+        expect(summary.meta.inventoryTruncated).toBe(true);
+        expect(summary.block).toContain('Inventory: 61 owned item/resource entries');
+        expect(summary.block).not.toContain('00000000-0000-4000-8000-000000000059');
+        expect(summary.block).toContain('omitted from this prompt');
+    });
+
+    it('includes query-relevant green PLA when present', () => {
+        const summary = buildPlayerStatePromptSummary(
+            {
+                versionNumberString: '3',
+                quests: {},
+                inventory: { ...manyInventory, [greenPlaId]: 42 },
+            },
+            { latestUserMessage: 'do I have enough green PLA?' }
+        );
+
+        expect(summary.block).toContain('green PLA filament');
+        expect(summary.block).toContain('42');
+        expect(summary.meta.inventoryIncludedCount).toBeLessThanOrEqual(8);
+    });
+
+    it('includes notable dSolar balances when mentioned or present', () => {
+        const summary = buildPlayerStatePromptSummary(
+            {
+                versionNumberString: '3',
+                quests: {},
+                inventory: { [dSolarId]: 7 },
+            },
+            { latestUserMessage: 'dSolar' }
+        );
+
+        expect(summary.block).toContain('dSolar');
+        expect(summary.block).toContain('7');
+        expect(summary.meta.inventoryTruncated).toBe(false);
+    });
+
+    it('does not include arbitrary huge inventory details for unrelated state questions', () => {
+        const summary = buildPlayerStatePromptSummary(
+            {
+                versionNumberString: '3',
+                quests: {},
+                inventory: { ...manyInventory, [greenPlaId]: 42 },
+            },
+            { latestUserMessage: 'what quest do I have left?' }
+        );
+
+        expect(summary.block).not.toContain('green PLA filament');
+        expect(summary.block).not.toContain('00000000-0000-4000-8000-000000000020');
+        expect(summary.meta.inventoryIncludedCount).toBe(0);
+        expect(summary.meta.inventoryTruncated).toBe(true);
+    });
+});


### PR DESCRIPTION
### Motivation
- Full-mode chat prompts were sending bulky raw PlayerState (long finished-quest arrays and full inventory dumps) that wasted tokens and hurt local-model performance.  
- Keep authoritative grounding for common progress/inventory/resource questions while avoiding UUID-heavy lists and duplicated state across PlayerState and dChat knowledge.  
- Make live-state inclusion query-aware (include specific owned items/balances only when relevant) and expose safe, non-sensitive prompt metrics.

### Description
- Add `buildPlayerStatePromptSummary(gameState, options)` as `frontend/src/utils/playerStatePromptSummary.js` to produce deterministic, side-effect-free compact state projections that return `{ block, meta, slices }` and an opt-in `raw` mode.  
- Wire full-mode prompt construction to use the compact PlayerState by default in `frontend/src/utils/openAI.js`, passing the structured summary into `buildDchatKnowledgePack` so both system PlayerState and dChat inventory highlights remain compact and consistent.  
- Update `frontend/src/utils/dchatKnowledge.js` to prefer the compact, bounded inventory slice from the state summary (query-relevant items + notable resource balances) and emit an omission note when truncation occurs.  
- Add safe prompt-metrics fields in `frontend/src/utils/promptMetrics.js` for state-summary metadata (mode, completed/total/remaining quest counts, inventory included/total/truncated, active-process counts, compact block char count) without exposing raw JSON or prompt text.  
- Add focused tests: `frontend/tests/playerStatePromptSummary.test.ts` (compact summary behavior and query-relevant selection), extend `frontend/tests/dchatKnowledgePack.test.ts` and `frontend/tests/openAI.test.ts` with assertions validating compact PlayerState injection and bounded dChat highlights.  
- Preserve existing behaviors: minimal-mode (P16) still omits PlayerState, docs-RAG gating/budgets (P17/P18) unchanged, and token.place / token-lite routing unchanged.

### Testing
- Ran the focused test commands and verification builds locally in `frontend/`:  
  - `npm test -- openAI` — Succeeded (OpenAI prompt tests and integration checks passed).  
  - `npm test -- dchatKnowledge` — Succeeded (dChat knowledge compaction tests passed).  
  - `npm test -- chatContextPlanner` — Succeeded (context planner regression tests passed).  
  - `npm test -- tokenPlace.test.js` — Succeeded (token.place routing and relay tests passed).  
  - `npm test -- playerStatePromptSummary` — Succeeded (new unit tests passed).  
  - `npm run check` — Succeeded (lint/format checks passed).  
  - `npm run build` — Succeeded (frontend build completed).  

All automated tests referenced in the prompt passed in this run and the build finished successfully. Follow-ups: monitor staging token counts for representative full-mode flows (e.g., “what quest do I have left?”, “do I have enough green PLA?”, “what is my inventory?”) to confirm token savings in practice and adjust caps if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f829242e4832f85775d207ff2b656)