### PR TITLE
Deepen focused game-data retrieval

### DIFF
--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -85,6 +85,8 @@ const SMALL_ALIASES = new Map([
     ['green pla', ['green pla filament']],
 ]);
 
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const normalize = (value) =>
     String(value || '')
         .replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -107,10 +109,11 @@ const expandAliases = (value) => {
     for (const resource of RESOURCE_ALIASES) {
         const normalized = normalize(resource);
         const compact = normalized.replace(/\s+/g, '');
-        if (new RegExp(`\\b(?:${normalized}|${compact})\\b`).test(base)) aliases.push(resource);
+        if (new RegExp(`\\b(?:${escapeRegExp(normalized)}|${escapeRegExp(compact)})\\b`).test(base))
+            aliases.push(resource);
     }
     for (const [needle, expansions] of SMALL_ALIASES.entries()) {
-        if (new RegExp(`\\b${needle}\\b`).test(base)) aliases.push(...expansions);
+        if (new RegExp(`\\b${escapeRegExp(needle)}\\b`).test(base)) aliases.push(...expansions);
     }
     return normalize([base, ...aliases].join(' '));
 };
@@ -156,6 +159,9 @@ const questRecords = () =>
             rewards: Array.isArray(quest.rewards) ? quest.rewards : [],
             rewardItems: Array.isArray(quest.rewardItems) ? quest.rewardItems : [],
             grantsItems: Array.isArray(quest.grantsItems) ? quest.grantsItems : [],
+            requiresItems: Array.isArray(quest.requiresItems) ? quest.requiresItems : [],
+            requiredItems: Array.isArray(quest.requiredItems) ? quest.requiredItems : [],
+            prerequisites: Array.isArray(quest.prerequisites) ? quest.prerequisites : [],
             nodes: Array.isArray(quest.nodes) ? quest.nodes : [],
             dialogue: Array.isArray(quest.dialogue) ? quest.dialogue : [],
         }));
@@ -185,15 +191,30 @@ const itemEntryText = (entries = []) =>
 const itemIdsFromEntries = (entries = []) =>
     entries.map((entry) => entry?.id).filter((id) => typeof id === 'string' && id.length > 0);
 
-const questRewardItemEntries = (quest) => [
-    ...(quest?.rewards || []),
-    ...(quest?.rewardItems || []),
-    ...(quest?.grantsItems || []),
-    ...[...(quest?.nodes || []), ...(quest?.dialogue || [])].flatMap((node) => [
-        ...(node?.grantsItems || []),
-        ...(node?.options || []).flatMap((option) => option?.grantsItems || []),
-    ]),
-];
+const collectQuestItemEntries = (quest, keys) => {
+    const entries = [];
+    const seenObjects = new Set();
+    const visit = (value) => {
+        if (!value || typeof value !== 'object' || seenObjects.has(value)) return;
+        seenObjects.add(value);
+        if (Array.isArray(value)) {
+            value.forEach(visit);
+            return;
+        }
+        for (const key of keys) {
+            if (Array.isArray(value[key])) entries.push(...value[key]);
+        }
+        Object.values(value).forEach(visit);
+    };
+    visit(quest);
+    return entries;
+};
+
+const questRewardItemEntries = (quest) =>
+    collectQuestItemEntries(quest, ['rewards', 'rewardItems', 'grantsItems']);
+
+const questRequiredItemEntries = (quest) =>
+    collectQuestItemEntries(quest, ['requiresItems', 'requiredItems', 'prerequisites']);
 
 const processItemIds = (process) =>
     new Set([
@@ -225,6 +246,7 @@ const questText = (quest) =>
         stringifyFields(quest.rewardItems),
         stringifyFields(quest.grantsItems),
         itemEntryText(questRewardItemEntries(quest)),
+        itemEntryText(questRequiredItemEntries(quest)),
         stringifyFields(quest.nodes),
         stringifyFields(quest.dialogue),
     ].join(' ');
@@ -256,7 +278,7 @@ const isVagueProcessQuery = (text) =>
         text
     );
 const isVagueEntityFollowup = (text) =>
