### PR TITLE
Instrument privacy-safe DSPACE application metrics

### DIFF
--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -1,8 +1,9 @@
 # DSPACE v3.1.0 Observability Release Gate
 
 This design turns observability into an explicit DSPACE v3.1.0 release requirement. It is a
-planning and QA contract only: it does not implement new metrics, dashboards, alerts, exporters,
-Helm templates, or version metadata.
+planning and QA contract. The application runtime now implements the first privacy-safe
+Prometheus metrics slice, but dashboards, alerts, exporters, canonical Helm scrape templates, and
+live Sugarkube scrape evidence remain separate release-gate work.
 
 Status: v3.1.0 is not treated as shipped by this document. The repository metadata still reports
 `package.json` version `3.0.1`, and the active GHCR Helm publishing workflow packages
@@ -19,16 +20,56 @@ smallest useful v3.1.0 release slice.
 
 ## Repository evidence inventory
 
-| Area                          | Evidence                                                                                                                                          | Classification                          | v3.1.0 implication                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime version               | `package.json` is `3.0.1`.                                                                                                                        | Implemented for v3.0.1; v3.1.0 missing. | Do not claim v3.1.0 shipped until release metadata and immutable artifacts exist.                                                                               |
-| Metrics route                 | `frontend/src/pages/metrics.ts` exposes `/metrics` and optionally requires `Authorization: Bearer <METRICS_TOKEN>`.                               | Partial.                                | Endpoint exists, but staging/prod scrape behavior and public exposure controls still need evidence.                                                             |
-| Metric implementation         | `frontend/src/utils/metrics.js` initializes `prom-client` default process metrics only, with a fallback text response.                            | Partial.                                | Process/runtime basics may exist; DSPACE-specific HTTP, dChat, token.place, fallback, and build-info metrics are missing until implemented elsewhere.           |
-| Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                             | Legacy/local scaffold.                  | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
-| Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                        | Implemented v3.0.1 path.                | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
-| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.               | Missing.                                | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
-| Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow. | Partial legacy/experimental duplicate.  | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
-| Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                     | Legacy/partial.                         | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
+| Area                          | Evidence                                                                                                                                                                                      | Classification                          | v3.1.0 implication                                                                                                                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime version               | `package.json` is `3.0.1`.                                                                                                                                                                    | Implemented for v3.0.1; v3.1.0 missing. | Do not claim v3.1.0 shipped until release metadata and immutable artifacts exist.                                                                               |
+| Metrics route                 | `frontend/src/pages/metrics.ts` exposes `/metrics`, optionally requires `Authorization: Bearer <METRICS_TOKEN>`, and returns 503 if instrumentation cannot initialize.                        | Implemented source behavior.            | Endpoint exists; staging/prod scrape behavior and public exposure controls still need live evidence.                                                            |
+| Metric implementation         | `frontend/src/utils/metrics.js` initializes a shared `prom-client` registry with default process metrics plus DSPACE HTTP, dChat, dependency, build-info, and instrumentation health metrics. | Implemented source behavior.            | Application metrics exist in source; live staging/prod non-empty scrape evidence is still required.                                                             |
+| Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                                                                         | Legacy/local scaffold.                  | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
+| Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                                                                    | Implemented v3.0.1 path.                | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
+| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.                                                           | Missing.                                | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
+| Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow.                                             | Partial legacy/experimental duplicate.  | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
+| Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                                                                 | Legacy/partial.                         | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
+
+## Implemented application metrics slice
+
+The application runtime emits these Prometheus families from the shared `prom-client` registry:
+
+- `dspace_http_requests_total{method,route,status_class,outcome}`
+- `dspace_http_request_duration_seconds{method,route,status_class,outcome}` with buckets `0.05`,
+  `0.1`, `0.25`, `0.5`, `1`, `2.5`, `5`, `10`, and `30` seconds
+- `dspace_dchat_requests_total{provider,outcome}`
+- `dspace_dchat_request_duration_seconds{provider,outcome}`
+- `dspace_dependency_requests_total{dependency,outcome}`
+- `dspace_dependency_request_duration_seconds{dependency,outcome}`
+- `dspace_build_info{version,revision}` fixed at `1`
+- `dspace_instrumentation_up` fixed at `1` after successful initialization
+
+Implemented source behavior is deliberately privacy-safe: routes are templates or route groups,
+status is a status class, provider/dependency/outcome labels are bounded enums, and `/metrics` is
+excluded from HTTP request instrumentation. These source-level guarantees are not a substitute for
+live Sugarkube scrape evidence; staging must still prove the endpoint is reachable only through the
+approved scrape path and that representative traffic produces non-empty series.
+
+### PromQL examples
+
+```promql
+# Request rate by route group
+sum by (route) (rate(dspace_http_requests_total[5m]))
+
+# HTTP error ratio
+sum(rate(dspace_http_requests_total{status_class=~"4xx|5xx"}[5m]))
+  / sum(rate(dspace_http_requests_total[5m]))
+
+# p95 HTTP latency by route group
+histogram_quantile(0.95, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket[5m])))
+
+# dChat outcomes by provider
+sum by (provider, outcome) (rate(dspace_dchat_requests_total[5m]))
+
+# token.place dependency outcomes
+sum by (outcome) (rate(dspace_dependency_requests_total{dependency="tokenplace"}[5m]))
+```
 
 ## Canonical Helm chart decision
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -198,6 +198,34 @@ evidence is attached.
 - [ ] **v3.1.0 release blocker:** Release/build identity is attached with bounded labels such as
       version, revision, Helm release, and environment.
 
