### PR TITLE
Add canonical Helm metrics scrape contract

### DIFF
--- a/charts/dspace/templates/deployment.yaml
+++ b/charts/dspace/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
               value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
             - name: DSPACE_ENV
               value: {{ .Values.environment | default "production" | quote }}
+          {{- if and .Values.metrics.enabled .Values.metrics.auth.existingSecret }}
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.metrics.auth.existingSecret | quote }}
+                  key: {{ .Values.metrics.auth.secretKey | quote }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/charts/dspace/templates/service.yaml
+++ b/charts/dspace/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "dspace.fullname" . }}
   labels:
     {{- include "dspace.labels" . | nindent 4 }}
+    dspace.io/environment: {{ .Values.environment | default "production" | quote }}
+    dspace.io/cluster: {{ .Values.cluster | default "" | quote }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/dspace/templates/servicemonitor.yaml
+++ b/charts/dspace/templates/servicemonitor.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.metrics.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dspace.fullname" . }}
+  labels:
+    {{- include "dspace.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "dspace.selectorLabels" . | nindent 6 }}
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.io/environment
+    - dspace.io/cluster
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      scheme: http
+      honorLabels: false
+      {{- if .Values.metrics.auth.existingSecret }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ .Values.metrics.auth.existingSecret | quote }}
+          key: {{ .Values.metrics.auth.secretKey | quote }}
+      {{- end }}
+      relabelings:
+        - targetLabel: app
+          replacement: {{ include "dspace.name" . | quote }}
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - targetLabel: environment
+          replacement: {{ .Values.environment | default "production" | quote }}
+        - targetLabel: release
+          replacement: {{ .Release.Name | quote }}
+        - targetLabel: cluster
+          replacement: {{ .Values.cluster | default "sugarkube" | quote }}
+        {{- with .Values.serviceMonitor.relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/dspace/values.schema.json
+++ b/charts/dspace/values.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "path": { "type": "string", "default": "/metrics", "minLength": 1 },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "existingSecret": { "type": "string", "default": "" },
+            "secretKey": { "type": "string", "default": "token", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "interval": { "type": "string", "default": "30s", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "scrapeTimeout": { "type": "string", "default": "10s", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "additionalLabels": {
+          "type": "object",
+          "default": { "release": "kube-prometheus-stack" },
+          "additionalProperties": { "type": "string" }
+        },
+        "relabelings": { "type": "array", "default": [], "items": { "type": "object" } },
+        "metricRelabelings": { "type": "array", "default": [], "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
+    "cluster": { "type": "string", "default": "" }
+  }
+}

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -58,6 +58,23 @@ secret:
   stringData: {}
 
 environment: production
+cluster: ""
+
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ""
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings: []
+  metricRelabelings: []
 
 env: []
 

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -2,11 +2,10 @@
 
 The `charts/dspace` Helm chart deploys the DSPACE application with sensible defaults for
 Traefik-based ingress, HTTP health checks, and optional configuration via ConfigMaps or Secrets.
-It is a lightweight chart intended for direct Helm usage; Flux-managed environments continue to
-use the existing production chart at `deploy/charts/dspace/`, which includes additional features
-like network policies, metrics, and production ingress/TLS automation. The chart uses the
-application container port `8080` by default, matching the `Dockerfile` `EXPOSE` and health check
-settings.
+It is the canonical chart packaged and published by the GHCR Helm workflow for DSPACE releases.
+Do not rely on the legacy duplicate `deploy/charts/dspace/` tree unless release automation is
+intentionally migrated in the same change. The chart uses the application container port `8080` by
+default, matching the `Dockerfile` `EXPOSE` and health check settings.
 
 ## Key values
 
@@ -17,6 +16,20 @@ settings.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
+- `metrics.enabled`: Enable the authenticated `/metrics` runtime contract. Defaults to `false`.
+- `metrics.path`: Prometheus scrape path. Defaults to `/metrics`.
+- `metrics.auth.existingSecret`: Existing Secret containing the Prometheus bearer token. Defaults to
+  empty and never creates or embeds a token value.
+- `metrics.auth.secretKey`: Key within `metrics.auth.existingSecret`. Defaults to `token`.
+- `serviceMonitor.enabled`: Render a Prometheus Operator `ServiceMonitor` only when explicitly set
+  to `true` with `metrics.enabled=true`. Defaults to `false`.
+- `serviceMonitor.interval` / `serviceMonitor.scrapeTimeout`: Defaults to `30s` / `10s` so the
+  timeout remains below the interval.
+- `serviceMonitor.additionalLabels`: Labels applied to the `ServiceMonitor`; defaults to
+  `release: kube-prometheus-stack` for Sugarkube discovery.
+- `serviceMonitor.relabelings`: Optional bounded metadata relabeling hooks appended after the
+  chart's app, namespace, environment, release, and cluster labels.
+- `cluster`: Optional bounded cluster label used by the Service and scrape relabeling.
 - `ingress.enabled`: Enable Traefik ingress. Defaults to `false`.
 - `ingress.host`: Hostname routed to the service. Required when ingress is enabled.
 - `ingress.className`: Ingress class name. Defaults to `traefik`.
@@ -40,6 +53,59 @@ settings.
 
 For development, `charts/dspace/values.dev.yaml` enables ingress and sets a placeholder host:
 `dspace-v3.example.dev`. Override this host for your own environment.
+
+
+## Metrics scrape examples
+
+### Local disabled mode
+
+The default chart render is backward-compatible and does not require a metrics Secret:
+
+```bash
+helm template dspace charts/dspace \
+  --namespace dspace-local
+```
+
+This renders no `ServiceMonitor`, no Prometheus/Grafana resources, no metrics ingress, and no
+`METRICS_TOKEN` environment variable.
+
+### Sugarkube staging mode
+
+Create the Secret outside the chart with your secret-management process, then reference only its
+name and key. The example uses a fake Secret name and intentionally does not include a token value:
+
+```bash
+helm upgrade --install dspace charts/dspace \
+  --namespace dspace-staging \
+  --set environment=staging \
+  --set cluster=sugarkube-staging \
+  --set metrics.enabled=true \
+  --set metrics.auth.existingSecret=dspace-staging-metrics-token \
+  --set metrics.auth.secretKey=token \
+  --set serviceMonitor.enabled=true \
+  --set serviceMonitor.additionalLabels.release=kube-prometheus-stack
+```
+
+The chart injects `METRICS_TOKEN` from the existing Secret and renders one
+`monitoring.coreos.com/v1` `ServiceMonitor` that selects the release's DSPACE Service, scrapes the
+named `http` port at `/metrics`, and uses Prometheus Operator `authorization.credentials` Secret
+wiring supported by Sugarkube's pinned `kube-prometheus-stack` `58.2.0` / Prometheus Operator
+`v0.73.1` CRD.
+
+Verification examples after deployment:
+
+```bash
+# Internal success through Prometheus using the referenced Secret
+kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up{app="dspace",environment="staging"}'
+
+# Public denial: unauthenticated public metrics requests must fail deliberately
+curl -i https://dspace-staging.example.com/metrics
+```
+
+A successful public-denial check returns `401` or another intentional denial. Because the normal
+public ingress routes the application prefix, application-side `METRICS_TOKEN` authentication is
+required whenever staging or production metrics are enabled.
 
 ## Common commands
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -75,13 +75,13 @@ Flux consumption details:
   release succeeds. Tune graceful shutdowns by adjusting
   `values.terminationGracePeriodSeconds` (default `30`) so in-flight requests finish before pods
   exit.
-- **Prometheus ServiceMonitor**: Disabled by default. Set `serviceMonitor.enabled=true` in
-  environment values to create a `ServiceMonitor` that scrapes the dedicated `metrics` port (9464)
-  at `/metrics`, tags the resource with `release: kube-prometheus-stack`, and defaults discovery to
-  the Helm release namespace while still allowing `namespaceSelector` overrides when the target
-  Service lives elsewhere. When metrics are enabled, the Helm `NetworkPolicy` also admits traffic
-  from the namespace configured via `networkPolicy.metricsScraper` (default `monitoring`) so the
-  collector can reach the metrics port.
+- **Prometheus ServiceMonitor**: Disabled by default in the canonical `charts/dspace` chart. Set
+  both `metrics.enabled=true` and `serviceMonitor.enabled=true`, and reference an existing Secret
+  with `metrics.auth.existingSecret`, to create one `ServiceMonitor` that scrapes the named `http`
+  service port at `/metrics`, tags the resource with `release: kube-prometheus-stack`, and wires
+  bearer-token authentication through the Prometheus Operator `authorization.credentials` Secret
+  reference. The public application ingress is not modified or split for metrics; when that ingress
+  can route `/metrics`, application-side `METRICS_TOKEN` authentication remains required.
 - **Logs**: The container emits structured JSON logs (fields: `time`, `level`, `msg`, etc.) and
   includes feature-flag metadata during startup and shutdown. For v3.0.0 launch readiness, rely on
   these operational logs in staging/prod; centralized error-reporting aggregation is deferred to a
@@ -129,8 +129,9 @@ The container listens on port `8080` internally. The Helm chart configures:
   `cert-manager.io/cluster-issuer: letsencrypt-dns01`. Each environment overlay now pins the
   `className` and annotation alongside its host list and TLS secret name so TLS stays intact even if
   chart defaults change.
-- A default-deny `NetworkPolicy` that allows ingress from Traefik for web traffic and, when metrics
-  are enabled, from the Prometheus namespace specified by `values.networkPolicy.metricsScraper`.
+- The canonical chart does not enable a metrics-specific `NetworkPolicy` by default. Use
+  application-side metrics authentication for public prefix ingress protection and add network
+  policy separately only when it can preserve normal application traffic.
   DNS egress to `kube-dns` stays open; use `values.networkPolicy.extraIngress` or
   `values.networkPolicy.extraEgress` to permit additional peers as needed.
 

--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -27,7 +27,7 @@ smallest useful v3.1.0 release slice.
 | Metric implementation         | `frontend/src/utils/metrics.js` initializes the shared `prom-client` registry, default process metrics, DSPACE HTTP metrics, dChat metrics, dependency metrics, build info, and instrumentation health. | Implemented source behavior; live evidence pending. | Application source emits the canonical privacy-safe metric families. Staging/prod scrape behavior, chart wiring, dashboards, and alerts still need evidence.    |
 | Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                                                                                   | Legacy/local scaffold.                              | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
 | Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                                                                              | Implemented v3.0.1 path.                            | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
-| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.                                                                     | Missing.                                            | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
+| Canonical chart scrape config | `charts/dspace` has Service, Deployment, authenticated metrics Secret wiring, safe-default metrics values, and an explicit ServiceMonitor template gated by `metrics.enabled` plus `serviceMonitor.enabled`. | Implemented source behavior; live evidence pending. | The canonical chart now owns the scrape contract; staging/prod live scrape evidence is still required before promotion. |
 | Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow.                                                       | Partial legacy/experimental duplicate.              | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
 | Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                                                                           | Legacy/partial.                                     | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
 
@@ -59,15 +59,15 @@ Every requirement below is classified as one of:
 
 - [ ] Staging and production expose a Prometheus-compatible DSPACE endpoint for in-cluster
       scraping.
-- [ ] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
-- [ ] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
+- [x] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
+- [x] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
       with Sugarkube's Prometheus operator labels.
-- [ ] Discovery labels include the Sugarkube-compatible monitoring release label selected by the
+- [x] Discovery labels include the Sugarkube-compatible monitoring release label selected by the
       cluster operator, plus stable app labels for `app=dspace`, namespace, environment, cluster,
       and Helm release identity through metric labels or Prometheus relabeling.
 - [ ] Authentication and network behavior allow Prometheus in the cluster to scrape metrics without
       exposing a privileged metrics surface publicly.
-- [ ] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
+- [x] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
       includes tested bearer-token Secret wiring; if a cluster-only metrics service or NetworkPolicy
       is used instead, public ingress must not route to `/metrics`.
 - [x] Application source exposes release/build identity with bounded labels:

--- a/tests/helmChartMetricsContract.test.ts
+++ b/tests/helmChartMetricsContract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+const repoRoot = join(__dirname, '..');
+const valuesYaml = readFileSync(join(repoRoot, 'charts', 'dspace', 'values.yaml'), 'utf8');
+const values = parse(valuesYaml) as {
+  metrics: { enabled: boolean; path: string; auth: { existingSecret: string; secretKey: string } };
+  serviceMonitor: {
+    enabled: boolean;
+    interval: string;
+    scrapeTimeout: string;
+    additionalLabels: Record<string, string>;
+    relabelings: unknown[];
+  };
+};
+const serviceMonitorTemplate = readFileSync(
+  join(repoRoot, 'charts', 'dspace', 'templates', 'servicemonitor.yaml'),
+  'utf8',
+);
+const deploymentTemplate = readFileSync(
+  join(repoRoot, 'charts', 'dspace', 'templates', 'deployment.yaml'),
+  'utf8',
+);
+const ingressTemplate = readFileSync(
+  join(repoRoot, 'charts', 'dspace', 'templates', 'ingress.yaml'),
+  'utf8',
+);
+const schema = JSON.parse(
+  readFileSync(join(repoRoot, 'charts', 'dspace', 'values.schema.json'), 'utf8'),
+) as Record<string, unknown>;
+
+describe('canonical Helm metrics scrape contract', () => {
+  it('keeps metrics and ServiceMonitor rendering disabled by default', () => {
+    expect(values.metrics.enabled).toBe(false);
+    expect(values.metrics.path).toBe('/metrics');
+    expect(values.metrics.auth).toMatchObject({ existingSecret: '', secretKey: 'token' });
+    expect(values.serviceMonitor.enabled).toBe(false);
+    expect(values.serviceMonitor.interval).toBe('30s');
+    expect(values.serviceMonitor.scrapeTimeout).toBe('10s');
+  });
+
+  it('documents the Sugarkube kube-prometheus-stack release label without embedding token values', () => {
+    expect(values.serviceMonitor.additionalLabels).toMatchObject({
+      release: 'kube-prometheus-stack',
+    });
+    expect(valuesYaml).not.toMatch(/METRICS_TOKEN:\s*[^\s{]/);
+  });
+
+  it('injects METRICS_TOKEN only from an existing Secret key reference', () => {
+    expect(deploymentTemplate).toContain('if and .Values.metrics.enabled .Values.metrics.auth.existingSecret');
+    expect(deploymentTemplate).toContain('name: METRICS_TOKEN');
+    expect(deploymentTemplate).toContain('secretKeyRef:');
+    expect(deploymentTemplate).toContain('name: {{ .Values.metrics.auth.existingSecret | quote }}');
+    expect(deploymentTemplate).toContain('key: {{ .Values.metrics.auth.secretKey | quote }}');
+  });
+
+  it('renders exactly one ServiceMonitor template gated by explicit metrics and ServiceMonitor enablement', () => {
+    expect(serviceMonitorTemplate).toMatch(/if and \.Values\.metrics\.enabled \.Values\.serviceMonitor\.enabled/);
+    expect(serviceMonitorTemplate.match(/kind: ServiceMonitor/g)).toHaveLength(1);
+  });
+
+  it('selects only the DSPACE Service for the release and uses supported authorization credentials', () => {
+    expect(serviceMonitorTemplate).toContain('matchLabels:');
+    expect(serviceMonitorTemplate).toContain('include "dspace.selectorLabels"');
+    expect(serviceMonitorTemplate).toContain('port: http');
+    expect(serviceMonitorTemplate).toContain('path: {{ .Values.metrics.path | quote }}');
+    expect(serviceMonitorTemplate).toContain('authorization:');
+    expect(serviceMonitorTemplate).toContain('type: Bearer');
+    expect(serviceMonitorTemplate).toContain('credentials:');
+  });
+
+  it('preserves bounded target metadata and does not define a public metrics ingress', () => {
+    for (const label of ['app', 'namespace', 'environment', 'release', 'cluster']) {
+      expect(serviceMonitorTemplate).toContain(`targetLabel: ${label}`);
+    }
+    expect(ingressTemplate).not.toMatch(/metrics|ServiceMonitor|Prometheus|Grafana/i);
+  });
+
+  it('extends the values schema for metrics and ServiceMonitor values', () => {
+    expect(JSON.stringify(schema)).toContain('serviceMonitor');
+    expect(JSON.stringify(schema)).toContain('existingSecret');
+    expect(JSON.stringify(schema)).toContain('additionalLabels');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a secure, canonical Prometheus scrape contract in `charts/dspace` so the GHCR-packaged chart owns staging/production scrape wiring instead of the legacy `deploy/charts/dspace` tree. 
- Ensure `/metrics` remains protected (no token values checked into the chart) while allowing Prometheus Operator scraping via a Secret-backed bearer token that matches the pinned Sugarkube `kube-prometheus-stack` CRD. 
- Keep safe defaults (metrics disabled, no extra Prometheus/Grafana or public metrics ingress) and preserve bounded app/environment/release/cluster metadata for target labeling.

### Description
- Added structured values and schema: `charts/dspace/values.schema.json` and extended `charts/dspace/values.yaml` with `metrics` and `serviceMonitor` sections (defaults: `metrics.enabled=false`, `metrics.path=/metrics`, `metrics.auth.existingSecret=""`, `metrics.auth.secretKey=token`, `serviceMonitor.enabled=false`, `serviceMonitor.interval=30s`, `serviceMonitor.scrapeTimeout=10s`, `serviceMonitor.additionalLabels.release=kube-prometheus-stack`).
- Inject `METRICS_TOKEN` into the container only when `metrics.enabled` and `metrics.auth.existingSecret` are set using a `secretKeyRef` in `templates/deployment.yaml`, so no token values appear in chart sources. 
- Add a gated `templates/servicemonitor.yaml` that renders exactly one `monitoring.coreos.com/v1` `ServiceMonitor` only when both `metrics.enabled` and `serviceMonitor.enabled` are true; the `ServiceMonitor` selects the release Service, scrapes the named `http` port at `/metrics`, uses Prometheus Operator `authorization.credentials` bearer-token wiring when an existing Secret is referenced, and preserves bounded labels via `targetLabels`/relabelings. 
- Add service labels for `dspace.io/environment` and `dspace.io/cluster`, update docs (`docs/charts.md`, `docs/config.md`, `docs/design/observability-v3.1.md`) with local and Sugarkube examples (fake Secret names only), and add contract tests at `tests/helmChartMetricsContract.test.ts` to verify defaults, rendering, selectors, Secret references, and absence of a public metrics ingress.

### Testing
- Unit/tests: Ran focused vitest tests with `npx vitest run --config vitest.config.mts tests/helmChartMetricsContract.test.ts tests/chartResourcesDefaults.test.ts` and the broader root test set via `npm run test:root`; all executed tests passed. 
- Helm lint/template: Ran `helm lint charts/dspace` (passed), `helm template dspace charts/dspace --namespace dspace-local` (metrics disabled renders no ServiceMonitor), and `helm template dspace charts/dspace --namespace dspace-staging --set environment=staging --set cluster=sugarkube-staging --set metrics.enabled=true --set metrics.auth.existingSecret=dspace-staging-metrics-token --set metrics.auth.secretKey=token --set serviceMonitor.enabled=true --set serviceMonitor.additionalLabels.release=kube-prometheus-stack` which rendered exactly one `ServiceMonitor` named `dspace` and the expected secretKeyRef and authorization fields. 
- CRD validation: Extracted the Prometheus Operator `ServiceMonitor` CRD from the pinned `kube-prometheus-stack` release and validated the rendered manifest with `kubeconform -strict -summary ... /tmp/dspace-enabled.yaml`, which succeeded. 
- Notes: `git diff | ./scripts/scan-secrets.py` raised false positives for placeholder `existingSecret` keys and the example fake Secret name; manual inspection confirms no token values were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f8bcea3c832f9807998c4878cbac)