### PR TITLE
Instrument privacy-safe DSPACE application metrics

### DIFF
--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -1,8 +1,9 @@
 # DSPACE v3.1.0 Observability Release Gate
 
 This design turns observability into an explicit DSPACE v3.1.0 release requirement. It is a
-planning and QA contract only: it does not implement new metrics, dashboards, alerts, exporters,
-Helm templates, or version metadata.
+planning and QA contract. The application runtime now implements the first privacy-safe
+DSPACE metric families, but dashboards, alerts, exporters, Helm templates, and live Sugarkube
+scrape evidence remain separate release work.
 
 Status: v3.1.0 is not treated as shipped by this document. The repository metadata still reports
 `package.json` version `3.0.1`, and the active GHCR Helm publishing workflow packages
@@ -19,16 +20,65 @@ smallest useful v3.1.0 release slice.
 
 ## Repository evidence inventory
 
-| Area                          | Evidence                                                                                                                                          | Classification                          | v3.1.0 implication                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime version               | `package.json` is `3.0.1`.                                                                                                                        | Implemented for v3.0.1; v3.1.0 missing. | Do not claim v3.1.0 shipped until release metadata and immutable artifacts exist.                                                                               |
-| Metrics route                 | `frontend/src/pages/metrics.ts` exposes `/metrics` and optionally requires `Authorization: Bearer <METRICS_TOKEN>`.                               | Partial.                                | Endpoint exists, but staging/prod scrape behavior and public exposure controls still need evidence.                                                             |
-| Metric implementation         | `frontend/src/utils/metrics.js` initializes `prom-client` default process metrics only, with a fallback text response.                            | Partial.                                | Process/runtime basics may exist; DSPACE-specific HTTP, dChat, token.place, fallback, and build-info metrics are missing until implemented elsewhere.           |
-| Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                             | Legacy/local scaffold.                  | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
-| Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                        | Implemented v3.0.1 path.                | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
-| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.               | Missing.                                | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
-| Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow. | Partial legacy/experimental duplicate.  | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
-| Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                     | Legacy/partial.                         | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
+| Area                          | Evidence                                                                                                                                                       | Classification                                | v3.1.0 implication                                                                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime version               | `package.json` is `3.0.1`.                                                                                                                                     | Implemented for v3.0.1; v3.1.0 missing.       | Do not claim v3.1.0 shipped until release metadata and immutable artifacts exist.                                                                               |
+| Metrics route                 | `frontend/src/pages/metrics.ts` exposes `/metrics` and optionally requires `Authorization: Bearer <METRICS_TOKEN>`.                                            | Partial.                                      | Endpoint exists, but staging/prod scrape behavior and public exposure controls still need evidence.                                                             |
+| Metric implementation         | `frontend/src/utils/metrics.js` initializes `prom-client` default process metrics plus DSPACE HTTP, dChat, dependency, build-info, and instrumentation gauges. | Implemented in source; live evidence missing. | Source emits the canonical metric families with bounded labels. Staging/prod scrape behavior still needs Sugarkube evidence.                                    |
+| Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                                          | Legacy/local scaffold.                        | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
+| Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                                     | Implemented v3.0.1 path.                      | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
+| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.                            | Missing.                                      | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
+| Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow.              | Partial legacy/experimental duplicate.        | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
+| Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                                  | Legacy/partial.                               | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
+
+## Implemented application metric families
+
+The source-level instrumentation emits these Prometheus families from `/metrics` when
+`prom-client` initializes successfully:
+
+- `dspace_http_requests_total{method,route,status_class,outcome}`
+- `dspace_http_request_duration_seconds{method,route,status_class,outcome}`
+- `dspace_dchat_requests_total{provider,outcome}`
+- `dspace_dchat_request_duration_seconds{provider,outcome}`
+- `dspace_dependency_requests_total{dependency,outcome}`
+- `dspace_dependency_request_duration_seconds{dependency,outcome}`
+- `dspace_build_info{version,revision}` fixed at `1`
+- `dspace_instrumentation_up` fixed at `1` after successful initialization
+
+Implemented label values are intentionally bounded. Routes are route templates or fixed groups,
+status is a class such as `2xx` or `5xx`, providers are `tokenplace`, `openai`, `none`, or
+`unknown`, and outcomes are selected from `success`, `timeout`, `rate_limited`,
+`validation_error`, `malformed_response`, `dependency_failure`, `server_error`,
+`fallback_used`, `fallback_unavailable`, or `unknown_error`. `/metrics` is excluded from HTTP
+request instrumentation. If metrics initialization fails, `/metrics` returns an explicit
+non-success response instead of a misleading placeholder body.
+
+### PromQL examples
+
+```promql
+# HTTP request rate by normalized route and outcome
+sum by (route, outcome) (rate(dspace_http_requests_total[5m]))
+
+# HTTP 5xx error ratio
+sum(rate(dspace_http_requests_total{status_class="5xx"}[5m]))
+  /
+sum(rate(dspace_http_requests_total[5m]))
+
+# p95 HTTP latency by route
+histogram_quantile(
+  0.95,
+  sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket[5m]))
+)
+
+# dChat outcomes by provider
+sum by (provider, outcome) (rate(dspace_dchat_requests_total[5m]))
+
+# token.place dependency outcomes
+sum by (outcome) (rate(dspace_dependency_requests_total{dependency="tokenplace"}[5m]))
+```
+
+The examples above describe implemented source behavior. They are not live Sugarkube scrape
+evidence until captured from a deployed staging or production target.
 
 ## Canonical Helm chart decision
 
@@ -70,8 +120,8 @@ Every requirement below is classified as one of:
       includes tested bearer-token Secret wiring; if a cluster-only metrics service or NetworkPolicy
       is used instead, public ingress must not route to `/metrics`.
 - [ ] Release/build identity is available with bounded labels, for example
-      `dspace_build_info{version,revision,release,environment}` with value `1` or equivalent
-      relabeled metadata.
+      `dspace_build_info{version,revision}` with value `1`; Helm release and environment may be
+      added by Prometheus relabeling rather than application labels.
 
 ### Required staging evidence
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -19,20 +19,20 @@ Tracking / release gate:
 - [ ] Release owner:
 - [ ] QA owner:
 - [ ] Stop-ship criteria agreed before execution. Treat any of these triggers as a release blocker:
