### PR TITLE
Lock metrics ingestion to trusted boundaries

### DIFF
--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -104,13 +104,11 @@ avoids duplicate registration during repeated imports, tests, and hot reload:
 
 Source instrumentation excludes `/metrics` HTTP self-scrapes, normalizes route labels to route
 templates or fixed route groups, maps unmatched paths to `/unknown`, maps status labels only to
-`2xx`, `4xx`, `5xx`, or `unknown`, and bounds method/provider/dependency/outcome labels. Browser
-dChat and token.place helpers report only bounded provider/dependency/outcome/duration fields to
-`POST /metrics`, which rejects oversized, cross-origin, malformed, extra-field, non-finite, and
-out-of-enum payloads, so Prometheus scrapes the server registry rather than a browser-local
-registry. If metrics initialization fails, `/metrics` returns `503` instead of a misleading
-successful placeholder. Metrics write failures are isolated from game functionality and do not
-expose secrets.
+`2xx`, `4xx`, `5xx`, or `unknown`, and bounds method/provider/dependency/outcome labels.
+Browser-reported operational metrics are not accepted: `POST /metrics` returns `405`, and the
+trusted Prometheus registry is written only at server-controlled HTTP/provider boundaries. If
+metrics initialization fails, `/metrics` returns `503` instead of a misleading successful
+placeholder. Metrics write failures are isolated from game functionality and do not expose secrets.
 
 ### v3.1.0 release blockers
 

--- a/docs/qa/v3.1.md
+++ b/docs/qa/v3.1.md
@@ -207,8 +207,8 @@ is attached.
 - [ ] **v3.1.0 release blocker:** Process/runtime health metrics are available from safe
       server-side collection.
 - [x] **implemented source behavior:** dChat request totals and latency are labeled only by bounded
-      provider and outcome categories, including browser chat reports forwarded through validated
-      same-origin `POST /metrics` payloads to the server metrics registry.
+      provider and outcome categories at trusted server-controlled provider boundaries; browser
+      metric ingestion is disabled with `POST /metrics` returning `405`.
 - [x] **implemented source behavior:** token.place dependency metrics distinguish successes, timeouts,
       rate limits, malformed responses, and server failures.
 - [x] **implemented source behavior:** Provider-selection failures and fallback behavior are measurable

