### PR TITLE
Add compact answer-focus steering message to full chat prompts

### DIFF
--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -391,6 +391,15 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         // Verify full path produces more messages than token-lite's fixed [system, user] pair.
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
+        expect(
+            decrypted.api_v1_request.messages.some((message) =>
+                message.content.includes('Answer the final user message directly.')
+            )
+        ).toBe(true);
+        expect(decrypted.api_v1_request.messages.at(-1)).toEqual({
+            role: 'user',
+            content: 'What should I build next?',
+        });
     });
 
     test('default token.place mode includes docs RAG for route questions', async () => {
@@ -410,6 +419,17 @@ describe('token.place API v1 client', () => {
         const decrypted = await decryptTokenPlaceEnvelope(body, relayServerKeys[0].privateKey);
         const serializedMessages = JSON.stringify(decrypted.api_v1_request.messages);
         expect(serializedMessages).toContain('Docs grounding canary for gamesaves.');
+        const docsIndex = decrypted.api_v1_request.messages.findIndex((message) =>
+            message.content.includes('Docs grounding canary for gamesaves.')
+        );
+        const focusIndex = decrypted.api_v1_request.messages.findIndex((message) =>
+            message.content.includes('Answer the final user message directly.')
+        );
+        expect(focusIndex).toBeGreaterThan(docsIndex);
+        expect(decrypted.api_v1_request.messages.at(-1)).toEqual({
+            role: 'user',
+            content: 'where do I import a gamesave?',
+        });
         expect(decrypted.api_v1_request.messages.length).toBeGreaterThan(2);
     });
 
@@ -450,6 +470,7 @@ describe('token.place API v1 client', () => {
         );
         expect(serializedMessages).not.toContain('RAG excerpt should not appear');
         expect(serializedMessages).not.toContain('DSPACE knowledge base');
+        expect(serializedMessages).not.toContain('Answer the final user message directly.');
         expect(serializedMessages).not.toContain('PlayerState');
         expect(serializedMessages).not.toContain('player-state-canary');
         expect(serializedMessages).not.toContain('old user history should not appear');

--- a/frontend/src/utils/chatAnswerFocus.js
+++ b/frontend/src/utils/chatAnswerFocus.js
@@ -1,0 +1,22 @@
+export const ANSWER_FOCUS_MAX_CHARS = 700;
+export const ANSWER_FOCUS_LATEST_PREVIEW_MAX_CHARS = 0;
+
+const ANSWER_FOCUS_CONTENT = [
+    'Answer the final user message directly.',
+    'Use PlayerState, focused game data, and docs grounding only when relevant.',
+    'Do not summarize or enumerate unrelated inventory, quests, docs, or processes.',
+    'Omitted compact-state details are not evidence that the player lacks them.',
+    'If selected context is insufficient, ask a clarifying question instead of guessing.',
+    'Give exact counts, costs, durations, requirements, or routes only when selected context includes them.',
+].join('\n');
+
+export const buildAnswerFocusMessage = ({ latestUserMessage, contextPlan } = {}) => {
+    if (contextPlan?.mode !== 'full') return null;
+    if (!latestUserMessage || typeof latestUserMessage.content !== 'string') return null;
+
+    const content = ANSWER_FOCUS_CONTENT.slice(0, ANSWER_FOCUS_MAX_CHARS);
+    return {
+        role: 'system',
+        content,
+    };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -9,6 +9,7 @@ import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
+import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -790,6 +791,16 @@ export const buildChatPrompt = async (messages, options = {}) => {
         role: 'assistant',
         content: persona?.welcomeMessage || fallbackWelcomeMessage,
     };
+    const answerFocusMessage = buildAnswerFocusMessage({
+        latestUserMessage,
+        contextPlan: contextPlanMetadata,
+        promptPayloadMeta: {
+            hasPlayerState: Boolean(playerStateMessage),
+            hasKnowledge: Boolean(knowledgeMessage),
+            hasDocsRag: Boolean(docsRagPayload.excerptsText),
+        },
+        options,
+    });
 
     let combinedMessages = [...normalizedMessages];
 
@@ -804,6 +815,9 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
+        }
         combinedMessages.push(openingMessage);
     } else {
         combinedMessages = [systemMessage];
@@ -816,7 +830,19 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
-        combinedMessages = [...combinedMessages, ...normalizedMessages];
+        const latestUserMessageIndex = latestUserMessage
+            ? normalizedMessages.lastIndexOf(latestUserMessage)
+            : -1;
+        if (answerFocusMessage && latestUserMessageIndex !== -1) {
+            combinedMessages = [
+                ...combinedMessages,
+                ...normalizedMessages.slice(0, latestUserMessageIndex),
+                answerFocusMessage,
+                ...normalizedMessages.slice(latestUserMessageIndex),
+            ];
+        } else {
+            combinedMessages = [...combinedMessages, ...normalizedMessages];
+        }
     }
 
     const ragMessages = new Set([knowledgeMessage, docsRagMessage].filter(Boolean));
@@ -843,6 +869,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         const playerStateMessageIndex = indexOfMessage(playerStateMessage);
         const knowledgeMessageIndex = indexOfMessage(knowledgeMessage);
         const docsRagMessageIndex = indexOfMessage(docsRagMessage);
+        const answerFocusMessageIndex = indexOfMessage(answerFocusMessage);
         const latestUserMessageIndex = latestUserMessage
             ? combinedMessages.lastIndexOf(latestUserMessage)
             : -1;
@@ -864,6 +891,12 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ragDurationMs,
             contextPlan: contextPlanMetadata,
             playerStateSummary: playerStateSnapshot.meta,
+            answerFocus: {
+                included: Boolean(answerFocusMessage),
+                characterCount: answerFocusMessage?.content?.length || 0,
+                placementIndex: answerFocusMessageIndex,
+                latestUserMessageIndex,
+            },
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -88,6 +88,28 @@ const sanitizePlayerStateSummary = (summary) => {
     return safeSummary;
 };
 
+const sanitizeAnswerFocus = (answerFocus) => {
+    if (!answerFocus || typeof answerFocus !== 'object') {
+        return {
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+            latestUserMessageIndex: -1,
+        };
+    }
+
+    return {
+        included: Boolean(answerFocus.included),
+        characterCount: numberOrZero(answerFocus.characterCount),
+        placementIndex: Number.isInteger(answerFocus.placementIndex)
+            ? answerFocus.placementIndex
+            : -1,
+        latestUserMessageIndex: Number.isInteger(answerFocus.latestUserMessageIndex)
+            ? answerFocus.latestUserMessageIndex
+            : -1,
+    };
+};
+
 export const buildPromptMetrics = (promptPayload, metadata = {}) => {
     const messages = Array.isArray(promptPayload?.combinedMessages)
         ? promptPayload.combinedMessages
@@ -163,6 +185,7 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
                   };
               })()
             : null,