-    /\b(what rewards? does (it|that|this) give|what does (it|that|this) give|what about (it|that|this|that))\b/i.test(
+    /\b(what rewards? does (it|that|this|those) give|what does (it|that|this|those) give|what about (?:\d+\s+)?(?:of\s+)?(it|that|this|those)|can i (make|build) (it|that|this|those)|what does (it|that|this|those) consume)\b/i.test(
         text
     );
 const wantsRemainingQuests = (text) =>
@@ -348,7 +370,9 @@ export function buildFocusedGameDataContext({
         RESOURCE_ALIASES.some((resource) => {
             const normalized = normalize(resource);
             const compact = normalized.replace(/\s+/g, '');
-            return new RegExp(`\\b(?:${normalized}|${compact})\\b`).test(queryText);
+            return new RegExp(
+                `\\b(?:${escapeRegExp(normalized)}|${escapeRegExp(compact)})\\b`
+            ).test(queryText);
         })
     )
         reasonCodes.push('resource-token-hit');
@@ -375,7 +399,14 @@ export function buildFocusedGameDataContext({
 
     const allQuestRecords = questRecords();
     const processItemIdCache = new Map(
-        processes.map((process) => [process.id, processItemIds(process)])
+        processes.map((process) => [
+            process.id,
+            {
+                all: processItemIds(process),
+                creates: new Set(itemIdsFromEntries(process.createItems)),
+                consumes: new Set(itemIdsFromEntries(process.consumeItems)),
+            },
+        ])
     );
 
     let selectedQuests = selectScored(
@@ -435,9 +466,9 @@ export function buildFocusedGameDataContext({
     for (const item of selectedItems.slice(0, caps.maxItems)) {
         for (const process of processes) {
             const relatedIds = processItemIdCache.get(process.id);
-            if (!relatedIds.has(item.id)) continue;
-            const creates = itemIdsFromEntries(process.createItems).includes(item.id);
-            const consumes = itemIdsFromEntries(process.consumeItems).includes(item.id);
+            if (!relatedIds?.all.has(item.id)) continue;
+            const creates = relatedIds.creates.has(item.id);
+            const consumes = relatedIds.consumes.has(item.id);
             const reason = creates
                 ? 'process-creates-match'
                 : consumes
@@ -449,7 +480,7 @@ export function buildFocusedGameDataContext({
         }
     }
     for (const process of selectedProcesses.slice(0, caps.maxProcesses)) {
-        for (const id of processItemIdCache.get(process.id) || [])
+        for (const id of processItemIdCache.get(process.id)?.all || [])
             addItem(id, 'process-item-relationship');
     }
     for (const quest of selectedQuests.slice(0, caps.maxQuests)) {
@@ -458,16 +489,28 @@ export function buildFocusedGameDataContext({
         for (const reward of questRewardItemEntries(quest)) {
             if (reward?.id) addItem(reward.id, 'quest-reward-match');
         }
+        for (const required of questRequiredItemEntries(quest)) {
+            if (required?.id) addItem(required.id, 'quest-requires-match');
+        }
     }
     for (const item of selectedItems.slice(0, caps.maxItems)) {
         for (const quest of allQuestRecords) {
             if (questRewardItemEntries(quest).some((reward) => reward?.id === item.id)) {
-                if (selectedQuests.length >= caps.maxQuests && rewardIntent) {
+                if (
+                    selectedQuests.length >= caps.maxQuests &&
+                    selectedQuests.length > 0 &&
+                    rewardIntent
+                ) {
                     selectedQuests[selectedQuests.length - 1] = quest;
                     reasonCodes.push('quest-reward-match');
                 }
                 addReasonForSelected(selectedQuests, quest.id, 'quest-reward-match');
                 addQuest(quest, 'quest-reward-match');
+            } else if (
+                questRequiredItemEntries(quest).some((required) => required?.id === item.id)
+            ) {
+                addReasonForSelected(selectedQuests, quest.id, 'quest-requires-match');
+                addQuest(quest, 'quest-requires-match');
             }
         }
     }
@@ -532,13 +575,13 @@ export function buildFocusedGameDataContext({
         reasonCodes.push('owned-inventory-hit');
         appendLine(
             lines,
-            `Relevant inventory: owned ${inventoryEntries.map((e) => `${e.name} [${e.id}]=${formatCount(e.count)}`).join('; ')}`,
+            `Relevant owned inventory: ${inventoryEntries.map((e) => `${e.name} [${e.id}]=${formatCount(e.count)}`).join('; ')}`,
             caps.maxTotalChars
         );
         sources.push({
             type: 'state',
             id: 'focused-inventory',
-            label: 'Relevant inventory',
+            label: 'Relevant owned inventory',
             detail: `${inventoryEntries.length} bounded owned entries`,
         });
     }
@@ -615,7 +658,7 @@ export function buildFocusedGameDataContext({
         }
         for (const quest of selectedQuests) {
             relationships.push(
-                `${quest.id}: prereqs ${(quest.requiresQuests || []).join(', ') || 'none listed'}; rewards ${formatQuestRewards(quest.rewards) || formatItemList(questRewardItemEntries(quest)) || 'none listed'}`
+                `${quest.id}: prereqs ${(quest.requiresQuests || []).join(', ') || 'none listed'}; requires ${formatItemList(questRequiredItemEntries(quest)) || 'none listed'}; rewards ${formatQuestRewards(quest.rewards) || formatItemList(questRewardItemEntries(quest)) || 'none listed'}`
             );
         }
         appendLine(

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -90,14 +90,14 @@ const normalize = (value) =>
         .replace(/([a-z])([A-Z])/g, '$1 $2')
         .toLowerCase()
         .replace(/[-_/]+/g, ' ')
-        .replace(/[^a-z0-9]+/gi, ' ')
+        .replace(/[^a-z0-9]+/g, ' ')
         .replace(/\s+/g, ' ')
         .trim();
 
 const singularize = (token) => {
     if (token.endsWith('ies') && token.length > 4) return `${token.slice(0, -3)}y`;
-    if (token.endsWith('es') && token.length > 3) return token.slice(0, -2);
-    if (token.endsWith('s') && token.length > 3) return token.slice(0, -1);
+    if (/(ches|shes|sses|xes|zes)$/.test(token) && token.length > 4) return token.slice(0, -2);
+    if (token.endsWith('s') && !token.endsWith('ss') && token.length > 3) return token.slice(0, -1);
     return token;
 };
 
@@ -105,10 +105,12 @@ const expandAliases = (value) => {
     const base = normalize(value);
     const aliases = [];
     for (const resource of RESOURCE_ALIASES) {
-        if (new RegExp(`\\b${normalize(resource)}\\b`, 'i').test(base)) aliases.push(resource);
+        const normalized = normalize(resource);
+        const compact = normalized.replace(/\s+/g, '');
+        if (new RegExp(`\\b(?:${normalized}|${compact})\\b`).test(base)) aliases.push(resource);
     }
     for (const [needle, expansions] of SMALL_ALIASES.entries()) {
-        if (base.includes(needle)) aliases.push(...expansions);
+        if (new RegExp(`\\b${needle}\\b`).test(base)) aliases.push(...expansions);
     }
     return normalize([base, ...aliases].join(' '));
 };
@@ -153,7 +155,9 @@ const questRecords = () =>
             requiresQuests: Array.isArray(quest.requiresQuests) ? quest.requiresQuests : [],
             rewards: Array.isArray(quest.rewards) ? quest.rewards : [],
             rewardItems: Array.isArray(quest.rewardItems) ? quest.rewardItems : [],
+            grantsItems: Array.isArray(quest.grantsItems) ? quest.grantsItems : [],
             nodes: Array.isArray(quest.nodes) ? quest.nodes : [],
+            dialogue: Array.isArray(quest.dialogue) ? quest.dialogue : [],
         }));
 
 const formatQuestRewards = (rewards = []) =>
@@ -180,6 +184,16 @@ const itemEntryText = (entries = []) =>
 
 const itemIdsFromEntries = (entries = []) =>
     entries.map((entry) => entry?.id).filter((id) => typeof id === 'string' && id.length > 0);
+
+const questRewardItemEntries = (quest) => [
+    ...(quest?.rewards || []),
+    ...(quest?.rewardItems || []),
+    ...(quest?.grantsItems || []),
+    ...[...(quest?.nodes || []), ...(quest?.dialogue || [])].flatMap((node) => [
+        ...(node?.grantsItems || []),
+        ...(node?.options || []).flatMap((option) => option?.grantsItems || []),
+    ]),
+];
 
 const processItemIds = (process) =>
     new Set([
@@ -209,7 +223,10 @@ const questText = (quest) =>
         stringifyFields(quest.requiresQuests),
         stringifyFields(quest.rewards),
         stringifyFields(quest.rewardItems),
+        stringifyFields(quest.grantsItems),
+        itemEntryText(questRewardItemEntries(quest)),
         stringifyFields(quest.nodes),
+        stringifyFields(quest.dialogue),
     ].join(' ');
 
 const scoreRecord = (record, haystackText, queryTokens, queryText) => {
@@ -287,11 +304,12 @@ export function buildFocusedGameDataContext({
     const latest = String(query || '');
     const recent = recentContextText(messages, caps.recentMessageCount);
     const vagueFollowup = isVagueProcessQuery(latest) || isVagueEntityFollowup(latest);
-    const rewardFollowup =
-        isVagueEntityFollowup(latest) && /\b(rewards?|give|gives)\b/i.test(latest);
+    const rewardIntent = /\b(rewards?|reward|gives?|grants?)\b/i.test(latest);
+    const rewardFollowup = isVagueEntityFollowup(latest) && rewardIntent;
     const queryText = expandAliases(`${latest} ${vagueFollowup ? recent : ''}`);
     const queryTokens = [...new Set(tokensFor(queryText))];
     const reasonCodes = [];
+    const questIntent = /\bquests?\b/i.test(latest);
 
     const achievementIntent = wantsAchievements(latest);
 
@@ -326,7 +344,13 @@ export function buildFocusedGameDataContext({
     }
 
     if (vagueFollowup) reasonCodes.push('followup-entity-carryover');
-    if (RESOURCE_ALIASES.some((resource) => queryText.includes(normalize(resource))))
+    if (
+        RESOURCE_ALIASES.some((resource) => {
+            const normalized = normalize(resource);
+            const compact = normalized.replace(/\s+/g, '');
+            return new RegExp(`\\b(?:${normalized}|${compact})\\b`).test(queryText);
+        })
+    )
         reasonCodes.push('resource-token-hit');
     if (wantsRemainingQuests(latest)) reasonCodes.push('remaining-quest-state');
     if (wantsInventory(latest)) reasonCodes.push('inventory-summary-request');
@@ -336,13 +360,10 @@ export function buildFocusedGameDataContext({
     let selectedItems = inventoryOnlyQuery
         ? []
         : selectScored(items, itemText, queryTokens, queryText, caps.maxItems);
-    let selectedProcesses = selectScored(
-        processes,
-        processText,
-        queryTokens,
-        queryText,
-        caps.maxProcesses
-    );
+    let selectedProcesses =
+        questIntent || rewardIntent
+            ? []
+            : selectScored(processes, processText, queryTokens, queryText, caps.maxProcesses);
     if (isVagueProcessQuery(latest)) {
         for (const id of activeProcessIds(gameState, playerStateSummary)) {
             const process = processById.get(id);
@@ -352,8 +373,13 @@ export function buildFocusedGameDataContext({
         selectedProcesses = selectedProcesses.slice(0, caps.maxProcesses);
     }
 
+    const allQuestRecords = questRecords();
+    const processItemIdCache = new Map(
+        processes.map((process) => [process.id, processItemIds(process)])
+    );
+
     let selectedQuests = selectScored(
-        questRecords(),
+        allQuestRecords,
         questText,
         queryTokens,
         queryText,
@@ -367,21 +393,40 @@ export function buildFocusedGameDataContext({
         }
         selectedQuests = selectedQuests.slice(0, caps.maxQuests);
     }
+    if (selectedItems.length || selectedProcesses.length || selectedQuests.length)
+        reasonCodes.push('direct-entity-hit');
+
+    const addReasonForSelected = (collection, id, reason) => {
+        if (collection.some((entry) => entry.id === id)) reasonCodes.push(reason);
+    };
+
     const addItem = (id, reason) => {
         const item = itemById.get(id);
-        if (item && !selectedItems.some((entry) => entry.id === id)) {
+        if (
+            item &&
+            selectedItems.length < caps.maxItems &&
+            !selectedItems.some((entry) => entry.id === id)
+        ) {
             selectedItems.push(item);
             reasonCodes.push(reason);
         }
     };
     const addProcess = (process, reason) => {
-        if (process && !selectedProcesses.some((entry) => entry.id === process.id)) {
+        if (
+            process &&
+            selectedProcesses.length < caps.maxProcesses &&
+            !selectedProcesses.some((entry) => entry.id === process.id)
+        ) {
             selectedProcesses.push(process);
             reasonCodes.push(reason);
         }
     };
     const addQuest = (quest, reason) => {
-        if (quest && !selectedQuests.some((entry) => entry.id === quest.id)) {
+        if (
+            quest &&
+            selectedQuests.length < caps.maxQuests &&
+            !selectedQuests.some((entry) => entry.id === quest.id)
+        ) {
             selectedQuests.push(quest);
             reasonCodes.push(reason);
         }
@@ -389,44 +434,46 @@ export function buildFocusedGameDataContext({
 
     for (const item of selectedItems.slice(0, caps.maxItems)) {
         for (const process of processes) {
-            const relatedIds = processItemIds(process);
+            const relatedIds = processItemIdCache.get(process.id);
             if (!relatedIds.has(item.id)) continue;
             const creates = itemIdsFromEntries(process.createItems).includes(item.id);
             const consumes = itemIdsFromEntries(process.consumeItems).includes(item.id);
-            addProcess(
-                process,
-                creates
-                    ? 'process-creates-match'
-                    : consumes
-                      ? 'process-consumes-match'
-                      : 'process-requires-match'
-            );
+            const reason = creates
+                ? 'process-creates-match'
+                : consumes
+                  ? 'process-consumes-match'
+                  : 'process-requires-match';
+            addReasonForSelected(selectedProcesses, process.id, reason);
+            addProcess(process, reason);
             if (selectedProcesses.length >= caps.maxProcesses) break;
         }
     }
     for (const process of selectedProcesses.slice(0, caps.maxProcesses)) {
-        for (const id of processItemIds(process)) addItem(id, 'process-item-relationship');
+        for (const id of processItemIdCache.get(process.id) || [])
+            addItem(id, 'process-item-relationship');
     }
     for (const quest of selectedQuests.slice(0, caps.maxQuests)) {
         for (const prereqId of quest.requiresQuests || [])
             addQuest(getBuiltInQuest(prereqId), 'quest-prereq-match');
-        for (const reward of [...(quest.rewards || []), ...(quest.rewardItems || [])]) {
+        for (const reward of questRewardItemEntries(quest)) {
             if (reward?.id) addItem(reward.id, 'quest-reward-match');
         }
     }
     for (const item of selectedItems.slice(0, caps.maxItems)) {
-        for (const quest of questRecords()) {
-            const rewards = [...(quest.rewards || []), ...(quest.rewardItems || [])];
-            if (rewards.some((reward) => reward?.id === item.id))
+        for (const quest of allQuestRecords) {
+            if (questRewardItemEntries(quest).some((reward) => reward?.id === item.id)) {
+                if (selectedQuests.length >= caps.maxQuests && rewardIntent) {
+                    selectedQuests[selectedQuests.length - 1] = quest;
+                    reasonCodes.push('quest-reward-match');
+                }
+                addReasonForSelected(selectedQuests, quest.id, 'quest-reward-match');
                 addQuest(quest, 'quest-reward-match');
+            }
         }
     }
     selectedItems = selectedItems.slice(0, caps.maxItems);
     selectedProcesses = selectedProcesses.slice(0, caps.maxProcesses);
     selectedQuests = selectedQuests.slice(0, caps.maxQuests);
-
-    if (selectedItems.length || selectedProcesses.length || selectedQuests.length)
-        reasonCodes.push('direct-entity-hit');
 
     if (rewardFollowup && selectedQuests.length > 0) {
         selectedProcesses = [];
@@ -536,7 +583,7 @@ export function buildFocusedGameDataContext({
     if (selectedQuests.length > 0) {
         appendLine(
             lines,
-            `Relevant quests: ${selectedQuests.map((quest) => truncate(`${quest.title || quest.id} [${quest.id}] — ${quest.description || ''}${quest.requiresQuests?.length ? ` Prereqs: ${quest.requiresQuests.join(', ')}.` : ''}${quest.rewards?.length ? ` Rewards: ${formatQuestRewards(quest.rewards)}.` : ''}${quest.rewardItems?.length ? ` Reward items: ${formatItemList(quest.rewardItems)}.` : ''}`, caps.maxEntityChars)).join(' || ')}`,
+            `Relevant quests: ${selectedQuests.map((quest) => truncate(`${quest.title || quest.id} [${quest.id}] — ${quest.description || ''}${quest.requiresQuests?.length ? ` Prereqs: ${quest.requiresQuests.join(', ')}.` : ''}${quest.rewards?.length ? ` Rewards: ${formatQuestRewards(quest.rewards)}.` : ''}${questRewardItemEntries(quest).length ? ` Reward items: ${formatItemList(questRewardItemEntries(quest))}.` : ''}`, caps.maxEntityChars)).join(' || ')}`,
             caps.maxTotalChars
         );
         sources.push(
@@ -568,7 +615,7 @@ export function buildFocusedGameDataContext({
         }
         for (const quest of selectedQuests) {
             relationships.push(
-                `${quest.id}: prereqs ${(quest.requiresQuests || []).join(', ') || 'none listed'}; rewards ${formatQuestRewards(quest.rewards) || formatItemList(quest.rewardItems) || 'none listed'}`
+                `${quest.id}: prereqs ${(quest.requiresQuests || []).join(', ') || 'none listed'}; rewards ${formatQuestRewards(quest.rewards) || formatItemList(questRewardItemEntries(quest)) || 'none listed'}`
             );
         }
         appendLine(

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -384,6 +384,7 @@ export function buildFocusedGameDataContext({
     let selectedItems = inventoryOnlyQuery
         ? []
         : selectScored(items, itemText, queryTokens, queryText, caps.maxItems);
+    const directlySelectedItemIds = new Set(selectedItems.map((item) => item.id));
     let selectedProcesses =
         questIntent || rewardIntent
             ? []
@@ -453,30 +454,46 @@ export function buildFocusedGameDataContext({
         }
     };
     const addQuest = (quest, reason) => {
+        if (!quest || selectedQuests.some((entry) => entry.id === quest.id)) return false;
+        if (selectedQuests.length >= caps.maxQuests) return false;
+        selectedQuests.push(quest);
+        reasonCodes.push(reason);
+        return true;
+    };
+    let rewardQuestReplaced = false;
+    const replaceLastQuestForRewardIntent = (quest, reason) => {
         if (
-            quest &&
-            selectedQuests.length < caps.maxQuests &&
-            !selectedQuests.some((entry) => entry.id === quest.id)
-        ) {
-            selectedQuests.push(quest);
-            reasonCodes.push(reason);
-        }
+            !quest ||
+            !rewardIntent ||
+            !questIntent ||
+            rewardQuestReplaced ||
+            caps.maxQuests <= 0 ||
+            selectedQuests.length === 0
+        )
+            return false;
+        if (selectedQuests.some((entry) => entry.id === quest.id)) return false;
+        selectedQuests[selectedQuests.length - 1] = quest;
+        rewardQuestReplaced = true;
+        reasonCodes.push(reason);
+        return true;
     };
 
-    for (const item of selectedItems.slice(0, caps.maxItems)) {
-        for (const process of processes) {
-            const relatedIds = processItemIdCache.get(process.id);
-            if (!relatedIds?.all.has(item.id)) continue;
-            const creates = relatedIds.creates.has(item.id);
-            const consumes = relatedIds.consumes.has(item.id);
-            const reason = creates
-                ? 'process-creates-match'
-                : consumes
-                  ? 'process-consumes-match'
-                  : 'process-requires-match';
-            addReasonForSelected(selectedProcesses, process.id, reason);
-            addProcess(process, reason);
-            if (selectedProcesses.length >= caps.maxProcesses) break;
+    if (!rewardIntent && !questIntent) {
+        for (const item of selectedItems.slice(0, caps.maxItems)) {
+            for (const process of processes) {
+                const relatedIds = processItemIdCache.get(process.id);
+                if (!relatedIds?.all.has(item.id)) continue;
+                const creates = relatedIds.creates.has(item.id);
+                const consumes = relatedIds.consumes.has(item.id);
+                const reason = creates
+                    ? 'process-creates-match'
+                    : consumes
+                      ? 'process-consumes-match'
+                      : 'process-requires-match';
+                addReasonForSelected(selectedProcesses, process.id, reason);
+                addProcess(process, reason);
+                if (selectedProcesses.length >= caps.maxProcesses) break;
+            }
         }
     }
     for (const process of selectedProcesses.slice(0, caps.maxProcesses)) {
@@ -496,16 +513,16 @@ export function buildFocusedGameDataContext({
     for (const item of selectedItems.slice(0, caps.maxItems)) {
         for (const quest of allQuestRecords) {
             if (questRewardItemEntries(quest).some((reward) => reward?.id === item.id)) {
-                if (
-                    selectedQuests.length >= caps.maxQuests &&
-                    selectedQuests.length > 0 &&
-                    rewardIntent
-                ) {
-                    selectedQuests[selectedQuests.length - 1] = quest;
-                    reasonCodes.push('quest-reward-match');
-                }
-                addReasonForSelected(selectedQuests, quest.id, 'quest-reward-match');
-                addQuest(quest, 'quest-reward-match');
+                const added = addQuest(quest, 'quest-reward-match');
+                const directlyNamedItem =
+                    queryText.includes(normalize(item.name)) ||
+                    queryText.includes(normalize(item.id));
+                const replaced =
+                    added || !directlySelectedItemIds.has(item.id) || !directlyNamedItem
+                        ? false
+                        : replaceLastQuestForRewardIntent(quest, 'quest-reward-match');
+                if (!added && !replaced)
+                    addReasonForSelected(selectedQuests, quest.id, 'quest-reward-match');
             } else if (
                 questRequiredItemEntries(quest).some((required) => required?.id === item.id)
             ) {

--- a/frontend/src/utils/gameDataRetrieval.js
+++ b/frontend/src/utils/gameDataRetrieval.js
@@ -78,19 +78,49 @@ const STOPWORDS = new Set([
 const itemById = new Map(items.map((item) => [item.id, item]));
 const processById = new Map(processes.map((process) => [process.id, process]));
 
+const RESOURCE_ALIASES = ['dUSD', 'dBI', 'dWatt', 'dSolar', 'dPrint', 'dLaunch', 'dWind'];
+const SMALL_ALIASES = new Map([
+    ['benchy', ['benchy calibration model', 'benchy calibration boat']],
+    ['rocket', ['model rocket', '3d printed rocket', '3d print rocket']],
+    ['green pla', ['green pla filament']],
+]);
+
 const normalize = (value) =>
     String(value || '')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
         .toLowerCase()
         .replace(/[-_/]+/g, ' ')
-        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/[^a-z0-9]+/gi, ' ')
         .replace(/\s+/g, ' ')
         .trim();
 
+const singularize = (token) => {
+    if (token.endsWith('ies') && token.length > 4) return `${token.slice(0, -3)}y`;
+    if (token.endsWith('es') && token.length > 3) return token.slice(0, -2);
+    if (token.endsWith('s') && token.length > 3) return token.slice(0, -1);
+    return token;
+};
+
+const expandAliases = (value) => {
+    const base = normalize(value);
+    const aliases = [];
+    for (const resource of RESOURCE_ALIASES) {
+        if (new RegExp(`\\b${normalize(resource)}\\b`, 'i').test(base)) aliases.push(resource);
+    }
+    for (const [needle, expansions] of SMALL_ALIASES.entries()) {
+        if (base.includes(needle)) aliases.push(...expansions);
+    }
+    return normalize([base, ...aliases].join(' '));
+};
+
 const tokensFor = (value) =>
-    normalize(value)
+    expandAliases(value)
         .split(' ')
         .filter((token) => token.length >= 2 && !STOPWORDS.has(token))
-        .flatMap((token) => (token.endsWith('ies') ? [token, `${token.slice(0, -3)}y`] : [token]));
+        .flatMap((token) => {
+            const singular = singularize(token);
+            return singular === token ? [token] : [token, singular];
+        });
 
 const truncate = (value, max) => {
     const text = String(value || '')
@@ -147,6 +177,16 @@ const stringifyFields = (value) => {
 
 const itemEntryText = (entries = []) =>
     entries.map((entry) => [stringifyFields(entry), itemName(entry?.id)].join(' ')).join(' ');
+
+const itemIdsFromEntries = (entries = []) =>
+    entries.map((entry) => entry?.id).filter((id) => typeof id === 'string' && id.length > 0);
+
+const processItemIds = (process) =>
+    new Set([
+        ...itemIdsFromEntries(process.requireItems),
+        ...itemIdsFromEntries(process.consumeItems),
+        ...itemIdsFromEntries(process.createItems),
+    ]);
 
 const processText = (process) =>
     [
@@ -249,7 +289,7 @@ export function buildFocusedGameDataContext({
     const vagueFollowup = isVagueProcessQuery(latest) || isVagueEntityFollowup(latest);
     const rewardFollowup =
         isVagueEntityFollowup(latest) && /\b(rewards?|give|gives)\b/i.test(latest);
-    const queryText = normalize(`${latest} ${vagueFollowup ? recent : ''}`);
+    const queryText = expandAliases(`${latest} ${vagueFollowup ? recent : ''}`);
     const queryTokens = [...new Set(tokensFor(queryText))];
     const reasonCodes = [];
 
@@ -285,7 +325,9 @@ export function buildFocusedGameDataContext({
         };
     }
 
-    if (vagueFollowup) reasonCodes.push('recent-context-expanded');
+    if (vagueFollowup) reasonCodes.push('followup-entity-carryover');
+    if (RESOURCE_ALIASES.some((resource) => queryText.includes(normalize(resource))))
+        reasonCodes.push('resource-token-hit');
     if (wantsRemainingQuests(latest)) reasonCodes.push('remaining-quest-state');
     if (wantsInventory(latest)) reasonCodes.push('inventory-summary-request');
     if (achievementIntent) reasonCodes.push('achievement-state-request');
@@ -325,8 +367,68 @@ export function buildFocusedGameDataContext({
         }
         selectedQuests = selectedQuests.slice(0, caps.maxQuests);
     }
+    const addItem = (id, reason) => {
+        const item = itemById.get(id);
+        if (item && !selectedItems.some((entry) => entry.id === id)) {
+            selectedItems.push(item);
+            reasonCodes.push(reason);
+        }
+    };
+    const addProcess = (process, reason) => {
+        if (process && !selectedProcesses.some((entry) => entry.id === process.id)) {
+            selectedProcesses.push(process);
+            reasonCodes.push(reason);
+        }
+    };
+    const addQuest = (quest, reason) => {
+        if (quest && !selectedQuests.some((entry) => entry.id === quest.id)) {
+            selectedQuests.push(quest);
+            reasonCodes.push(reason);
+        }
+    };
+
+    for (const item of selectedItems.slice(0, caps.maxItems)) {
+        for (const process of processes) {
+            const relatedIds = processItemIds(process);
+            if (!relatedIds.has(item.id)) continue;
+            const creates = itemIdsFromEntries(process.createItems).includes(item.id);
+            const consumes = itemIdsFromEntries(process.consumeItems).includes(item.id);
+            addProcess(
+                process,
+                creates
+                    ? 'process-creates-match'
+                    : consumes
+                      ? 'process-consumes-match'
+                      : 'process-requires-match'
+            );
+            if (selectedProcesses.length >= caps.maxProcesses) break;
+        }
+    }
+    for (const process of selectedProcesses.slice(0, caps.maxProcesses)) {
+        for (const id of processItemIds(process)) addItem(id, 'process-item-relationship');
+    }
+    for (const quest of selectedQuests.slice(0, caps.maxQuests)) {
+        for (const prereqId of quest.requiresQuests || [])
+            addQuest(getBuiltInQuest(prereqId), 'quest-prereq-match');
+        for (const reward of [...(quest.rewards || []), ...(quest.rewardItems || [])]) {
+            if (reward?.id) addItem(reward.id, 'quest-reward-match');
+        }
+    }
+    for (const item of selectedItems.slice(0, caps.maxItems)) {
+        for (const quest of questRecords()) {
+            const rewards = [...(quest.rewards || []), ...(quest.rewardItems || [])];
+            if (rewards.some((reward) => reward?.id === item.id))
+                addQuest(quest, 'quest-reward-match');
+        }
+    }
+    selectedItems = selectedItems.slice(0, caps.maxItems);
+    selectedProcesses = selectedProcesses.slice(0, caps.maxProcesses);
+    selectedQuests = selectedQuests.slice(0, caps.maxQuests);
+
+    if (selectedItems.length || selectedProcesses.length || selectedQuests.length)
+        reasonCodes.push('direct-entity-hit');
+
     if (rewardFollowup && selectedQuests.length > 0) {
-        selectedItems = [];
         selectedProcesses = [];
     }
 
@@ -362,6 +464,7 @@ export function buildFocusedGameDataContext({
         .filter(
             (entry) =>
                 wantsInventory(latest) ||
+                selectedItems.some((item) => item.id === entry.id) ||
                 scoreRecord(
                     entry,
                     `${entry.id} ${entry.name} ${itemById.get(entry.id)?.description || ''}`,
@@ -379,10 +482,10 @@ export function buildFocusedGameDataContext({
         caps.maxTotalChars
     );
     if (inventoryEntries.length > 0) {
-        reasonCodes.push('matched-owned-inventory');
+        reasonCodes.push('owned-inventory-hit');
         appendLine(
             lines,
-            `Relevant inventory: ${inventoryEntries.map((e) => `${e.name} [${e.id}]=${formatCount(e.count)}`).join('; ')}`,
+            `Relevant inventory: owned ${inventoryEntries.map((e) => `${e.name} [${e.id}]=${formatCount(e.count)}`).join('; ')}`,
             caps.maxTotalChars
         );
         sources.push({
@@ -456,6 +559,33 @@ export function buildFocusedGameDataContext({
             ...selectedAchievements.map((a) => ({ type: 'achievement', id: a.id, label: a.title }))
         );
     }
+    if (selectedProcesses.length > 0 || selectedQuests.length > 0) {
+        const relationships = [];
+        for (const process of selectedProcesses) {
+            relationships.push(
+                `${process.id}: requires ${formatItemList(process.requireItems) || 'none listed'}; consumes ${formatItemList(process.consumeItems) || 'none listed'}; creates ${formatItemList(process.createItems) || 'none listed'}`
+            );
+        }
+        for (const quest of selectedQuests) {
+            relationships.push(
+                `${quest.id}: prereqs ${(quest.requiresQuests || []).join(', ') || 'none listed'}; rewards ${formatQuestRewards(quest.rewards) || formatItemList(quest.rewardItems) || 'none listed'}`
+            );
+        }
+        appendLine(
+            lines,
+            `Relevant relationships: ${relationships.slice(0, 6).join(' | ')}`,
+            caps.maxTotalChars
+        );
+    }
+    if (vagueFollowup) {
+        appendLine(
+            lines,
+            selectedProcesses.length || selectedQuests.length || selectedItems.length
+                ? 'Relevant follow-up context: entity candidates were recovered from the immediately recent chat only; ask a clarifying question if these do not match the player’s “it/that”.'
+                : 'Relevant follow-up context: no clear prior entity was recovered; ask a clarifying question instead of using broad catalog data.',
+            caps.maxTotalChars
+        );
+    }
     if (
         (wantsRemainingQuests(latest) || playerStateSummary?.slices?.remainingQuests?.length) &&
         selectedQuests.length > 0
@@ -494,5 +624,5 @@ export function buildFocusedGameDataContext({
 }
 
 export function __testables() {
-    return { normalize, tokensFor, scoreRecord };
+    return { normalize, expandAliases, tokensFor, scoreRecord };
 }

--- a/frontend/tests/dchatKnowledgePack.test.ts
+++ b/frontend/tests/dchatKnowledgePack.test.ts
@@ -82,7 +82,7 @@ describe('buildDchatKnowledgePack', () => {
         );
 
         expect(pack.summary).toContain('Inventory highlights: compact bounded');
-        expect(pack.summary).toContain('Relevant inventory:');
+        expect(pack.summary).toContain('Relevant owned inventory:');
         expect(pack.summary).not.toContain('Relevant achievements:');
         expect(pack.summary).not.toContain('Relevant quests:');
         expect(pack.summary).not.toContain('Relevant processes:');

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -12,6 +12,12 @@ describe('buildFocusedGameDataContext', () => {
         expect(tokensFor('dSolar, dWatt, dPrint and dLaunch')).toEqual(
             expect.arrayContaining(['solar', 'watt', 'print', 'launch'])
         );
+        expect(tokensFor('dusd dbi dwatt dsolar dprint dlaunch dwind')).toEqual(
+            expect.arrayContaining(['usd', 'bi', 'watt', 'solar', 'print', 'launch', 'wind'])
+        );
+        expect(tokensFor('D-USD D BI D-WATT D SOLAR D-PRINT DLAUNCH D-WIND')).toEqual(
+            expect.arrayContaining(['usd', 'bi', 'watt', 'solar', 'print', 'launch', 'wind'])
+        );
         expect(tokensFor('BENCHIES')).toContain('benchy');
     });
 
@@ -24,6 +30,8 @@ describe('buildFocusedGameDataContext', () => {
         expect(expandAliases('what quests are in the rocketry category?')).not.toContain(
             'model rocket'
         );
+        expect(expandAliases('show me the workbench')).not.toContain('benchy calibration model');
+        expect(expandAliases('show me a bench')).not.toContain('benchy calibration model');
     });
 
     it('keeps verb tokens intact when singularizing plurals', () => {
@@ -108,7 +116,7 @@ describe('buildFocusedGameDataContext', () => {
             gameState: { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 13 } },
         });
 
-        expect(result.block).toContain('Relevant inventory:');
+        expect(result.block).toContain('Relevant owned inventory:');
         expect(result.block).toContain('green PLA filament');
         expect(result.sources.some((source) => source.type === 'item')).toBe(true);
         expect(result.meta.selectedInventoryIds).toContain('d3590107-25ff-4de5-af3a-46e2497bfc52');
@@ -125,7 +133,7 @@ describe('buildFocusedGameDataContext', () => {
             },
         });
 
-        expect(result.block).toContain('Relevant inventory:');
+        expect(result.block).toContain('Relevant owned inventory:');
         expect(result.block).toContain('white PLA filament');
         expect(result.meta.selectedInventoryCount).toBe(2);
         expect(result.meta.selectedInventoryIds).toContain('58580f6f-f3be-4be0-80b9-f6f8bf0b05a6');
@@ -213,6 +221,38 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.block).toContain('Relevant processes:');
         expect(result.block).toContain('3dprint-rocket');
         expect(result.meta.reasonCodes).toContain('followup-entity-carryover');
+    });
+
+    it('includes owned inventory selected through process requirements', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'Can I make 3dprint-rocket?',
+            gameState: { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 42 } },
+            options: { maxProcesses: 2, maxItems: 6, maxTotalChars: 9000 },
+        });
+
+        expect(result.block).toContain('Relevant owned inventory:');
+        expect(result.block).toContain(
+            'green PLA filament [d3590107-25ff-4de5-af3a-46e2497bfc52]=42'
+        );
+        expect(result.meta.selectedInventoryIds).toContain('d3590107-25ff-4de5-af3a-46e2497bfc52');
+    });
+
+    it('uses prior entity context for make/build/that/those follow-ups', () => {
+        for (const query of [
+            'can I make that?',
+            'can I build that?',
+            'what about 10 of those?',
+            'what does that consume?',
+        ]) {
+            const result = buildFocusedGameDataContext({
+                query,
+                messages: [{ role: 'user', content: 'Tell me about 3D print a Benchy' }],
+                options: { maxProcesses: 3, maxItems: 5, maxTotalChars: 9000 },
+            });
+
+            expect(result.meta.reasonCodes).toContain('followup-entity-carryover');
+            expect(result.meta.selectedProcessIds).toContain('3dprint-benchy');
+        }
     });
 
     it('returns achievement state for direct achievement requests without unrelated filler', () => {

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -15,6 +15,28 @@ describe('buildFocusedGameDataContext', () => {
         expect(tokensFor('BENCHIES')).toContain('benchy');
     });
 
+    it('matches compact lowercase resource tokens and avoids small-alias substrings', () => {
+        const { expandAliases, tokensFor } = __testables();
+
+        expect(tokensFor('how much dsolar and dwatt do I have?')).toEqual(
+            expect.arrayContaining(['solar', 'watt'])
+        );
+        expect(expandAliases('what quests are in the rocketry category?')).not.toContain(
+            'model rocket'
+        );
+    });
+
+    it('keeps verb tokens intact when singularizing plurals', () => {
+        const { tokensFor } = __testables();
+
+        expect(tokensFor('what process creates or requires boxes')).toEqual(
+            expect.arrayContaining(['creates', 'requires', 'boxes', 'box'])
+        );
+        expect(tokensFor('what process creates or requires boxes')).not.toEqual(
+            expect.arrayContaining(['creat', 'requir'])
+        );
+    });
+
     it('traverses from a created item to making processes', () => {
         const result = buildFocusedGameDataContext({
             query: 'What process makes a Benchy?',
@@ -37,6 +59,27 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.block).toContain('green PLA filament');
         expect(result.block).toContain('3D printed model rocket');
         expect(result.block).toContain('Consumes:');
+    });
+
+    it('selects quests that grant matched items through dialogue options', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what quest gives the NEMA 17 stepper motor pair?',
+            options: { maxQuests: 6, maxItems: 6, maxTotalChars: 9000 },
+        });
+
+        expect(result.meta.selectedItemIds).toContain('648aee3c-907e-4cd1-a361-49c4bd771102');
+        expect(result.meta.selectedQuestIds).toContain('energy/solar-tracker');
+        expect(result.block).toContain('NEMA 17 stepper motor pair');
+    });
+
+    it('only emits traversal reason codes for entities kept within caps', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what process makes a Benchy?',
+            options: { maxProcesses: 0, maxItems: 5, maxTotalChars: 9000 },
+        });
+
+        expect(result.meta.selectedProcessIds).toEqual([]);
+        expect(result.meta.reasonCodes).not.toContain('process-creates-match');
     });
 
     it('selects resource token items and matching owned balances', () => {

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -2,7 +2,63 @@ import { describe, expect, it } from 'vitest';
 import { buildPromptMetrics } from '../src/utils/promptMetrics.js';
 import { buildFocusedGameDataContext } from '../src/utils/gameDataRetrieval.js';
 
+import { __testables } from '../src/utils/gameDataRetrieval.js';
+
 describe('buildFocusedGameDataContext', () => {
+    it('normalizes aliases, resources, punctuation, hyphens, and plurals', () => {
+        const { expandAliases, tokensFor } = __testables();
+
+        expect(expandAliases('GREEN-PLA/benchies')).toContain('green pla filament');
+        expect(tokensFor('dSolar, dWatt, dPrint and dLaunch')).toEqual(
+            expect.arrayContaining(['solar', 'watt', 'print', 'launch'])
+        );
+        expect(tokensFor('BENCHIES')).toContain('benchy');
+    });
+
+    it('traverses from a created item to making processes', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'What process makes a Benchy?',
+            options: { maxProcesses: 3, maxItems: 5, maxTotalChars: 9000 },
+        });
+
+        expect(result.meta.selectedProcessIds).toContain('3dprint-benchy');
+        expect(result.meta.reasonCodes).toContain('process-creates-match');
+        expect(result.block).toContain('Relevant relationships:');
+        expect(result.meta.selectedProcessCount).toBeLessThanOrEqual(3);
+    });
+
+    it('traverses from a process to required, consumed, and created items', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'Can I make 3dprint-rocket?',
+            gameState: { inventory: { 'd3590107-25ff-4de5-af3a-46e2497bfc52': 100 } },
+        });
+
+        expect(result.meta.selectedProcessIds).toContain('3dprint-rocket');
+        expect(result.block).toContain('green PLA filament');
+        expect(result.block).toContain('3D printed model rocket');
+        expect(result.block).toContain('Consumes:');
+    });
+
+    it('selects resource token items and matching owned balances', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'How much dSolar and dWatt do I have for dPrint or dLaunch?',
+            gameState: {
+                inventory: {
+                    'b02ecff5-1f7d-4247-a09d-7d6cd6bb218a': 2,
+                    '061fd221-404a-4bd1-9432-3e25b0f17a2c': 50,
+                    '071ba424-3940-4c80-a782-5d7ea4d829ff': 7,
+                    'eb9c2a75-a87a-4171-8bc3-088e75936bcf': 1,
+                },
+            },
+        });
+
+        expect(result.meta.reasonCodes).toContain('resource-token-hit');
+        expect(result.block).toContain('dSolar');
+        expect(result.block).toContain('dWatt');
+        expect(result.block).toContain('dPrint');
+        expect(result.block).toContain('dLaunch');
+    });
+
     it('selects green PLA item and owned state', () => {
         const result = buildFocusedGameDataContext({
             query: 'do I have enough green PLA?',
@@ -113,7 +169,7 @@ describe('buildFocusedGameDataContext', () => {
 
         expect(result.block).toContain('Relevant processes:');
         expect(result.block).toContain('3dprint-rocket');
-        expect(result.meta.reasonCodes).toContain('recent-context-expanded');
+        expect(result.meta.reasonCodes).toContain('followup-entity-carryover');
     });
 
     it('returns achievement state for direct achievement requests without unrelated filler', () => {

--- a/frontend/tests/gameDataRetrieval.test.ts
+++ b/frontend/tests/gameDataRetrieval.test.ts
@@ -80,6 +80,19 @@ describe('buildFocusedGameDataContext', () => {
         expect(result.block).toContain('NEMA 17 stepper motor pair');
     });
 
+    it('retains reward-matching quests without duplicate eviction under tiny quest caps', () => {
+        const result = buildFocusedGameDataContext({
+            query: 'what quest gives the NEMA 17 stepper motor pair?',
+            options: { maxQuests: 1, maxItems: 6, maxTotalChars: 9000 },
+        });
+
+        expect(result.meta.selectedQuestIds).toEqual(['energy/solar-tracker']);
+        expect(new Set(result.meta.selectedQuestIds).size).toBe(
+            result.meta.selectedQuestIds.length
+        );
+        expect(result.meta.reasonCodes).toContain('quest-reward-match');
+    });
+
     it('only emits traversal reason codes for entities kept within caps', () => {
         const result = buildFocusedGameDataContext({
             query: 'what process makes a Benchy?',

--- a/frontend/tests/openAI.test.ts
+++ b/frontend/tests/openAI.test.ts
@@ -642,6 +642,27 @@ describe('buildChatPrompt', () => {
         expect(payload.promptMetrics.docsRag.status).toBe('skipped');
     });
 
+    it.each([
+        ['build question', 'Can I make 3dprint-rocket?'],
+        ['material question', 'do I have enough green PLA?'],
+        ['quest question', 'what quest gives the NEMA 17 stepper motor pair?'],
+        ['player-state question', 'what quest do I have left?'],
+    ])('skips docs RAG for focused game-data %s', async (_label, content) => {
+        vi.mocked(searchDocsRag).mockClear();
+
+        const payload = await buildChatPrompt([{ role: 'user', content }], {
+            includePromptMetrics: true,
+        });
+        const prompt = payload.combinedMessages.map((message) => message.content).join('\n');
+
+        expect(payload.contextPlan.mode).toBe('full');
+        expect(payload.contextPlan.includeDocsRag).toBe(false);
+        expect(prompt).not.toContain('Docs grounding');
+        expect(searchDocsRag).not.toHaveBeenCalled();
+        expect(payload.contextSources.every((source) => source.type !== 'doc')).toBe(true);
+        expect(payload.promptMetrics.docsRag.status).toBe('skipped');
+    });
+
     it('preserves transcript order when inserting answer-focus before a non-final user turn', async () => {
         const latest = { role: 'user', content: 'what quest do I have left?' };
         const assistantReply = {


### PR DESCRIPTION
### Motivation
- Improve deterministic, compact structured retrieval so chat can handle practical build/craft/progress questions (can I make X, do I have enough Y, what process makes X, what quest rewards X, follow-ups) without falling back to broad catalog dumps or docs RAG.
- Keep P20 focused retrieval as the baseline and preserve P16–P21 behaviors, PlayerState compaction, and token.place/token-lite routing while adding better normalization, aliasing, and shallow relationship traversal.

### Description
- Extended `frontend/src/utils/gameDataRetrieval.js` with stronger entity normalization and small aliases (resource tokens like `dSolar`, `dWatt`, `dPrint`, `dLaunch`, and light aliases for `benchy`, `rocket`, `green pla`) plus camelCase/punctuation/plural handling via `expandAliases` and `singularize`.
- Added shallow, bounded relationship traversal so selected items pull in matching processes, selected processes pull in related required/consumed/created items, and selected quests pull in prereqs/reward items, and included owned inventory matches when available.
- Added new reason codes and safe focused metadata (`followup-entity-carryover`, `resource-token-hit`, `process-creates-match`, `process-consumes-match`, `quest-reward-match`, `quest-prereq-match`, `owned-inventory-hit`, `direct-entity-hit`) and compact `Relevant ...` sections: inventory, items, processes, quests, relationships, follow-up context.
- Added focused unit tests and test helpers in `frontend/tests/gameDataRetrieval.test.ts` (exporting `__testables`) to validate alias normalization, resource tokens, relationship traversal, build/material queries, follow-up carryover, and bounded output; kept changes limited to the allowed P20/ frontend utilities and tests.

### Testing
- Ran focused tests: `cd frontend && npm test -- gameDataRetrieval` and the test file passed (17 tests, all passed).
- Ran other affected frontend suites: `cd frontend && npm test -- dchatKnowledge && npm test -- openAI && npm test -- chatContextPlanner && npm test -- tokenPlace.test.js` and all targeted suites passed (dchatKnowledgePack tests, openAI tests, chatContextPlanner tests, tokenPlace tests all green).
- Ran repo checks and build: `cd frontend && npm run check && npm run build` completed successfully and formatting/lint/build passed.

All automated checks listed above succeeded; remaining manual staging and runtime validation steps from the prompt are recommended as follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a409b9237cc832f88a867b59625eeab)