-    1. Fresh users cannot send a default token.place Chat message.
-    2. `/chat` prompts fresh users for an OpenAI key.
-    3. token.place relay requests include an `Authorization` header, OpenAI key, token.place
-       credentials, plaintext prompt messages, raw save data, or player inventory details.
-    4. Settings cannot switch providers or persist the selected provider.
-    5. Staging has not passed before production deploy.
+  1. Fresh users cannot send a default token.place Chat message.
+  2. `/chat` prompts fresh users for an OpenAI key.
+  3. token.place relay requests include an `Authorization` header, OpenAI key, token.place
+     credentials, plaintext prompt messages, raw save data, or player inventory details.
+  4. Settings cannot switch providers or persist the selected provider.
+  5. Staging has not passed before production deploy.
 
 ## 2) token.place API v1 relay E2EE contract
 
 - [ ] DSPACE uses the token.place API v1 relay E2EE route sequence on the configured origin:
-    - [ ] `GET /api/v1/relay/servers/next` to select compute.
-    - [ ] `POST /api/v1/relay/requests` to dispatch ciphertext.
-    - [ ] `POST /api/v1/relay/responses/retrieve` to retrieve encrypted responses.
-    - [ ] Optional timeout cleanup uses `POST /api/v1/relay/requests/cancel` only if supported.
+  - [ ] `GET /api/v1/relay/servers/next` to select compute.
+  - [ ] `POST /api/v1/relay/requests` to dispatch ciphertext.
+  - [ ] `POST /api/v1/relay/responses/retrieve` to retrieve encrypted responses.
+  - [ ] Optional timeout cleanup uses `POST /api/v1/relay/requests/cancel` only if supported.
 - [ ] The browser generates and holds the DSPACE `/chat` client private key.
 - [ ] The browser normalizes the returned `server_public_key` before encryption.
 - [ ] The local pre-encryption envelope includes `protocol: "tokenplace_api_v1_relay_e2ee"`,
@@ -49,20 +49,20 @@ Tracking / release gate:
 - [ ] Assistant text is extracted from `api_v1_response.choices[0].message.content` only after
       decrypting and validating the response envelope.
 - [ ] API v1 is treated as non-streaming.
-    - [ ] The encrypted `api_v1_request` omits `stream` or sends `stream: false`.
-    - [ ] The encrypted `api_v1_request` never sends `stream: true`.
-    - [ ] UI copy and spinners tolerate waiting until the full completion is ready.
+  - [ ] The encrypted `api_v1_request` omits `stream` or sends `stream: false`.
+  - [ ] The encrypted `api_v1_request` never sends `stream: true`.
+  - [ ] UI copy and spinners tolerate waiting until the full completion is ready.
 - [ ] No token.place auth or API key is requested, stored, or sent.
 - [ ] token.place request headers contain no `Authorization` header.
 - [ ] `usage` counters are displayed, logged, or preserved only when returned inside the decrypted
       `api_v1_response`.
 - [ ] Optional metadata is safe and minimal, and plaintext metadata exposed to relay-owned state is
       limited to safe routing/correlation fields.
-    - [ ] Metadata contains no secrets.
-    - [ ] Metadata contains no raw save data.
-    - [ ] Metadata contains no player inventory details.
-    - [ ] Response metadata is treated as optional and only expected when non-empty safe request
-          metadata is echoed.
+  - [ ] Metadata contains no secrets.
+  - [ ] Metadata contains no raw save data.
+  - [ ] Metadata contains no player inventory details.
+  - [ ] Response metadata is treated as optional and only expected when non-empty safe request
+        metadata is echoed.
 - [ ] No plaintext default DSPACE `/chat` request is sent to `/api/v1/chat/completions`.
 - [ ] No token.place API v2, SSE, streaming, token.place npm package, legacy `/api/chat`, legacy
       `/chat`, deprecated `/next_server`, `/sink`, `/source`, `/faucet`, or `/retrieve` path is
@@ -90,7 +90,7 @@ Tracking / release gate:
       relevant, and service worker state if needed).
 - [ ] Visit `/chat` as a fresh user.
 - [ ] Confirm the active Chat panel uses token.place by default.
-    - [ ] UI marker is visible, or DOM/test marker such as `data-provider="token-place"` is present.
+  - [ ] UI marker is visible, or DOM/test marker such as `data-provider="token-place"` is present.
 - [ ] Select an NPC/persona if the UI does not already default to one.
 - [ ] Send a simple game-related message.
 - [ ] Verify the assistant response renders in Chat.
@@ -195,10 +195,27 @@ evidence is attached.
       with Sugarkube's Prometheus operator selection.
 - [ ] **v3.1.0 release blocker:** In-cluster Prometheus can scrape metrics without exposing a
       privileged metrics surface publicly.
-- [ ] **v3.1.0 release blocker:** Release/build identity is attached with bounded labels such as
-      version, revision, Helm release, and environment.
+- [ ] **v3.1.0 release blocker:** Application build identity is attached with bounded `version`
+      and `revision` labels; Helm release and environment should come from scrape/relabel metadata.
 
-### 11.2 Release-blocking metric families
+### 11.2 Implemented source metric smoke checks
+
+Run controlled local or staging traffic, then verify `/metrics` contains the source-level metric
+families before collecting live Sugarkube evidence:
+
+```promql
+sum by (route, outcome) (rate(dspace_http_requests_total[5m]))
+sum(rate(dspace_http_requests_total{status_class="5xx"}[5m])) / sum(rate(dspace_http_requests_total[5m]))
+histogram_quantile(0.95, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket[5m])))
+sum by (provider, outcome) (rate(dspace_dchat_requests_total[5m]))
+sum by (outcome) (rate(dspace_dependency_requests_total{dependency="tokenplace"}[5m]))
+```
+
+These queries prove source behavior only when run against controlled local output. They become
+release evidence only after screenshots or query results are captured from Sugarkube staging with
+the canonical chart scrape path.
+
+### 11.3 Release-blocking metric families
 
 - [ ] **v3.1.0 release blocker:** HTTP request totals and latency histograms use bounded route
       groups and status classes.
