### PR TITLE
Add full prompt answer-focus steering

### DIFF
--- a/frontend/src/utils/chatAnswerFocus.js
+++ b/frontend/src/utils/chatAnswerFocus.js
@@ -1,0 +1,35 @@
+export const ANSWER_FOCUS_MAX_CHARS = 700;
+export const ANSWER_FOCUS_PREVIEW_MAX_CHARS = 0;
+
+const ANSWER_FOCUS_TEXT = [
+    'Answer the final user message directly in the selected persona voice.',
+    'Use PlayerState, focused game data, and docs grounding only when relevant.',
+    'Do not summarize unrelated inventory, quests, docs, or processes.',
+    'Omitted compact-state details are not evidence that the player lacks them.',
+    'If selected context is insufficient, ask a clarifying question instead of guessing.',
+    'Give exact counts, costs, durations, requirements, or routes only when selected context says so.',
+].join('\n');
+
+const truncateFocusText = (text, maxChars = ANSWER_FOCUS_MAX_CHARS) => {
+    const normalizedMax = Number.isFinite(Number(maxChars))
+        ? Math.max(0, Number(maxChars))
+        : ANSWER_FOCUS_MAX_CHARS;
+    if (text.length <= normalizedMax) return text;
+    return text.slice(0, normalizedMax).trimEnd();
+};
+
+export const buildAnswerFocusMessage = ({ contextPlan, options = {} } = {}) => {
+    if (contextPlan?.mode !== 'full') return null;
+    if (options.includeAnswerFocus === false) return null;
+
+    const content = truncateFocusText(
+        ANSWER_FOCUS_TEXT,
+        options.answerFocusMaxChars || ANSWER_FOCUS_MAX_CHARS
+    );
+    if (!content.trim()) return null;
+
+    return {
+        role: 'system',
+        content,
+    };
+};

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -9,6 +9,7 @@ import { buildPromptMetrics } from './promptMetrics.js';
 import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
+import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -786,6 +787,10 @@ export const buildChatPrompt = async (messages, options = {}) => {
         knowledgeMessage.content = `${knowledgeMessage.content}\n\n${docsRagPayload.excerptsText}`;
     }
 
