### PR TITLE
Avoid arbitrary live inventory highlights in dChat knowledge

### DIFF
--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -305,15 +305,6 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
         ...(stateSummary.slices?.resourceBalances || []),
         ...(stateSummary.slices?.relevantInventory || []),
     ];
-    if (compactInventoryEntries.length === 0 && gameState?.inventory) {
-        const fallbackSummary = buildPlayerStatePromptSummary(gameState, {
-            latestUserMessage: `${options.latestUserMessage || ''} inventory items`,
-        });
-        compactInventoryEntries.push(
-            ...(fallbackSummary.slices?.resourceBalances || []),
-            ...(fallbackSummary.slices?.relevantInventory || [])
-        );
-    }
     const compactInventorySummary = compactInventoryEntries
         .slice(0, 10)
         .map(

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -89,15 +89,17 @@ describe('buildDchatKnowledgePack', () => {
         expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
     });
 
-    it('keeps bounded live inventory highlights for broad progress questions', () => {
+    it('does not add arbitrary live inventory highlights for unrelated progress questions', () => {
         const pack = buildDchatKnowledgePack(
             { inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 2 } },
             { latestUserMessage: 'How am I progressing?' }
         );
 
-        expect(pack.summary).toContain('Inventory highlights: compact bounded');
-        expect(pack.summary).toContain('white PLA filament');
-        expect(pack.summary).toContain('x2');
+        const highlights = pack.summary
+            .split('\n\n')
+            .find((section) => section.startsWith('Inventory highlights:'));
+
+        expect(highlights).toBeUndefined();
     });
 
     it('keeps query-relevant live inventory in compact highlights', () => {


### PR DESCRIPTION
### Motivation
- Reduce prompt bloat by preventing dChat knowledge packing from re-querying a broad live-inventory fallback and injecting arbitrary owned-item samples into unrelated progress prompts.
- Keep compact PlayerState behavior intact while ensuring inventory highlights are only added when query-relevant or inventory-focused.

### Description
- Removed the fallback that called `buildPlayerStatePromptSummary(..., "inventory items")` when the initial compact inventory slice was empty, preventing unrelated prompts from forcing owned-inventory highlights (changed in `frontend/src/utils/dchatKnowledge.js`).
- Updated the test `frontend/tests/dchatKnowledgePack.test.ts` to assert unrelated progress questions do not add an `Inventory highlights:` section while preserving bounded highlights for inventory-specific and query-relevant prompts.
- No runtime or public API behavior was changed beyond the compact live-state selection within dChat knowledge packing.

### Testing
- Ran focused unit suites and integration checks: `cd frontend && npm test -- openAI` (narrow `openAI.test.ts` passed; a broader `openAI` invocation timed out once at Vitest default 5s but passed on rerun), `cd frontend && npm test -- dchatKnowledge` (passed), `cd frontend && npm test -- chatContextPlanner` (passed), and `cd frontend && npm test -- tokenPlace.test.js` (passed).
- Ran formatting/lint/build: `cd frontend && npm run check` (passed) and `cd frontend && npm run build` (passed).
- All modified tests now pass locally after the change; one intermittent `tests/openAI.persona.test.ts` timeout was observed and resolved by rerunning the affected suites during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fac9539c0832f907b6ed01450bc43)