@@ -212,7 +229,7 @@ evidence is attached.
       on the server where applicable.
 - [ ] **v3.1.0 release blocker:** Deployment/release information is queryable in Prometheus.
 
-### 11.3 Release-blocking privacy and cardinality rules
+### 11.4 Release-blocking privacy and cardinality rules
 
 - [ ] **v3.1.0 release blocker:** Metrics, labels, dashboards, alerts, and routine operational logs
       never record prompts, responses, OpenAI keys, token.place credentials, save data, inventory,
@@ -224,7 +241,7 @@ evidence is attached.
 - [ ] **v3.1.0 release blocker:** Safe operational Prometheus metrics remain explicitly separate
       from browser-only debugging information.
 
-### 11.4 Release-blocking dashboard and alerts
+### 11.5 Release-blocking dashboard and alerts
 
 - [ ] **v3.1.0 release blocker:** A DSPACE dashboard exists with availability and request rate,
       latency percentiles, status/error ratio, dChat traffic and outcomes, token.place dependency
@@ -235,7 +252,7 @@ evidence is attached.
 - [ ] **v3.1.0 release blocker:** Alert thresholds remain provisional until staging establishes a
       baseline; no historical production numbers are invented.
 
-### 11.5 Required staging evidence
+### 11.6 Required staging evidence
 
 - [ ] **required staging evidence:** Prometheus target discovery shows the canonical DSPACE staging
       target as `up`.
@@ -297,11 +314,11 @@ Build/debug evidence:
 - [ ] Build metadata/debug panel identifies the expected candidate SHA or image digest.
 - [ ] Console has no uncaught SSR, hydration, provider-selection, or storage errors.
 - [ ] Relevant Playwright specs pass or have release-owner-approved environment exceptions:
-    - [ ] token.place default Chat spec.
-    - [ ] OpenAI opt-in/provider persistence spec.
-    - [ ] token.place error handling spec.
-    - [ ] persona switching spec.
-    - [ ] docs RAG/context spec.
+  - [ ] token.place default Chat spec.
+  - [ ] OpenAI opt-in/provider persistence spec.
+  - [ ] token.place error handling spec.
+  - [ ] persona switching spec.
+  - [ ] docs RAG/context spec.
 
 ## 12) Automation evidence
 
@@ -337,16 +354,16 @@ cd frontend && npm run build
 
 - [ ] Search results are reviewed and any stale user-facing wording is removed or explicitly
       justified as historical QA/design context.
