### PR TITLE
Expose player-state prompt mode metadata

### DIFF
--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -163,6 +163,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             meta: {
                 included: false,
                 mode: 'none',
+                playerStatePromptMode: 'none',
                 questsFinishedCount: 0,
                 completedQuestCount: questStats.completedQuestCount,
                 totalOfficialQuestCount: questStats.totalOfficialQuestCount,
@@ -191,6 +192,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
             meta: {
                 included: true,
                 mode: 'raw',
+                playerStatePromptMode: 'raw',
                 questsFinishedCount: Object.values(gameState.quests || {}).filter(
                     (quest) => quest?.finished
                 ).length,
@@ -282,6 +284,7 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
         meta: {
             included: true,
             mode: 'compact',
+            playerStatePromptMode: 'compact',
             questsFinishedCount: Object.values(gameState.quests || {}).filter(
                 (quest) => quest?.finished
             ).length,

--- a/frontend/tests/playerStatePromptSummary.test.ts
+++ b/frontend/tests/playerStatePromptSummary.test.ts
@@ -22,8 +22,11 @@ describe('buildPlayerStatePromptSummary', () => {
         const missing = buildPlayerStatePromptSummary(null);
 
         expect(compact.meta.questsFinishedCount).toBe(3);
+        expect(compact.meta.playerStatePromptMode).toBe('compact');
         expect(raw.meta.questsFinishedCount).toBe(3);
+        expect(raw.meta.playerStatePromptMode).toBe('raw');
         expect(missing.meta.questsFinishedCount).toBe(0);
+        expect(missing.meta.playerStatePromptMode).toBe('none');
         expect(compact.block).not.toContain('questsFinished');
         expect(raw.block).toContain('questsFinished');
     });


### PR DESCRIPTION
### Motivation
- Provide a safe, explicit flag so prompt-metrics and debug consumers can tell whether the PlayerState block was sent in `compact`, `raw`, or `none` mode without exposing raw save data.

### Description
- Add `playerStatePromptMode` to the `meta` object returned by `buildPlayerStatePromptSummary` with values `'compact' | 'raw' | 'none'` and update the unit test `frontend/tests/playerStatePromptSummary.test.ts` to assert the new metadata.

### Testing
- Ran focused and broader frontend checks: `cd frontend && npm test -- playerStatePromptSummary dchatKnowledgePack openAIContextPlanner` (passed), `cd frontend && npm test -- openAI dchatKnowledge chatContextPlanner tokenPlace.test.js` (passed), `cd frontend && npm run check` (passed), and `cd frontend && npm run build` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3facab455c832fa49b182144b30a69)