--- a/frontend/__tests__/tokenPlace.test.js
+++ b/frontend/__tests__/tokenPlace.test.js
@@ -1401,7 +1401,7 @@ ${ragExcerpt.repeat(4000)}`,
 
         global.fetch = makeRelayFetch({ retrieveStatuses: [404, 404] });
         await expect(tokenPlaceChat([], { pollIntervalMs: 1 })).rejects.toMatchObject({
-            type: 'malformed',
+            type: 'fallback_unavailable',
             message: 'No token.place compute node is available.',
         });
     });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,7 +4,12 @@ import {
     buildRuntimeConfigResponse,
 } from './utils/runtimeEndpoints';
 import { logServerError } from './utils/serverLogger';
-import { recordHttpRequest, normalizeRoute, outcomeFromStatus } from './utils/metrics.js';
+import {
+    ensureMetricsInitialized,
+    recordHttpRequest,
+    normalizeRoute,
+    outcomeFromStatus,
+} from './utils/metrics.js';
 
 export interface MiddlewareContext {
     request: Request;
@@ -13,6 +18,8 @@ export interface MiddlewareContext {
 export const onRequest = async (context: MiddlewareContext, next: () => Promise<Response>) => {
     const { pathname } = new URL(context.request.url);
     const requestStartedAt = performance.now();
+    const metricsStatus =
+        pathname === '/metrics' ? { available: false } : await ensureMetricsInitialized();
     const handledPaths = new Set(['/config.json', '/healthz', '/health', '/livez']);
 
     let response: Response;
@@ -26,7 +33,7 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             message: 'Unhandled error while processing request',
             error,
         });
-        if (pathname !== '/metrics') {
+        if (pathname !== '/metrics' && metricsStatus.available) {
             recordHttpRequest({
                 method: context.request.method,
                 route: normalizeRoute(pathname),
@@ -63,7 +70,7 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
         }
 
-        if (pathname !== '/metrics') {
+        if (pathname !== '/metrics' && metricsStatus.available) {
             recordHttpRequest({
                 method: context.request.method,
                 route: normalizeRoute(pathname),
@@ -92,13 +99,15 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             fallbackResponse = response;
     }
 
-    recordHttpRequest({
-        method: context.request.method,
-        route: normalizeRoute(pathname),
-        status: fallbackResponse.status,
-        outcome: outcomeFromStatus(fallbackResponse.status),
-        durationSeconds: Math.max(0, (performance.now() - requestStartedAt) / 1000),
-    });
+    if (metricsStatus.available) {
+        recordHttpRequest({
+            method: context.request.method,
+            route: normalizeRoute(pathname),
+            status: fallbackResponse.status,
+            outcome: outcomeFromStatus(fallbackResponse.status),
+            durationSeconds: Math.max(0, (performance.now() - requestStartedAt) / 1000),
+        });
+    }
 
     return fallbackResponse;
 };

--- a/frontend/src/pages/metrics.ts
+++ b/frontend/src/pages/metrics.ts
@@ -1,51 +1,6 @@
-import {
-    ensureMetricsInitialized,
-    register,
-    recordDchatRequest,
-    recordDependencyRequest,
-} from '../utils/metrics.js';
+import { ensureMetricsInitialized, register } from '../utils/metrics.js';
 
 export const prerender = false;
-
-const MAX_BODY_BYTES = 512;
-const VALID_KINDS = new Set(['dchat', 'dependency']);
-const VALID_PROVIDERS = new Set(['tokenplace', 'openai', 'none', 'unknown']);
-const VALID_DEPENDENCIES = new Set(['tokenplace', 'openai', 'unknown']);
-const VALID_OUTCOMES = new Set([
-    'success',
-    'timeout',
-    'rate_limited',
-    'validation_error',
-    'malformed_response',
-    'dependency_failure',
-    'server_error',
-    'fallback_used',
-    'fallback_unavailable',
-    'unknown_error',
-]);
-const DCHAT_KEYS = new Set(['kind', 'provider', 'outcome', 'durationSeconds']);
-const DEPENDENCY_KEYS = new Set(['kind', 'dependency', 'outcome', 'durationSeconds']);
-
-const isSameOrigin = (request: Request) => {
-    const origin = request.headers.get('origin');
-    if (!origin) return true;
-    try {
-        return new URL(origin).origin === new URL(request.url).origin;
-    } catch {
-        return false;
-    }
-};
-
-const boundedDuration = (value: unknown) => {
-    const duration = Number(value);
-    if (!Number.isFinite(duration) || duration < 0 || duration > 300) return undefined;
-    return duration;
-};
-
-const hasOnlyKeys = (payload: Record<string, unknown>, allowed: Set<string>) =>
-    Object.keys(payload).every((key) => allowed.has(key));
-
-const invalidPayload = () => new Response('invalid metrics payload\n', { status: 400 });
 
 /**
  * Returns Prometheus metrics for the running instance.
@@ -75,45 +30,8 @@ export async function GET({ request }: { request: Request }) {
     });
 }
 
-export async function POST({ request }: { request: Request }) {
-    if (!isSameOrigin(request)) return invalidPayload();
-
-    const contentType = request.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().includes('application/json')) return invalidPayload();
-
-    const text = await request.text();
-    if (!text || new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
-        return invalidPayload();
-    }
-
-    let payload: Record<string, unknown>;
-    try {
-        const parsed = JSON.parse(text);
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return invalidPayload();
-        payload = parsed as Record<string, unknown>;
-    } catch {
-        return invalidPayload();
-    }
-
-    const kind = String(payload.kind || '');
-    const outcome = String(payload.outcome || '');
-    const durationSeconds = boundedDuration(payload.durationSeconds);
-    if (!VALID_KINDS.has(kind) || !VALID_OUTCOMES.has(outcome) || durationSeconds === undefined) {
-        return invalidPayload();
-    }
-
-    if (kind === 'dchat') {
-        const provider = String(payload.provider || '');
-        if (!hasOnlyKeys(payload, DCHAT_KEYS) || !VALID_PROVIDERS.has(provider))
-            return invalidPayload();
-        recordDchatRequest({ provider, outcome, durationSeconds });
-        return new Response(null, { status: 204 });
-    }
-
-    const dependency = String(payload.dependency || '');
-    if (!hasOnlyKeys(payload, DEPENDENCY_KEYS) || !VALID_DEPENDENCIES.has(dependency)) {
-        return invalidPayload();
-    }
-    recordDependencyRequest({ dependency, outcome, durationSeconds });
-    return new Response(null, { status: 204 });
+export async function POST(_context?: { request?: Request }) {
+    // Browser dChat/dependency telemetry is intentionally not accepted here: the trusted
+    // Prometheus registry is written only by server-controlled request/provider boundaries.
+    return new Response('metrics ingestion disabled\n', { status: 405 });
 }

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -36,31 +36,9 @@ const globalState = () => {
 
 const sanitizeEnum = (value, allowed, fallback) =>
     allowed.has(String(value || '').toLowerCase()) ? String(value).toLowerCase() : fallback;
-const postClientMetric = (kind, labels) => {
-    try {
-        if (!isBrowserRuntime) return;
-        const body = JSON.stringify({ kind, ...labels });
-        const url =
-            typeof window !== 'undefined' && window.location?.origin
-                ? `${window.location.origin}/metrics`
-                : '/metrics';
-        if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
-            navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }));
-            return;
-        }
-        if (typeof fetch === 'function') {
-            Promise.resolve(
-                fetch(url, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body,
-                    keepalive: true,
-                })
-            ).catch(() => {});
-        }
-    } catch {
-        // Browser delivery is best-effort and must never affect chat behavior.
-    }
+const postClientMetric = () => {
+    // Browser-reported operational metrics are intentionally dropped. The shared
+    // Prometheus registry is trusted only at server-controlled HTTP/provider boundaries.
 };
 
 export const normalizeOutcome = (value) => sanitizeEnum(value, OUTCOMES, 'unknown_error');
@@ -374,6 +352,7 @@ export const instrumentDchatOperation = async (provider, operation) => {
         outcome = outcomeFromError(error);
         throw error;
     } finally {
+        if (!isBrowserRuntime) await ensureMetricsInitialized();
         recordDchatRequest({
             provider: normalizedProvider,
             outcome,
@@ -394,6 +373,7 @@ export const instrumentDependencyOperation = async (dependency, operation) => {
         outcome = outcomeFromError(error);
         throw error;
     } finally {
+        if (!isBrowserRuntime) await ensureMetricsInitialized();
         recordDependencyRequest({
             dependency: normalizedDependency,
             outcome,

--- a/frontend/src/utils/openAI.js
+++ b/frontend/src/utils/openAI.js
@@ -567,13 +567,13 @@ async function createChatResponse(openai, input) {
             const hasFallback = index < models.length - 1;
             recordDependencyRequest({
                 dependency: 'openai',
-                outcome:
-                    hasFallback && isModelAccessError(error)
-                        ? 'fallback_unavailable'
-                        : outcomeFromError(error),
+                outcome: outcomeFromError(error),
                 durationSeconds: secondsSinceMetricsStart(attemptStart),
             });
             if (!hasFallback || !isModelAccessError(error)) {
+                if (!hasFallback && isModelAccessError(error)) {
+                    error.type = 'fallback_unavailable';
+                }
                 throw error;
             }
         }

--- a/frontend/src/utils/tokenPlace.js
+++ b/frontend/src/utils/tokenPlace.js
@@ -668,7 +668,7 @@ const retrieveRelayResponse = async (baseUrl, body, options = {}) => {
     if ([404, 410].includes(response.status)) {
         recordDependencyRequest({
             dependency: 'tokenplace',
-            outcome: 'fallback_unavailable',
+            outcome: 'dependency_failure',
             durationSeconds: secondsSinceMetricsStart(metricsStart),
         });
         return { terminalSelectedServerFailure: true };
@@ -929,17 +929,21 @@ const runTokenPlaceChatV2 = async (messages, options = {}) => {
     if (contextEstimate.overLimit) throw createTokenPlaceContextBudgetError(contextEstimate);
 
     const baseAttemptOptions = { ...options, model, contextTier: contextEstimate.selectedTier };
+    let fallbackUsed = false;
     let attempt = await runRelayAttempt(baseUrl, sanitizedMessages, baseAttemptOptions);
     if (attempt?.terminalSelectedServerFailure) {
+        fallbackUsed = true;
         attempt = await runRelayAttempt(baseUrl, sanitizedMessages, {
             ...baseAttemptOptions,
             requestId: undefined,
             cancelToken: undefined,
         });
         if (attempt?.terminalSelectedServerFailure) {
-            throw createMalformedTokenPlaceResponseError(
+            const error = createMalformedTokenPlaceResponseError(
                 'No token.place compute node is available.'
             );
+            error.type = 'fallback_unavailable';
+            throw error;
         }
     }
 
@@ -951,6 +955,7 @@ const runTokenPlaceChatV2 = async (messages, options = {}) => {
             requestId: undefined,
             cancelToken: undefined,
         };
+        fallbackUsed = true;
         let retry = await runRelayAttempt(baseUrl, sanitizedMessages, retryAttemptOptions);
         if (retry?.terminalSelectedServerFailure) {
             retry = await runRelayAttempt(baseUrl, sanitizedMessages, {
@@ -959,9 +964,11 @@ const runTokenPlaceChatV2 = async (messages, options = {}) => {
                 cancelToken: undefined,
             });
             if (retry?.terminalSelectedServerFailure) {
-                throw createMalformedTokenPlaceResponseError(
+                const error = createMalformedTokenPlaceResponseError(
                     'No token.place compute node is available.'
                 );
+                error.type = 'fallback_unavailable';
+                throw error;
             }
         }
         attempt = {
@@ -978,6 +985,7 @@ const runTokenPlaceChatV2 = async (messages, options = {}) => {
     return {
         text,
         contextSources,
+        ...(fallbackUsed ? { metricsOutcome: 'fallback_used' } : {}),
         usage: data?.usage,
         metadata: {
             ...(data?.metadata && typeof data.metadata === 'object' ? data.metadata : {}),

--- a/tests/metricsFallback.test.ts
+++ b/tests/metricsFallback.test.ts
@@ -214,7 +214,7 @@ describe('DSPACE application metrics', () => {
     expect(text).not.toContain('exception-message-secret-42');
   });
 
-  it('accepts bounded browser dChat metric reports through the server registry endpoint', async () => {
+  it('rejects browser dChat metric reports at the trusted server registry boundary', async () => {
     const metrics = await importMetrics();
     const endpoint = await import('../frontend/src/pages/metrics');
 
@@ -230,7 +230,7 @@ describe('DSPACE application metrics', () => {
         }),
       }),
     });
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(405);
 
     const dependencyResponse = await endpoint.POST({
       request: new Request('http://dspace.local/metrics', {
@@ -244,13 +244,13 @@ describe('DSPACE application metrics', () => {
         }),
       }),
     });
-    expect(dependencyResponse.status).toBe(204);
+    expect(dependencyResponse.status).toBe(405);
 
     const text = await metrics.register.metrics();
-    expect(text).toContain(
+    expect(text).not.toContain(
       'dspace_dchat_requests_total{provider="unknown",outcome="success"}'
     );
-    expect(text).toContain(
+    expect(text).not.toContain(
       'dspace_dependency_requests_total{dependency="tokenplace",outcome="server_error"}'
     );
     const rejected = await endpoint.POST({
@@ -269,7 +269,7 @@ describe('DSPACE application metrics', () => {
         }),
       }),
     });
-    expect(rejected.status).toBe(400);
+    expect(rejected.status).toBe(405);
     expect(text).not.toContain('browser-secret-provider');
   });
 


### PR DESCRIPTION
### Motivation
- Prevent untrusted clients from writing fabricated metrics into the server-side Prometheus registry and eliminate an unauthenticated writable surface that could corrupt alerting and release evidence. 
- Ensure metrics recorded during cold-start are not silently dropped by awaiting initialization at server recording boundaries. 
- Make fallback and dependency metrics reflect actual network/selection outcomes (no double-counting or misclassification) so monitoring data is accurate for incident response.

### Description
- Restrict browser metric ingestion by disabling writable browser-forwarding and returning `405` from `POST /metrics`, with a trust-boundary comment clarifying that the Prometheus registry is written only from server-controlled provider/HTTP boundaries (`frontend/src/pages/metrics.ts`).
- Drop browser-forwarded delivery in the metrics helper and keep browser paths failure-safe/no-op (`frontend/src/utils/metrics.js`).
- Await metrics initialization at HTTP middleware and dChat/dependency instrumentation boundaries and skip recording when initialization is unavailable to prevent cold-start sample loss (`frontend/src/middleware.ts`, `frontend/src/utils/metrics.js`).
- Adjust OpenAI and token.place instrumentation so each outbound dependency attempt is counted once, primary attempts are classified by their actual error, successful later attempts emit `fallback_used`, and final exhaustion emits `fallback_unavailable` (fixes in `frontend/src/utils/openAI.js` and `frontend/src/utils/tokenPlace.js`).
- Reduce label cardinality and preserve bounded enums/routing normalization; update tests to assert the trusted ingestion boundary and correct fallback semantics and update observability docs to reflect the server-side ingestion policy (`tests/metricsFallback.test.ts`, `frontend/__tests__/tokenPlace.test.js`, `docs/design/observability-v3.1.md`, `docs/qa/v3.1.md`).

### Testing
- Ran targeted unit tests: `npm run test:root -- tests/metricsFallback.test.ts tests/metricsEndpoint.test.ts frontend/tests/openAI.test.ts frontend/__tests__/tokenPlace.test.js`, and the focused suites passed. 
- Ran full CI-style verification: `npm run lint`, `npm run type-check`, `npm run check`, `npm run link-check`, `npm run build`, `timeout 900 npm run test:ci`, and `npm run coverage`, and these completed successfully in this environment. 
- Performed repository checks: `rg` searches for related symbols and `git diff | python3 scripts/scan-secrets.py` and `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a533df9ce44832fa8b0de04dadfd9e8)