-    - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
-          planning-only design notes, literal test assertions that prevent stale text from
-          returning, compatibility coverage in `frontend/__tests__/tokenPlace.test.js` (excluded
-          from the command above), non-token.place GitHub/metrics `Authorization` checks, and the
-          audit command itself.
-    - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
-          `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
-          legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths such as
-          `/api/v2/chat/completions` or `/v2/chat/completions`, or token.place `Authorization`
-          header logic.
+  - [ ] Expected acceptable residuals are limited to historical v3.0 QA/changelog files,
+        planning-only design notes, literal test assertions that prevent stale text from
+        returning, compatibility coverage in `frontend/__tests__/tokenPlace.test.js` (excluded
+        from the command above), non-token.place GitHub/metrics `Authorization` checks, and the
+        audit command itself.
+  - [ ] Runtime code, active v3.1 docs, and E2E fixtures have no `VITE_TOKEN_PLACE_ENABLED`,
+        `VITE_TOKEN_PLACE_BASE_URL`, `VITE_TOKEN_PLACE_MODEL`, token.place API key wording,
+        legacy token.place `/api/chat` or backend `/chat` calls, API v2 chat paths such as
+        `/api/v2/chat/completions` or `/v2/chat/completions`, or token.place `Authorization`
+        header logic.
 - [ ] Prettier check passes.
 - [ ] Frontend build passes.
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,7 @@ import {
     buildRuntimeConfigResponse,
 } from './utils/runtimeEndpoints';
 import { logServerError } from './utils/serverLogger';
+import { recordHttpRequest } from './utils/metrics.js';
 
 export interface MiddlewareContext {
     request: Request;
@@ -11,6 +12,7 @@ export interface MiddlewareContext {
 
 export const onRequest = async (context: MiddlewareContext, next: () => Promise<Response>) => {
     const { pathname } = new URL(context.request.url);
+    const startedAt = Date.now();
     const handledPaths = new Set(['/config.json', '/healthz', '/health', '/livez']);
 
     let response: Response;
@@ -52,18 +54,37 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
         }
 
+        recordHttpRequest({
+            method: context.request.method,
+            route: pathname,
+            status: response.status,
+            outcome: response.status >= 500 ? 'server_error' : 'success',
+            durationSeconds: (Date.now() - startedAt) / 1000,
+        });
         return response;
     }
 
     switch (pathname) {
         case '/config.json':
-            return buildRuntimeConfigResponse();
+            response = buildRuntimeConfigResponse();
+            break;
         case '/healthz':
         case '/health':
-            return buildHealthResponse();
+            response = buildHealthResponse();
+            break;
         case '/livez':
-            return buildLivezResponse();
+            response = buildLivezResponse();
+            break;
         default:
-            return response;
+            break;
     }
+
+    recordHttpRequest({
+        method: context.request.method,
+        route: pathname,
+        status: response.status,
+        outcome: response.status >= 500 ? 'server_error' : 'success',
+        durationSeconds: (Date.now() - startedAt) / 1000,
+    });
+    return response;
 };

--- a/frontend/src/pages/metrics.ts
+++ b/frontend/src/pages/metrics.ts
@@ -1,4 +1,4 @@
-import { register } from '../utils/metrics.js';
+import { isMetricsReady, register } from '../utils/metrics.js';
 
 export const prerender = false;
 
@@ -16,8 +16,22 @@ export async function GET({ request }: { request: Request }) {
         }
     }
 
-    const metrics = await register.metrics();
-    return new Response(metrics, {
-        headers: { 'Content-Type': register.contentType },
-    });
+    if (!isMetricsReady()) {
+        return new Response('metrics unavailable\n', {
+            status: 503,
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+    }
+
+    try {
+        const metrics = await register.metrics();
+        return new Response(metrics, {
+            headers: { 'Content-Type': register.contentType },
+        });
+    } catch {
+        return new Response('metrics unavailable\n', {
+            status: 503,
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+    }
 }

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,19 +1,220 @@
+let promClient;
 let register;
+let metricsReady = false;
+let instrumentationUp;
+let httpRequestsTotal;
+let httpRequestDurationSeconds;
+let dchatRequestsTotal;
+let dchatRequestDurationSeconds;
+let dependencyRequestsTotal;
+let dependencyRequestDurationSeconds;
+let buildInfo;
 
 const defaultLoader = () => import(/* @vite-ignore */ 'prom-client');
 
+const OUTCOMES = new Set([
+    'success',
+    'timeout',
+    'rate_limited',
+    'validation_error',
+    'malformed_response',
+    'dependency_failure',
+    'server_error',
+    'fallback_used',
+    'fallback_unavailable',
+    'unknown_error',
+]);
+const PROVIDERS = new Set(['tokenplace', 'openai', 'none', 'unknown']);
+const DEPENDENCIES = new Set(['tokenplace', 'openai']);
+const HTTP_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30];
+const CHAT_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30];
+
+const normalizeEnum = (value, allowed, fallback) => {
+    const normalized = String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[-\s]+/g, '_');
+    return allowed.has(normalized) ? normalized : fallback;
+};
+
+export const normalizeProvider = (provider) => {
+    const normalized = String(provider || '')
+        .toLowerCase()
+        .replace(/[-_\s.]+/g, '');
+    if (normalized === 'tokenplace') return 'tokenplace';
+    if (normalized === 'openai') return 'openai';
+    if (normalized === 'none') return 'none';
+    return 'unknown';
+};
+
+export const normalizeDependency = (dependency) => {
+    const normalized = normalizeProvider(dependency);
+    return DEPENDENCIES.has(normalized) ? normalized : 'openai';
+};
+
+export const normalizeOutcome = (outcome) => normalizeEnum(outcome, OUTCOMES, 'unknown_error');
+
+export const outcomeFromError = (error) => {
+    const status = Number(error?.status || error?.response?.status || 0);
+    const type = String(error?.type || error?.code || error?.name || '').toLowerCase();
+    const message = String(error?.message || '').toLowerCase();
+    if (status === 429 || type.includes('rate_limit') || message.includes('rate limit')) {
+        return 'rate_limited';
+    }
+    if (type.includes('abort') || type.includes('timeout') || message.includes('timeout'))
+        return 'timeout';
+    if (type.includes('validation') || status === 400 || status === 422) return 'validation_error';
+    if (
+        type.includes('malformed') ||
+        message.includes('malformed') ||
+        message.includes('invalid json')
+    ) {
+        return 'malformed_response';
+    }
+    if (status >= 500 || type.includes('server')) return 'server_error';
+    if (status >= 400 || type.includes('network') || type.includes('provider')) {
+        return 'dependency_failure';
+    }
+    return 'unknown_error';
+};
+
+export const statusClass = (status) => {
+    const code = Number(status);
+    return Number.isFinite(code) && code >= 100 && code < 600
+        ? `${Math.floor(code / 100)}xx`
+        : 'unknown';
+};
+
+export const normalizeRoute = (pathname) => {
+    const path = String(pathname || '/').split('?')[0] || '/';
+    if (path === '/') return '/';
+    if (path === '/metrics') return '/metrics';
+    if (path === '/health' || path === '/healthz' || path === '/livez') return path;
+    if (path === '/config.json' || path === '/cache-version.js' || path === '/build-meta.json')
+        return path;
+    if (path.startsWith('/_astro/')) return '/_astro/[asset]';
+    if (path.startsWith('/assets/')) return '/assets/[asset]';
+    if (path.startsWith('/docs/')) return '/docs/[slug]';
+    if (path.startsWith('/inventory/item/')) return '/inventory/item/[itemId]';
+    if (path.startsWith('/processes/')) return '/processes/[processId]';
+    if (path.startsWith('/quests/')) return '/quests/[pathId]/[questId]';
+    return path.replace(/[0-9a-f]{8,}/gi, '[id]').replace(/\/\d+/g, '/[id]');
+};
+
+const createMetric = (Metric, config) => new Metric({ registers: [register], ...config });
+
+const revision = () =>
+    process.env.VITE_GIT_SHA || process.env.GITHUB_SHA || process.env.GIT_SHA || 'unknown';
+
 async function initMetrics(loader = defaultLoader) {
     try {
-        const { Registry, collectDefaultMetrics } = await loader();
+        promClient = await loader();
+        const { Registry, collectDefaultMetrics, Counter, Histogram, Gauge } = promClient;
         register = new Registry();
         collectDefaultMetrics({ register });
-    } catch {
+        httpRequestsTotal = createMetric(Counter, {
+            name: 'dspace_http_requests_total',
+            help: 'Total DSPACE HTTP requests.',
+            labelNames: ['method', 'route', 'status_class', 'outcome'],
+        });
+        httpRequestDurationSeconds = createMetric(Histogram, {
+            name: 'dspace_http_request_duration_seconds',
+            help: 'DSPACE HTTP request duration in seconds.',
+            labelNames: ['method', 'route', 'status_class', 'outcome'],
+            buckets: HTTP_BUCKETS,
+        });
+        dchatRequestsTotal = createMetric(Counter, {
+            name: 'dspace_dchat_requests_total',
+            help: 'Total dChat logical requests.',
+            labelNames: ['provider', 'outcome'],
+        });
+        dchatRequestDurationSeconds = createMetric(Histogram, {
+            name: 'dspace_dchat_request_duration_seconds',
+            help: 'dChat logical request duration in seconds.',
+            labelNames: ['provider', 'outcome'],
+            buckets: CHAT_BUCKETS,
+        });
+        dependencyRequestsTotal = createMetric(Counter, {
+            name: 'dspace_dependency_requests_total',
+            help: 'Total outbound dependency requests.',
+            labelNames: ['dependency', 'outcome'],
+        });
+        dependencyRequestDurationSeconds = createMetric(Histogram, {
+            name: 'dspace_dependency_request_duration_seconds',
+            help: 'Outbound dependency request duration in seconds.',
+            labelNames: ['dependency', 'outcome'],
+            buckets: CHAT_BUCKETS,
+        });
+        buildInfo = createMetric(Gauge, {
+            name: 'dspace_build_info',
+            help: 'DSPACE build information.',
+            labelNames: ['version', 'revision'],
+        });
+        instrumentationUp = createMetric(Gauge, {
+            name: 'dspace_instrumentation_up',
+            help: 'DSPACE metrics instrumentation initialization status.',
+        });
+        buildInfo.set(
+            { version: process.env.npm_package_version || '3.0.1', revision: revision() },
+            1
+        );
+        instrumentationUp.set(1);
+        metricsReady = true;
+    } catch (error) {
+        metricsReady = false;
         register = {
-            contentType: 'text/plain',
-            metrics: async () => '# metrics unavailable\n',
+            contentType: 'text/plain; version=0.0.4; charset=utf-8',
+            metrics: async () => {
+                throw new Error('metrics unavailable');
+            },
         };
     }
 }
+
+export const isMetricsReady = () => metricsReady;
+
+export const recordHttpRequest = ({
+    method = 'GET',
+    route = '/',
+    status = 200,
+    outcome,
+    durationSeconds = 0,
+}) => {
+    if (!metricsReady || normalizeRoute(route) === '/metrics') return;
+    const labels = {
+        method: String(method || 'GET').toUpperCase(),
+        route: normalizeRoute(route),
+        status_class: statusClass(status),
+        outcome: normalizeOutcome(outcome || (Number(status) >= 500 ? 'server_error' : 'success')),
+    };
+    httpRequestsTotal.inc(labels);
+    httpRequestDurationSeconds.observe(labels, Math.max(0, Number(durationSeconds) || 0));
+};
+
+export const recordDchatRequest = ({
+    provider = 'unknown',
+    outcome = 'success',
+    durationSeconds = 0,
+}) => {
+    if (!metricsReady) return;
+    const labels = { provider: normalizeProvider(provider), outcome: normalizeOutcome(outcome) };
+    dchatRequestsTotal.inc(labels);
+    dchatRequestDurationSeconds.observe(labels, Math.max(0, Number(durationSeconds) || 0));
+};
+
+export const recordDependencyRequest = ({
+    dependency = 'openai',
+    outcome = 'success',
+    durationSeconds = 0,
+}) => {
+    if (!metricsReady) return;
+    const labels = {
+        dependency: normalizeDependency(dependency),
+        outcome: normalizeOutcome(outcome),
+    };
+    dependencyRequestsTotal.inc(labels);
+    dependencyRequestDurationSeconds.observe(labels, Math.max(0, Number(durationSeconds) || 0));
+};
 
 await initMetrics();
 

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -10,6 +10,7 @@ import { planChatContext } from './chatContextPlanner.js';
 import { renderPersonaVoiceSamples } from './npcDialogueSamples.js';
 import { buildPlayerStatePromptSummary } from './playerStatePromptSummary.js';
 import { buildAnswerFocusMessage } from './chatAnswerFocus.js';
+import { outcomeFromError, recordDchatRequest, recordDependencyRequest } from './metrics.js';
 
 const resolveOpenAIClient = () => {
     if (
@@ -905,6 +906,11 @@ export const buildChatPrompt = async (messages, options = {}) => {
 };
 
 export const GPT5Chat = async (messages, options = {}) => {
+    const result = await GPT5ChatV2(messages, options);
+    return result.text;
+};
+
+export const GPT5ChatLegacy = async (messages, options = {}) => {
     const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
     const { combinedMessages, gameState, contextSources } = promptPayload;
     const apiKey = gameState?.openAI?.apiKey || ''; // scan-secrets: ignore
@@ -919,18 +925,48 @@ export const GPT5Chat = async (messages, options = {}) => {
 };
 
 export const GPT5ChatV2 = async (messages, options = {}) => {
-    const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
-    const { combinedMessages, gameState, contextSources } = promptPayload;
-    const apiKey = gameState?.openAI?.apiKey || ''; // scan-secrets: ignore
-    const OpenAIClient = resolveOpenAIClient();
-    const openai = new OpenAIClient({ apiKey, dangerouslyAllowBrowser: true });
+    const startedAt = Date.now();
+    let outcome = 'success';
+    try {
+        const promptPayload = options.promptPayload || (await buildChatPrompt(messages, options));
+        const { combinedMessages, gameState, contextSources } = promptPayload;
+        const apiKey = gameState?.openAI?.apiKey || ''; // scan-secrets: ignore
+        const OpenAIClient = resolveOpenAIClient();
+        const openai = new OpenAIClient({ apiKey, dangerouslyAllowBrowser: true });
 
-    const response = await createChatResponse(openai, combinedMessages.map(toResponseMessage));
-    const outputText = toOutputText(response);
-    const { text } = validateChatResponseText(outputText, { contextSources });
+        const dependencyStartedAt = Date.now();
+        let dependencyOutcome = 'success';
+        let text;
+        try {
+            const response = await createChatResponse(
+                openai,
+                combinedMessages.map(toResponseMessage)
+            );
+            const outputText = toOutputText(response);
+            ({ text } = validateChatResponseText(outputText, { contextSources }));
+        } catch (error) {
+            dependencyOutcome = outcomeFromError(error);
+            throw error;
+        } finally {
+            recordDependencyRequest({
+                dependency: 'openai',
+                outcome: dependencyOutcome,
+                durationSeconds: (Date.now() - dependencyStartedAt) / 1000,
+            });
+        }
 
-    return {
-        text,
-        contextSources: Array.isArray(contextSources) ? contextSources : [],
-    };
+        return {
+            text,
+            contextSources: Array.isArray(contextSources) ? contextSources : [],
+        };
+    } catch (error) {
+        outcome = outcomeFromError(error);
+        throw error;
+    } finally {
+        recordDchatRequest({
+            provider: 'openai',
+            outcome,
+            durationSeconds: (Date.now() - startedAt) / 1000,
+        });
+    }
 };

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -17,6 +17,7 @@ import {
     createTokenPlaceHttpError,
     createTokenPlaceNetworkError,
 } from './tokenPlaceErrors.js';
+import { outcomeFromError, recordDchatRequest, recordDependencyRequest } from './metrics.js';
 
 const DEFAULT_ORIGIN = 'https://token.place';
 const CHAT_COMPLETIONS_PATH = '/api/v1/chat/completions';
@@ -840,92 +841,122 @@ const runRelayAttempt = async (baseUrl, messages, options = {}) => {
 };
 
 export const TokenPlaceChatV2 = async (messages, options = {}) => {
-    await ready;
-    const promptPayload = await resolveTokenPlacePromptPayload(messages, options);
-    const contextSources = Array.isArray(promptPayload.contextSources)
-        ? promptPayload.contextSources
-        : [];
-    const baseUrl = resolveTokenPlaceBaseUrl({
-        url: options.url,
-        state: promptPayload.gameState,
-        runtimeUrl: options.runtimeUrl,
-    });
-
-    const model = getTokenPlaceChatModel(options);
-    const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
-    const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
-        reservedOutputTokens: options.reservedOutputTokens,
-        safetyMarginTokens: options.safetyMarginTokens,
-    });
-    if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
-
-    const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
-    let attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
-    if (attempt?.terminalSelectedServerFailure) {
-        attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
-            ...baseAttemptOptions,
-            requestId: undefined,
-            cancelToken: undefined,
+    const startedAt = Date.now();
+    let outcome = 'success';
+    try {
+        await ready;
+        const promptPayload = await resolveTokenPlacePromptPayload(messages, options);
+        const contextSources = Array.isArray(promptPayload.contextSources)
+            ? promptPayload.contextSources
+            : [];
+        const baseUrl = resolveTokenPlaceBaseUrl({
+            url: options.url,
+            state: promptPayload.gameState,
+            runtimeUrl: options.runtimeUrl,
         });
-        if (attempt?.terminalSelectedServerFailure) {
-            throw createMalformedTokenPlaceResponseError(
-                'No token.place compute node is available.'
-            );
-        }
-    }
 
-    let data = attempt.apiResponse;
-    if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
-        const retryAttemptOptions = {
-            ...baseAttemptOptions,
-            contextTier: '64k-full',
-            requestId: undefined,
-            cancelToken: undefined,
-        };
-        let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
-        if (retry?.terminalSelectedServerFailure) {
-            retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
-                ...retryAttemptOptions,
-                requestId: undefined,
-                cancelToken: undefined,
-            });
-            if (retry?.terminalSelectedServerFailure) {
-                throw createMalformedTokenPlaceResponseError(
-                    'No token.place compute node is available.'
-                );
+        const model = getTokenPlaceChatModel(options);
+        const sanitizedMessages = sanitizeTokenPlaceMessages(promptPayload.combinedMessages);
+        const contextEstimate = estimateTokenPlaceContextForSanitizedMessages(sanitizedMessages, {
+            reservedOutputTokens: options.reservedOutputTokens,
+            safetyMarginTokens: options.safetyMarginTokens,
+        });
+        if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
+
+        const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
+        const dependencyStartedAt = Date.now();
+        let dependencyOutcome = 'success';
+        let attempt;
+        let data;
+        let outputText;
+        try {
+            attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
+            if (attempt?.terminalSelectedServerFailure) {
+                attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
+                    ...baseAttemptOptions,
+                    requestId: undefined,
+                    cancelToken: undefined, // scan-secrets: ignore
+                });
+                if (attempt?.terminalSelectedServerFailure) {
+                    throw createMalformedTokenPlaceResponseError(
+                        'No token.place compute node is available.'
+                    );
+                }
             }
+
+            data = attempt.apiResponse;
+            if (shouldRetryContextOverflow(data, attempt.diagnostics)) {
+                const retryAttemptOptions = {
+                    ...baseAttemptOptions,
+                    contextTier: '64k-full',
+                    requestId: undefined,
+                    cancelToken: undefined, // scan-secrets: ignore
+                };
+                let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
+                if (retry?.terminalSelectedServerFailure) {
+                    retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
+                        ...retryAttemptOptions,
+                        requestId: undefined,
+                        cancelToken: undefined, // scan-secrets: ignore
+                    });
+                    if (retry?.terminalSelectedServerFailure) {
+                        throw createMalformedTokenPlaceResponseError(
+                            'No token.place compute node is available.'
+                        );
+                    }
+                }
+                attempt = {
+                    ...retry,
+                    diagnostics: { ...retry.diagnostics, escalationRetry: true },
+                };
+                data = retry.apiResponse;
+            }
+            throwStructuredTokenPlaceApiError(data);
+            outputText = extractTokenPlaceAssistantText(data);
+        } catch (error) {
+            dependencyOutcome = outcomeFromError(error);
+            throw error;
+        } finally {
+            recordDependencyRequest({
+                dependency: 'tokenplace',
+                outcome: dependencyOutcome,
+                durationSeconds: (Date.now() - dependencyStartedAt) / 1000,
+            });
         }
-        attempt = {
-            ...retry,
-            diagnostics: { ...retry.diagnostics, escalationRetry: true },
-        };
-        data = retry.apiResponse;
-    }
 
-    throwStructuredTokenPlaceApiError(data);
-    const outputText = extractTokenPlaceAssistantText(data);
-    const { text } = validateChatResponseText(outputText, { contextSources });
+        const { text } = validateChatResponseText(outputText, { contextSources });
 
-    return {
-        text,
-        contextSources,
-        usage: data?.usage,
-        metadata: {
-            ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
-            tokenPlaceContext: {
-                requestedTier: attempt.diagnostics?.requestedTier || contextEstimate.selectedTier,
-                relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
-                finalActiveTier: getApiErrorActiveTier(data),
-                spillover: Boolean(attempt.diagnostics?.spillover),
-                escalationRetry: Boolean(attempt.diagnostics?.escalationRetry),
-                estimatorVersion: contextEstimate.estimatorVersion,
-                estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
-                reservedOutputTokens: contextEstimate.reservedOutputTokens,
-                timeoutClass: attempt.diagnostics?.timeoutClass,
-                safeErrorCode: getApiErrorCode(data),
+        return {
+            text,
+            contextSources,
+            usage: data?.usage,
+            metadata: {
+                ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),
+                tokenPlaceContext: {
+                    requestedTier:
+                        attempt.diagnostics?.requestedTier || contextEstimate.selectedTier,
+                    relaySelectedTier: attempt.diagnostics?.relaySelectedTier,
+                    finalActiveTier: getApiErrorActiveTier(data),
+                    spillover: Boolean(attempt.diagnostics?.spillover),
+                    escalationRetry: Boolean(attempt.diagnostics?.escalationRetry),
+                    estimatorVersion: contextEstimate.estimatorVersion,
+                    estimatedPromptTokens: contextEstimate.estimatedPromptTokens,
+                    reservedOutputTokens: contextEstimate.reservedOutputTokens,
+                    timeoutClass: attempt.diagnostics?.timeoutClass,
+                    safeErrorCode: getApiErrorCode(data),
+                },
             },
-        },
-    };
+        };
+    } catch (error) {
+        outcome = outcomeFromError(error);
+        throw error;
+    } finally {
+        recordDchatRequest({
+            provider: 'tokenplace',
+            outcome,
+            durationSeconds: (Date.now() - startedAt) / 1000,
+        });
+    }
 };
 
 export const tokenPlaceChat = async (messages, options = {}) => {

--- a/frontend/tests/metricsInstrumentation.test.ts
+++ b/frontend/tests/metricsInstrumentation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+    normalizeOutcome,
+    normalizeProvider,
+    normalizeRoute,
+    outcomeFromError,
+    recordDchatRequest,
+    recordDependencyRequest,
+    recordHttpRequest,
+    register,
+} from '../src/utils/metrics.js';
+
+const prohibitedValues = [
+    'user-secret-123',
+    'session-secret-123',
+    'request-secret-123',
+    'prompt-secret-123',
+    'https://evil.example/path/secret',
+    'exception secret text',
+    '192.0.2.55',
+    'tok_secret_123',
+];
+
+const metricOutput = () => register.metrics();
+
+describe('DSPACE metrics instrumentation', () => {
+    it('normalizes routes, providers, and outcomes to bounded label values', () => {
+        expect(normalizeRoute('/quests/play/123?requestId=secret')).toBe(
+            '/quests/[pathId]/[questId]'
+        );
+        expect(normalizeRoute('/docs/token-place')).toBe('/docs/[slug]');
+        expect(normalizeRoute('/_astro/index.secret.js')).toBe('/_astro/[asset]');
+        expect(normalizeProvider('token-place')).toBe('tokenplace');
+        expect(normalizeProvider('arbitrary-provider-secret')).toBe('unknown');
+        expect(normalizeOutcome('rate-limited')).toBe('rate_limited');
+        expect(normalizeOutcome('secret-outcome')).toBe('unknown_error');
+    });
+
+    it.each([
+        ['timeout', { type: 'abort', message: 'prompt-secret-123' }],
+        ['rate_limited', { status: 429, message: 'request-secret-123' }],
+        ['validation_error', { type: 'validation', message: 'user-secret-123' }],
+        ['malformed_response', { type: 'malformed', message: 'exception secret text' }],
+        ['dependency_failure', { type: 'network', message: 'https://evil.example/path/secret' }],
+        ['server_error', { status: 503, message: 'tok_secret_123' }],
+        ['unknown_error', { message: 'session-secret-123' }],
+    ])('maps %s errors without exposing raw messages', (expected, error) => {
+        expect(outcomeFromError(error)).toBe(expected);
+    });
+
+    it('emits required counters and histograms after controlled traffic', async () => {
+        recordHttpRequest({
+            method: 'GET',
+            route: '/docs/about?user=user-secret-123',
+            status: 200,
+        });
+        recordHttpRequest({ method: 'POST', route: '/metrics', status: 200 });
+        recordDchatRequest({ provider: 'token-place', outcome: 'success', durationSeconds: 0.01 });
+        recordDchatRequest({ provider: 'openai', outcome: 'fallback_used', durationSeconds: 0.02 });
+        recordDependencyRequest({
+            dependency: 'token-place',
+            outcome: 'rate_limited',
+            durationSeconds: 0.03,
+        });
+        recordDependencyRequest({
+            dependency: 'openai',
+            outcome: 'server_error',
+            durationSeconds: 0.04,
+        });
+
+        const output = await metricOutput();
+        expect(output).toContain('dspace_http_requests_total');
+        expect(output).toContain('dspace_http_request_duration_seconds_bucket');
+        expect(output).toContain(
+            'dspace_dchat_requests_total{provider="tokenplace",outcome="success"}'
+        );
+        expect(output).toContain('dspace_dchat_request_duration_seconds_bucket');
+        expect(output).toContain(
+            'dspace_dependency_requests_total{dependency="tokenplace",outcome="rate_limited"}'
+        );
+        expect(output).toContain('dspace_dependency_request_duration_seconds_bucket');
+        expect(output).toContain('dspace_build_info{version="3.0.1"');
+        expect(output).toContain('dspace_instrumentation_up 1');
+        expect(output).not.toContain('/metrics",status_class');
+    });
+
+    it('keeps label sets bounded for synthetic high-cardinality inputs', async () => {
+        for (let i = 0; i < 50; i += 1) {
+            recordHttpRequest({
+                method: 'GET',
+                route: `/docs/page-${i}?requestId=request-secret-123-${i}&user=user-secret-123-${i}`,
+                status: 500,
+                outcome: 'server_error',
+            });
+            recordDchatRequest({ provider: `provider-${i}`, outcome: `outcome-${i}` });
+            recordDependencyRequest({
+                dependency: `https://evil.example/${i}`,
+                outcome: `outcome-${i}`,
+            });
+        }
+        const output = await metricOutput();
+        const docsHttpLines = output
+            .split('\n')
+            .filter(
+                (line) =>
+                    line.startsWith('dspace_http_requests_total{') &&
+                    line.includes('route="/docs/[slug]"') &&
+                    line.includes('status_class="5xx"')
+            );
+        const unknownDchatLines = output
+            .split('\n')
+            .filter((line) =>
+                line.startsWith(
+                    'dspace_dchat_requests_total{provider="unknown",outcome="unknown_error"'
+                )
+            );
+        const openaiDependencyLines = output
+            .split('\n')
+            .filter((line) =>
+                line.startsWith(
+                    'dspace_dependency_requests_total{dependency="openai",outcome="unknown_error"'
+                )
+            );
+        expect(docsHttpLines).toHaveLength(1);
+        expect(unknownDchatLines).toHaveLength(1);
+        expect(openaiDependencyLines).toHaveLength(1);
+        for (const value of prohibitedValues) {
+            expect(output).not.toContain(value);
+        }
+    });
+});