+### 11.0 Implemented source metrics checks
+
+- [ ] Source `/metrics` emits valid Prometheus text for `dspace_http_requests_total`,
+      `dspace_http_request_duration_seconds`, `dspace_dchat_requests_total`,
+      `dspace_dchat_request_duration_seconds`, `dspace_dependency_requests_total`,
+      `dspace_dependency_request_duration_seconds`, `dspace_build_info`, and
+      `dspace_instrumentation_up`.
+- [ ] Controlled local or staging traffic makes the required DSPACE metric families non-empty.
+- [ ] `/metrics` scrape requests do not increment `dspace_http_requests_total`.
+- [ ] Metrics output contains no prompts, responses, OpenAI keys, token.place credentials, save data,
+      inventory, player identity, IP addresses, raw URLs, request IDs, exception text, NPC names, or
+      arbitrary provider/model names.
+- [ ] If instrumentation initialization fails, `/metrics` returns an explicit non-success response
+      instead of a misleading HTTP 200 placeholder.
+
+PromQL examples for live Sugarkube evidence:
+
+```promql
+sum by (route) (rate(dspace_http_requests_total[5m]))
+sum(rate(dspace_http_requests_total{status_class=~"4xx|5xx"}[5m])) / sum(rate(dspace_http_requests_total[5m]))
+histogram_quantile(0.95, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket[5m])))
+sum by (provider, outcome) (rate(dspace_dchat_requests_total[5m]))
+sum by (outcome) (rate(dspace_dependency_requests_total{dependency="tokenplace"}[5m]))
+```
+
+The checks above verify implemented application behavior. Sections 11.1 through 11.7 still require
+live Sugarkube scrape, dashboard, alert, and exposure-control evidence before production promotion.
+
 ### 11.2 Release-blocking metric families
 
 - [ ] **v3.1.0 release blocker:** HTTP request totals and latency histograms use bounded route

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,7 @@ import {
     buildRuntimeConfigResponse,
 } from './utils/runtimeEndpoints';
 import { logServerError } from './utils/serverLogger';
+import { normalizeRoute, recordHttpRequest } from './utils/metrics.js';
 
 export interface MiddlewareContext {
     request: Request;
@@ -11,6 +12,7 @@ export interface MiddlewareContext {
 
 export const onRequest = async (context: MiddlewareContext, next: () => Promise<Response>) => {
     const { pathname } = new URL(context.request.url);
+    const startedAt = performance.now();
     const handledPaths = new Set(['/config.json', '/healthz', '/health', '/livez']);
 
     let response: Response;
@@ -23,6 +25,13 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             method: context.request.method,
             message: 'Unhandled error while processing request',
             error,
+        });
+        recordHttpRequest({
+            method: context.request.method,
+            route: normalizeRoute(pathname),
+            status: 500,
+            outcome: 'server_error',
+            durationSeconds: (performance.now() - startedAt) / 1000,
         });
         throw error;
     }
@@ -52,18 +61,59 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
         }
 
+        recordHttpRequest({
+            method: context.request.method,
+            route: normalizeRoute(pathname),
+            status: response.status,
+            outcome:
+                response.status >= 500
+                    ? 'server_error'
+                    : response.status >= 400
+                      ? 'validation_error'
+                      : 'success',
+            durationSeconds: (performance.now() - startedAt) / 1000,
+        });
         return response;
     }
 
     switch (pathname) {
         case '/config.json':
-            return buildRuntimeConfigResponse();
+            response = buildRuntimeConfigResponse();
+            break;
         case '/healthz':
         case '/health':
-            return buildHealthResponse();
+            response = buildHealthResponse();
+            break;
         case '/livez':
-            return buildLivezResponse();
+            response = buildLivezResponse();
+            break;
         default:
+            recordHttpRequest({
+                method: context.request.method,
+                route: normalizeRoute(pathname),
+                status: response.status,
+                outcome:
+                    response.status >= 500
+                        ? 'server_error'
+                        : response.status >= 400
+                          ? 'validation_error'
+                          : 'success',
+                durationSeconds: (performance.now() - startedAt) / 1000,
+            });
             return response;
     }
+
+    recordHttpRequest({
+        method: context.request.method,
+        route: normalizeRoute(pathname),
+        status: response.status,
+        outcome:
+            response.status >= 500
+                ? 'server_error'
+                : response.status >= 400
+                  ? 'validation_error'
+                  : 'success',
+        durationSeconds: (performance.now() - startedAt) / 1000,
+    });
+    return response;
 };

--- a/frontend/src/pages/metrics.ts
+++ b/frontend/src/pages/metrics.ts
@@ -16,6 +16,14 @@ export async function GET({ request }: { request: Request }) {
         }
     }
 
