### PR TITLE
Bound notable resource balances in compact PlayerState summary

### DIFF
--- a/frontend/src/utils/playerStatePromptSummary.js
+++ b/frontend/src/utils/playerStatePromptSummary.js
@@ -7,6 +7,7 @@ export const PLAYER_STATE_PROMPT_DEFAULTS = Object.freeze({
     remainingQuestCap: 12,
     inventoryRelevantCap: 8,
     inventorySampleCap: 8,
+    notableBalanceCap: 8,
     activeProcessCap: 6,
 });
 
@@ -217,7 +218,8 @@ export const buildPlayerStatePromptSummary = (gameState, options = {}) => {
     const queryText = normalizeText(options.latestUserMessage || options.query || '');
     const queryTokens = tokenSet(queryText);
     const entries = inventoryEntries(gameState.inventory);
-    const resourceBalances = entries.filter(isResourceEntry);
+    const allResourceBalances = entries.filter(isResourceEntry);
+    const resourceBalances = allResourceBalances.slice(0, caps.notableBalanceCap);
     const queryRelevant = entries
         .filter(
             (entry) => !isResourceEntry(entry) && entryMatchesQuery(entry, queryTokens, queryText)


### PR DESCRIPTION
### Motivation
- Reduce prompt bloat from unbounded resource/balance listings in full-mode PlayerState by imposing a named cap on notable live resource balances included in compact player-state summaries.

### Description
- Added `notableBalanceCap` to `PLAYER_STATE_PROMPT_DEFAULTS` and applied it when projecting resource balances into the compact PlayerState slices. (`frontend/src/utils/playerStatePromptSummary.js`).
- Resource balances are now selected as a bounded slice (`.slice(0, caps.notableBalanceCap)`) so compact PlayerState summaries remain size-bounded while keeping notable balances available for grounding.
- Changes are local to the compact PlayerState helper and do not alter raw/debug `playerStatePromptMode='raw'` behavior or other prompt routing logic.

### Testing
- Ran focused unit tests: `cd frontend && npm test -- playerStatePromptSummary` — passed.
- Ran broader focused suites: `cd frontend && npm test -- openAI dchatKnowledge chatContextPlanner tokenPlace.test.js` — all tests passed.
- Ran repository checks: `cd frontend && npm run check` — lint/format checks passed; `cd frontend && npm run build` — build succeeded.
- No test failures observed; the change is minimal and covered by existing PlayerState and dChat knowledge tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3facb46484832fb68e4ca30b422f82)