### PR TITLE
Compact live PlayerState prompt summaries

### DIFF
--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -2,6 +2,7 @@ import items from '../pages/inventory/json/items/index.js';
 import processes from '../generated/processes.json' assert { type: 'json' };
 import { evaluateAchievements } from './achievements.js';
 import { mergeSources } from './contextSources.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 
 const MAX_ITEMS = 25;
 const MAX_PROCESSES = 20;
@@ -9,6 +10,7 @@ const MAX_QUESTS = 25;
 const MAX_QUEST_STATUS_ENTRIES = 12;
 const MAX_PROCESS_STATUS_ENTRIES = 8;
 const MAX_ACHIEVEMENT_ENTRIES = 6;
+const MAX_STATE_INVENTORY_HIGHLIGHTS = 8;
 const PRIORITY_QUEST_IDS = [
     'welcome/howtodoquests',
     'welcome/intro-inventory',
@@ -288,17 +290,31 @@ function summarizeProcessProgress(gameState = {}) {
         .sort((a, b) => a.localeCompare(b));
 }
 
-export function buildDchatKnowledgePack(gameState = {}) {
+export function buildDchatKnowledgePack(gameState = {}, options = {}) {
     const knowledgeSections = [];
     const sources = [];
     const stateDetails = [];
 
-    const inventorySummary = formatInventory(gameState.inventory);
-    if (inventorySummary.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.inventoryHighlights}: ${inventorySummary.join('; ')}`
+    const stateSummary =
+        options.playerStateSummary ||
+        buildPlayerStatePromptSummary(gameState, {
+            latestUserMessage: options.latestUserMessage || '',
+            includeInventorySample: true,
+        });
+    const compactInventoryEntries = (stateSummary.slices?.inventory?.included || [])
+        .slice(0, MAX_STATE_INVENTORY_HIGHLIGHTS)
+        .map(
+            (entry) =>
+                `${entry.name} (x${Number.isInteger(entry.count) ? entry.count : Number(entry.count).toFixed(2)})`
         );
-        stateDetails.push('inventory');
+    if (compactInventoryEntries.length > 0) {
+        const omittedNote = stateSummary.meta?.inventoryTruncated
+            ? `; additional owned inventory omitted (${stateSummary.meta.inventoryTotalCount} total item types)`
+            : '';
+        knowledgeSections.push(
+            `${dchatKnowledgeScaffolding.inventoryHighlights}: ${compactInventoryEntries.join('; ')}${omittedNote}`
+        );
+        stateDetails.push('compact inventory');
     }
 
     const itemEntries = getItemsForKnowledge();

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -1,5 +1,4 @@
 import { loadGameState, ready } from './gameState/common.js';
-import { getOfficialQuestStats } from './gameState/questStats.js';
 import { buildDchatKnowledgePack } from './dchatKnowledge.js';
 import { mergeSources } from './contextSources.js';
 import { searchDocsRag } from './docsRag.js';
@@ -9,6 +8,7 @@ import { getPromptVersionLabel, getPromptVersionSha } from './buildInfo.js';
 import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
+import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -113,7 +113,6 @@ const vagueFollowupPattern =
     /^\s*(what about|and then|that step|the second step|next step|step 2)\b/i;
 const retrievalContextLimit = 800;
 const retrievalQueryLimit = 1000;
-const MAX_PLAYER_STATE_ITEMS = 50;
 export const CHAT_DOCS_RAG_DEFAULTS = Object.freeze({
     maxResults: 6,
     maxChars: 8000,
@@ -317,94 +316,9 @@ const countPromptChars = (messages) => {
     return messages.reduce((total, message) => total + (message?.content?.length || 0), 0);
 };
 
-const normalizeVersionNumberString = (value) => {
-    if (typeof value === 'string' && value.trim()) {
-        return value.trim();
-    }
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return String(value);
-    }
-    return '3';
-};
-
-const buildPlayerStateSnapshot = (gameState, options = {}) => {
-    const { maxInventoryEntries = MAX_PLAYER_STATE_ITEMS } = options;
-    if (!gameState || typeof gameState !== 'object') {
-        const questStats = getOfficialQuestStats(null);
-        return {
-            block: null,
-            meta: {
-                included: false,
-                questsFinishedCount: 0,
-                completedQuestCount: questStats.completedQuestCount,
-                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-                inventoryIncludedCount: 0,
-                inventoryTotalCount: 0,
-                inventoryTruncated: false,
-            },
-        };
-    }
-
-    const questsFinished = Object.entries(gameState.quests || {})
-        .filter(([, questState]) => questState?.finished)
-        .map(([questId]) => questId)
-        .sort((a, b) => a.localeCompare(b));
-
-    const inventoryEntries = Object.entries(gameState.inventory || {})
-        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
-        .map(([id, count]) => ({ id, count }))
-        .sort((a, b) => {
-            if (b.count !== a.count) {
-                return b.count - a.count;
-            }
-            return a.id.localeCompare(b.id);
-        });
-
-    const totalItems = inventoryEntries.length;
-    const truncated = totalItems > maxInventoryEntries;
-    const includedInventory = truncated
-        ? inventoryEntries.slice(0, maxInventoryEntries)
-        : inventoryEntries;
-
-    const versionNumberString = normalizeVersionNumberString(gameState.versionNumberString);
-    const questStats = getOfficialQuestStats(gameState);
-    const snapshot = {
-        versionNumberString,
-        questsFinished,
-        inventory: includedInventory,
-    };
-
-    if (truncated) {
-        snapshot.truncated = true;
-        snapshot.totalItems = totalItems;
-    }
-
-    const statsBlock = `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}`;
-    const block = `${statsBlock}\nPlayerState v${versionNumberString} (authoritative; do not infer beyond this):\n${JSON.stringify(
-        snapshot,
-        null,
-        2
-    )}`;
-
-    return {
-        block,
-        meta: {
-            included: true,
-            questsFinishedCount: questsFinished.length,
-            completedQuestCount: questStats.completedQuestCount,
-            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
-            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
-            inventoryIncludedCount: includedInventory.length,
-            inventoryTotalCount: totalItems,
-            inventoryTruncated: truncated,
-        },
-    };
-};
-
 export const getPlayerStateSummary = (gameState = loadGameState()) => {
     const hasGameState = gameState && typeof gameState === 'object';
-    return buildPlayerStateSnapshot(hasGameState ? gameState : null).meta;
+    return buildPlayerStatePromptSummary(hasGameState ? gameState : null).meta;
 };
 
 const buildDocsRagOptions = ({ promptBudgetChars, options, baseMessages }) => {
@@ -726,6 +640,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 inventoryIncludedCount: 0,
                 inventoryTotalCount: 0,
                 inventoryTruncated: false,
+                playerStatePromptMode: 'none',
+                remainingQuestIncludedCount: 0,
+                activeProcessIncludedCount: 0,
+                compactStateBlockChars: 0,
             },
             contextPlan: contextPlanMetadata,
         };
@@ -772,7 +690,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
         role: 'system',
         content: `Prompt version: v3:${getPromptVersionSha()}\n${fullSystemPrompt}`,
     };
-    const playerStateSnapshot = buildPlayerStateSnapshot(hasGameState ? rawGameState : null);
+    const playerStateSnapshot = buildPlayerStatePromptSummary(hasGameState ? rawGameState : null, {
+        latestUserMessage: latestUserMessage?.content || '',
+        playerStatePromptMode: options.playerStatePromptMode,
+        includeRawPlayerState: options.includeRawPlayerState,
+    });
     const playerStateMessage = playerStateSnapshot.block
         ? {
               role: 'system',
@@ -780,7 +702,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
           }
         : null;
 
-    const knowledgePack = buildDchatKnowledgePack(gameState);
+    const knowledgePack = buildDchatKnowledgePack(gameState, {
+        latestUserMessage: latestUserMessage?.content || '',
+        playerStateSummary: playerStateSnapshot,
+    });
     const knowledgeSummary = knowledgePack.summary;
     const knowledgeMessage = knowledgeSummary
         ? {
@@ -938,6 +863,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 chatHistory: chatHistoryIndexes,
                 latestUserMessage: latestUserMessageIndex,
             },
+            playerStateSummary: playerStateSnapshot.meta,
         });
     }
 

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -1,0 +1,260 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+import { getOfficialQuestStats } from './gameState/questStats.js';
+import { getBuiltInQuest, listBuiltInQuestIds } from './builtInQuests.js';
+
+export const PLAYER_STATE_SUMMARY_LIMITS = Object.freeze({
+    remainingQuestCap: 12,
+    activeProcessCap: 6,
+    relevantInventoryCap: 8,
+    inventorySampleCap: 8,
+});
+
+const NOTABLE_RESOURCE_NAMES = [
+    'dUSD',
+    'dBI',
+    'dWatt',
+    'dSolar',
+    'dPrint',
+    'dLaunch',
+    'dWind',
+    'dCarbon',
+    'dOffset',
+];
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const itemById = new Map(items.map((item) => [item.id, item]));
+const processById = new Map(processes.map((process) => [process.id, process]));
+
+const normalizeVersionNumberString = (value) => {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+    return '3';
+};
+
+const formatCount = (count) => (Number.isInteger(count) ? String(count) : Number(count).toFixed(2));
+const normalizeText = (text) =>
+    String(text || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+const hasInventoryIntent = (query) => {
+    const text = query || '';
+    if (
+        /\bquests?\b|\bprocess(?:es)?\b/i.test(text) &&
+        !/\binventory\b|\bitems?\b|\bowned\b|\bbalance\b|\bafford\b|\benough\b/i.test(text)
+    ) {
+        return false;
+    }
+    return /\binventory\b|\bitems?\b|\bowned\b|\bhave\b|\benough\b|\bbalance\b|\bafford\b/i.test(
+        text
+    );
+};
+
+const getInventoryEntries = (inventory = {}) =>
+    Object.entries(inventory || {})
+        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
+        .map(([id, count]) => {
+            const item = itemById.get(id);
+            return {
+                id,
+                count,
+                name: item?.name || id,
+                category: item?.category || '',
+                isUuid: uuidPattern.test(id),
+            };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
+const queryMatchesEntry = (entry, queryText) => {
+    const normalizedQuery = normalizeText(queryText);
+    if (!normalizedQuery) return false;
+    const haystacks = [entry.name, entry.id, entry.category].map(normalizeText).filter(Boolean);
+    if (haystacks.some((haystack) => haystack && normalizedQuery.includes(haystack))) return true;
+    const queryTokens = new Set(normalizedQuery.split(' ').filter((token) => token.length >= 2));
+    return haystacks.some((haystack) => {
+        const tokens = haystack.split(' ').filter((token) => token.length >= 2);
+        return tokens.length > 0 && tokens.every((token) => queryTokens.has(token));
+    });
+};
+
+const summarizeInventoryEntry = (entry) => `${entry.name} (x${formatCount(entry.count)})`;
+
+const buildInventorySlices = (gameState, latestUserMessage, limits) => {
+    const entries = getInventoryEntries(gameState?.inventory);
+    const notableResources = entries.filter((entry) => NOTABLE_RESOURCE_NAMES.includes(entry.name));
+    const queryRelevant = entries.filter((entry) => queryMatchesEntry(entry, latestUserMessage));
+    const wantsInventory =
+        Boolean(limits.includeInventorySample) || hasInventoryIntent(latestUserMessage);
+    const sample = wantsInventory
+        ? entries
+              .filter(
+                  (entry) => !notableResources.includes(entry) && !queryRelevant.includes(entry)
+              )
+              .slice(0, limits.inventorySampleCap)
+        : [];
+    const merged = [];
+    for (const entry of [...notableResources, ...queryRelevant, ...sample]) {
+        if (!merged.some((existing) => existing.id === entry.id)) merged.push(entry);
+    }
+    const included = merged.slice(0, limits.relevantInventoryCap);
+    return {
+        entries,
+        notableResources,
+        queryRelevant: queryRelevant.slice(0, limits.relevantInventoryCap),
+        sample,
+        included,
+        omitted: entries.length > included.length,
+    };
+};
+
+const getRemainingQuestEntries = (gameState, cap) => {
+    const finished = new Set(
+        Object.entries(gameState?.quests || {})
+            .filter(([, questState]) => questState?.finished)
+            .map(([questId]) => questId)
+    );
+    return listBuiltInQuestIds()
+        .filter((questId) => !finished.has(questId))
+        .sort((a, b) => a.localeCompare(b))
+        .slice(0, cap)
+        .map((questId) => {
+            const quest = getBuiltInQuest(questId);
+            return { id: questId, title: quest?.title || questId };
+        });
+};
+
+const getActiveProcesses = (gameState, cap) =>
+    Object.entries(gameState?.processes || {})
+        .filter(([, processState]) => processState?.startedAt && !processState?.completedAt)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .slice(0, cap)
+        .map(([processId, processState]) => ({
+            id: processId,
+            title: processById.get(processId)?.title || processId,
+            status: processState?.pausedAt ? 'paused' : 'running',
+        }));
+
+export function buildRawPlayerStatePromptSummary(gameState, options = {}) {
+    const maxInventoryEntries = Number.isInteger(options.maxInventoryEntries)
+        ? options.maxInventoryEntries
+        : 50;
+    if (!gameState || typeof gameState !== 'object') {
+        const questStats = getOfficialQuestStats(null);
+        return {
+            block: null,
+            meta: {
+                playerStatePromptMode: 'none',
+                included: false,
+                completedQuestCount: questStats.completedQuestCount,
+                totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+                remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+                remainingQuestIncludedCount: 0,
+                inventoryIncludedCount: 0,
+                inventoryTotalCount: 0,
+                inventoryTruncated: false,
+                activeProcessIncludedCount: 0,
+                compactStateBlockChars: 0,
+            },
+        };
+    }
+    const questsFinished = Object.entries(gameState.quests || {})
+        .filter(([, questState]) => questState?.finished)
+        .map(([questId]) => questId)
+        .sort((a, b) => a.localeCompare(b));
+    const inventory = getInventoryEntries(gameState.inventory).sort(
+        (a, b) => b.count - a.count || a.id.localeCompare(b.id)
+    );
+    const includedInventory = inventory.slice(0, maxInventoryEntries);
+    const questStats = getOfficialQuestStats(gameState);
+    const block = `PlayerStateStats: completedOfficialQuests=${questStats.completedQuestCount}, totalOfficialQuests=${questStats.totalOfficialQuestCount}, remainingOfficialQuests=${questStats.remainingOfficialQuestCount}\nPlayerState v${normalizeVersionNumberString(gameState.versionNumberString)} (authoritative; do not infer beyond this):\n${JSON.stringify({ versionNumberString: normalizeVersionNumberString(gameState.versionNumberString), questsFinished, inventory: includedInventory.map(({ id, count }) => ({ id, count })), ...(inventory.length > includedInventory.length ? { truncated: true, totalItems: inventory.length } : {}) }, null, 2)}`;
+    return {
+        block,
+        meta: {
+            playerStatePromptMode: 'raw',
+            included: true,
+            questsFinishedCount: questsFinished.length,
+            completedQuestCount: questStats.completedQuestCount,
+            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+            remainingQuestIncludedCount: 0,
+            inventoryIncludedCount: includedInventory.length,
+            inventoryTotalCount: inventory.length,
+            inventoryTruncated: inventory.length > includedInventory.length,
+            activeProcessIncludedCount: 0,
+            compactStateBlockChars: block.length,
+        },
+    };
+}
+
+export function buildPlayerStatePromptSummary(gameState, options = {}) {
+    if (options.playerStatePromptMode === 'raw' || options.includeRawPlayerState) {
+        return buildRawPlayerStatePromptSummary(gameState, options);
+    }
+    const limits = {
+        ...PLAYER_STATE_SUMMARY_LIMITS,
+        includeInventorySample: Boolean(options.includeInventorySample),
+        ...(options.limits || {}),
+    };
+    if (!gameState || typeof gameState !== 'object')
+        return buildRawPlayerStatePromptSummary(null, options);
+
+    const questStats = getOfficialQuestStats(gameState);
+    const remainingQuests = getRemainingQuestEntries(gameState, limits.remainingQuestCap);
+    const activeProcesses = getActiveProcesses(gameState, limits.activeProcessCap);
+    const inventorySlices = buildInventorySlices(
+        gameState,
+        options.latestUserMessage || '',
+        limits
+    );
+    const lines = [
+        `PlayerState compact summary v${normalizeVersionNumberString(gameState.versionNumberString)}.`,
+        'This compact PlayerState summary is authoritative for the fields shown.',
+        `Official quests: completed ${questStats.completedQuestCount}/${questStats.totalOfficialQuestCount}; remaining ${questStats.remainingOfficialQuestCount}.`,
+    ];
+    if (remainingQuests.length > 0)
+        lines.push(
+            `Remaining official quests shown (cap ${limits.remainingQuestCap}): ${remainingQuests.map((quest) => `${quest.id} — ${quest.title}`).join(' | ')}`
+        );
+    if (questStats.remainingOfficialQuestCount > remainingQuests.length)
+        lines.push(
+            `Remaining quest list truncated: ${questStats.remainingOfficialQuestCount - remainingQuests.length} additional official quest(s) omitted.`
+        );
+    lines.push(
+        `Active/running processes: ${activeProcesses.length}${activeProcesses.length ? ` shown (cap ${limits.activeProcessCap}): ${activeProcesses.map((process) => `${process.title} [${process.id}] ${process.status}`).join(' | ')}` : ''}.`
+    );
+    lines.push(`Inventory: ${inventorySlices.entries.length} owned item type(s).`);
+    if (inventorySlices.notableResources.length > 0)
+        lines.push(
+            `Notable balances: ${inventorySlices.notableResources.map(summarizeInventoryEntry).join('; ')}.`
+        );
+    if (inventorySlices.included.length > 0)
+        lines.push(
+            `Inventory entries shown (query-relevant/resources/sample; cap ${limits.relevantInventoryCap}): ${inventorySlices.included.map(summarizeInventoryEntry).join('; ')}.`
+        );
+    if (inventorySlices.omitted)
+        lines.push(
+            `Inventory details omitted/truncated: ${Math.max(0, inventorySlices.entries.length - inventorySlices.included.length)} owned item type(s) not shown.`
+        );
+    lines.push(
+        'Omitted inventory/quest details are not evidence that the player lacks them; for exact missing details, ask a clarifying question or suggest checking the relevant DSPACE page.'
+    );
+    const block = lines.join('\n');
+    return {
+        block,
+        meta: {
+            playerStatePromptMode: 'compact',
+            included: true,
+            completedQuestCount: questStats.completedQuestCount,
+            totalOfficialQuestCount: questStats.totalOfficialQuestCount,
+            remainingOfficialQuestCount: questStats.remainingOfficialQuestCount,
+            remainingQuestIncludedCount: remainingQuests.length,
+            inventoryTotalCount: inventorySlices.entries.length,
+            inventoryIncludedCount: inventorySlices.included.length,
+            inventoryTruncated: inventorySlices.omitted,
+            activeProcessIncludedCount: activeProcesses.length,
+            compactStateBlockChars: block.length,
+        },
+        slices: { remainingQuests, activeProcesses, inventory: inventorySlices },
+    };
+}

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -73,6 +73,33 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        playerStateSummary: metadata.playerStateSummary
+            ? {
+                  playerStatePromptMode:
+                      metadata.playerStateSummary.playerStatePromptMode || 'none',
+                  completedQuestCount: Number(metadata.playerStateSummary.completedQuestCount || 0),
+                  totalOfficialQuestCount: Number(
+                      metadata.playerStateSummary.totalOfficialQuestCount || 0
+                  ),
+                  remainingOfficialQuestCount: Number(
+                      metadata.playerStateSummary.remainingOfficialQuestCount || 0
+                  ),
+                  remainingQuestIncludedCount: Number(
+                      metadata.playerStateSummary.remainingQuestIncludedCount || 0
+                  ),
+                  inventoryTotalCount: Number(metadata.playerStateSummary.inventoryTotalCount || 0),
+                  inventoryIncludedCount: Number(
+                      metadata.playerStateSummary.inventoryIncludedCount || 0
+                  ),
+                  inventoryTruncated: Boolean(metadata.playerStateSummary.inventoryTruncated),
+                  activeProcessIncludedCount: Number(
+                      metadata.playerStateSummary.activeProcessIncludedCount || 0
+                  ),
+                  compactStateBlockChars: Number(
+                      metadata.playerStateSummary.compactStateBlockChars || 0
+                  ),
+              }
+            : null,
         docsRag: metadata.contextPlan
             ? (() => {
                   const status =

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -557,7 +557,7 @@ describe('buildChatPrompt', () => {
         expect(content).toContain('/docs/routes');
     });
 
-    it('injects PlayerState with finished quests and inventory entries', async () => {
+    it('injects compact PlayerState with quest counts and bounded inventory entries', async () => {
         vi.mocked(loadGameState).mockReturnValueOnce({
             openAI: {},
             versionNumberString: '3',
@@ -573,46 +573,30 @@ describe('buildChatPrompt', () => {
             },
         });
 
-        const payload = await buildChatPrompt([{ role: 'user', content: 'Status?' }]);
+        const payload = await buildChatPrompt([{ role: 'user', content: 'what is my inventory?' }]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerState v3')
+            message.content?.includes('PlayerState compact summary v3')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
-        );
-        const jsonStart = content.indexOf('{');
-        const jsonBody = jsonStart >= 0 ? content.slice(jsonStart) : '';
-        const snapshot = jsonBody ? JSON.parse(jsonBody) : null;
 
-        expect(snapshot?.versionNumberString).toBe('3');
-        expect(statsMatch).not.toBeNull();
-        expect(snapshot?.questsFinished).toEqual(
-            expect.arrayContaining(['welcome/howtodoquests', '3dprinter/start'])
-        );
-        expect(snapshot?.questsFinished).not.toEqual(
-            expect.arrayContaining(['welcome/intro-inventory'])
-        );
-        expect(snapshot?.inventory).toEqual(
-            expect.arrayContaining([
-                { id: 'item-alpha', count: 12 },
-                { id: 'item-gamma', count: 5.5 },
-            ])
-        );
+        expect(content).toContain('Official quests: completed 1/');
+        expect(content).toContain('remaining');
+        expect(content).toContain('Inventory: 2 owned item type(s).');
+        expect(content).toContain('item-alpha (x12)');
+        expect(content).toContain('item-gamma (x5.50)');
+        expect(content).not.toContain('questsFinished');
+        expect(content).not.toContain('"inventory"');
+        expect(content).toContain('Omitted inventory/quest details are not evidence');
         expect(payload.playerStateSummary).toEqual(
             expect.objectContaining({
                 included: true,
-                questsFinishedCount: 2,
-                completedQuestCount: Number(statsMatch?.[1]),
-                totalOfficialQuestCount: Number(statsMatch?.[2]),
-                remainingOfficialQuestCount: Number(statsMatch?.[3]),
+                playerStatePromptMode: 'compact',
+                completedQuestCount: 1,
                 inventoryIncludedCount: 2,
+                inventoryTotalCount: 2,
                 inventoryTruncated: false,
             })
         );
-        // '3dprinter/start' is intentionally non-canonical (real ID is '3dprinting/start').
-        // This verifies only official quest IDs count toward completedQuestCount.
-        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
         expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
             Math.max(
                 payload.playerStateSummary.totalOfficialQuestCount -
@@ -635,17 +619,16 @@ describe('buildChatPrompt', () => {
 
         const payload = await buildChatPrompt([{ role: 'user', content: 'Quest totals?' }]);
         const playerStateMessage = payload.debugMessages.find((message) =>
-            message.content?.includes('PlayerStateStats:')
+            message.content?.includes('PlayerState compact summary')
         );
         const content = playerStateMessage?.content ?? '';
-        const statsMatch = content.match(
-            /PlayerStateStats: completedOfficialQuests=(\d+), totalOfficialQuests=(\d+), remainingOfficialQuests=(\d+)/
-        );
 
-        expect(statsMatch).not.toBeNull();
-        expect(Number(statsMatch?.[1])).toBe(1);
-        expect(Number(statsMatch?.[2])).toBeGreaterThan(1);
-        expect(Number(statsMatch?.[3])).toBe(Number(statsMatch?.[2]) - Number(statsMatch?.[1]));
+        expect(content).toContain('Official quests: completed 1/');
+        expect(payload.playerStateSummary.completedQuestCount).toBe(1);
+        expect(payload.playerStateSummary.totalOfficialQuestCount).toBeGreaterThan(1);
+        expect(payload.playerStateSummary.remainingOfficialQuestCount).toBe(
+            payload.playerStateSummary.totalOfficialQuestCount - 1
+        );
     });
 
     it('skips docs RAG for player-state-only full prompts', async () => {

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildPlayerStatePromptSummary,
+    PLAYER_STATE_SUMMARY_LIMITS,
+} from '../src/utils/playerStatePromptSummary.js';
+
+const makeInventory = (count: number) =>
+    Object.fromEntries(
+        Array.from({ length: count }, (_, index) => [`uuid-item-${index}`, index + 1])
+    );
+
+describe('buildPlayerStatePromptSummary', () => {
+    it('summarizes many finished quests with counts instead of a questsFinished array', () => {
+        const summary = buildPlayerStatePromptSummary({
+            versionNumberString: '3',
+            quests: {
+                'welcome/howtodoquests': { finished: true },
+                'welcome/intro-inventory': { finished: true },
+                'custom/very-long-finished': { finished: true },
+            },
+            inventory: {},
+        });
+
+        expect(summary.block).toContain('PlayerState compact summary v3');
+        expect(summary.block).toContain('Official quests: completed');
+        expect(summary.block).not.toContain('questsFinished');
+        expect(summary.meta.playerStatePromptMode).toBe('compact');
+        expect(summary.meta.completedQuestCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it('includes remaining official quest IDs and titles up to the cap', () => {
+        const summary = buildPlayerStatePromptSummary({
+            versionNumberString: '3',
+            quests: {},
+            inventory: {},
+        });
+
+        expect(summary.slices?.remainingQuests.length).toBeLessThanOrEqual(
+            PLAYER_STATE_SUMMARY_LIMITS.remainingQuestCap
+        );
+        expect(summary.block).toContain('Remaining official quests shown');
+        expect(summary.meta.remainingQuestIncludedCount).toBe(
+            summary.slices?.remainingQuests.length
+        );
+    });
+
+    it('bounds inventory summaries and records truncation metadata', () => {
+        const summary = buildPlayerStatePromptSummary(
+            { versionNumberString: '3', quests: {}, inventory: makeInventory(30) },
+            { latestUserMessage: 'what is my inventory?' }
+        );
+
+        expect(summary.block).toContain('Inventory: 30 owned item type(s).');
+        expect(summary.block).toContain('Inventory details omitted/truncated');
+        expect(summary.meta.inventoryTotalCount).toBe(30);
+        expect(summary.meta.inventoryIncludedCount).toBeLessThanOrEqual(
+            PLAYER_STATE_SUMMARY_LIMITS.relevantInventoryCap
+        );
+        expect(summary.meta.inventoryTruncated).toBe(true);
+    });
+
+    it('includes query-relevant green PLA and notable dSolar balances', () => {
+        const summary = buildPlayerStatePromptSummary(
+            {
+                versionNumberString: '3',
+                quests: {},
+                inventory: {
+                    'd3590107-25ff-4de5-af3a-46e2497bfc52': 42,
+                    'b02ecff5-1f7d-4247-a09d-7d6cd6bb218a': 7,
+                },
+            },
+            { latestUserMessage: 'do I have enough green PLA or dSolar?' }
+        );
+
+        expect(summary.block).toContain('green PLA filament (x42)');
+        expect(summary.block).toContain('dSolar (x7)');
+    });
+
+    it('does not include arbitrary inventory details for unrelated state questions', () => {
+        const summary = buildPlayerStatePromptSummary(
+            { versionNumberString: '3', quests: {}, inventory: makeInventory(20) },
+            { latestUserMessage: 'what quest do I have left?' }
+        );
+
+        expect(summary.meta.inventoryIncludedCount).toBe(0);
+        expect(summary.block).not.toContain('uuid-item-');
+        expect(summary.block).toContain('Omitted inventory/quest details are not evidence');
+    });
+});

--- a/tests/openAI.persona.test.ts
+++ b/tests/openAI.persona.test.ts
@@ -41,5 +41,5 @@ describe('GPT5Chat persona integration', () => {
         const lastMessage = call.input.at(-1);
         expect(lastMessage?.role).toBe('assistant');
         expect(lastMessage?.content?.[0]?.text).toContain(persona.welcomeMessage);
-    });
+    }, 10000);
 });


### PR DESCRIPTION
### Motivation
- Reduce expensive prompt payloads by replacing raw PlayerState/questsFinished/inventory dumps with a compact, authoritative summary that still supports common player-progress and resource queries.  
- Avoid duplicative bulky state signals between PlayerState and dChat knowledge while preserving full-mode routing and P16/P17/P18 behaviors.  
- Provide a deterministic, local helper that can be toggled into a raw/debug mode for tests/dev tools without exposing raw save JSON in logs.

### Description
- Add `frontend/src/utils/playerStatePromptSummary.js` implementing `buildPlayerStatePromptSummary(gameState, options)` and `buildRawPlayerStatePromptSummary(...)`, returning `block`, `meta`, and `slices` with named caps and query-aware inventory selection.  
- Replace the old PlayerState snapshot usage in `frontend/src/utils/openAI.js` so full-mode prompts use the compact summary by default and pass the summary into `buildDchatKnowledgePack`; preserve opt-in `playerStatePromptMode: 'raw'` / `includeRawPlayerState`.  
- Update `frontend/src/utils/dchatKnowledge.js` to derive bounded inventory highlights from the compact state slices (no full owned-inventory dump) and avoid duplicating facts already present in the compact block.  
- Extend `frontend/src/utils/promptMetrics.js` to expose safe state-summary metadata (mode, quest/inventory counts, truncation flags, compact block char count) and add focused unit tests: `frontend/tests/playerStatePromptSummary.test.ts`, update assertions in `frontend/tests/openAI.test.ts`, and increase persona test timeout in `tests/openAI.persona.test.ts` to accommodate the heavier prompt path.

### Testing
- Ran `cd frontend && npm test -- openAI` and related OpenAI-focused suites; all tests in that run passed.  
- Ran `cd frontend && npm test -- playerStatePromptSummary dchatKnowledge` to exercise the new helper and dChat integration; tests passed.  
- Ran `cd frontend && npm test -- tokenPlace.test.js` to validate token.place routing/behavior; suite passed.  
- Ran repository checks and build: `cd frontend && npm run check` and `cd frontend && npm run build`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f82841bdc832f9364deb9b7099c77)