### PR TITLE
Add compact answer-focus steering for full chat prompts

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -391,6 +391,12 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        const messages = decrypted.api_v1_request.messages;
+        const focusIndex = messages.findIndex((message) =>
+            message.content.includes('Answer the final user message directly.')
+        );
+        expect(focusIndex).toBe(messages.length - 2);
+        expect(messages.at(-1)).toEqual({ role: 'user', content: 'What should I build next?' });
     });
 
     test('default token.place mode includes docs RAG for route questions', async () => {
@@ -411,6 +417,13 @@ describe('token.place API v1 client', () => {
         const serializedMessages = JSON.stringify(decrypted.api_v1_request.messages);
         expect(serializedMessages).toContain('Docs grounding canary for gamesaves.');
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        expect(decrypted.api_v1_request.messages.at(-2).content).toContain(
+            'Answer the final user message directly.'
+        );
+        expect(decrypted.api_v1_request.messages.at(-1)).toEqual({
+            role: 'user',
+            content: 'where do I import a gamesave?',
+        });
     });
 
     test('token-lite setting sends a tiny decrypted API v1 message set', async () => {

--- a/frontend/src/utils/chatAnswerFocus.js
+++ b/frontend/src/utils/chatAnswerFocus.js
@@ -1,0 +1,22 @@
+export const ANSWER_FOCUS_MAX_CHARS = 700;
+export const ANSWER_FOCUS_LATEST_REQUEST_PREVIEW_MAX_CHARS = 200;
+
+const ANSWER_FOCUS_TEXT = [
+    'Answer the final user message directly.',
+    'Use PlayerState, focused game data, and docs grounding only when relevant.',
+    'Do not summarize unrelated inventory, quests, docs, or processes.',
+    'Omitted compact-state details are not evidence that the player lacks them.',
+    'If selected context is insufficient, ask a clarifying question instead of guessing.',
+    'Give exact counts, costs, durations, requirements, or routes only when selected context states them.',
+].join(' ');
+
+export const buildAnswerFocusMessage = ({ latestUserMessage, contextPlan } = {}) => {
+    if (contextPlan?.mode !== 'full') return null;
+    if (!latestUserMessage || latestUserMessage.role !== 'user') return null;
+    if (!String(latestUserMessage.content || '').trim()) return null;
+
+    return {
+        role: 'system',
+        content: ANSWER_FOCUS_TEXT.slice(0, ANSWER_FOCUS_MAX_CHARS),
+    };
+};

--- a/frontend/src/utils/chatAnswerFocus.js
+++ b/frontend/src/utils/chatAnswerFocus.js
@@ -1,6 +1,3 @@
-export const ANSWER_FOCUS_MAX_CHARS = 700;
-export const ANSWER_FOCUS_LATEST_REQUEST_PREVIEW_MAX_CHARS = 200;
-
 const ANSWER_FOCUS_TEXT = [
     'Answer the final user message directly.',
     'Use PlayerState, focused game data, and docs grounding only when relevant.',
@@ -17,6 +14,6 @@ export const buildAnswerFocusMessage = ({ latestUserMessage, contextPlan } = {})
 
     return {
         role: 'system',
-        content: ANSWER_FOCUS_TEXT.slice(0, ANSWER_FOCUS_MAX_CHARS),
+        content: ANSWER_FOCUS_TEXT,
     };
 };

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -798,10 +798,6 @@ export const buildChatPrompt = async (messages, options = {}) => {
     const latestUserMessageSourceIndex = latestUserMessage
         ? normalizedMessages.lastIndexOf(latestUserMessage)
         : -1;
-    const priorMessages =
-        latestUserMessageSourceIndex === -1
-            ? normalizedMessages
-            : normalizedMessages.filter((_, index) => index !== latestUserMessageSourceIndex);
 
     let combinedMessages = [...normalizedMessages];
 
@@ -831,12 +827,15 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
-        combinedMessages = [...combinedMessages, ...priorMessages];
-        if (answerFocusMessage) {
-            combinedMessages.push(answerFocusMessage);
-        }
-        if (latestUserMessage) {
-            combinedMessages.push(latestUserMessage);
+        if (answerFocusMessage && latestUserMessageSourceIndex !== -1) {
+            combinedMessages = [
+                ...combinedMessages,
+                ...normalizedMessages.slice(0, latestUserMessageSourceIndex),
+                answerFocusMessage,
+                ...normalizedMessages.slice(latestUserMessageSourceIndex),
+            ];
+        } else {
+            combinedMessages = [...combinedMessages, ...normalizedMessages];
         }
     }
 

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -9,6 +9,7 @@ import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
+import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -790,6 +791,17 @@ export const buildChatPrompt = async (messages, options = {}) => {
         role: 'assistant',
         content: persona?.welcomeMessage || fallbackWelcomeMessage,
     };
+    const answerFocusMessage = buildAnswerFocusMessage({
+        latestUserMessage,
+        contextPlan: contextPlanMetadata,
+    });
+    const latestUserMessageSourceIndex = latestUserMessage
+        ? normalizedMessages.lastIndexOf(latestUserMessage)
+        : -1;
+    const priorMessages =
+        latestUserMessageSourceIndex === -1
+            ? normalizedMessages
+            : normalizedMessages.filter((_, index) => index !== latestUserMessageSourceIndex);
 
     let combinedMessages = [...normalizedMessages];
 
@@ -804,6 +816,9 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
+        }
         combinedMessages.push(openingMessage);
     } else {
         combinedMessages = [systemMessage];
@@ -816,7 +831,13 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
-        combinedMessages = [...combinedMessages, ...normalizedMessages];
+        combinedMessages = [...combinedMessages, ...priorMessages];
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
+        }
+        if (latestUserMessage) {
+            combinedMessages.push(latestUserMessage);
+        }
     }
 
     const ragMessages = new Set([knowledgeMessage, docsRagMessage].filter(Boolean));
@@ -846,6 +867,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         const latestUserMessageIndex = latestUserMessage
             ? combinedMessages.lastIndexOf(latestUserMessage)
             : -1;
+        const answerFocusMessageIndex = indexOfMessage(answerFocusMessage);
         const chatHistoryIndexes = combinedMessages
             .map((message, index) => ({ message, index }))
             .filter(
@@ -870,6 +892,12 @@ export const buildChatPrompt = async (messages, options = {}) => {
                 playerState: playerStateMessageIndex,
                 chatHistory: chatHistoryIndexes,
                 latestUserMessage: latestUserMessageIndex,
+            },
+            answerFocus: {
+                included: Boolean(answerFocusMessage),
+                characterCount: answerFocusMessage?.content?.length || 0,
+                placementIndex: answerFocusMessageIndex,
+                latestUserMessageIndex,
             },
         });
     }

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -31,6 +31,15 @@ const numberOrZero = (value) => (Number.isFinite(Number(value)) ? Number(value) 
 const stringList = (value, max = 12) =>
     Array.isArray(value) ? value.slice(0, max).map((entry) => String(entry)) : [];
 
+const sanitizeAnswerFocus = (value) => ({
+    included: Boolean(value?.included),
+    characterCount: numberOrZero(value?.characterCount),
+    placementIndex: Number.isInteger(value?.placementIndex) ? value.placementIndex : -1,
+    latestUserMessageIndex: Number.isInteger(value?.latestUserMessageIndex)
+        ? value.latestUserMessageIndex
+        : -1,
+});
+
 const sanitizeFocusedGameData = (focused) => {
     if (!focused || typeof focused !== 'object') return null;
     return {
@@ -135,6 +144,7 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                 ? null
                 : Number(metadata.ragDurationMs),
         focusedGameData: sanitizeFocusedGameData(metadata.contextPlan?.focusedGameData),
+        answerFocus: sanitizeAnswerFocus(metadata.answerFocus),
         docsRag: metadata.contextPlan
             ? (() => {
                   const status =

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -642,6 +642,43 @@ describe('buildChatPrompt', () => {
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
     });
 
+    it('adds answer-focus before the latest user message for player-state full prompts', async () => {
+        const latest = { role: 'user', content: 'what quest do I have left?' };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const messages = payload.combinedMessages;
+        const latestIndex = messages.lastIndexOf(latest);
+        const focusIndex = messages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const playerStateIndex = messages.findIndex((message) =>
+            message.content?.includes('PlayerState')
+        );
+        const knowledgeIndex = messages.findIndex((message) =>
+            message.content?.includes('DSPACE knowledge base')
+        );
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(focusIndex).toBeGreaterThan(knowledgeIndex);
+        expect(focusIndex).toBeGreaterThan(playerStateIndex);
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(messages.at(-1)).toBe(latest);
+        expect(messages[focusIndex].role).toBe('system');
+        expect(messages[focusIndex].content).not.toContain(latest.content);
+        expect(messages[focusIndex].content).not.toContain('PlayerStateCompact');
+        expect(messages[focusIndex].content).not.toContain('DSPACE knowledge base');
+        expect(messages[focusIndex].content).not.toContain('Docs grounding');
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: true,
+            characterCount: messages[focusIndex].content.length,
+            placementIndex: focusIndex,
+            latestUserMessageIndex: latestIndex,
+        });
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(latest.content);
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(
+            messages[focusIndex].content
+        );
+    });
+
     it('exposes only safe PlayerState summary fields in prompt metrics', async () => {
         vi.mocked(loadGameState).mockReturnValueOnce({
             openAI: {},
@@ -727,6 +764,102 @@ Docs grounding (gitSha: test):
         expect(searchDocsRag).toHaveBeenCalled();
         expect(prompt).toContain('Docs grounding');
         expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+
+        const focusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const latestIndex = payload.combinedMessages.length - 1;
+        const docsIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Docs grounding')
+        );
+
+        expect(focusIndex).toBeGreaterThan(docsIndex);
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(payload.combinedMessages.at(-1)).toEqual({
+            role: 'user',
+            content: 'where do I import a gamesave?',
+        });
+    });
+
+    it('keeps focused game-data context and adds answer-focus for resource comparison prompts', async () => {
+        vi.mocked(buildDchatKnowledgePack).mockReturnValueOnce({
+            summary:
+                'Focused game data:\nRelevant processes:\n- 3D print a model rocket\n- 3D print a Benchy',
+            sources: [{ type: 'process', id: 'benchy', label: 'Benchy' }],
+            focusedGameData: {
+                included: true,
+                selectedProcessCount: 2,
+                selectedItemCount: 0,
+                selectedQuestCount: 0,
+                selectedAchievementCount: 0,
+                selectedInventoryCount: 1,
+                selectedProcessIds: ['print-rocket', 'benchy'],
+                renderedChars: 90,
+                reasonCodes: ['focused-game-data'],
+            },
+        });
+        const latest = {
+            role: 'user',
+            content: "I'd like to make a 3D printed rocket and 10 benchies. Is it enough for that?",
+        };
+
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+        const focusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.promptMetrics.focusedGameData).toEqual(
+            expect.objectContaining({ included: true, selectedProcessCount: 2 })
+        );
+        expect(prompt).toContain('Focused game data:');
+        expect(prompt).not.toContain('Complete item catalog');
+        expect(prompt).not.toContain('Complete quest catalog');
+        expect(focusIndex).toBe(payload.combinedMessages.length - 2);
+        expect(payload.combinedMessages.at(-1)).toBe(latest);
+    });
+
+    it('keeps answer-focus out of minimal prompts and reports safe metrics', async () => {
+        const payload = await buildChatPrompt([{ role: 'user', content: 'hi' }], {
+            includePromptMetrics: true,
+        });
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(prompt).not.toContain('PlayerState');
+        expect(prompt).not.toContain('DSPACE knowledge base');
+        expect(prompt).not.toContain('Docs grounding');
+        expect(prompt).not.toContain('Answer the final user message directly.');
+        expect(payload.contextSources).toEqual([]);
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+            latestUserMessageIndex: -1,
+        });
+    });
+
+    it('preserves selected persona identity when answer-focus is added', async () => {
+        const persona = {
+            id: 'sydney',
+            name: 'Sydney',
+            systemPrompt: 'You are Sydney, a careful mission planner.',
+            welcomeMessage: 'Sydney here.',
+        };
+        const payload = await buildChatPrompt(
+            [{ role: 'user', content: 'what quest do I have left?' }],
+            { persona }
+        );
+        const systemPrompt = payload.combinedMessages[0].content;
+        const focusMessage = payload.combinedMessages.find((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+
+        expect(systemPrompt).toContain('You are Sydney');
+        expect(focusMessage?.content).toBeTruthy();
+        expect(focusMessage.content).not.toContain('dChat');
+        expect(focusMessage.content).not.toContain('You are');
     });
 
     it('does not duplicate docs excerpts when knowledge summary exists', async () => {
@@ -945,6 +1078,19 @@ Docs grounding (gitSha: test):
         expect(payload.contextPlan.includeDocsRag).toBe(true);
         expect(prompt).toContain('Docs grounding');
         expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+
+        const focusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const latestIndex = payload.combinedMessages.length - 1;
+        const docsIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Docs grounding')
+        );
+
+        expect(focusIndex).toBeGreaterThan(docsIndex);
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(payload.combinedMessages.at(-1)).toBe(messages.at(-1));
+
         expect(payload.contextPlan.docsRagRenderedChars).toBeLessThanOrEqual(
             payload.contextPlan.docsRagBudget.maxChars
         );

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -642,6 +642,35 @@ describe('buildChatPrompt', () => {
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
     });
 
+    it('preserves transcript order when inserting answer-focus before a non-final user turn', async () => {
+        const latest = { role: 'user', content: 'what quest do I have left?' };
+        const assistantReply = {
+            role: 'assistant',
+            content: 'You have the orbital intro quest left.',
+        };
+        const payload = await buildChatPrompt([latest, assistantReply], {
+            includePromptMetrics: true,
+        });
+        const messages = payload.combinedMessages;
+        const latestIndex = messages.lastIndexOf(latest);
+        const assistantIndex = messages.lastIndexOf(assistantReply);
+        const focusIndex = messages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(assistantIndex).toBe(latestIndex + 1);
+        expect(messages[latestIndex]).toBe(latest);
+        expect(messages[assistantIndex]).toBe(assistantReply);
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: true,
+            characterCount: messages[focusIndex].content.length,
+            placementIndex: focusIndex,
+            latestUserMessageIndex: latestIndex,
+        });
+    });
+
     it('adds answer-focus before the latest user message for player-state full prompts', async () => {
         const latest = { role: 'user', content: 'what quest do I have left?' };
         const payload = await buildChatPrompt([latest], { includePromptMetrics: true });

--- a/tests/gpt5ChatResponses.test.ts
+++ b/tests/gpt5ChatResponses.test.ts
@@ -115,7 +115,7 @@ describe('gpt-5 chat responses integration', () => {
 
     const payload = JSON.parse(init?.body ?? '{}');
     expect(payload.model).toBe('gpt-5.2');
-    expect(payload.input).toHaveLength(4);
+    expect(payload.input).toHaveLength(5);
     expect(payload.input[0].role).toBe('system');
     if (!dchatPersona) {
       throw new Error('Expected to find the default dChat persona');
@@ -126,7 +126,9 @@ describe('gpt-5 chat responses integration', () => {
     expect(payload.input[1].content[0].text).toContain('PlayerState');
     expect(payload.input[2].role).toBe('system');
     expect(payload.input[2].content[0].text).toContain('Quest facts');
-    expect(payload.input[3]).toEqual({
+    expect(payload.input[3].role).toBe('system');
+    expect(payload.input[3].content[0].text).toContain('Answer the final user message directly.');
+    expect(payload.input[4]).toEqual({
       role: 'user',
       content: [
         {


### PR DESCRIPTION
### Motivation
- Local models were getting 'magnetized' by context blocks and answering adjacent facts instead of the user's final request, so a tiny steer is needed to make full prompts focus on the latest user message.
- This change must be deterministic, safe, and apply only to full-mode prompts without changing what context is selected or persona behavior.

### Description
- Added a small deterministic helper `buildAnswerFocusMessage` in `frontend/src/utils/chatAnswerFocus.js` that returns a compact `system` steering message only when `contextPlan.mode === 'full'` and a real latest user turn exists, with named max-size constants. 
- Inserted the answer-focus message near the end of the assembled prompt in `frontend/src/utils/openAI.js` so it appears after persona/system, PlayerState, focused game-data, docs RAG (when present), and prior history, and immediately before the real latest `user` message; the latest user message remains a true `user` entry. 
- Added safe prompt metrics for answer-focus under `promptPayload.promptMetrics.answerFocus` (fields: `included`, `characterCount`, `placementIndex`, `latestUserMessageIndex`) and wired sanitization in `frontend/src/utils/promptMetrics.js` without exposing any prompt/user/context text.
- Added/updated focused tests in `frontend/tests/openAI.test.ts` and `frontend/__tests__/tokenPlace.test.js` to verify full-mode insertion, placement relative to docs RAG and focused game-data, absence in minimal mode, persona preservation, token.place payload behavior, and prompt-metrics reporting.

### Testing
- Ran focused frontend tests: `cd frontend && npm test -- openAI` and `npm test -- dchatKnowledge` and `npm test -- chatContextPlanner`, and `npm test -- tokenPlace.test.js`, and all test suites passed locally (openAI tests, docs-RAG and token.place tests included). 
- Ran repository checks: `cd frontend && npm run check` and `npm run build`, and both completed successfully. 
- Test coverage exercised: full-mode insertion, docs-grounded full prompts, focused game-data prompts, minimal-mode regression, persona regression, prompt metrics safety, and token.place provider behavior were validated and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407eb261a8832fac669423fc625744)