### PR TITLE
Add compact full-mode answer-focus system message

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -391,6 +391,12 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        const messages = decrypted.api_v1_request.messages;
+        expect(messages.at(-1)).toMatchObject({
+            role: 'user',
+            content: 'What should I build next?',
+        });
+        expect(messages.at(-2).content).toContain('Answer focus:');
     });
 
     test('default token.place mode includes docs RAG for route questions', async () => {
@@ -408,9 +414,15 @@ describe('token.place API v1 client', () => {
         expect(searchDocsRag).toHaveBeenCalledTimes(1);
         const { body } = getFetchCallByPath('/api/v1/relay/requests');
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
-        const serializedMessages = JSON.stringify(decrypted.api_v1_request.messages);
+        const messages = decrypted.api_v1_request.messages;
+        const serializedMessages = JSON.stringify(messages);
         expect(serializedMessages).toContain('Docs grounding canary for gamesaves.');
-        expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        expect(messages.length).toBeGreaterThan(2);
+        expect(messages.at(-1)).toMatchObject({
+            role: 'user',
+            content: 'where do I import a gamesave?',
+        });
+        expect(messages.at(-2).content).toContain('Answer focus:');
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {

--- a/frontend/src/utils/chatAnswerFocus.js
+++ b/frontend/src/utils/chatAnswerFocus.js
@@ -1,0 +1,25 @@
+export const ANSWER_FOCUS_MAX_CHARS = 700;
+export const ANSWER_FOCUS_LATEST_REQUEST_PREVIEW_MAX_CHARS = 0;
+
+const ANSWER_FOCUS_TEXT = [
+    'Answer the final user message directly.',
+    'Use PlayerState, focused game data, and docs grounding only when relevant.',
+    'Do not summarize or enumerate unrelated inventory, quests, docs, or processes.',
+    'Omitted compact-state details are not evidence that the player lacks them.',
+    'If selected context is insufficient, ask a clarifying question instead of guessing.',
+    'Give exact counts, costs, durations, requirements, or routes only when they appear in selected context.',
+].join(' ');
+
+const truncateAnswerFocus = (text) => {
+    if (text.length <= ANSWER_FOCUS_MAX_CHARS) return text;
+    return text.slice(0, ANSWER_FOCUS_MAX_CHARS).trimEnd();
+};
+
+export const buildAnswerFocusMessage = ({ contextPlan } = {}) => {
+    if (contextPlan?.mode !== 'full') return null;
+
+    return {
+        role: 'system',
+        content: truncateAnswerFocus(`Answer focus: ${ANSWER_FOCUS_TEXT}`),
+    };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -9,6 +9,7 @@ import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
+import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -674,6 +675,12 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 ragDurationMs: 0,
                 contextPlan: contextPlanMetadata,
                 playerStateSummary: promptPayload.playerStateSummary,
+                answerFocus: {
+                    included: false,
+                    characterCount: 0,
+                    placementIndex: -1,
+                    latestUserMessageIndex,
+                },
                 componentMessageIndexes: {
                     systemInstructions: [
                         combinedMessages.indexOf(systemMessage),
@@ -791,32 +798,40 @@ export const buildChatPrompt = async (messages, options = {}) => {
         content: persona?.welcomeMessage || fallbackWelcomeMessage,
     };
 
+    const answerFocusMessage = buildAnswerFocusMessage({
+        latestUserMessage,
+        contextPlan: contextPlanMetadata,
+    });
+    const contextMessages = [
+        systemMessage,
+        ...(playerStateMessage ? [playerStateMessage] : []),
+        ...(knowledgeMessage ? [knowledgeMessage] : []),
+        ...(docsRagMessage && !knowledgeMessage ? [docsRagMessage] : []),
+    ];
     let combinedMessages = [...normalizedMessages];
 
     if (combinedMessages.length === 0) {
-        combinedMessages = [systemMessage];
-        if (playerStateMessage) {
-            combinedMessages.push(playerStateMessage);
-        }
-        if (knowledgeMessage) {
-            combinedMessages.push(knowledgeMessage);
-        }
-        if (docsRagMessage && !knowledgeMessage) {
-            combinedMessages.push(docsRagMessage);
+        combinedMessages = [...contextMessages];
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
         }
         combinedMessages.push(openingMessage);
     } else {
-        combinedMessages = [systemMessage];
-        if (playerStateMessage) {
-            combinedMessages.push(playerStateMessage);
+        const latestUserMessageIndex = latestUserMessage
+            ? normalizedMessages.lastIndexOf(latestUserMessage)
+            : -1;
+        const messagesBeforeLatest =
+            latestUserMessageIndex === -1
+                ? normalizedMessages
+                : normalizedMessages.slice(0, latestUserMessageIndex);
+        const messagesFromLatest =
+            latestUserMessageIndex === -1 ? [] : normalizedMessages.slice(latestUserMessageIndex);
+
+        combinedMessages = [...contextMessages, ...messagesBeforeLatest];
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
         }
-        if (knowledgeMessage) {
-            combinedMessages.push(knowledgeMessage);
-        }
-        if (docsRagMessage && !knowledgeMessage) {
-            combinedMessages.push(docsRagMessage);
-        }
-        combinedMessages = [...combinedMessages, ...normalizedMessages];
+        combinedMessages.push(...messagesFromLatest);
     }
 
     const ragMessages = new Set([knowledgeMessage, docsRagMessage].filter(Boolean));
@@ -846,6 +861,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         const latestUserMessageIndex = latestUserMessage
             ? combinedMessages.lastIndexOf(latestUserMessage)
             : -1;
+        const answerFocusMessageIndex = indexOfMessage(answerFocusMessage);
         const chatHistoryIndexes = combinedMessages
             .map((message, index) => ({ message, index }))
             .filter(
@@ -864,6 +880,12 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ragDurationMs,
             contextPlan: contextPlanMetadata,
             playerStateSummary: playerStateSnapshot.meta,
+            answerFocus: {
+                included: Boolean(answerFocusMessage),
+                characterCount: answerFocusMessage?.content?.length || 0,
+                placementIndex: answerFocusMessageIndex,
+                latestUserMessageIndex,
+            },
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -31,6 +31,28 @@ const numberOrZero = (value) => (Number.isFinite(Number(value)) ? Number(value) 
 const stringList = (value, max = 12) =>
     Array.isArray(value) ? value.slice(0, max).map((entry) => String(entry)) : [];
 
+const sanitizeAnswerFocus = (answerFocus) => {
+    if (!answerFocus || typeof answerFocus !== 'object') {
+        return {
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+            latestUserMessageIndex: -1,
+        };
+    }
+
+    return {
+        included: Boolean(answerFocus.included),
+        characterCount: numberOrZero(answerFocus.characterCount),
+        placementIndex: Number.isInteger(answerFocus.placementIndex)
+            ? answerFocus.placementIndex
+            : -1,
+        latestUserMessageIndex: Number.isInteger(answerFocus.latestUserMessageIndex)
+            ? answerFocus.latestUserMessageIndex
+            : -1,
+    };
+};
+
 const sanitizeFocusedGameData = (focused) => {
     if (!focused || typeof focused !== 'object') return null;
     return {
@@ -135,6 +157,7 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                 ? null
                 : Number(metadata.ragDurationMs),
         focusedGameData: sanitizeFocusedGameData(metadata.contextPlan?.focusedGameData),
+        answerFocus: sanitizeAnswerFocus(metadata.answerFocus),
         docsRag: metadata.contextPlan
             ? (() => {
                   const status =

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -26,6 +26,9 @@ const persona = (id: string) => npcPersonas.find((entry) => entry.id === id)!;
 const joinedPrompt = (payload: { combinedMessages: Array<{ content: string }> }) =>
     payload.combinedMessages.map((message) => message.content).join('\n\n');
 
+const findAnswerFocusIndex = (payload: { combinedMessages: Array<{ content: string }> }) =>
+    payload.combinedMessages.findIndex((message) => message.content.includes('Answer focus:'));
+
 describe('buildChatPrompt context planning', () => {
     beforeEach(() => {
         vi.mocked(buildDchatKnowledgePack).mockClear();
@@ -44,12 +47,18 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).not.toContain('DSPACE knowledge base');
         expect(prompt).not.toContain('Docs grounding');
         expect(prompt).not.toContain('inventory highlights');
+        expect(prompt).not.toContain('Answer focus:');
         expect(prompt).toContain('Never invent game facts or player state.');
         expect(prompt).toContain('Only give exact counts/durations/rates');
         expect(prompt).not.toContain('Use the PlayerState block when present.');
         expect(prompt).not.toContain('If PlayerState is missing');
         expect(prompt.length).toBeLessThan(5000);
         expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
+        expect(payload.promptMetrics.answerFocus).toMatchObject({
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+        });
         expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
         expect(searchDocsRag).not.toHaveBeenCalled();
     });
@@ -144,6 +153,36 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).toContain('DSPACE knowledge base');
         expect(prompt).toContain('Use the PlayerState block when present.');
         expect(prompt).toContain('If PlayerState is missing');
+        const answerFocusIndex = findAnswerFocusIndex(payload);
+        const latestUserIndex = payload.combinedMessages.length - 1;
+        expect(answerFocusIndex).toBeGreaterThan(
+            payload.combinedMessages.findIndex((message) =>
+                message.content.includes('DSPACE knowledge base')
+            )
+        );
+        expect(answerFocusIndex).toBe(latestUserIndex - 1);
+        expect(payload.combinedMessages[latestUserIndex]).toMatchObject({
+            role: 'user',
+            content: 'what quest do I have left?',
+        });
+        expect(payload.combinedMessages[answerFocusIndex].content).toMatch(
+            /answer the final user message directly/i
+        );
+        expect(payload.combinedMessages[answerFocusIndex].content).not.toContain('PlayerState:');
+        expect(payload.combinedMessages[answerFocusIndex].content).not.toContain('Docs grounding');
+        expect(payload.combinedMessages[answerFocusIndex].content).not.toContain(
+            'what quest do I have left?'
+        );
+        expect(payload.combinedMessages[answerFocusIndex].content).not.toContain('You are dChat');
+        expect(payload.promptMetrics.answerFocus).toMatchObject({
+            included: true,
+            placementIndex: answerFocusIndex,
+            latestUserMessageIndex: latestUserIndex,
+        });
+        expect(payload.promptMetrics.answerFocus.characterCount).toBeLessThanOrEqual(700);
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(
+            'what quest do I have left?'
+        );
         expect(buildDchatKnowledgePack).toHaveBeenCalled();
         expect(searchDocsRag).not.toHaveBeenCalled();
     });
@@ -157,6 +196,18 @@ describe('buildChatPrompt context planning', () => {
         expect(routePayload.contextPlan.mode).toBe('full');
         expect(routePayload.contextPlan.includeDocsRag).toBe(true);
         expect(routePayload.promptMetrics.docsRag.status).toBe('included');
+        const routeAnswerFocusIndex = findAnswerFocusIndex(routePayload);
+        const routeLatestUserIndex = routePayload.combinedMessages.length - 1;
+        expect(routeAnswerFocusIndex).toBe(routeLatestUserIndex - 1);
+        expect(routePayload.combinedMessages[routeLatestUserIndex]).toMatchObject({
+            role: 'user',
+            content: 'where do I import a gamesave?',
+        });
+        expect(routeAnswerFocusIndex).toBeGreaterThan(
+            routePayload.combinedMessages.findIndex((message) =>
+                message.content.includes('Docs grounding')
+            )
+        );
         expect(searchDocsRag).toHaveBeenCalledTimes(1);
 
         vi.mocked(searchDocsRag).mockClear();
@@ -170,5 +221,36 @@ describe('buildChatPrompt context planning', () => {
         expect(customPayload.contextPlan.includeDocsRag).toBe(true);
         expect(customPayload.contextPlan.docsRagReasonCodes).toContain('custom-content-docs');
         expect(searchDocsRag).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps focused game data with answer focus near the latest request', async () => {
+        vi.mocked(buildDchatKnowledgePack).mockReturnValueOnce({
+            summary: `Focused game data:
+Items: 3D printed rocket, benchy.
+Processes: 3D printing.`,
+            sources: [],
+            focusedGameData: {
+                included: true,
+                selectedItemCount: 2,
+                selectedQuestCount: 0,
+                selectedProcessCount: 1,
+                renderedChars: 74,
+            },
+        });
+        const latest =
+            'I’d like to make a 3D printed rocket and 10 benchies. Is it enough for that?';
+        const payload = await buildChatPrompt([{ role: 'user', content: latest }], {
+            includePromptMetrics: true,
+        });
+        const prompt = joinedPrompt(payload);
+        const answerFocusIndex = findAnswerFocusIndex(payload);
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.promptMetrics.focusedGameData?.included).toBe(true);
+        expect(prompt).toContain('Focused game data');
+        expect(prompt).not.toContain('Complete item catalog');
+        expect(prompt).not.toContain('Complete quest catalog');
+        expect(answerFocusIndex).toBe(payload.combinedMessages.length - 2);
+        expect(payload.combinedMessages.at(-1)).toMatchObject({ role: 'user', content: latest });
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent local models from being magnetized by context blocks by steering them to answer the latest user request directly while preserving all existing context-selection logic.
- Keep minimal-mode prompts unchanged and ensure the focus note does not override persona voice or leak sensitive prompt/user/context contents.

### Description
- Add `frontend/src/utils/chatAnswerFocus.js` with `ANSWER_FOCUS_MAX_CHARS`, `ANSWER_FOCUS_LATEST_REQUEST_PREVIEW_MAX_CHARS`, and a deterministic `buildAnswerFocusMessage({ contextPlan })` helper that returns a compact system message only when `contextPlan.mode === 'full'`.
- Integrate the answer-focus message into `buildChatPrompt` in `frontend/src/utils/openAI.js` so it is inserted after persona/playerState/knowledge/docs blocks and before the final `user` message, preserving the final user message as a real `user` role.
- Extend prompt metrics in `frontend/src/utils/promptMetrics.js` and the prompt payload metadata to expose safe answer-focus metadata (`included`, `characterCount`, `placementIndex`, `latestUserMessageIndex`) while avoiding any exposure of prompt text, user text, PlayerState JSON, docs excerpts, keys, or ciphertext.
- Add/adjust tests to validate full-mode insertion, docs-grounded/full-focused game-data behavior, minimal-mode regressions, persona preservation, token.place payload placement, and prompt-metrics behavior (`frontend/tests/openAIContextPlanner.test.ts` and `frontend/__tests__/tokenPlace.test.js`).

### Testing
- Ran focused unit tests: `cd frontend && npm test -- openAIContextPlanner chatAnswerFocus openAI` and `cd frontend && npm test -- dchatKnowledge chatContextPlanner tokenPlace.test.js`, both succeeded (all tests passed).
- Ran repository checks: `cd frontend && npm run check` and `cd frontend && npm run build`, both succeeded (lint/format checks and Astro build completed).
- All modified tests and broader token.place path tests passed in CI-local runs described above (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407ebfe494832f85cc6199b2539c62)