--- a/tests/metricsFallback.test.ts
+++ b/tests/metricsFallback.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 
 describe('metrics util', () => {
-    it('falls back when prom-client is missing', async () => {
-        const mod = await import('../frontend/src/utils/metrics.js');
-        await mod.initMetrics(() => {
-            throw new Error('module not found');
-        });
-        expect(mod.register.contentType).toBe('text/plain');
-        const metrics = await mod.register.metrics();
-        expect(metrics).toContain('metrics unavailable');
+  it('uses an explicit failure contract when prom-client is missing', async () => {
+    const mod = await import('../frontend/src/utils/metrics.js');
+    await mod.initMetrics(() => {
+      throw new Error('module not found');
     });
+    expect(mod.isMetricsReady()).toBe(false);
+    expect(mod.register.contentType).toContain('text/plain');
+    await expect(mod.register.metrics()).rejects.toThrow('metrics unavailable');
+    await mod.initMetrics();
+  });
 });


### PR DESCRIPTION
### Motivation

- Add a minimal, production-quality metrics slice to the runtime so DSPACE emits Prometheus-compatible, privacy-safe application metrics required by the observability design. 
- Ensure metrics obey cardinality and privacy constraints by normalizing routes/providers/outcomes and excluding `/metrics` from self-instrumentation. 
- Reuse the existing `prom-client` registry and provide an explicit failure contract when the library cannot initialize to avoid misleading successful responses.

### Description

- Implemented a centralized metrics module `frontend/src/utils/metrics.js` that lazily loads `prom-client`, creates a single `Registry`, and registers the following metric families: `dspace_http_requests_total`, `dspace_http_request_duration_seconds`, `dspace_dchat_requests_total`, `dspace_dchat_request_duration_seconds`, `dspace_dependency_requests_total`, `dspace_dependency_request_duration_seconds`, `dspace_build_info`, and `dspace_instrumentation_up`. 
- Added bounded enums and normalization helpers for labels so routes map to templates (e.g. `/docs/[slug]`, `/quests/[pathId]/[questId]`), status to classes like `2xx/5xx`, providers to `tokenplace|openai|none|unknown`, dependencies to `tokenplace|openai`, and outcomes to `success|timeout|rate_limited|validation_error|malformed_response|dependency_failure|server_error|fallback_used|fallback_unavailable|unknown_error`. 
- Instrumented server middleware `frontend/src/middleware.ts` to record HTTP counters and histograms (excluding `/metrics`), and instrumented server-side dChat paths in `frontend/src/utils/openAI.js` and `frontend/src/utils/tokenPlace.js` to record dependency and dChat metrics with finally-safe outcome recording; histograms use initial buckets [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]. 
- Made `/metrics` (in `frontend/src/pages/metrics.ts`) return an explicit non-success `503` contract when metrics are not ready or when `prom-client` cannot produce metrics, updated observability docs `docs/design/observability-v3.1.md` and `docs/qa/v3.1.md` with implemented source behavior and PromQL examples, and added unit tests to assert privacy/cardinality and fallback behaviors. 
- Files changed: `frontend/src/utils/metrics.js`, `frontend/src/middleware.ts`, `frontend/src/pages/metrics.ts`, `frontend/src/utils/openAI.js`, `frontend/src/utils/tokenPlace.js`, `frontend/tests/metricsInstrumentation.test.ts`, `tests/metricsFallback.test.ts`, and updated docs `docs/design/observability-v3.1.md` and `docs/qa/v3.1.md`.

### Testing

- Focused metrics tests: `npm run test:root -- frontend/tests/metricsInstrumentation.test.ts` passed. 
- Fallback behavior test: `npm run test:root -- tests/metricsFallback.test.ts frontend/tests/metricsInstrumentation.test.ts` passed. 
- Integration sanity: `npm run test:root -- frontend/__tests__/tokenPlace.test.js frontend/tests/openAI.test.ts frontend/tests/metricsInstrumentation.test.ts tests/metricsFallback.test.ts` passed. 
- Full repository checks and build: `npm run link-check`, `npm run test:root`, `npm run test:quest-validation`, `npm run type-check`, `npm run lint`, `npm run build`, and `npm run check` were executed and completed successfully. 

Notes on exact commands used during verification: `npm run test:root -- frontend/tests/metricsInstrumentation.test.ts`, `npm run test:root -- tests/metricsFallback.test.ts frontend/tests/metricsInstrumentation.test.ts`, `npm run test:root -- frontend/__tests__/tokenPlace.test.js frontend/tests/openAI.test.ts frontend/tests/metricsInstrumentation.test.ts tests/metricsFallback.test.ts`, `npm run link-check`, `npm run test:root`, `npm run test:quest-validation`, `npm run type-check`, `npm run lint`, `npm run build`, `npm run check`, and `git diff | ./scripts/scan-secrets.py` (secret scan passed after adding `// scan-secrets: ignore` annotations where appropriate). 

Metric names, bounded label values, and histogram buckets are documented in `frontend/src/utils/metrics.js` and the updated design docs; all automated assertions confirmed that the `/metrics` output contains the required families, the build info gauge has stable low-cardinality labels, and no prohibited sensitive/high-cardinality values appear in metric outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a531ad24814832f9098b6964283e2d0)