+    if (register.unavailable) {
+        const metrics = await register.metrics();
+        return new Response(metrics, {
+            status: 503,
+            headers: { 'Content-Type': register.contentType },
+        });
+    }
+
     const metrics = await register.metrics();
     return new Response(metrics, {
         headers: { 'Content-Type': register.contentType },

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,17 +1,246 @@
+import packageMetadata from '../../../package.json' with { type: 'json' };
+
 let register;
+let metricsReady = false;
+let metricHandles = {};
 
 const defaultLoader = () => import(/* @vite-ignore */ 'prom-client');
 
-async function initMetrics(loader = defaultLoader) {
+const HTTP_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30];
+const DEPENDENCY_BUCKETS = HTTP_BUCKETS;
+
+const OUTCOMES = new Set([
+    'success',
+    'timeout',
+    'rate_limited',
+    'validation_error',
+    'malformed_response',
+    'dependency_failure',
+    'server_error',
+    'fallback_used',
+    'fallback_unavailable',
+    'unknown_error',
+]);
+const PROVIDERS = new Set(['tokenplace', 'openai', 'none', 'unknown']);
+const DEPENDENCIES = new Set(['tokenplace', 'openai']);
+
+const unavailableRegistry = (reason = 'metrics unavailable') => ({
+    contentType: 'text/plain',
+    unavailable: true,
+    reason,
+    metrics: async () => `# ${reason}\n`,
+});
+
+const getOrCreateMetric = (MetricClass, config) => {
+    const existing = register.getSingleMetric?.(config.name);
+    if (existing) return existing;
+    return new MetricClass({ ...config, registers: [register] });
+};
+
+const normalizeEnum = (value, allowed, fallback) => {
+    const normalized = String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_]+/g, '_');
+    return allowed.has(normalized) ? normalized : fallback;
+};
+
+export const normalizeOutcome = (value) => normalizeEnum(value, OUTCOMES, 'unknown_error');
+export const normalizeProvider = (value) => normalizeEnum(value, PROVIDERS, 'unknown');
+export const normalizeDependency = (value) => normalizeEnum(value, DEPENDENCIES, 'unknown');
+
+export const statusClassFor = (status) => {
+    const numeric = Number(status);
+    if (!Number.isFinite(numeric) || numeric < 100) return 'unknown';
+    return `${Math.trunc(numeric / 100)}xx`;
+};
+
+export const normalizeRoute = (urlOrPath) => {
+    let path = '/unknown';
     try {
-        const { Registry, collectDefaultMetrics } = await loader();
+        path = new URL(urlOrPath, 'http://dspace.local').pathname;
+    } catch {
+        path = String(urlOrPath || '/unknown').split('?')[0] || '/unknown';
+    }
+
+    if (path === '/metrics') return '/metrics';
+    if (path === '/' || path === '/health' || path === '/healthz' || path === '/livez') return path;
+    if (path === '/config.json' || path === '/service-worker.js' || path === '/cache-version.js') {
+        return path;
+    }
+    if (path.startsWith('/_astro/')) return '/_astro/*';
+    if (path.startsWith('/assets/')) return '/assets/*';
+    if (path.startsWith('/docs/')) return '/docs/[slug]';
+    if (path.startsWith('/inventory/item/')) return '/inventory/item/[itemId]';
+    if (path.startsWith('/processes/')) return '/processes/[processId]';
+    if (path.startsWith('/quests/')) return '/quests/[pathId]/[questId]';
+    return path.replace(/[0-9a-f]{8,}/gi, '[id]').replace(/\d+/g, '[id]');
+};
+
+export const outcomeFromError = (error) => {
+    const status = Number(error?.status ?? error?.response?.status);
+    const code = String(error?.code || error?.type || '').toLowerCase();
+    const name = String(error?.name || '').toLowerCase();
+    if (
+        status === 408 ||
+        code.includes('timeout') ||
+        name.includes('timeout') ||
+        name === 'aborterror'
+    ) {
+        return 'timeout';
+    }
+    if (status === 429 || code.includes('rate_limit')) return 'rate_limited';
+    if (status >= 500) return 'server_error';
+    if (status >= 400) return 'dependency_failure';
+    if (code.includes('malformed')) return 'malformed_response';
+    return 'unknown_error';
+};
+
+const safeObserve = (operation) => {
+    try {
+        if (metricsReady) operation();
+    } catch {
+        // Metrics must never break game functionality.
+    }
+};
+
+export const recordHttpRequest = ({ method, route, status, outcome, durationSeconds }) =>
+    safeObserve(() => {
+        const labels = {
+            method: String(method || 'GET').toUpperCase(),
+            route: normalizeRoute(route),
+            status_class: statusClassFor(status),
+            outcome: normalizeOutcome(outcome),
+        };
+        if (labels.route === '/metrics') return;
+        metricHandles.httpRequests.inc(labels);
+        if (Number.isFinite(durationSeconds)) {
+            metricHandles.httpDuration.observe(labels, Math.max(0, durationSeconds));
+        }
+    });
+
+export const recordDchatRequest = ({ provider, outcome, durationSeconds }) =>
+    safeObserve(() => {
+        const labels = {
+            provider: normalizeProvider(provider),
+            outcome: normalizeOutcome(outcome),
+        };
+        metricHandles.dchatRequests.inc(labels);
+        if (Number.isFinite(durationSeconds)) {
+            metricHandles.dchatDuration.observe(labels, Math.max(0, durationSeconds));
+        }
+    });
+
+export const recordDependencyRequest = ({ dependency, outcome, durationSeconds }) =>
+    safeObserve(() => {
+        const labels = {
+            dependency: normalizeDependency(dependency),
+            outcome: normalizeOutcome(outcome),
+        };
+        metricHandles.dependencyRequests.inc(labels);
+        if (Number.isFinite(durationSeconds)) {
+            metricHandles.dependencyDuration.observe(labels, Math.max(0, durationSeconds));
+        }
+    });
+
+export const withDchatMetrics = async (provider, operation) => {
+    const startedAt = performance.now();
+    let outcome = 'success';
+    try {
+        const result = await operation();
+        if (result?.metricsOutcome) outcome = result.metricsOutcome;
+        return result;
+    } catch (error) {
+        outcome = outcomeFromError(error);
+        throw error;
+    } finally {
+        recordDchatRequest({
+            provider,
+            outcome,
+            durationSeconds: (performance.now() - startedAt) / 1000,
+        });
+    }
+};
+
+export const withDependencyMetrics = async (dependency, operation) => {
+    const startedAt = performance.now();
+    let outcome = 'success';
+    try {
+        const result = await operation();
+        if (result?.metricsOutcome) outcome = result.metricsOutcome;
+        return result;
+    } catch (error) {
+        outcome = outcomeFromError(error);
+        throw error;
+    } finally {
+        recordDependencyRequest({
+            dependency,
+            outcome,
+            durationSeconds: (performance.now() - startedAt) / 1000,
+        });
+    }
+};
+
+async function initMetrics(loader = defaultLoader) {
+    metricsReady = false;
+    metricHandles = {};
+    try {
+        const { Registry, collectDefaultMetrics, Counter, Histogram, Gauge } = await loader();
         register = new Registry();
         collectDefaultMetrics({ register });
-    } catch {
-        register = {
-            contentType: 'text/plain',
-            metrics: async () => '# metrics unavailable\n',
-        };
+        metricHandles.httpRequests = getOrCreateMetric(Counter, {
+            name: 'dspace_http_requests_total',
+            help: 'DSPACE HTTP requests by bounded route, status class, and outcome.',
+            labelNames: ['method', 'route', 'status_class', 'outcome'],
+        });
+        metricHandles.httpDuration = getOrCreateMetric(Histogram, {
+            name: 'dspace_http_request_duration_seconds',
+            help: 'DSPACE HTTP request duration in seconds.',
+            labelNames: ['method', 'route', 'status_class', 'outcome'],
+            buckets: HTTP_BUCKETS,
+        });
+        metricHandles.dchatRequests = getOrCreateMetric(Counter, {
+            name: 'dspace_dchat_requests_total',
+            help: 'DSPACE dChat logical requests by provider and terminal outcome.',
+            labelNames: ['provider', 'outcome'],
+        });
+        metricHandles.dchatDuration = getOrCreateMetric(Histogram, {
+            name: 'dspace_dchat_request_duration_seconds',
+            help: 'DSPACE dChat logical request duration in seconds.',
+            labelNames: ['provider', 'outcome'],
+            buckets: HTTP_BUCKETS,
+        });
+        metricHandles.dependencyRequests = getOrCreateMetric(Counter, {
+            name: 'dspace_dependency_requests_total',
+            help: 'DSPACE bounded dependency requests by dependency and outcome.',
+            labelNames: ['dependency', 'outcome'],
+        });
+        metricHandles.dependencyDuration = getOrCreateMetric(Histogram, {
+            name: 'dspace_dependency_request_duration_seconds',
+            help: 'DSPACE bounded dependency request duration in seconds.',
+            labelNames: ['dependency', 'outcome'],
+            buckets: DEPENDENCY_BUCKETS,
+        });
+        metricHandles.buildInfo = getOrCreateMetric(Gauge, {
+            name: 'dspace_build_info',
+            help: 'DSPACE build metadata as one low-cardinality sample.',
+            labelNames: ['version', 'revision'],
+        });
+        metricHandles.instrumentationUp = getOrCreateMetric(Gauge, {
+            name: 'dspace_instrumentation_up',
+            help: 'Whether DSPACE metrics instrumentation initialized successfully.',
+        });
+        metricHandles.buildInfo.set(
+            {
+                version: packageMetadata.version || 'unknown',
+                revision: process.env.VITE_GIT_SHA || process.env.GITHUB_SHA || 'missing',
+            },
+            1
+        );
+        metricHandles.instrumentationUp.set(1);
+        metricsReady = true;
+    } catch (error) {
+        register = unavailableRegistry('metrics unavailable');
     }
 }
 

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -10,6 +10,7 @@ import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
+import { withDchatMetrics, withDependencyMetrics } from './metrics.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -552,7 +553,9 @@ async function createChatResponse(openai, input) {
         const model = models[index];
 
         try {
-            return await openai.responses.create({ model, input });
+            return await withDependencyMetrics('openai', () =>
+                openai.responses.create({ model, input })
+            );
         } catch (error) {
             const hasFallback = index < models.length - 1;
             if (!hasFallback || !isModelAccessError(error)) {
@@ -911,7 +914,9 @@ export const GPT5Chat = async (messages, options = {}) => {
     const OpenAIClient = resolveOpenAIClient();
     const openai = new OpenAIClient({ apiKey, dangerouslyAllowBrowser: true });
 
-    const response = await createChatResponse(openai, combinedMessages.map(toResponseMessage));
+    const response = await withDchatMetrics('openai', () =>
+        createChatResponse(openai, combinedMessages.map(toResponseMessage))
+    );
     const outputText = toOutputText(response);
     const { text } = validateChatResponseText(outputText, { contextSources });
 
@@ -925,7 +930,9 @@ export const GPT5ChatV2 = async (messages, options = {}) => {
     const OpenAIClient = resolveOpenAIClient();
     const openai = new OpenAIClient({ apiKey, dangerouslyAllowBrowser: true });
 
-    const response = await createChatResponse(openai, combinedMessages.map(toResponseMessage));
+    const response = await withDchatMetrics('openai', () =>
+        createChatResponse(openai, combinedMessages.map(toResponseMessage))
+    );
     const outputText = toOutputText(response);
     const { text } = validateChatResponseText(outputText, { contextSources });
 

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -17,6 +17,7 @@ import {
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
 } from './tokenPlaceErrors.js';
+import { withDchatMetrics, withDependencyMetrics } from './metrics.js';
 
 const DEFAULT_ORIGIN = 'https://token.place';
 const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
@@ -547,10 +548,12 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
     if (options.model) params.set('model', options.model);
     if (options.contextTier) params.set('context_tier', options.contextTier);
     const suffix = params.toString() ? `?${params}` : '';
-    const data = await fetchJson(
-        `${baseUrl}/api/v1/relay/servers/next${suffix}`,
-        { method: 'GET', signal: options.signal },
-        'token.place relay is unavailable.'
+    const data = await withDependencyMetrics('tokenplace', () =>
+        fetchJson(
+            `${baseUrl}/api/v1/relay/servers/next${suffix}`,
+            { method: 'GET', signal: options.signal },
+            'token.place relay is unavailable.'
+        )
     );
     const rawKey = data?.server_public_key || data?.serverPublicKey || data?.public_key;
     if (!rawKey)
@@ -597,15 +600,17 @@ export const selectTokenPlaceRelayServer = async (baseUrl, options = {}) => {
 };
 
 export const dispatchTokenPlaceRelayRequest = async (baseUrl, body, options = {}) =>
-    fetchJson(
-        `${baseUrl}/api/v1/relay/requests`,
-        {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-            signal: options.signal,
-        },
-        'token.place relay is unavailable.'
+    withDependencyMetrics('tokenplace', () =>
+        fetchJson(
+            `${baseUrl}/api/v1/relay/requests`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                signal: options.signal,
+            },
+            'token.place relay is unavailable.'
+        )
     );
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -613,13 +618,15 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const retrieveRelayResponse = async (baseUrl, body, options = {}) => {
     let response;
     try {
-        response = await fetch(`${baseUrl}/api/v1/relay/responses/retrieve`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-            signal: options.signal,
-            credentials: 'omit',
-        });
+        response = await withDependencyMetrics('tokenplace', () =>
+            fetch(`${baseUrl}/api/v1/relay/responses/retrieve`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                signal: options.signal,
+                credentials: 'omit',
+            })
+        );
     } catch (error) {
         throw createTokenPlaceNetworkError(error);
     }
@@ -839,94 +846,96 @@ const runRelayAttempt = async (baseUrl, messages, options = {}) => {
     };
 };
 
-export const TokenPlaceChatV2 = async (messages, options = {}) => {
-    await ready;
-    const promptPayload = await resolveTokenPlacePromptPayload(messages, options);
-    const contextSources = Array.isArray(promptPayload.contextSources)
-        ? promptPayload.contextSources
-        : [];
-    const baseUrl = resolveTokenPlaceBaseUrl({
-        url: options.url,
-        state: promptPayload.gameState,
-        runtimeUrl: options.runtimeUrl,
-    });
-
-    const model = getTokenPlaceChatModel(options);
-    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
-    const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
-        reservedOutputTokens: options.reservedOutputTokens,
-        safetyMarginTokens: options.safetyMarginTokens,
-    });
-    if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
-
-    const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
-    let attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
-    if (attempt?.terminalSelectedServerFailure) {
-        attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
-            ...baseAttemptOptions,
-            requestId: undefined,
-            cancelToken: undefined,
+export const TokenPlaceChatV2 = async (messages, options = {}) =>
+    withDchatMetrics('tokenplace', async () => {
+        await ready;
+        const promptPayload = await resolveTokenPlacePromptPayload(messages, options);
+        const contextSources = Array.isArray(promptPayload.contextSources)
+            ? promptPayload.contextSources
+            : [];
+        const baseUrl = resolveTokenPlaceBaseUrl({
+            url: options.url,
+            state: promptPayload.gameState,
+            runtimeUrl: options.runtimeUrl,
         });
-        if (attempt?.terminalSelectedServerFailure) {
-            throw createMalformedTokenPlaceResponseError(
-                'No token.place compute node is available.'
-            );
-        }
-    }
 
-    let data = attempt.apiResponse;
-    if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
-        const retryAttemptOptions = {
-            ...baseAttemptOptions,
-            contextTier: '64k-full',
-            requestId: undefined,
-            cancelToken: undefined,
-        };
-        let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
-        if (retry?.terminalSelectedServerFailure) {
-            retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
-                ...retryAttemptOptions,
+        const model = getTokenPlaceChatModel(options);
+        const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+        const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
+            reservedOutputTokens: options.reservedOutputTokens,
+            safetyMarginTokens: options.safetyMarginTokens,
+        });
+        if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
+
+        const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
+        let attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
+        if (attempt?.terminalSelectedServerFailure) {
+            attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
+                ...baseAttemptOptions,
                 requestId: undefined,
                 cancelToken: undefined,
             });
-            if (retry?.terminalSelectedServerFailure) {
+            if (attempt?.terminalSelectedServerFailure) {
                 throw createMalformedTokenPlaceResponseError(
                     'No token.place compute node is available.'
                 );
             }
         }
-        attempt = {
-            ...retry,
-            diagnostics: { ...retry.diagnostics, escalationRetry: true },
-        };
-        data = retry.apiResponse;
-    }
 
-    throwStructuredTokenPlaceApiError(data);
-    const outputText = extractTokenPlaceAssistantText(data);
-    const { text } = validateChatResponseText(outputText, { contextSources });
+        let data = attempt.apiResponse;
+        if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
+            const retryAttemptOptions = {
+                ...baseAttemptOptions,
+                contextTier: '64k-full',
+                requestId: undefined,
+                cancelToken: undefined,
+            };
+            let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
+            if (retry?.terminalSelectedServerFailure) {
+                retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
+                    ...retryAttemptOptions,
+                    requestId: undefined,
+                    cancelToken: undefined,
+                });
+                if (retry?.terminalSelectedServerFailure) {
+                    throw createMalformedTokenPlaceResponseError(
+                        'No token.place compute node is available.'
+                    );
+                }
+            }
+            attempt = {
+                ...retry,
+                diagnostics: { ...retry.diagnostics, escalationRetry: true },
+            };
+            data = retry.apiResponse;
+        }
 