+    const answerFocusMessage = latestUserMessage
+        ? buildAnswerFocusMessage({ latestUserMessage, contextPlan: contextPlanMetadata, options })
+        : null;
+
     const openingMessage = {
         role: 'assistant',
         content: persona?.welcomeMessage || fallbackWelcomeMessage,
@@ -816,7 +821,19 @@ export const buildChatPrompt = async (messages, options = {}) => {
         if (docsRagMessage && !knowledgeMessage) {
             combinedMessages.push(docsRagMessage);
         }
-        combinedMessages = [...combinedMessages, ...normalizedMessages];
+        const latestUserSourceIndex = latestUserMessage
+            ? normalizedMessages.lastIndexOf(latestUserMessage)
+            : -1;
+        const priorMessages = normalizedMessages.filter(
+            (_message, index) => index !== latestUserSourceIndex
+        );
+        combinedMessages = [...combinedMessages, ...priorMessages];
+        if (answerFocusMessage) {
+            combinedMessages.push(answerFocusMessage);
+        }
+        if (latestUserMessage) {
+            combinedMessages.push(latestUserMessage);
+        }
     }
 
     const ragMessages = new Set([knowledgeMessage, docsRagMessage].filter(Boolean));
@@ -843,6 +860,7 @@ export const buildChatPrompt = async (messages, options = {}) => {
         const playerStateMessageIndex = indexOfMessage(playerStateMessage);
         const knowledgeMessageIndex = indexOfMessage(knowledgeMessage);
         const docsRagMessageIndex = indexOfMessage(docsRagMessage);
+        const answerFocusMessageIndex = indexOfMessage(answerFocusMessage);
         const latestUserMessageIndex = latestUserMessage
             ? combinedMessages.lastIndexOf(latestUserMessage)
             : -1;
@@ -864,6 +882,12 @@ export const buildChatPrompt = async (messages, options = {}) => {
             ragDurationMs,
             contextPlan: contextPlanMetadata,
             playerStateSummary: playerStateSnapshot.meta,
+            answerFocus: {
+                included: Boolean(answerFocusMessage),
+                characterCount: answerFocusMessage?.content?.length || 0,
+                placementIndex: answerFocusMessageIndex,
+                latestUserMessageIndex,
+            },
             componentMessageIndexes: {
                 systemInstructions: systemMessageIndex,
                 rag: ragIndexes,

--- a/frontend/src/utils/promptMetrics.js
+++ b/frontend/src/utils/promptMetrics.js
@@ -62,6 +62,15 @@ const sanitizeFocusedGameData = (focused) => {
     };
 };
 
+const sanitizeAnswerFocus = (answerFocus) => ({
+    included: Boolean(answerFocus?.included),
+    characterCount: numberOrZero(answerFocus?.characterCount),
+    placementIndex: Number.isInteger(answerFocus?.placementIndex) ? answerFocus.placementIndex : -1,
+    latestUserMessageIndex: Number.isInteger(answerFocus?.latestUserMessageIndex)
+        ? answerFocus.latestUserMessageIndex
+        : -1,
+});
+
 const sanitizePlayerStateSummary = (summary) => {
     if (!summary || typeof summary !== 'object') return null;
 
@@ -164,6 +173,7 @@ export const buildPromptMetrics = (promptPayload, metadata = {}) => {
               })()
             : null,
         contextPlan: metadata.contextPlan || null,
+        answerFocus: sanitizeAnswerFocus(metadata.answerFocus),
         playerStateSummary: sanitizePlayerStateSummary(metadata.playerStateSummary),
     };
 };

--- a/frontend/tests/openAIContextPlanner.test.ts
+++ b/frontend/tests/openAIContextPlanner.test.ts
@@ -127,6 +127,86 @@ describe('buildChatPrompt context planning', () => {
         expect(payload.contextSources).toEqual([]);
     });
 
+    it('adds answer focus after full context and before the latest user message', async () => {
+        const latest = { role: 'user', content: 'what quest do I have left?' };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const messages = payload.combinedMessages;
+        const latestIndex = messages.lastIndexOf(latest);
+        const focusIndex = messages.findIndex((message) =>
+            message.content.includes('Answer the final user message directly')
+        );
+        const playerStateIndex = messages.findIndex((message) =>
+            message.content.includes('PlayerState')
+        );
+        const knowledgeIndex = messages.findIndex((message) =>
+            message.content.includes('DSPACE knowledge base')
+        );
+        const focusContent = messages[focusIndex]?.content || '';
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(focusIndex).toBeGreaterThan(knowledgeIndex);
+        expect(focusIndex).toBeGreaterThan(playerStateIndex);
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(messages.at(-1)).toBe(latest);
+        expect(focusContent.length).toBeLessThan(700);
+        expect(focusContent).toContain(
+            'Use PlayerState, focused game data, and docs grounding only when relevant.'
+        );
+        expect(focusContent).not.toContain(latest.content);
+        expect(focusContent).not.toContain('{');
+        expect(focusContent).not.toContain('Docs grounding');
+        expect(focusContent).not.toContain('DSPACE knowledge base');
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: true,
+            characterCount: focusContent.length,
+            placementIndex: focusIndex,
+            latestUserMessageIndex: latestIndex,
+        });
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(latest.content);
+        expect(JSON.stringify(payload.promptMetrics.answerFocus)).not.toContain(focusContent);
+    });
+
+    it('places answer focus after docs grounding and keeps latest gamesave question final', async () => {
+        vi.mocked(searchDocsRag).mockResolvedValueOnce({
+            excerptsText:
+                '---\nDocs grounding (gitSha: test):\n- [route] Backups — /docs/backups#top\n  import saves\n---',
+            sources: [{ type: 'doc', id: 'backups', label: 'Backups', url: '/docs/backups#top' }],
+            sourcesMeta: { results: [{ id: 'backups' }] },
+        });
+        const latest = { role: 'user', content: 'where do I import a gamesave?' };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const messages = payload.combinedMessages;
+        const latestIndex = messages.lastIndexOf(latest);
+        const focusIndex = messages.findIndex((message) =>
+            message.content.includes('Answer the final user message directly')
+        );
+        const docsIndex = messages.findIndex((message) =>
+            message.content.includes('Docs grounding')
+        );
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(true);
+        expect(docsIndex).toBeGreaterThan(-1);
+        expect(focusIndex).toBeGreaterThan(docsIndex);
+        expect(focusIndex).toBe(latestIndex - 1);
+        expect(messages.at(-1)).toBe(latest);
+    });
+
+    it('keeps answer focus out of minimal prompts and minimal metrics', async () => {
+        const latest = { role: 'user', content: 'hi' };
+        const payload = await buildChatPrompt([latest], { includePromptMetrics: true });
+        const prompt = joinedPrompt(payload);
+
+        expect(payload.contextPlan.mode).toBe('minimal');
+        expect(prompt).not.toContain('Answer the final user message directly');
+        expect(payload.promptMetrics.answerFocus).toEqual({
+            included: false,
+            characterCount: 0,
+            placementIndex: -1,
+            latestUserMessageIndex: -1,
+        });
+    });
+
     it('preserves Hydro persona and full grounding when planner selects full', async () => {
         const payload = await buildChatPrompt(
             [{ role: 'user', content: 'what quest do I have left?' }],


### PR DESCRIPTION
### Motivation
- Local models were being magnetized by context blocks and sometimes answered adjacent facts instead of the latest user request, so a tiny deterministic steering note is needed to focus replies on the final user message.
- The steering must be compact, appear after retrieved context and before the final user message, preserve NPC persona, and not change what context is selected.
- Prompt metrics should record safe metadata about the presence and placement of the focus block without exposing any prompt or player data.

### Description
- Added a deterministic helper `buildAnswerFocusMessage` in `frontend/src/utils/chatAnswerFocus.js` with named size limits and a compact task-oriented steering message that returns a system message or `null` when not applicable.
- Integrated the answer-focus message into the full-mode prompt path in `frontend/src/utils/openAI.js` so it is appended after persona/system, PlayerState, focused game-data, and docs RAG (when present), and before the latest `user` message while preserving the latest user message as the final message.
- Exposed safe answer-focus metadata in prompt metrics via `frontend/src/utils/promptMetrics.js` (included, characterCount, placementIndex, latestUserMessageIndex) and ensured no prompt/user/context text is logged.
- Added tests in `frontend/tests/openAIContextPlanner.test.ts` validating full-mode insertion, docs-grounded placement, minimal-mode absence, and metrics safety.

### Testing
- Ran focused unit tests with `cd frontend && npm test -- openAI` and `cd frontend && npm test -- openAIContextPlanner.test.ts`, both succeeded (all tests passed).
- Ran related test suites `cd frontend && npm test -- dchatKnowledge && npm test -- chatContextPlanner && npm test -- tokenPlace.test.js`, all succeeded (all tests passed).
- Ran repository checks `cd frontend && npm run check` and `cd frontend && npm run build`, both succeeded (lint/format checks and build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407ecdabe0832fabebf0e539b2f495)