### PR TITLE
Compact PlayerState summary + bounded dChat inventory highlights

### DIFF
--- a/frontend/e2e/chat-rag-context.spec.ts
+++ b/frontend/e2e/chat-rag-context.spec.ts
@@ -70,7 +70,9 @@ test.describe('chat RAG context', () => {
             'Hydroponics caretaker focused on nutrient balance.'
         );
 
-        await chatPanel.getByRole('textbox').fill('How am I progressing?');
+        await chatPanel
+            .getByRole('textbox')
+            .fill('How is my white PLA filament inventory and quest progress?');
         await chatPanel.getByRole('button', { name: 'Send' }).click();
 
         const payloadHandle = await page.waitForFunction(() => {

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -305,15 +305,6 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
         ...(stateSummary.slices?.resourceBalances || []),
         ...(stateSummary.slices?.relevantInventory || []),
     ];
-    if (compactInventoryEntries.length === 0 && gameState?.inventory) {
-        const fallbackSummary = buildPlayerStatePromptSummary(gameState, {
-            latestUserMessage: `${options.latestUserMessage || ''} inventory items`,
-        });
-        compactInventoryEntries.push(
-            ...(fallbackSummary.slices?.resourceBalances || []),
-            ...(fallbackSummary.slices?.relevantInventory || [])
-        );
-    }
     const compactInventorySummary = compactInventoryEntries
         .slice(0, 10)
         .map(

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -163,6 +163,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             meta: {
                 included: false,
                 mode: 'none',
+                playerStatePromptMode: 'none',
                 questsFinishedCount: 0,
                 completedQuestCount: questStats.completedQuestCount,
                 totalOfficialQuestCount: questStats.totalOfficialQuestCount,
@@ -191,6 +192,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             meta: {
                 included: true,
                 mode: 'raw',
+                playerStatePromptMode: 'raw',
                 questsFinishedCount: Object.values(gameState.quests || {}).filter(
                     (quest) => quest?.finished
                 ).length,
@@ -282,6 +284,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
         meta: {
             included: true,
             mode: 'compact',
+            playerStatePromptMode: 'compact',
             questsFinishedCount: Object.values(gameState.quests || {}).filter(
                 (quest) => quest?.finished
             ).length,

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -7,6 +7,7 @@ export const PLAYER_STATE_PROMPT_DEFAULTS = Object.freeze({
     remainingQuestCap: 12,
     inventoryRelevantCap: 8,
     inventorySampleCap: 8,
+    notableBalanceCap: 8,
     activeProcessCap: 6,
 });
 
@@ -217,7 +218,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
     const queryText = normalizeText(options.latestUserMessage || options.query || '');
     const queryTokens = tokenSet(queryText);
     const entries = inventoryEntries(gameState.inventory);
-    const resourceBalances = entries.filter(isResourceEntry);
+    const resourceBalances = entries.filter(isResourceEntry).slice(0, caps.notableBalanceCap);
     const queryRelevant = entries
         .filter(
             (entry) => !isResourceEntry(entry) && entryMatchesQuery(entry, queryTokens, queryText)
@@ -259,7 +260,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
     lines.push(`Inventory: ${entries.length} owned item/resource types total.`);
     if (resourceBalances.length > 0) {
         lines.push(
-            `Notable balances: ${resourceBalances.map((entry) => `${entry.name}=${formatCount(entry.count)}`).join(', ')}.`
+            `Notable balances (cap ${caps.notableBalanceCap}): ${resourceBalances.map((entry) => `${entry.name}=${formatCount(entry.count)}`).join(', ')}.`
         );
     }
     if (relevantInventory.length > 0) {

--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -162,7 +162,6 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             block: null,
             meta: {
                 included: false,
-                mode: 'none',
                 playerStatePromptMode: 'none',
                 questsFinishedCount: 0,
                 completedQuestCount: questStats.completedQuestCount,
@@ -191,7 +190,6 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             block,
             meta: {
                 included: true,
-                mode: 'raw',
                 playerStatePromptMode: 'raw',
                 questsFinishedCount: Object.values(gameState.quests || {}).filter(
                     (quest) => quest?.finished
@@ -283,7 +281,6 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
         block,
         meta: {
             included: true,
-            mode: 'compact',
             playerStatePromptMode: 'compact',
             questsFinishedCount: Object.values(gameState.quests || {}).filter(
                 (quest) => quest?.finished

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -33,13 +33,10 @@ const sanitizePlayerStateSummary = (summary) => {
     if (!summary || typeof summary !== 'object') return null;
 
     const safeSummary = {
-        mode: typeof summary.mode === 'string' ? summary.mode : 'unknown',
         playerStatePromptMode:
             typeof summary.playerStatePromptMode === 'string'
                 ? summary.playerStatePromptMode
-                : typeof summary.mode === 'string'
-                  ? summary.mode
-                  : 'unknown',
+                : 'unknown',
         completedQuestCount: numberOrZero(summary.completedQuestCount),
         totalOfficialQuestCount: numberOrZero(summary.totalOfficialQuestCount),
         remainingOfficialQuestCount: numberOrZero(summary.remainingOfficialQuestCount),

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -102,6 +102,20 @@ describe('buildDchatKnowledgePack', () => {
         expect(highlights).toBeUndefined();
     });
 
+    it('keeps resource balances in compact highlights for unrelated progress questions', () => {
+        const pack = buildDchatKnowledgePack(
+            { inventory: { '5247a603-294a-4a34-a884-1ae20969b2a1': 25 } },
+            { latestUserMessage: 'How am I progressing?' }
+        );
+
+        const highlights = pack.summary
+            .split('\n\n')
+            .find((section) => section.startsWith('Inventory highlights:'));
+
+        expect(highlights).toContain('compact bounded live-state highlights');
+        expect(highlights).toContain('dUSD (x25)');
+    });
+
     it('keeps query-relevant live inventory in compact highlights', () => {
         const pack = buildDchatKnowledgePack(
             { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -89,15 +89,17 @@ describe('buildDchatKnowledgePack', () => {
         expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
     });
 
-    it('keeps bounded live inventory highlights for broad progress questions', () => {
+    it('does not add arbitrary live inventory highlights for unrelated progress questions', () => {
         const pack = buildDchatKnowledgePack(
             { inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 2 } },
             { latestUserMessage: 'How am I progressing?' }
         );
 
-        expect(pack.summary).toContain('Inventory highlights: compact bounded');
-        expect(pack.summary).toContain('white PLA filament');
-        expect(pack.summary).toContain('x2');
+        const highlights = pack.summary
+            .split('\n\n')
+            .find((section) => section.startsWith('Inventory highlights:'));
+
+        expect(highlights).toBeUndefined();
     });
 
     it('keeps query-relevant live inventory in compact highlights', () => {

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -589,7 +589,7 @@ describe('buildChatPrompt', () => {
         expect(payload.playerStateSummary).toEqual(
             expect.objectContaining({
                 included: true,
-                mode: 'compact',
+                playerStatePromptMode: 'compact',
                 questsFinishedCount: 2,
                 completedQuestCount: 1,
                 inventoryIncludedCount: 1,
@@ -663,7 +663,6 @@ describe('buildChatPrompt', () => {
         const summary = payload.promptMetrics.playerStateSummary;
 
         expect(summary).toEqual({
-            mode: 'compact',
             playerStatePromptMode: 'compact',
             completedQuestCount: 1,
             totalOfficialQuestCount: expect.any(Number),

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -3,6 +3,8 @@ import { buildPlayerStatePromptSummary } from '../src/utils/playerStatePromptSum
 
 const GREEN_PLA_ID = 'd3590107-25ff-4de5-af3a-46e2497bfc52';
 const DSOLAR_ID = 'b02ecff5-1f7d-4247-a09d-7d6cd6bb218a';
+const DUSD_ID = '5247a603-294a-4a34-a884-1ae20969b2a1';
+const DBI_ID = '016d4758-d114-4e04-9e6a-853db93a2eee';
 
 const makeState = (inventory = {}) => ({
     versionNumberString: '3',
@@ -131,6 +133,28 @@ describe('buildPlayerStatePromptSummary', () => {
 
         expect(result.block).toContain('dSolar=7');
         expect(result.meta.inventoryIncludedCount).toBe(1);
+    });
+
+    it('bounds notable resource balances with a named cap', () => {
+        const result = buildPlayerStatePromptSummary(
+            makeState({
+                [DSOLAR_ID]: 7,
+                [DUSD_ID]: 20,
+                [DBI_ID]: 3,
+            }),
+            { notableBalanceCap: 2 }
+        );
+
+        expect(result.slices.resourceBalances).toHaveLength(2);
+        expect(result.slices.resourceBalances.map((entry) => entry.name)).toEqual([
+            'dBI',
+            'dSolar',
+        ]);
+        expect(result.meta.inventoryTotalCount).toBe(3);
+        expect(result.meta.inventoryIncludedCount).toBe(2);
+        expect(result.meta.inventoryTruncated).toBe(true);
+        expect(result.block).toContain('Notable balances (cap 2): dBI=3, dSolar=7.');
+        expect(result.block).not.toContain('dUSD=20');
     });
 
     it('shows a bounded inventory sample for broad inventory questions', () => {

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -22,8 +22,11 @@ describe('buildPlayerStatePromptSummary', () => {
         const missing = buildPlayerStatePromptSummary(null);
 
         expect(compact.meta.questsFinishedCount).toBe(3);
+        expect(compact.meta.playerStatePromptMode).toBe('compact');
         expect(raw.meta.questsFinishedCount).toBe(3);
+        expect(raw.meta.playerStatePromptMode).toBe('raw');
         expect(missing.meta.questsFinishedCount).toBe(0);
+        expect(missing.meta.playerStatePromptMode).toBe('none');
         expect(compact.block).not.toContain('questsFinished');
         expect(raw.block).toContain('questsFinished');
     });


### PR DESCRIPTION
### Motivation

- Reduce bulky live PlayerState material (long `questsFinished` arrays and UUID-heavy inventory dumps) in full-mode chat prompts while preserving authoritative grounding for common progress/inventory questions.
- Ensure dChat knowledge highlights are compact and derived from the authoritative PlayerState summary rather than being manufactured as a fallback, reducing prompt size and duplication.

### Description

- Add explicit safe `playerStatePromptMode` metadata to `buildPlayerStatePromptSummary` for `compact`, `raw`, and `none` modes so metrics/debug consumers can identify summary mode without exposing raw save data.
- Keep the compact PlayerState block query-aware and bounded (completed/total/remaining counts, bounded remaining quest IDs/titles, notable resource balances, query-relevant inventory slice, capped active process summary, and an omission note) in `frontend/src/utils/playerStatePromptSummary.js`.
- Stop `buildDchatKnowledgePack` from invoking a fallback PlayerState summary to manufacture arbitrary live inventory highlights; it now only uses the compact slices provided by the state summary (resource balances and relevant inventory) in `frontend/src/utils/dchatKnowledge.js`.
- Update focused tests to reflect the new metadata and behavior: `frontend/tests/playerStatePromptSummary.test.ts` now asserts `playerStatePromptMode`, and `frontend/tests/dchatKnowledgePack.test.ts` asserts unrelated progress queries do not produce inventory highlights while query-relevant cases remain bounded.

### Testing

- Ran scoped unit tests: `cd frontend && npm test -- playerStatePromptSummary dchatKnowledge openAIContextPlanner chatContextPlanner tokenPlace.test.js`, and all targeted test suites passed (scoped tests and token.place integration tests succeeded).
- Ran broader checks: `cd frontend && npm run check` (lint + format check) and `cd frontend && npm run build`, both succeeded with no formatting or build errors.
- Test commands used during verification: `npm test -- openAI`, `npm test -- dchatKnowledge`, `npm test -- chatContextPlanner`, and `npm test -- tokenPlace.test.js`; all passed in CI-like local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fac9f4960832fb67094fc0ca37ca1)