+        answerFocus: sanitizeAnswerFocus(metadata.answerFocus),
         contextPlan: metadata.contextPlan || null,
         playerStateSummary: sanitizePlayerStateSummary(metadata.playerStateSummary),
     };

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -642,6 +642,92 @@ describe('buildChatPrompt', () => {
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
     });
 
+    it('inserts answer focus after full-mode context and before the latest user message', async () => {
+        const latest = { role: 'user', content: 'what quest do I have left?' };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const answerFocusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const latestUserMessageIndex = payload.combinedMessages.lastIndexOf(latest);
+        const playerStateIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('PlayerState')
+        );
+        const knowledgeIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('DSPACE knowledge base')
+        );
+        const focusContent = payload.combinedMessages[answerFocusIndex]?.content || '';
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(answerFocusIndex).toBeGreaterThan(-1);
+        expect(playerStateIndex).toBeGreaterThan(-1);
+        expect(knowledgeIndex).toBeGreaterThan(-1);
+        expect(answerFocusIndex).toBeGreaterThan(playerStateIndex);
+        expect(answerFocusIndex).toBeGreaterThan(knowledgeIndex);
+        expect(answerFocusIndex).toBe(latestUserMessageIndex - 1);
+        expect(payload.combinedMessages.at(-1)).toBe(latest);
+        expect(focusContent.length).toBeLessThanOrEqual(700);
+        expect(focusContent).toContain('Answer the final user message directly.');
+        expect(focusContent).not.toContain(latest.content);
+        expect(focusContent).not.toContain('PlayerStateCompact');
+        expect(focusContent).not.toContain('DSPACE knowledge base');
+        expect(focusContent).not.toContain('Docs grounding');
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: true,
+            characterCount: focusContent.length,
+            placementIndex: answerFocusIndex,
+            latestUserMessageIndex,
+        });
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(latest.content);
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(focusContent);
+    });
+
+    it('keeps focused game data context and appends answer focus without broad catalog dumps', async () => {
+        vi.mocked(buildDchatKnowledgePack).mockReturnValueOnce({
+            summary:
+                'Focused game data:\n- Process: 3D print a 100 mm model rocket\n- Item: Benchy\n',
+            sources: [{ type: 'process', id: 'print-rocket', label: '3D print rocket' }],
+            focusedGameData: {
+                included: true,
+                reasonCodes: ['focused-query'],
+                selectedItemCount: 1,
+                selectedQuestCount: 0,
+                selectedProcessCount: 1,
+                selectedAchievementCount: 0,
+                selectedInventoryCount: 0,
+                selectedItemIds: ['benchy'],
+                selectedQuestIds: [],
+                selectedProcessIds: ['print-rocket'],
+                selectedAchievementIds: [],
+                selectedInventoryIds: [],
+                renderedChars: 78,
+                caps: { maxItems: 6, maxQuests: 4, maxProcesses: 4, maxAchievements: 2 },
+                truncated: false,
+            },
+        });
+
+        const latest = {
+            role: 'user',
+            content: 'I’d like to make a 3D printed rocket and 10 benchies. Is it enough for that?',
+        };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+        const answerFocusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const knowledgeIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Focused game data:')
+        );
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.promptMetrics.focusedGameData.included).toBe(true);
+        expect(prompt).toContain('Focused game data:');
+        expect(prompt).toContain('3D print a 100 mm model rocket');
+        expect(prompt).not.toContain('Full item catalog');
+        expect(prompt).not.toContain('Full quest catalog');
+        expect(answerFocusIndex).toBeGreaterThan(knowledgeIndex);
+        expect(payload.combinedMessages.at(-1)).toBe(latest);
+    });
+
     it('exposes only safe PlayerState summary fields in prompt metrics', async () => {
         vi.mocked(loadGameState).mockReturnValueOnce({
             openAI: {},
@@ -727,6 +813,15 @@ Docs grounding (gitSha: test):
         expect(searchDocsRag).toHaveBeenCalled();
         expect(prompt).toContain('Docs grounding');
         expect(payload.contextSources.some((source) => source.type === 'doc')).toBe(true);
+
+        const answerFocusIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Answer the final user message directly.')
+        );
+        const docsIndex = payload.combinedMessages.findIndex((message) =>
+            message.content?.includes('Docs grounding')
+        );
+        expect(answerFocusIndex).toBeGreaterThan(docsIndex);
+        expect(payload.combinedMessages.at(-1)?.content).toBe('where do I import a gamesave?');
     });
 
     it('does not duplicate docs excerpts when knowledge summary exists', async () => {

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -43,6 +43,7 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).not.toContain('PlayerState');
         expect(prompt).not.toContain('DSPACE knowledge base');
         expect(prompt).not.toContain('Docs grounding');
+        expect(prompt).not.toContain('Answer the final user message directly.');
         expect(prompt).not.toContain('inventory highlights');
         expect(prompt).toContain('Never invent game facts or player state.');
         expect(prompt).toContain('Only give exact counts/durations/rates');
@@ -50,6 +51,12 @@ describe('buildChatPrompt context planning', () => {
         expect(prompt).not.toContain('If PlayerState is missing');
         expect(prompt.length).toBeLessThan(5000);
         expect(payload.promptMetrics.contextPlan.mode).toBe('minimal');
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+            latestUserMessageIndex: -1,
+        });
         expect(buildDchatKnowledgePack).not.toHaveBeenCalled();
         expect(searchDocsRag).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
### Motivation
- Local/edge models can be magnetized by context blocks and answer adjacent facts instead of the user’s final request, so a tiny deterministic steering message is needed to prioritize the latest user turn.
- The change must be minimal, deterministic, only apply to `full` mode, preserve persona voice, and not change what context is selected.

### Description
- Added a new helper `frontend/src/utils/chatAnswerFocus.js` with `buildAnswerFocusMessage(...)` that returns a compact system message only when `contextPlan.mode === 'full'` and a latest user message exists, capped at 700 characters and avoiding quoting user text.
- Inserted the answer-focus system message into `frontend/src/utils/openAI.js` after persona/system + PlayerState + focused game-data + docs RAG blocks and immediately before the latest user message so the latest user message remains the final user role.
- Exposed safe prompt-metrics in `frontend/src/utils/promptMetrics.js` under `promptMetrics.answerFocus` with fields `included`, `characterCount`, `placementIndex`, and `latestUserMessageIndex` while avoiding inclusion of any user text or raw prompt content.
- Updated and added tests to validate full-mode insertion, docs-grounded and focused-game-data ordering, minimal-mode regression (no focus in minimal), persona preservation, and token.place token-lite behavior (`frontend/tests/openAI.test.ts`, `frontend/tests/openAIContextPlanner.test.ts`, `frontend/__tests__/tokenPlace.test.js`).

### Testing
- Ran focused tests: `cd frontend && npm test -- openAI` and the openAI suite passed (all tests green).
- Ran additional focused suites: `cd frontend && npm test -- dchatKnowledge && npm test -- chatContextPlanner && npm test -- tokenPlace.test.js` and each suite passed (dchatKnowledge, chatContextPlanner, tokenPlace tests all passed).
- Ran broader checks: `cd frontend && npm run check && npm run build` and both formatting/lint checks and the build completed successfully.

All automated tests exercised during the rollout passed; the answer-focus block is only included in `full` prompts, does not duplicate or log user text, and prompt metrics report only safe numeric/index metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407ec79798832fa3fb8d517972d15e)