-    return {
-        text,
-        contextSources,
-        usage: data?.usage,
-        metadata: {
-            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
-            tokenPlaceContext: {
-                requestedTier: attempt.diagnostics?.requestedTier || contextEstimate.selectedTier,
-                relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
-                finalActiveTier: getApiErrorActiveTier(data),
-                spillover: Boolean(attempt.diagnostics?.spillover),
-                escalationRetry: Boolean(attempt.diagnostics?.escalationRetry),
-                estimatorVersion: contextEstimate.estimatorVersion,
-                estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
-                reservedOutputTokens: contextEstimate.reservedOutputTokens,
-                timeoutClass: attempt.diagnostics?.timeoutClass,
-                safeErrorCode: getApiErrorCode(data),
+        throwStructuredTokenPlaceApiError(data);
+        const outputText = extractTokenPlaceAssistantText(data);
+        const { text } = validateChatResponseText(outputText, { contextSources });
+
+        return {
+            text,
+            contextSources,
+            usage: data?.usage,
+            metadata: {
+                ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+                tokenPlaceContext: {
+                    requestedTier:
+                        attempt.diagnostics?.requestedTier || contextEstimate.selectedTier,
+                    relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
+                    finalActiveTier: getApiErrorActiveTier(data),
+                    spillover: Boolean(attempt.diagnostics?.spillover),
+                    escalationRetry: Boolean(attempt.diagnostics?.escalationRetry),
+                    estimatorVersion: contextEstimate.estimatorVersion,
+                    estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
+                    reservedOutputTokens: contextEstimate.reservedOutputTokens,
+                    timeoutClass: attempt.diagnostics?.timeoutClass,
+                    safeErrorCode: getApiErrorCode(data),
+                },
             },
-        },
-    };
-};
+        };
+    });
 
 export const tokenPlaceChat = async (messages, options = {}) => {
     const result = await TokenPlaceChatV2(messages, options);

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
   },
   "dependencies": {
     "@dspace/feature-flags": "file:packages/feature-flags",
-    "openai": "^5.16.0"
+    "openai": "^5.16.0",
+    "prom-client": "^15.1.0"
   },
   "overrides": {
     "caniuse-lite": ">=1.0.30001792",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       openai:
         specifier: ^5.16.0
         version: 5.16.0(ws@8.18.3)(zod@3.25.76)
+      prom-client:
+        specifier: ^15.1.0
+        version: 15.1.3
     devDependencies:
       '@jest/globals':
         specifier: ^29.5.0

--- a/tests/metricsEndpoint.test.ts
+++ b/tests/metricsEndpoint.test.ts
@@ -35,6 +35,17 @@ describe('metrics endpoint', () => {
         delete process.env.METRICS_TOKEN;
     });
 
+    it('returns 503 when metrics initialization failed', async () => {
+        const mod = await import('../frontend/src/utils/metrics.js');
+        await mod.initMetrics(() => {
+            throw new Error('module not found');
+        });
+        const res = await metricsGET({ request: new Request(url) });
+        expect(res.status).toBe(503);
+        expect(await res.text()).toContain('metrics unavailable');
+        await mod.initMetrics();
+    });
+
     it('is not prerendered', () => {
         expect(prerender).toBe(false);
     });

--- a/tests/metricsInstrumentation.test.ts
+++ b/tests/metricsInstrumentation.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    initMetrics,
+    normalizeOutcome,
+    normalizeProvider,
+    normalizeRoute,
+    recordDchatRequest,
+    recordDependencyRequest,
+    recordHttpRequest,
+    register,
+} from '../frontend/src/utils/metrics.js';
+
+const prohibitedValues = [
+    'user-abc-123',
+    'session-xyz-789',
+    'request-secret-456',
+    'how do I launch a rocket with secret sauce?',
+    'https://example.test/private/path?token=abc',
+    'Error: database exploded for player alice',
+    'npc-sydney',
+    'Bearer secret-token',
+];
+
+const metricLines = async () => (await register.metrics()).split('\n');
+const sampleLinesFor = async (name: string) =>
+    (await metricLines()).filter((line) => line.startsWith(`${name}{`));
+
+describe('DSPACE application metrics', () => {
+    beforeEach(async () => {
+        await initMetrics();
+    });
+
+    it('emits valid canonical metric families after controlled traffic', async () => {
+        recordHttpRequest({
+            method: 'GET',
+            route: '/quests/play/2?requestId=user-abc-123',
+            status: 200,
+            outcome: 'success',
+            durationSeconds: 0.12,
+        });
+        recordDchatRequest({ provider: 'tokenplace', outcome: 'success', durationSeconds: 0.25 });
+        recordDependencyRequest({
+            dependency: 'tokenplace',
+            outcome: 'success',
+            durationSeconds: 0.2,
+        });
+
+        const text = await register.metrics();
+        expect(text).toContain('# HELP dspace_http_requests_total');
+        expect(text).toContain('dspace_http_request_duration_seconds_bucket');
+        expect(text).toContain('dspace_dchat_requests_total');
+        expect(text).toContain('dspace_dchat_request_duration_seconds_bucket');
+        expect(text).toContain('dspace_dependency_requests_total');
+        expect(text).toContain('dspace_dependency_request_duration_seconds_bucket');
+        expect(text).toContain('dspace_build_info{version="3.0.1",revision=');
+        expect(text).toContain('dspace_instrumentation_up 1');
+    });
+
+    it('normalizes routes and bounded enum label values', () => {
+        expect(normalizeRoute('/metrics')).toBe('/metrics');
+        expect(normalizeRoute('/quests/play/2?raw=secret')).toBe('/quests/[pathId]/[questId]');
+        expect(normalizeRoute('/inventory/item/37/edit')).toBe('/inventory/item/[itemId]');
+        expect(normalizeRoute('/docs/solar?source=https://example.test')).toBe('/docs/[slug]');
+        expect(normalizeProvider('malicious-provider-user-abc-123')).toBe('unknown');
+        expect(normalizeOutcome('rate limited')).toBe('rate_limited');
+        expect(normalizeOutcome('contains-secret-user-id')).toBe('unknown_error');
+    });
+
+    it('records expected terminal dChat and dependency outcomes', async () => {
+        for (const outcome of [
+            'success',
+            'timeout',
+            'rate_limited',
+            'validation_error',
+            'dependency_failure',
+            'fallback_used',
+            'fallback_unavailable',
+            'server_error',
+        ]) {
+            recordDchatRequest({ provider: 'openai', outcome, durationSeconds: 0.01 });
+            recordDependencyRequest({ dependency: 'openai', outcome, durationSeconds: 0.01 });
+        }
+
+        const text = await register.metrics();
+        expect(text).toContain('dspace_dchat_requests_total{provider="openai",outcome="timeout"}');
+        expect(text).toContain(
+            'dspace_dependency_requests_total{dependency="openai",outcome="rate_limited"}'
+        );
+        expect(text).toContain('dspace_dchat_request_duration_seconds_bucket');
+        expect(text).toContain('dspace_dependency_request_duration_seconds_bucket');
+    });
+
+    it('does not instrument /metrics HTTP scrapes', async () => {
+        recordHttpRequest({
+            method: 'GET',
+            route: '/metrics',
+            status: 200,
+            outcome: 'success',
+            durationSeconds: 0.001,
+        });
+        expect(await sampleLinesFor('dspace_http_requests_total')).toHaveLength(0);
+    });
+
+    it('keeps label sets bounded for high-cardinality synthetic inputs', async () => {
+        for (let index = 0; index < 50; index += 1) {
+            recordHttpRequest({
+                method: 'POST',
+                route: `/quests/play/${index}?requestId=request-secret-${index}&prompt=${encodeURIComponent(prohibitedValues[3])}`,
+                status: 500,
+                outcome: `Error: database exploded for player ${index}`,
+                durationSeconds: 0.01,
+            });
+            recordDchatRequest({
+                provider: `provider-user-${index}`,
+                outcome: `exception-message-${index}`,
+                durationSeconds: 0.01,
+            });
+            recordDependencyRequest({
+                dependency: `https://example.test/private/${index}`,
+                outcome: `token-${index}`,
+                durationSeconds: 0.01,
+            });
+        }
+
+        const text = await register.metrics();
+        for (const value of prohibitedValues) {
+            expect(text).not.toContain(value);
+        }
+        expect(await sampleLinesFor('dspace_http_requests_total')).toHaveLength(1);
+        expect(await sampleLinesFor('dspace_dchat_requests_total')).toHaveLength(1);
+        expect(await sampleLinesFor('dspace_dependency_requests_total')).toHaveLength(1);
+        expect(text).toContain('route="/quests/[pathId]/[questId]"');
+        expect(text).toContain('provider="unknown"');
+        expect(text).toContain('dependency="unknown"');
+    });
+
+    it('keeps build info stable and low cardinality', async () => {
+        recordHttpRequest({
+            method: 'GET',
+            route: '/config.json',
+            status: 200,
+            outcome: 'success',
+            durationSeconds: 0.01,
+        });
+        const lines = await sampleLinesFor('dspace_build_info');
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^dspace_build_info\{version="3\.0\.1",revision="[^"]+"\} 1$/);
+        expect(lines[0]).not.toMatch(/user|session|request|prompt|model|url|ip/i);
+    });
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, production-quality, privacy-safe Prometheus metrics slice in the application runtime so staging/prod can emit the required families for v3.1 release gating. 
- Enforce privacy and cardinality rules by normalizing routes to templates, using status classes (e.g., `2xx`, `4xx`, `5xx`), and bounding provider/dependency/outcome label enums. 
- Make metric collection robust to missing `prom-client` during tests or environments and surface initialization failure as an observable 503 from `/metrics` instead of a misleading HTTP 200 placeholder. 

### Description
- Added a shared `prom-client` registry and DSPACE metric families in `frontend/src/utils/metrics.js` including: `dspace_http_requests_total{method,route,status_class,outcome}`, `dspace_http_request_duration_seconds{method,route,status_class,outcome}` (buckets `0.05,0.1,0.25,0.5,1,2.5,5,10,30`), `dspace_dchat_requests_total{provider,outcome}`, `dspace_dchat_request_duration_seconds{provider,outcome}`, `dspace_dependency_requests_total{dependency,outcome}`, `dspace_dependency_request_duration_seconds{dependency,outcome}`, `dspace_build_info{version,revision}` (gauge=1), and `dspace_instrumentation_up` (gauge). 
- Bounded enums implemented: outcomes = `success, timeout, rate_limited, validation_error, malformed_response, dependency_failure, server_error, fallback_used, fallback_unavailable, unknown_error`; providers = `tokenplace, openai, none, unknown`; dependencies = `tokenplace, openai`; routes are normalized to templates (examples: `/docs/[slug]`, `/inventory/item/[itemId]`, `/processes/[processId]`, `/quests/[pathId]/[questId]`) and `/metrics` is excluded from instrumentation. 
- Instrumented runtime code paths to record real operations: middleware HTTP requests (`frontend/src/middleware.ts`) record request counts and durations, OpenAI calls wrapped with `withDependencyMetrics('openai', ...)` and `withDchatMetrics('openai', ...)` (`frontend/src/utils/openAI.js`), token.place relay operations and logical chat wrapped with `withDependencyMetrics('tokenplace', ...)` and `withDchatMetrics('tokenplace', ...)` (`frontend/src/utils/tokenPlace.js`), and `/metrics` now returns 503 when metrics initialization fails (`frontend/src/pages/metrics.ts`). 
- Tests and docs: added focused tests `tests/metricsInstrumentation.test.ts` (cardinality, normalization, families present), updated `tests/metricsEndpoint.test.ts` to assert 503 fallback behavior, and updated `docs/design/observability-v3.1.md` and `docs/qa/v3.1.md` with implemented-source notes and PromQL examples; added `prom-client` dependency to `package.json`. Files changed: `frontend/src/utils/metrics.js`, `frontend/src/middleware.ts`, `frontend/src/pages/metrics.ts`, `frontend/src/utils/openAI.js`, `frontend/src/utils/tokenPlace.js`, `tests/metricsInstrumentation.test.ts`, `tests/metricsEndpoint.test.ts`, `docs/design/observability-v3.1.md`, `docs/qa/v3.1.md`, and `package.json`/lockfile. 

### Testing
- Ran focused unit tests: `npm run test:root -- tests/metricsInstrumentation.test.ts tests/metricsEndpoint.test.ts tests/metricsFallback.test.ts` and the three test files passed (11 tests total) after adding `prom-client`. 
- Verified metrics fallback behavior: `tests/metricsFallback.test.ts` asserts the fallback registry and `tests/metricsEndpoint.test.ts` asserts `/metrics` returns `503` when initialization fails and `200` when healthy. 
- Ran lint, type-check, and build: `npm run lint` passed, `npm run type-check` (which runs `build:meta`/`build:docs-rag` + `tsc --noEmit`) passed, and `npm run build` completed successfully. 
- Attempted the repo CI-style run `SKIP_E2E=1 npm run test:ci` which executed the build and chat build stamp verification but the `run-tests.js` harness stalled in a long run and was terminated; focused root tests above were used for verification instead. 


Notes and follow-ups: the implementation intentionally avoids high-cardinality labels and never exposes secrets in metrics; staging must still provide live Sugarkube scrape evidence and a canonical Helm scrape config before production promotion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a531b080d84832f9426ff34efcd0176)