### PR TITLE
Add focused structured game-data retrieval for chat prompts

### DIFF
--- a/frontend/__tests__/dchatKnowledge.test.js
+++ b/frontend/__tests__/dchatKnowledge.test.js
@@ -1,4 +1,4 @@
-const { buildDchatKnowledge } = require('../src/utils/dchatKnowledge.js');
+const { buildDchatKnowledge, buildDchatKnowledgePack } = require('../src/utils/dchatKnowledge.js');
 
 describe('buildDchatKnowledge', () => {
     test('includes inventory when available', () => {
@@ -8,15 +8,17 @@ describe('buildDchatKnowledge', () => {
             },
         };
 
-        const knowledge = buildDchatKnowledge(gameState);
+        const knowledge = buildDchatKnowledge(gameState, {
+            latestUserMessage: 'what is my inventory?',
+        });
         expect(knowledge).toContain('Inventory highlights');
         expect(knowledge).toContain('white PLA filament');
     });
 
-    test('includes quests and processes summary', () => {
+    test('does not include broad quests and processes summary by default', () => {
         const knowledge = buildDchatKnowledge({});
-        expect(knowledge).toContain('Quests:');
-        expect(knowledge).toContain('Processes:');
+        expect(knowledge).not.toContain('Quests:');
+        expect(knowledge).not.toContain('Processes:');
     });
 
     test('summarizes quest progress and process state', () => {
@@ -42,9 +44,18 @@ describe('buildDchatKnowledge', () => {
         expect(knowledge).toMatch(/Buy 1 kWh of electricity from a wall outlet/);
     });
 
-    test('includes essential tutorial quests', () => {
-        const knowledge = buildDchatKnowledge({});
-        expect(knowledge).toContain('How to do quests');
+    test('includes focused selected entities', () => {
+        const pack = buildDchatKnowledgePack(
+            {},
+            { latestUserMessage: 'what rewards does How to do quests give?' }
+        );
+        expect(pack.summary).toContain('Relevant quests:');
+        expect(pack.summary).toContain('How to do quests');
+        expect(
+            pack.sources.every(
+                (entry) => entry.type !== 'quest' || entry.label.includes('How to do quests')
+            )
+        ).toBe(true);
     });
 
     test('summarizes achievements progress', () => {

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -331,6 +331,14 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
         sources.push(...(focusedContext.sources || []));
     }
 
+    const questProgressSummary = summarizeQuestProgress(gameState);
+    if (questProgressSummary.length > 0) {
+        knowledgeSections.push(
+            `${dchatKnowledgeScaffolding.questProgress}: ${questProgressSummary.join(' | ')}`
+        );
+        stateDetails.push('quest progress');
+    }
+
     const processProgressSummary = summarizeProcessProgress(gameState);
     if (processProgressSummary.length > 0) {
         knowledgeSections.push(

--- a/frontend/src/utils/dchatKnowledge.js
+++ b/frontend/src/utils/dchatKnowledge.js
@@ -3,6 +3,7 @@ import processes from '../generated/processes.json' assert { type: 'json' };
 import { evaluateAchievements } from './achievements.js';
 import { mergeSources } from './contextSources.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
+import { buildFocusedGameDataContext } from './gameDataRetrieval.js';
 
 const MAX_ITEMS = 25;
 const MAX_PROCESSES = 20;
@@ -318,118 +319,16 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
         stateDetails.push('inventory highlights');
     }
 
-    const itemEntries = getItemsForKnowledge();
-    if (itemEntries.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.items}: ${itemEntries
-                .map((item) => `${item.name}: ${truncate(item.description || '')}`)
-                .join(' | ')}`
-        );
-        sources.push(
-            ...itemEntries.map((item) => ({
-                type: 'item',
-                id: item.id,
-                label: item.name,
-                url: `/inventory/item/${item.id}`,
-                detail: truncate(item.description || ''),
-            }))
-        );
-    }
-
-    const questEntries = getQuestsForKnowledge();
-    if (questEntries.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.quests}: ${questEntries
-                .map((quest) => {
-                    const parts = [`${quest.title} [${quest.id}]`];
-                    if (quest.description) {
-                        parts.push(quest.description);
-                    }
-                    if (quest.requiresQuests.length > 0) {
-                        parts.push(
-                            `${dchatKnowledgeScaffolding.prereqs}: ${quest.requiresQuests.join(
-                                ', '
-                            )}`
-                        );
-                    }
-                    if (quest.rewards.length > 0) {
-                        parts.push(
-                            `${dchatKnowledgeScaffolding.rewards}: ${quest.rewards.join(', ')}`
-                        );
-                    }
-                    return parts.join(' — ');
-                })
-                .join(' || ')}`
-        );
-        sources.push(
-            ...questEntries.map((quest) => ({
-                type: 'quest',
-                id: quest.id,
-                label: quest.title || quest.id,
-                url: `/quests/${quest.id}`,
-                detail: quest.description || '',
-            }))
-        );
-    }
-
-    const questProgressSummary = summarizeQuestProgress(gameState);
-    if (questProgressSummary.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.questProgress}: ${questProgressSummary.join(' | ')}`
-        );
-        stateDetails.push('quest progress');
-    }
-
-    const { unlockedEntries, progressEntries, unlockedSlice, inProgressSlice } =
-        getAchievementEntries(gameState);
-    if (unlockedEntries.length > 0 || progressEntries.length > 0) {
-        const sections = [];
-        if (unlockedEntries.length > 0) {
-            sections.push(`${dchatKnowledgeScaffolding.unlocked}: ${unlockedEntries.join(', ')}`);
-        }
-        if (progressEntries.length > 0) {
-            sections.push(`${dchatKnowledgeScaffolding.inProgress}: ${progressEntries.join(', ')}`);
-        }
-        if (sections.length === 0) {
-            sections.push(dchatKnowledgeScaffolding.noAchievements);
-        }
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.achievements}: ${sections.join(' | ')}`
-        );
-        stateDetails.push('achievements');
-        sources.push(
-            ...unlockedSlice.map((achievement) => ({
-                type: 'achievement',
-                id: achievement.id,
-                label: achievement.title,
-            })),
-            ...inProgressSlice.map((achievement) => ({
-                type: 'achievement',
-                id: achievement.id,
-                label: achievement.title,
-                detail: achievement.progress?.displayValue || '',
-            }))
-        );
-    }
-
-    const processEntries = getProcessesForKnowledge();
-    if (processEntries.length > 0) {
-        knowledgeSections.push(
-            `${dchatKnowledgeScaffolding.processes}: ${processEntries
-                .map((process) => {
-                    const duration = process.duration ? ` (duration ${process.duration})` : '';
-                    return `${process.title}${duration}`;
-                })
-                .join(' | ')}`
-        );
-        sources.push(
-            ...processEntries.map((process) => ({
-                type: 'process',
-                id: process.id,
-                label: process.title,
-                url: `/processes/${process.id}`,
-            }))
-        );
+    const focusedContext = buildFocusedGameDataContext({
+        query: options.latestUserMessage || '',
+        messages: options.messages || [],
+        gameState,
+        playerStateSummary: stateSummary,
+        options: options.focusedGameDataOptions || {},
+    });
+    if (focusedContext.block) {
+        knowledgeSections.push(focusedContext.block);
+        sources.push(...(focusedContext.sources || []));
     }
 
     const processProgressSummary = summarizeProcessProgress(gameState);
@@ -452,11 +351,12 @@ export function buildDchatKnowledgePack(gameState = {}, options = {}) {
     return {
         summary: knowledgeSections.join('\n\n'),
         sources: mergeSources(sources),
+        focusedGameData: focusedContext?.meta || null,
     };
 }
 
-export function buildDchatKnowledge(gameState = {}) {
-    return buildDchatKnowledgePack(gameState).summary;
+export function buildDchatKnowledge(gameState = {}, options = {}) {
+    return buildDchatKnowledgePack(gameState, options).summary;
 }
 
 export function __testables() {

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -195,7 +195,11 @@ const recentContextText = (messages = [], count) =>
         .join(' ');
 
 const isVagueProcessQuery = (text) =>
-    /\b(what does (it|that|this) consume|what does (it|that|this) create|what about that)\b/i.test(
+    /\b(what does (it|that|this)( process)? consume|what does (it|that|this)( process)? create)\b/i.test(
+        text
+    );
+const isVagueEntityFollowup = (text) =>
+    /\b(what rewards? does (it|that|this) give|what does (it|that|this) give|what about (it|that|this|that))\b/i.test(
         text
     );
 const wantsRemainingQuests = (text) =>
@@ -242,7 +246,10 @@ export function buildFocusedGameDataContext({
     const caps = { ...FOCUSED_GAME_DATA_DEFAULTS, ...options };
     const latest = String(query || '');
     const recent = recentContextText(messages, caps.recentMessageCount);
-    const queryText = normalize(`${latest} ${isVagueProcessQuery(latest) ? recent : ''}`);
+    const vagueFollowup = isVagueProcessQuery(latest) || isVagueEntityFollowup(latest);
+    const rewardFollowup =
+        isVagueEntityFollowup(latest) && /\b(rewards?|give|gives)\b/i.test(latest);
+    const queryText = normalize(`${latest} ${vagueFollowup ? recent : ''}`);
     const queryTokens = [...new Set(tokensFor(queryText))];
     const reasonCodes = [];
 
@@ -252,7 +259,8 @@ export function buildFocusedGameDataContext({
         queryTokens.length === 0 &&
         !wantsRemainingQuests(latest) &&
         !wantsInventory(latest) &&
-        !achievementIntent
+        !achievementIntent &&
+        !vagueFollowup
     ) {
         return {
             block: '',
@@ -277,13 +285,13 @@ export function buildFocusedGameDataContext({
         };
     }
 
-    if (isVagueProcessQuery(latest)) reasonCodes.push('recent-context-expanded');
+    if (vagueFollowup) reasonCodes.push('recent-context-expanded');
     if (wantsRemainingQuests(latest)) reasonCodes.push('remaining-quest-state');
     if (wantsInventory(latest)) reasonCodes.push('inventory-summary-request');
     if (achievementIntent) reasonCodes.push('achievement-state-request');
 
     const inventoryOnlyQuery = wantsInventory(latest) && queryTokens.length === 0;
-    const selectedItems = inventoryOnlyQuery
+    let selectedItems = inventoryOnlyQuery
         ? []
         : selectScored(items, itemText, queryTokens, queryText, caps.maxItems);
     let selectedProcesses = selectScored(
@@ -317,6 +325,10 @@ export function buildFocusedGameDataContext({
         }
         selectedQuests = selectedQuests.slice(0, caps.maxQuests);
     }
+    if (rewardFollowup && selectedQuests.length > 0) {
+        selectedItems = [];
+        selectedProcesses = [];
+    }
 
     const achievements = evaluateAchievements(gameState || {});
     const achievementStateEntries = achievements.filter(
@@ -326,7 +338,7 @@ export function buildFocusedGameDataContext({
         achievementIntent && (queryTokens.length === 0 || /\bunlocked\b/i.test(latest));
     const selectedAchievements = shouldReturnAchievementState
         ? achievementStateEntries.slice(0, caps.maxAchievements)
-        : queryTokens.length > 0
+        : achievementIntent && queryTokens.length > 0
           ? selectScored(
                 achievements,
                 (a) =>

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -1,0 +1,458 @@
+import items from '../pages/inventory/json/items/index.js';
+import processes from '../generated/processes.json' assert { type: 'json' };
+import { evaluateAchievements } from './achievements.js';
+import { mergeSources } from './contextSources.js';
+import { getBuiltInQuest, listBuiltInQuestIds } from './builtInQuests.js';
+
+export const FOCUSED_GAME_DATA_DEFAULTS = Object.freeze({
+    maxItems: 8,
+    maxQuests: 6,
+    maxProcesses: 6,
+    maxAchievements: 4,
+    maxTotalChars: 6000,
+    maxEntityChars: 650,
+    maxSources: 18,
+    recentMessageCount: 4,
+});
+
+const STOPWORDS = new Set([
+    'the',
+    'and',
+    'for',
+    'that',
+    'this',
+    'with',
+    'have',
+    'does',
+    'what',
+    'where',
+    'when',
+    'how',
+    'much',
+    'many',
+    'enough',
+    'like',
+    'make',
+    'give',
+    'gives',
+    'left',
+    'consume',
+    'consumes',
+    'process',
+    'quest',
+    'quests',
+    'item',
+    'items',
+    'inventory',
+    'about',
+    'that',
+    'would',
+    'want',
+    'need',
+    'please',
+    'into',
+    'from',
+    'using',
+    'used',
+    'all',
+    'any',
+    'can',
+    'could',
+    'should',
+    'is',
+    'it',
+    'i',
+    'my',
+    'do',
+    'to',
+    'a',
+    'an',
+    'of',
+    'in',
+    'on',
+    'or',
+    'be',
+    'if',
+    'there',
+]);
+
+const itemById = new Map(items.map((item) => [item.id, item]));
+const processById = new Map(processes.map((process) => [process.id, process]));
+
+const normalize = (value) =>
+    String(value || '')
+        .toLowerCase()
+        .replace(/[-_/]+/g, ' ')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const tokensFor = (value) =>
+    normalize(value)
+        .split(' ')
+        .filter((token) => token.length >= 2 && !STOPWORDS.has(token))
+        .flatMap((token) => (token.endsWith('ies') ? [token, `${token.slice(0, -3)}y`] : [token]));
+
+const truncate = (value, max) => {
+    const text = String(value || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    return text.length <= max ? text : `${text.slice(0, Math.max(0, max - 1)).trim()}…`;
+};
+
+const formatCount = (count) =>
+    Number.isInteger(count) ? String(count) : String(Number(count).toFixed(4));
+
+const itemName = (id) => itemById.get(id)?.name || id;
+
+const formatItemList = (entries = []) =>
+    entries
+        .map(
+            (entry) =>
+                `${itemName(entry.id)} [${entry.id}] x${formatCount(entry.quantity ?? entry.count ?? 1)}`
+        )
+        .join(', ');
+
+const questRecords = () =>
+    listBuiltInQuestIds()
+        .map((id) => getBuiltInQuest(id))
+        .filter(Boolean)
+        .map((quest) => ({
+            id: quest.id,
+            title: quest.title || quest.id,
+            description: quest.description || '',
+            requiresQuests: Array.isArray(quest.requiresQuests) ? quest.requiresQuests : [],
+            rewards: Array.isArray(quest.rewards) ? quest.rewards : [],
+            rewardItems: Array.isArray(quest.rewardItems) ? quest.rewardItems : [],
+            nodes: Array.isArray(quest.nodes) ? quest.nodes : [],
+        }));
+
+const formatQuestRewards = (rewards = []) =>
+    rewards
+        .map((reward) => {
+            if (typeof reward === 'string' || typeof reward === 'number') return String(reward);
+            if (reward?.id)
+                return `${itemName(reward.id)} [${reward.id}] x${formatCount(reward.quantity ?? reward.count ?? 1)}`;
+            return truncate(stringifyFields(reward), 120);
+        })
+        .filter(Boolean)
+        .join(', ');
+
+const stringifyFields = (value) => {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string' || typeof value === 'number') return String(value);
+    if (Array.isArray(value)) return value.map(stringifyFields).join(' ');
+    if (typeof value === 'object') return Object.values(value).map(stringifyFields).join(' ');
+    return '';
+};
+
+const processText = (process) =>
+    [
+        process.id,
+        process.title,
+        process.description,
+        stringifyFields(process.requireItems),
+        stringifyFields(process.consumeItems),
+        stringifyFields(process.createItems),
+        process.duration,
+    ].join(' ');
+
+const itemText = (item) =>
+    [item.id, item.name, item.description, item.category, item.price].join(' ');
+const questText = (quest) =>
+    [
+        quest.id,
+        quest.title,
+        quest.description,
+        stringifyFields(quest.requiresQuests),
+        stringifyFields(quest.rewards),
+        stringifyFields(quest.rewardItems),
+        stringifyFields(quest.nodes),
+    ].join(' ');
+
+const scoreRecord = (record, haystackText, queryTokens, queryText) => {
+    const haystack = normalize(haystackText);
+    if (!haystack || queryTokens.length === 0) return 0;
+    let score = 0;
+    for (const token of queryTokens) {
+        if (haystack.split(' ').includes(token)) score += 2;
+        else if (haystack.includes(token)) score += 1;
+    }
+    const title = normalize(record.title || record.name || record.id);
+    if (title && queryText.includes(title)) score += 12;
+    const id = normalize(record.id);
+    if (id && queryText.includes(id)) score += 10;
+    return score;
+};
+
+const recentContextText = (messages = [], count) =>
+    messages
+        .slice(-count)
+        .map((message) => (typeof message?.content === 'string' ? message.content : ''))
+        .join(' ');
+
+const isVagueProcessQuery = (text) =>
+    /\b(what does (it|that|this) consume|what does (it|that|this) create|what about that)\b/i.test(
+        text
+    );
+const wantsRemainingQuests = (text) =>
+    /\bquests?\b.*\b(left|remaining|next|todo|to do)\b|\b(left|remaining)\b.*\bquests?\b/i.test(
+        text
+    );
+const wantsInventory = (text) => /\binventory\b|\bwhat do i have\b/i.test(text);
+
+const activeProcessIds = (gameState = {}, playerStateSummary) => {
+    const fromSummary = playerStateSummary?.slices?.activeProcesses?.map((entry) => entry.id) || [];
+    const fromState = Object.entries(gameState?.processes || {})
+        .filter(([, state]) => state && !state.finished)
+        .map(([id]) => id);
+    return [...new Set([...fromSummary, ...fromState])];
+};
+
+const selectScored = (records, textFn, queryTokens, queryText, cap) =>
+    records
+        .map((record) => ({
+            record,
+            score: scoreRecord(record, textFn(record), queryTokens, queryText),
+        }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || String(a.record.id).localeCompare(String(b.record.id)))
+        .slice(0, cap)
+        .map((entry) => entry.record);
+
+const appendLine = (lines, line, maxTotalChars) => {
+    if (!line) return false;
+    const nextLength = lines.join('\n').length + line.length + 1;
+    if (nextLength > maxTotalChars) return false;
+    lines.push(line);
+    return true;
+};
+
+export function buildFocusedGameDataContext({
+    query = '',
+    messages = [],
+    gameState = {},
+    playerStateSummary = null,
+    options = {},
+} = {}) {
+    const caps = { ...FOCUSED_GAME_DATA_DEFAULTS, ...options };
+    const latest = String(query || '');
+    const recent = recentContextText(messages, caps.recentMessageCount);
+    const queryText = normalize(`${latest} ${isVagueProcessQuery(latest) ? recent : ''}`);
+    const queryTokens = [...new Set(tokensFor(queryText))];
+    const reasonCodes = [];
+
+    if (queryTokens.length === 0 && !wantsRemainingQuests(latest) && !wantsInventory(latest)) {
+        return {
+            block: '',
+            sources: [],
+            meta: {
+                included: false,
+                reasonCodes: ['no-focused-game-data-intent'],
+                selectedItemCount: 0,
+                selectedQuestCount: 0,
+                selectedProcessCount: 0,
+                selectedAchievementCount: 0,
+                renderedChars: 0,
+                caps,
+                truncated: false,
+            },
+        };
+    }
+
+    if (isVagueProcessQuery(latest)) reasonCodes.push('recent-context-expanded');
+    if (wantsRemainingQuests(latest)) reasonCodes.push('remaining-quest-state');
+    if (wantsInventory(latest)) reasonCodes.push('inventory-summary-request');
+
+    const inventoryOnlyQuery = wantsInventory(latest) && queryTokens.length === 0;
+    const selectedItems = inventoryOnlyQuery
+        ? []
+        : selectScored(items, itemText, queryTokens, queryText, caps.maxItems);
+    let selectedProcesses = selectScored(
+        processes,
+        processText,
+        queryTokens,
+        queryText,
+        caps.maxProcesses
+    );
+    if (isVagueProcessQuery(latest)) {
+        for (const id of activeProcessIds(gameState, playerStateSummary)) {
+            const process = processById.get(id);
+            if (process && !selectedProcesses.some((entry) => entry.id === id))
+                selectedProcesses.unshift(process);
+        }
+        selectedProcesses = selectedProcesses.slice(0, caps.maxProcesses);
+    }
+
+    let selectedQuests = selectScored(
+        questRecords(),
+        questText,
+        queryTokens,
+        queryText,
+        caps.maxQuests
+    );
+    if (wantsRemainingQuests(latest)) {
+        for (const remaining of playerStateSummary?.slices?.remainingQuests || []) {
+            const quest = getBuiltInQuest(remaining.id);
+            if (quest && !selectedQuests.some((entry) => entry.id === quest.id))
+                selectedQuests.push(quest);
+        }
+        selectedQuests = selectedQuests.slice(0, caps.maxQuests);
+    }
+
+    const achievements = evaluateAchievements(gameState || {});
+    const selectedAchievements =
+        queryTokens.length > 0
+            ? selectScored(
+                  achievements,
+                  (a) => [a.id, a.title, a.description, stringifyFields(a.progress)].join(' '),
+                  queryTokens,
+                  queryText,
+                  caps.maxAchievements
+              )
+            : achievements
+                  .filter(
+                      (achievement) => achievement.unlocked || achievement.progress?.percent > 0
+                  )
+                  .slice(0, caps.maxAchievements);
+
+    const inventoryEntries = (inventoryOnlyQuery ? [] : Object.entries(gameState?.inventory || {}))
+        .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
+        .map(([id, count]) => ({ id, name: itemName(id), count }))
+        .filter(
+            (entry) =>
+                wantsInventory(latest) ||
+                scoreRecord(
+                    entry,
+                    `${entry.id} ${entry.name} ${itemById.get(entry.id)?.description || ''}`,
+                    queryTokens,
+                    queryText
+                ) > 0
+        )
+        .slice(0, caps.maxItems);
+
+    const lines = [];
+    const sources = [];
+    appendLine(
+        lines,
+        'Focused DSPACE game data (query-selected; omitted catalog entries are unknown/omitted, not absent).',
+        caps.maxTotalChars
+    );
+    if (inventoryEntries.length > 0) {
+        reasonCodes.push('matched-owned-inventory');
+        appendLine(
+            lines,
+            `Relevant inventory: ${inventoryEntries.map((e) => `${e.name} [${e.id}]=${formatCount(e.count)}`).join('; ')}`,
+            caps.maxTotalChars
+        );
+        sources.push({
+            type: 'state',
+            id: 'local-game-state',
+            label: 'Relevant inventory',
+            detail: `${inventoryEntries.length} bounded owned entries`,
+        });
+    }
+    if (selectedProcesses.length > 0) {
+        appendLine(
+            lines,
+            `Relevant processes: ${selectedProcesses.map((process) => truncate(`${process.title} [${process.id}]${process.duration ? ` duration ${process.duration}.` : ''} Requires: ${formatItemList(process.requireItems)}. Consumes: ${formatItemList(process.consumeItems)}. Creates: ${formatItemList(process.createItems)}.`, caps.maxEntityChars)).join(' || ')}`,
+            caps.maxTotalChars
+        );
+        sources.push(
+            ...selectedProcesses.map((process) => ({
+                type: 'process',
+                id: process.id,
+                label: process.title,
+                url: `/processes/${process.id}`,
+            }))
+        );
+    } else if (isVagueProcessQuery(latest)) {
+        reasonCodes.push('ambiguous-process-followup');
+        appendLine(
+            lines,
+            'Relevant processes: no unambiguous process recovered from recent chat; ask which process the player means instead of guessing.',
+            caps.maxTotalChars
+        );
+    }
+    if (selectedItems.length > 0) {
+        appendLine(
+            lines,
+            `Relevant items: ${selectedItems.map((item) => truncate(`${item.name} [${item.id}] — ${item.description || ''}${item.category ? ` Category: ${item.category}.` : ''}`, caps.maxEntityChars)).join(' | ')}`,
+            caps.maxTotalChars
+        );
+        sources.push(
+            ...selectedItems.map((item) => ({
+                type: 'item',
+                id: item.id,
+                label: item.name,
+                url: `/inventory/item/${item.id}`,
+                detail: truncate(item.description || '', 180),
+            }))
+        );
+    }
+    if (selectedQuests.length > 0) {
+        appendLine(
+            lines,
+            `Relevant quests: ${selectedQuests.map((quest) => truncate(`${quest.title || quest.id} [${quest.id}] — ${quest.description || ''}${quest.requiresQuests?.length ? ` Prereqs: ${quest.requiresQuests.join(', ')}.` : ''}${quest.rewards?.length ? ` Rewards: ${formatQuestRewards(quest.rewards)}.` : ''}${quest.rewardItems?.length ? ` Reward items: ${formatItemList(quest.rewardItems)}.` : ''}`, caps.maxEntityChars)).join(' || ')}`,
+            caps.maxTotalChars
+        );
+        sources.push(
+            ...selectedQuests.map((quest) => ({
+                type: 'quest',
+                id: quest.id,
+                label: quest.title || quest.id,
+                url: `/quests/${quest.id}`,
+                detail: truncate(quest.description || '', 180),
+            }))
+        );
+    }
+    if (selectedAchievements.length > 0) {
+        appendLine(
+            lines,
+            `Relevant achievements: ${selectedAchievements.map((a) => truncate(`${a.title} [${a.id}]${a.progress?.displayValue ? ` progress ${a.progress.displayValue}` : ''}`, caps.maxEntityChars)).join(' | ')}`,
+            caps.maxTotalChars
+        );
+        sources.push(
+            ...selectedAchievements.map((a) => ({ type: 'achievement', id: a.id, label: a.title }))
+        );
+    }
+    if (
+        (wantsRemainingQuests(latest) || playerStateSummary?.slices?.remainingQuests?.length) &&
+        selectedQuests.length > 0
+    ) {
+        appendLine(
+            lines,
+            `Relevant player progress: compact PlayerState is authoritative for remaining/finished quest counts; selected quest definitions above are only details for shown IDs.`,
+            caps.maxTotalChars
+        );
+    }
+
+    const block = lines.length > 1 ? lines.join('\n') : '';
+    return {
+        block,
+        sources: mergeSources(sources).slice(0, caps.maxSources),
+        meta: {
+            included: Boolean(block),
+            reasonCodes: reasonCodes.length
+                ? [...new Set(reasonCodes)]
+                : [block ? 'lexical-match' : 'no-focused-matches'],
+            selectedItemIds: selectedItems.map((item) => item.id),
+            selectedQuestIds: selectedQuests.map((quest) => quest.id),
+            selectedProcessIds: selectedProcesses.map((process) => process.id),
+            selectedAchievementIds: selectedAchievements.map((achievement) => achievement.id),
+            selectedInventoryIds: inventoryEntries.map((entry) => entry.id),
+            selectedItemCount: selectedItems.length,
+            selectedQuestCount: selectedQuests.length,
+            selectedProcessCount: selectedProcesses.length,
+            selectedAchievementCount: selectedAchievements.length,
+            selectedInventoryCount: inventoryEntries.length,
+            renderedChars: block.length,
+            caps,
+            truncated: block.length >= caps.maxTotalChars || sources.length > caps.maxSources,
+        },
+    };
+}
+
+export function __testables() {
+    return { normalize, tokensFor, scoreRecord };
+}

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -45,7 +45,6 @@ const STOPWORDS = new Set([
     'items',
     'inventory',
     'about',
-    'that',
     'would',
     'want',
     'need',
@@ -146,14 +145,17 @@ const stringifyFields = (value) => {
     return '';
 };
 
+const itemEntryText = (entries = []) =>
+    entries.map((entry) => [stringifyFields(entry), itemName(entry?.id)].join(' ')).join(' ');
+
 const processText = (process) =>
     [
         process.id,
         process.title,
         process.description,
-        stringifyFields(process.requireItems),
-        stringifyFields(process.consumeItems),
-        stringifyFields(process.createItems),
+        itemEntryText(process.requireItems),
+        itemEntryText(process.consumeItems),
+        itemEntryText(process.createItems),
         process.duration,
     ].join(' ');
 
@@ -173,9 +175,10 @@ const questText = (quest) =>
 const scoreRecord = (record, haystackText, queryTokens, queryText) => {
     const haystack = normalize(haystackText);
     if (!haystack || queryTokens.length === 0) return 0;
+    const haystackWords = new Set(haystack.split(' '));
     let score = 0;
     for (const token of queryTokens) {
-        if (haystack.split(' ').includes(token)) score += 2;
+        if (haystackWords.has(token)) score += 2;
         else if (haystack.includes(token)) score += 1;
     }
     const title = normalize(record.title || record.name || record.id);
@@ -200,6 +203,7 @@ const wantsRemainingQuests = (text) =>
         text
     );
 const wantsInventory = (text) => /\binventory\b|\bwhat do i have\b/i.test(text);
+const wantsAchievements = (text) => /\bachievements?\b|\bunlocked\b.*\bachievements?\b/i.test(text);
 
 const activeProcessIds = (gameState = {}, playerStateSummary) => {
     const fromSummary = playerStateSummary?.slices?.activeProcesses?.map((entry) => entry.id) || [];
@@ -242,7 +246,14 @@ export function buildFocusedGameDataContext({
     const queryTokens = [...new Set(tokensFor(queryText))];
     const reasonCodes = [];
 
-    if (queryTokens.length === 0 && !wantsRemainingQuests(latest) && !wantsInventory(latest)) {
+    const achievementIntent = wantsAchievements(latest);
+
+    if (
+        queryTokens.length === 0 &&
+        !wantsRemainingQuests(latest) &&
+        !wantsInventory(latest) &&
+        !achievementIntent
+    ) {
         return {
             block: '',
             sources: [],
@@ -253,6 +264,12 @@ export function buildFocusedGameDataContext({
                 selectedQuestCount: 0,
                 selectedProcessCount: 0,
                 selectedAchievementCount: 0,
+                selectedInventoryCount: 0,
+                selectedItemIds: [],
+                selectedQuestIds: [],
+                selectedProcessIds: [],
+                selectedAchievementIds: [],
+                selectedInventoryIds: [],
                 renderedChars: 0,
                 caps,
                 truncated: false,
@@ -263,6 +280,7 @@ export function buildFocusedGameDataContext({
     if (isVagueProcessQuery(latest)) reasonCodes.push('recent-context-expanded');
     if (wantsRemainingQuests(latest)) reasonCodes.push('remaining-quest-state');
     if (wantsInventory(latest)) reasonCodes.push('inventory-summary-request');
+    if (achievementIntent) reasonCodes.push('achievement-state-request');
 
     const inventoryOnlyQuery = wantsInventory(latest) && queryTokens.length === 0;
     const selectedItems = inventoryOnlyQuery
@@ -301,22 +319,32 @@ export function buildFocusedGameDataContext({
     }
 
     const achievements = evaluateAchievements(gameState || {});
-    const selectedAchievements =
-        queryTokens.length > 0
-            ? selectScored(
-                  achievements,
-                  (a) => [a.id, a.title, a.description, stringifyFields(a.progress)].join(' '),
-                  queryTokens,
-                  queryText,
-                  caps.maxAchievements
-              )
-            : achievements
-                  .filter(
-                      (achievement) => achievement.unlocked || achievement.progress?.percent > 0
-                  )
-                  .slice(0, caps.maxAchievements);
+    const achievementStateEntries = achievements.filter(
+        (achievement) => achievement.unlocked || achievement.progress?.percent > 0
+    );
+    const shouldReturnAchievementState =
+        achievementIntent && (queryTokens.length === 0 || /\bunlocked\b/i.test(latest));
+    const selectedAchievements = shouldReturnAchievementState
+        ? achievementStateEntries.slice(0, caps.maxAchievements)
+        : queryTokens.length > 0
+          ? selectScored(
+                achievements,
+                (a) =>
+                    [
+                        a.id,
+                        a.title,
+                        a.description,
+                        a.unlocked ? 'achievement unlocked earned complete' : '',
+                        a.progress?.percent > 0 ? 'achievement progress in progress' : '',
+                        stringifyFields(a.progress),
+                    ].join(' '),
+                queryTokens,
+                queryText,
+                caps.maxAchievements
+            )
+          : [];
 
-    const inventoryEntries = (inventoryOnlyQuery ? [] : Object.entries(gameState?.inventory || {}))
+    const inventoryEntries = Object.entries(gameState?.inventory || {})
         .filter(([, count]) => typeof count === 'number' && Number.isFinite(count) && count > 0)
         .map(([id, count]) => ({ id, name: itemName(id), count }))
         .filter(
@@ -347,7 +375,7 @@ export function buildFocusedGameDataContext({
         );
         sources.push({
             type: 'state',
-            id: 'local-game-state',
+            id: 'focused-inventory',
             label: 'Relevant inventory',
             detail: `${inventoryEntries.length} bounded owned entries`,
         });

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -709,6 +709,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
 
     const knowledgePack = buildDchatKnowledgePack(gameState, {
         latestUserMessage: latestUserMessage?.content || '',
+        messages: normalizedMessages,
         playerStateSummary: playerStateSnapshot,
     });
     const knowledgeSummary = knowledgePack.summary;
@@ -763,6 +764,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         // Read the rendered text directly so empty/early-return payloads remain accurate even if
         // external searchDocsRag metadata consumers evolve independently.
         docsRagRenderedChars: docsRagPayload.excerptsText?.length || 0,
+        focusedGameData: knowledgePack.focusedGameData || null,
         docsRagBudget: docsRagRequestOptions
             ? {
                   maxResults: docsRagRequestOptions.maxResults,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -29,6 +29,41 @@ const normalizeIndexes = (value) => {
 
 const numberOrZero = (value) => (Number.isFinite(value) ? Number(value) : 0);
 
+const sanitizeFocusedGameData = (focused) => {
+    if (!focused || typeof focused !== 'object') return null;
+    return {
+        included: Boolean(focused.included),
+        reasonCodes: Array.isArray(focused.reasonCodes) ? focused.reasonCodes.slice(0, 12) : [],
+        selectedItemCount: numberOrZero(focused.selectedItemCount),
+        selectedQuestCount: numberOrZero(focused.selectedQuestCount),
+        selectedProcessCount: numberOrZero(focused.selectedProcessCount),
+        selectedAchievementCount: numberOrZero(focused.selectedAchievementCount),
+        selectedInventoryCount: numberOrZero(focused.selectedInventoryCount),
+        selectedItemIds: Array.isArray(focused.selectedItemIds)
+            ? focused.selectedItemIds.slice(0, 12)
+            : [],
+        selectedQuestIds: Array.isArray(focused.selectedQuestIds)
+            ? focused.selectedQuestIds.slice(0, 12)
+            : [],
+        selectedProcessIds: Array.isArray(focused.selectedProcessIds)
+            ? focused.selectedProcessIds.slice(0, 12)
+            : [],
+        renderedChars: numberOrZero(focused.renderedChars),
+        caps: focused.caps
+            ? {
+                  maxItems: focused.caps.maxItems,
+                  maxQuests: focused.caps.maxQuests,
+                  maxProcesses: focused.caps.maxProcesses,
+                  maxAchievements: focused.caps.maxAchievements,
+                  maxTotalChars: focused.caps.maxTotalChars,
+                  maxEntityChars: focused.caps.maxEntityChars,
+                  maxSources: focused.caps.maxSources,
+              }
+            : null,
+        truncated: Boolean(focused.truncated),
+    };
+};
+
 const sanitizePlayerStateSummary = (summary) => {
     if (!summary || typeof summary !== 'object') return null;
 
@@ -101,6 +136,7 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
             metadata.ragDurationMs === undefined || metadata.ragDurationMs === null
                 ? null
                 : Number(metadata.ragDurationMs),
+        focusedGameData: sanitizeFocusedGameData(metadata.contextPlan?.focusedGameData),
         docsRag: metadata.contextPlan
             ? (() => {
                   const status =

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -27,37 +27,35 @@ const normalizeIndexes = (value) => {
     return [];
 };
 
-const numberOrZero = (value) => (Number.isFinite(value) ? Number(value) : 0);
+const numberOrZero = (value) => (Number.isFinite(Number(value)) ? Number(value) : 0);
+const stringList = (value, max = 12) =>
+    Array.isArray(value) ? value.slice(0, max).map((entry) => String(entry)) : [];
 
 const sanitizeFocusedGameData = (focused) => {
     if (!focused || typeof focused !== 'object') return null;
     return {
         included: Boolean(focused.included),
-        reasonCodes: Array.isArray(focused.reasonCodes) ? focused.reasonCodes.slice(0, 12) : [],
+        reasonCodes: stringList(focused.reasonCodes),
         selectedItemCount: numberOrZero(focused.selectedItemCount),
         selectedQuestCount: numberOrZero(focused.selectedQuestCount),
         selectedProcessCount: numberOrZero(focused.selectedProcessCount),
         selectedAchievementCount: numberOrZero(focused.selectedAchievementCount),
         selectedInventoryCount: numberOrZero(focused.selectedInventoryCount),
-        selectedItemIds: Array.isArray(focused.selectedItemIds)
-            ? focused.selectedItemIds.slice(0, 12)
-            : [],
-        selectedQuestIds: Array.isArray(focused.selectedQuestIds)
-            ? focused.selectedQuestIds.slice(0, 12)
-            : [],
-        selectedProcessIds: Array.isArray(focused.selectedProcessIds)
-            ? focused.selectedProcessIds.slice(0, 12)
-            : [],
+        selectedItemIds: stringList(focused.selectedItemIds),
+        selectedQuestIds: stringList(focused.selectedQuestIds),
+        selectedProcessIds: stringList(focused.selectedProcessIds),
+        selectedAchievementIds: stringList(focused.selectedAchievementIds),
+        selectedInventoryIds: stringList(focused.selectedInventoryIds),
         renderedChars: numberOrZero(focused.renderedChars),
         caps: focused.caps
             ? {
-                  maxItems: focused.caps.maxItems,
-                  maxQuests: focused.caps.maxQuests,
-                  maxProcesses: focused.caps.maxProcesses,
-                  maxAchievements: focused.caps.maxAchievements,
-                  maxTotalChars: focused.caps.maxTotalChars,
-                  maxEntityChars: focused.caps.maxEntityChars,
-                  maxSources: focused.caps.maxSources,
+                  maxItems: numberOrZero(focused.caps.maxItems),
+                  maxQuests: numberOrZero(focused.caps.maxQuests),
+                  maxProcesses: numberOrZero(focused.caps.maxProcesses),
+                  maxAchievements: numberOrZero(focused.caps.maxAchievements),
+                  maxTotalChars: numberOrZero(focused.caps.maxTotalChars),
+                  maxEntityChars: numberOrZero(focused.caps.maxEntityChars),
+                  maxSources: numberOrZero(focused.caps.maxSources),
               }
             : null,
         truncated: Boolean(focused.truncated),

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -134,6 +134,23 @@ describe('buildDchatKnowledgePack', () => {
         expect(highlights).toContain('dUSD (x25)');
     });
 
+    it('keeps compact quest progress alongside focused chat context', () => {
+        const pack = buildDchatKnowledgePack(
+            {
+                quests: {
+                    'welcome/howtodoquests': { finished: true },
+                },
+                inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 2 },
+            },
+            { latestUserMessage: 'How is my white PLA filament inventory and quest progress?' }
+        );
+
+        expect(pack.summary).toContain('Quest progress:');
+        expect(pack.summary).toContain('welcome/howtodoquests: finished');
+        expect(pack.summary).toContain('white PLA filament');
+        expect(pack.sources.some((entry) => entry.detail?.includes('quest progress'))).toBe(true);
+    });
+
     it('keeps query-relevant live inventory in compact highlights', () => {
         const pack = buildDchatKnowledgePack(
             { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -71,6 +71,24 @@ describe('buildDchatKnowledgePack', () => {
         expect(new Set(achievementSources.map((entry) => entry.id))).toEqual(new Set(expectedIds));
     });
 
+    it('keeps inventory requests on compact inventory state without achievement or catalog filler', () => {
+        mockEvaluateAchievements.mockReturnValue([
+            { id: 'first-steps', title: 'First Steps', unlocked: true },
+        ]);
+
+        const pack = buildDchatKnowledgePack(
+            { inventory: { '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 3 } },
+            { latestUserMessage: 'what is my inventory?' }
+        );
+
+        expect(pack.summary).toContain('Inventory highlights: compact bounded');
+        expect(pack.summary).toContain('Relevant inventory:');
+        expect(pack.summary).not.toContain('Relevant achievements:');
+        expect(pack.summary).not.toContain('Relevant quests:');
+        expect(pack.summary).not.toContain('Relevant processes:');
+        expect(pack.focusedGameData?.selectedAchievementCount).toBe(0);
+    });
+
     it('bounds live-state inventory highlights instead of dumping all owned inventory', () => {
         const inventory = Object.fromEntries(
             Array.from({ length: 150 }, (_, index) => [`raw-owned-${index}`, index + 1])

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -17,13 +17,15 @@ beforeEach(async () => {
 });
 
 describe('buildDchatKnowledgePack', () => {
-    it('returns summary and sources for non-empty catalogs', () => {
+    it('does not include broad catalog filler without a focused query', () => {
         const pack = buildDchatKnowledgePack({});
 
-        expect(pack.summary).toContain('Items:');
-        expect(pack.sources.length).toBeGreaterThan(0);
-        expect(pack.sources.some((entry) => entry.type === 'item')).toBe(true);
+        expect(pack.summary).not.toContain('Items:');
+        expect(pack.summary).not.toContain('Quests:');
+        expect(pack.summary).not.toContain('Processes:');
+        expect(pack.sources.some((entry) => entry.type === 'item')).toBe(false);
         expect(pack.sources.some((entry) => entry.type === 'state')).toBe(false);
+        expect(pack.focusedGameData?.included).toBe(false);
     });
 
     it('adds a state source when game state context is used', () => {
@@ -51,12 +53,9 @@ describe('buildDchatKnowledgePack', () => {
 
         mockEvaluateAchievements.mockReturnValue([...unlocked, ...inProgress]);
 
-        const pack = buildDchatKnowledgePack({});
+        const pack = buildDchatKnowledgePack({}, { latestUserMessage: 'achievement progress' });
         const achievementSources = pack.sources.filter((entry) => entry.type === 'achievement');
-        const expectedIds = [
-            ...unlocked.map((entry) => entry.id),
-            ...inProgress.slice(0, 2).map((entry) => entry.id),
-        ];
+        const expectedIds = inProgress.slice(0, 4).map((entry) => entry.id);
         const sortedAchievementIds = [...achievementSources]
             .sort((a, b) => {
                 const labelCompare = a.label.localeCompare(b.label);
@@ -67,7 +66,7 @@ describe('buildDchatKnowledgePack', () => {
             })
             .map((entry) => entry.id);
 
-        expect(achievementSources.length).toBe(6);
+        expect(achievementSources.length).toBe(4);
         expect(achievementSources.map((entry) => entry.id)).toEqual(sortedAchievementIds);
         expect(new Set(achievementSources.map((entry) => entry.id))).toEqual(new Set(expectedIds));
     });

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -85,7 +85,8 @@ describe('buildDchatKnowledgePack', () => {
 
         expect(highlights).toContain('compact bounded live-state highlights');
         expect((highlights?.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
-        expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(8);
+        expect(pack.focusedGameData?.selectedInventoryCount).toBeLessThanOrEqual(8);
+        expect((pack.summary.match(/raw-owned-/g) || []).length).toBeLessThanOrEqual(24);
     });
 
     it('does not add arbitrary live inventory highlights for unrelated progress questions', () => {

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -82,6 +82,29 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.sources.some((source) => source.type === 'quest')).toBe(true);
     });
 
+    it('uses prior quest context for vague reward follow-ups', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what rewards does it give?',
+            messages: [{ role: 'user', content: 'Tell me about Preflight Checklist' }],
+        });
+
+        expect(result.block).toContain('Relevant quests:');
+        expect(result.meta.selectedQuestIds).toContain('rocketry/preflight-check');
+        expect(result.block).toMatch(/Rewards:|Reward items:/);
+        expect(result.block).not.toContain('Relevant processes:');
+    });
+
+    it('asks for clarification instead of dumping processes for ambiguous process follow-ups', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what does this process consume?',
+        });
+
+        expect(result.block).toContain('no unambiguous process recovered from recent chat');
+        expect(result.block).not.toMatch(/\|\||Requires:/);
+        expect(result.meta.selectedProcessCount).toBe(0);
+        expect(result.meta.reasonCodes).toContain('ambiguous-process-followup');
+    });
+
     it('uses prior process context for vague consume follow-ups', () => {
         const result = buildFocusedGameDataContext({
             query: 'what does it consume?',
@@ -148,7 +171,7 @@ describe('buildFocusedGameDataContext', () => {
                         selectedProcessCount: '3',
                         selectedAchievementCount: '1',
                         selectedInventoryCount: '4',
-                        selectedItemIds: [1],
+                        selectedItemIds: Array.from({ length: 20 }, (_, index) => index),
                         selectedQuestIds: ['quest'],
                         selectedProcessIds: ['process'],
                         selectedAchievementIds: [{ id: 'achievement' }],
@@ -164,6 +187,7 @@ describe('buildFocusedGameDataContext', () => {
         expect(metrics.focusedGameData).toMatchObject({
             reasonCodes: ['[object Object]'],
             selectedItemCount: 2,
+            selectedItemIds: Array.from({ length: 12 }, (_, index) => String(index)),
             selectedQuestCount: 0,
             selectedProcessCount: 3,
             selectedAchievementIds: ['[object Object]'],

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { buildPromptMetrics } from '../src/utils/promptMetrics.js';
 import { buildFocusedGameDataContext } from '../src/utils/gameDataRetrieval.js';
 
 describe('buildFocusedGameDataContext', () => {
@@ -14,6 +15,41 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.meta.selectedInventoryIds).toContain('d3590107-25ff-4de5-af3a-46e2497bfc52');
     });
 
+    it('includes bounded owned inventory for pure inventory requests', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what do I have?',
+            gameState: {
+                inventory: {
+                    '58580f6f-f3be-4be0-80b9-f6f8bf0b05a6': 3,
+                    'd3590107-25ff-4de5-af3a-46e2497bfc52': 13,
+                },
+            },
+        });
+
+        expect(result.block).toContain('Relevant inventory:');
+        expect(result.block).toContain('white PLA filament');
+        expect(result.meta.selectedInventoryCount).toBe(2);
+        expect(result.meta.selectedInventoryIds).toContain('58580f6f-f3be-4be0-80b9-f6f8bf0b05a6');
+        expect(result.sources.some((source) => source.id === 'focused-inventory')).toBe(true);
+    });
+
+    it('keeps early-return meta shape stable', () => {
+        const result = buildFocusedGameDataContext({ query: 'what is it?' });
+
+        expect(result.meta).toMatchObject({
+            selectedItemCount: 0,
+            selectedQuestCount: 0,
+            selectedProcessCount: 0,
+            selectedAchievementCount: 0,
+            selectedInventoryCount: 0,
+            selectedItemIds: [],
+            selectedQuestIds: [],
+            selectedProcessIds: [],
+            selectedAchievementIds: [],
+            selectedInventoryIds: [],
+        });
+    });
+
     it('selects rocket and Benchy process data', () => {
         const result = buildFocusedGameDataContext({
             query: "I'd like to make a 3D printed rocket and 10 benchies. Is it enough for that?",
@@ -24,6 +60,16 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.block).toMatch(/rocket/i);
         expect(result.block).toMatch(/Benchy/i);
         expect(result.block).toMatch(/Consumes:/);
+    });
+
+    it('matches process inputs and outputs by item names', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'how do I get dLaunch?',
+        });
+
+        expect(result.block).toContain('Relevant processes:');
+        expect(result.meta.selectedProcessIds).toContain('launch-rocket');
+        expect(result.block).toContain('dLaunch');
     });
 
     it('selects a preflight quest and reward data', () => {
@@ -47,6 +93,36 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.meta.reasonCodes).toContain('recent-context-expanded');
     });
 
+    it('returns achievement state for direct achievement requests without unrelated filler', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what achievements have I unlocked?',
+            gameState: {
+                quests: {
+                    'welcome/howtodoquests': { finished: true },
+                },
+            },
+        });
+
+        expect(result.block).toContain('Relevant achievements:');
+        expect(result.meta.selectedAchievementCount).toBeGreaterThan(0);
+        expect(result.meta.reasonCodes).toContain('achievement-state-request');
+    });
+
+    it('does not fall back to achievement filler when no achievement intent exists', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what do I have?',
+            gameState: {
+                quests: {
+                    'welcome/howtodoquests': { finished: true },
+                },
+                inventory: {},
+            },
+        });
+
+        expect(result.block).not.toContain('Relevant achievements:');
+        expect(result.meta.selectedAchievementCount).toBe(0);
+    });
+
     it('does not select broad catalog filler for unrelated queries and enforces budgets', () => {
         const result = buildFocusedGameDataContext({
             query: 'tell me a joke about clouds',
@@ -57,5 +133,43 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.meta.selectedItemCount).toBeLessThanOrEqual(1);
         expect(result.meta.selectedQuestCount).toBeLessThanOrEqual(1);
         expect(result.meta.selectedProcessCount).toBeLessThanOrEqual(1);
+    });
+
+    it('sanitizes focused game-data metrics values', () => {
+        const metrics = buildPromptMetrics(
+            { messages: [{ role: 'user', content: 'hello' }] },
+            {
+                contextPlan: {
+                    focusedGameData: {
+                        included: true,
+                        reasonCodes: [{ reason: 'object' }],
+                        selectedItemCount: '2',
+                        selectedQuestCount: undefined,
+                        selectedProcessCount: '3',
+                        selectedAchievementCount: '1',
+                        selectedInventoryCount: '4',
+                        selectedItemIds: [1],
+                        selectedQuestIds: ['quest'],
+                        selectedProcessIds: ['process'],
+                        selectedAchievementIds: [{ id: 'achievement' }],
+                        selectedInventoryIds: [Symbol.for('item')],
+                        renderedChars: '99',
+                        caps: { maxItems: '8', maxQuests: undefined, maxProcesses: '6' },
+                        truncated: true,
+                    },
+                },
+            }
+        );
+
+        expect(metrics.focusedGameData).toMatchObject({
+            reasonCodes: ['[object Object]'],
+            selectedItemCount: 2,
+            selectedQuestCount: 0,
+            selectedProcessCount: 3,
+            selectedAchievementIds: ['[object Object]'],
+            selectedInventoryIds: ['Symbol(item)'],
+            renderedChars: 99,
+            caps: { maxItems: 8, maxQuests: 0, maxProcesses: 6 },
+        });
     });
 });

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildFocusedGameDataContext } from '../src/utils/gameDataRetrieval.js';
+
+describe('buildFocusedGameDataContext', () => {
+    it('selects green PLA item and owned state', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'do I have enough green PLA?',
+            gameState: { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },
+        });
+
+        expect(result.block).toContain('Relevant inventory:');
+        expect(result.block).toContain('green PLA filament');
+        expect(result.sources.some((source) => source.type === 'item')).toBe(true);
+        expect(result.meta.selectedInventoryIds).toContain('d3590107-25ff-4de5-af3a-46e2497bfc52');
+    });
+
+    it('selects rocket and Benchy process data', () => {
+        const result = buildFocusedGameDataContext({
+            query: "I'd like to make a 3D printed rocket and 10 benchies. Is it enough for that?",
+            gameState: { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 250 } },
+        });
+
+        expect(result.block).toContain('Relevant processes:');
+        expect(result.block).toMatch(/rocket/i);
+        expect(result.block).toMatch(/Benchy/i);
+        expect(result.block).toMatch(/Consumes:/);
+    });
+
+    it('selects a preflight quest and reward data', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what rewards does preflight check give?',
+        });
+
+        expect(result.block).toContain('Relevant quests:');
+        expect(result.block).toMatch(/preflight/i);
+        expect(result.sources.some((source) => source.type === 'quest')).toBe(true);
+    });
+
+    it('uses prior process context for vague consume follow-ups', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what does it consume?',
+            messages: [{ role: 'user', content: 'Tell me about 3D print a 100 mm model rocket' }],
+        });
+
+        expect(result.block).toContain('Relevant processes:');
+        expect(result.block).toContain('3dprint-rocket');
+        expect(result.meta.reasonCodes).toContain('recent-context-expanded');
+    });
+
+    it('does not select broad catalog filler for unrelated queries and enforces budgets', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'tell me a joke about clouds',
+            options: { maxTotalChars: 500, maxItems: 1, maxQuests: 1, maxProcesses: 1 },
+        });
+
+        expect(result.block.length).toBeLessThanOrEqual(500);
+        expect(result.meta.selectedItemCount).toBeLessThanOrEqual(1);
+        expect(result.meta.selectedQuestCount).toBeLessThanOrEqual(1);
+        expect(result.meta.selectedProcessCount).toBeLessThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
### Motivation
- Full-mode chat was still including broad static item/quest/process catalogs which bloated prompts and hurt local-model performance. 
- We need a deterministic, local, lexical retrieval layer to select only game entities relevant to the latest user query and recent grounded context. 
- This must preserve compact P19 PlayerState behavior and P16/P17/P18 gating while exposing safe metrics for prompt budgeting.

### Description
- Added a deterministic focused retrieval helper `buildFocusedGameDataContext` in `frontend/src/utils/gameDataRetrieval.js` that performs local lexical matching over items, quests, processes, achievements, and bounded owned inventory, applies caps/budgets, and emits `block`, `sources`, and `meta` results. 
- Replaced the previous broad catalog sections in `buildDchatKnowledgePack` (`frontend/src/utils/dchatKnowledge.js`) with the focused block and selected-only sources, and kept compact PlayerState highlights as the live-state baseline. 
- Wired recent chat messages into focused retrieval by passing `messages` through `buildDchatKnowledgePack` from `frontend/src/utils/openAI.js`, and exposed safe focused-retrieval metadata into prompt metrics via `frontend/src/utils/promptMetrics.js` (sanitizer added). 
- Implemented simple lexical scoring (tokenization, normalization, title/id boosts), recent-context expansion for vague follow-ups, stable route URLs for selected sources, and truncation/caps (items/quests/processes/achievements, max chars, max sources). 
- Added unit tests `frontend/tests/gameDataRetrieval.test.ts` and updated `frontend/tests/dchatKnowledgePack.test.ts` and `frontend/__tests__/dchatKnowledge.test.js` to validate focused selection, omission of broad catalog filler by default, vague follow-ups, budgets, and sources.

### Testing
- Ran focused unit suites: `cd frontend && npm test -- dchatKnowledge gameDataRetrieval` and the tests passed (`gameDataRetrieval` and `dchatKnowledgePack` tests passed). 
- Ran broader integration suites: `cd frontend && npm test -- openAI` and `cd frontend && npm test -- chatContextPlanner tokenPlace.test.js` and these passed (OpenAI, chat planner, and token.place provider tests passed). 
- Verified lint/format/build: `cd frontend && npm run check` and `cd frontend && npm run build` both succeeded. 
- New/modified tests: added `frontend/tests/gameDataRetrieval.test.ts`, updated `frontend/tests/dchatKnowledgePack.test.ts` and `frontend/__tests__/dchatKnowledge.test.js` to assert focused behavior and caps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4055d46dec832fb5c3c71a10b80984)