### PR TITLE
Add canonical Helm metrics scrape contract

### DIFF
--- a/charts/dspace/templates/deployment.yaml
+++ b/charts/dspace/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
               value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
             - name: DSPACE_ENV
               value: {{ .Values.environment | default "production" | quote }}
+          {{- if and .Values.metrics.enabled .Values.metrics.auth.existingSecret }}
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.metrics.auth.existingSecret | quote }}
+                  key: {{ .Values.metrics.auth.secretKey | quote }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/charts/dspace/templates/servicemonitor.yaml
+++ b/charts/dspace/templates/servicemonitor.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.serviceMonitor.enabled .Values.metrics.enabled }}
+{{- $metricsSecret := .Values.metrics.auth.existingSecret | default "" -}}
+{{- if not $metricsSecret -}}
+{{- fail "metrics.auth.existingSecret is required when serviceMonitor.enabled and metrics.enabled are true" -}}
+{{- end -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dspace.fullname" . }}
+  labels:
+    {{- include "dspace.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dspace.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    {{- range .Values.serviceMonitor.targetLabels }}
+    {{- if and (ne . "app.kubernetes.io/name") (ne . "app.kubernetes.io/instance") }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- end }}
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      scheme: http
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ $metricsSecret | quote }}
+          key: {{ .Values.metrics.auth.secretKey | quote }}
+      relabelings:
+        - targetLabel: app
+          replacement: {{ include "dspace.name" . | quote }}
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - targetLabel: environment
+          replacement: {{ .Values.environment | default "production" | quote }}
+        - targetLabel: release
+          replacement: {{ .Release.Name | quote }}
+        - targetLabel: cluster
+          replacement: {{ .Values.serviceMonitor.cluster | default "sugarkube" | quote }}
+        {{- with .Values.serviceMonitor.relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/dspace/values.schema.json
+++ b/charts/dspace/values.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string", "pattern": "^/" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "existingSecret": { "type": "string" },
+            "secretKey": { "type": "string", "minLength": 1 }
+          },
+          "required": ["existingSecret", "secretKey"]
+        }
+      },
+      "required": ["enabled", "path", "auth"]
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "scrapeTimeout": { "type": "string", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "additionalLabels": {
+          "type": "object",
+          "additionalProperties": { "type": ["string", "number", "boolean"] }
+        },
+        "cluster": { "type": "string" },
+        "targetLabels": { "type": "array", "items": { "type": "string" } },
+        "relabelings": { "type": "array", "items": { "type": "object" } },
+        "metricRelabelings": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": [
+        "enabled",
+        "interval",
+        "scrapeTimeout",
+        "additionalLabels",
+        "cluster",
+        "targetLabels",
+        "relabelings",
+        "metricRelabelings"
+      ]
+    }
+  }
+}

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 image:
   repository: ghcr.io/democratizedspace/dspace
@@ -15,16 +15,16 @@ service:
 ingress:
   enabled: false
   className: traefik
-  host: ""
+  host: ''
   annotations: {}
   tls:
     enabled: false
-    secretName: ""
+    secretName: ''
 
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
+  name: ''
   automountServiceAccountToken: false
 
 podSecurityContext:
@@ -61,9 +61,29 @@ environment: production
 
 env: []
 
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ''
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+  relabelings: []
+  metricRelabelings: []
+
 resources:
   limits:
-    cpu: "1"
+    cpu: '1'
     memory: 1536Mi
   requests:
     cpu: 500m

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -1,12 +1,11 @@
 # DSPACE Helm chart
 
 The `charts/dspace` Helm chart deploys the DSPACE application with sensible defaults for
-Traefik-based ingress, HTTP health checks, and optional configuration via ConfigMaps or Secrets.
-It is a lightweight chart intended for direct Helm usage; Flux-managed environments continue to
-use the existing production chart at `deploy/charts/dspace/`, which includes additional features
-like network policies, metrics, and production ingress/TLS automation. The chart uses the
-application container port `8080` by default, matching the `Dockerfile` `EXPOSE` and health check
-settings.
+Traefik-based ingress, HTTP health checks, optional configuration via ConfigMaps or Secrets, and an
+explicit opt-in Prometheus scrape contract. This chart is the canonical GHCR/Sugarkube chart path;
+do not rely on `deploy/charts/dspace/` for release scrape behavior unless release automation is
+intentionally migrated. The chart uses the application container port `8080` by default, matching
+the `Dockerfile` `EXPOSE` and health check settings.
 
 ## Key values
 
@@ -17,6 +16,21 @@ settings.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
+- `metrics.enabled`: Enable the application `/metrics` endpoint contract. Defaults to `false`.
+- `metrics.path`: Metrics scrape path. Defaults to `/metrics`.
+- `metrics.auth.existingSecret`: Existing Secret name used for the bearer credential. Empty by
+  default, so the default render does not require a Secret.
+- `metrics.auth.secretKey`: Secret key read for `METRICS_TOKEN` and Prometheus bearer
+  authorization. Defaults to `token`.
+- `serviceMonitor.enabled`: Render one Prometheus Operator `ServiceMonitor` only when explicitly
+  enabled. Defaults to `false`.
+- `serviceMonitor.interval` / `serviceMonitor.scrapeTimeout`: Defaults to `30s` and `10s`. Keep
+  the timeout below the interval.
+- `serviceMonitor.additionalLabels`: Labels for Prometheus discovery. The Sugarkube-compatible
+  default is `release: kube-prometheus-stack`.
+- `serviceMonitor.cluster`, `serviceMonitor.targetLabels`, `serviceMonitor.relabelings`, and
+  `serviceMonitor.metricRelabelings`: Bounded metadata hooks for cluster, app, namespace,
+  environment, release, and any future operator-approved relabeling.
 - `ingress.enabled`: Enable Traefik ingress. Defaults to `false`.
 - `ingress.host`: Hostname routed to the service. Required when ingress is enabled.
 - `ingress.className`: Ingress class name. Defaults to `traefik`.
@@ -26,7 +40,7 @@ settings.
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
   `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-  RuntimeDefault`.
+RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for
@@ -49,6 +63,45 @@ Lint the chart and render the manifests with development values:
 npm run helm:lint
 npm run helm:template
 ```
+
+## Metrics scrape modes
+
+Default/local rendering keeps metrics disabled and does not require a metrics Secret:
+
+```bash
+helm template dspace charts/dspace -f docs/examples/dspace.values.local-disabled.yaml
+```
+
+Sugarkube staging can opt into the authenticated scrape contract with a pre-created Secret:
+
+```bash
+helm template dspace charts/dspace -f docs/examples/dspace.values.sugarkube-staging-metrics.yaml
+```
+
+When both `metrics.enabled` and `metrics.auth.existingSecret` are set, the Deployment injects
+`METRICS_TOKEN` from `secretKeyRef`. When `serviceMonitor.enabled` is also set, the chart renders
+exactly one `ServiceMonitor` that selects the current DSPACE Service by Helm release labels, scrapes
+the named `http` port at `metrics.path`, and wires the same Secret through the Prometheus Operator
+`authorization.credentials` bearer-token fields used by kube-prometheus-stack 58.2.0. The public
+Ingress still routes the normal application prefix only; it does not create a Prometheus, Grafana,
+separate metrics ingress, or unauthenticated metrics bypass. Because the application Prefix ingress
+can reach `/metrics`, keep application-side token authentication enabled for staging and production.
+
+Internal success check after deploying staging values:
+
+```bash
+kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up%7Bapp%3D%22dspace%22%2Cenvironment%3D%22staging%22%7D'
+```
+
+Public denial check from outside the cluster:
+
+```bash
+curl -i https://dspace-staging.example.com/metrics
+```
+
+The public check must return `401` or another deliberate denial unless a request supplies the
+approved bearer credential through trusted operational tooling.
 
 ## Install example
 

--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -27,7 +27,7 @@ smallest useful v3.1.0 release slice.
 | Metric implementation         | `frontend/src/utils/metrics.js` initializes the shared `prom-client` registry, default process metrics, DSPACE HTTP metrics, dChat metrics, dependency metrics, build info, and instrumentation health. | Implemented source behavior; live evidence pending. | Application source emits the canonical privacy-safe metric families. Staging/prod scrape behavior, chart wiring, dashboards, and alerts still need evidence.    |
 | Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                                                                                   | Legacy/local scaffold.                              | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
 | Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                                                                              | Implemented v3.0.1 path.                            | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
-| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.                                                                     | Missing.                                            | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
+| Canonical chart scrape config | `charts/dspace` has Service, Deployment, probes, opt-in metrics values, Secret-backed `METRICS_TOKEN` wiring, and an authenticated ServiceMonitor contract.                                             | Implemented source behavior; live evidence pending. | v3.1.0 still needs rendered staging/prod evidence and Prometheus target verification before promotion.                                                          |
 | Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow.                                                       | Partial legacy/experimental duplicate.              | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
 | Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                                                                           | Legacy/partial.                                     | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
 
@@ -59,15 +59,15 @@ Every requirement below is classified as one of:
 
 - [ ] Staging and production expose a Prometheus-compatible DSPACE endpoint for in-cluster
       scraping.
-- [ ] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
-- [ ] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
+- [x] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
+- [x] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
       with Sugarkube's Prometheus operator labels.
 - [ ] Discovery labels include the Sugarkube-compatible monitoring release label selected by the
       cluster operator, plus stable app labels for `app=dspace`, namespace, environment, cluster,
       and Helm release identity through metric labels or Prometheus relabeling.
 - [ ] Authentication and network behavior allow Prometheus in the cluster to scrape metrics without
       exposing a privileged metrics surface publicly.
-- [ ] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
+- [x] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
       includes tested bearer-token Secret wiring; if a cluster-only metrics service or NetworkPolicy
       is used instead, public ingress must not route to `/metrics`.
 - [x] Application source exposes release/build identity with bounded labels:

--- a/docs/examples/dspace.values.local-disabled.yaml
+++ b/docs/examples/dspace.values.local-disabled.yaml
@@ -1,0 +1,6 @@
+# Local/default observability mode: no ServiceMonitor and no metrics Secret required.
+metrics:
+  enabled: false
+
+serviceMonitor:
+  enabled: false

--- a/docs/examples/dspace.values.sugarkube-staging-metrics.yaml
+++ b/docs/examples/dspace.values.sugarkube-staging-metrics.yaml
@@ -1,0 +1,18 @@
+# Sugarkube staging scrape mode. The Secret must be created out-of-band in the
+# DSPACE namespace; this file intentionally contains only a fake Secret name.
+environment: staging
+
+metrics:
+  enabled: true
+  path: /metrics
+  auth:
+    existingSecret: dspace-staging-metrics-auth
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube-staging

--- a/tests/helmChartMetrics.test.ts
+++ b/tests/helmChartMetrics.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const read = (path: string) => readFileSync(join(repoRoot, path), 'utf8');
+
+describe('canonical dspace helm metrics contract', () => {
+  const values = YAML.parse(read('charts/dspace/values.yaml'));
+  const deployment = read('charts/dspace/templates/deployment.yaml');
+  const serviceMonitor = read('charts/dspace/templates/servicemonitor.yaml');
+  const ingress = read('charts/dspace/templates/ingress.yaml');
+  const workflow = read('.github/workflows/ci-helm.yml');
+
+  it('keeps default metrics and ServiceMonitor rendering disabled', () => {
+    expect(values.metrics.enabled).toBe(false);
+    expect(values.metrics.path).toBe('/metrics');
+    expect(values.metrics.auth.existingSecret).toBe('');
+    expect(values.metrics.auth.secretKey).toBe('token');
+    expect(values.serviceMonitor.enabled).toBe(false);
+  });
+
+  it('uses a scrape timeout below the default interval', () => {
+    expect(values.serviceMonitor.interval).toBe('30s');
+    expect(values.serviceMonitor.scrapeTimeout).toBe('10s');
+  });
+
+  it('injects METRICS_TOKEN only from an existing Secret reference', () => {
+    expect(deployment).toContain('name: METRICS_TOKEN');
+    expect(deployment).toContain('secretKeyRef:');
+    expect(deployment).toContain(
+      'name: {{ .Values.metrics.auth.existingSecret | quote }}'
+    );
+    expect(deployment).toContain(
+      'key: {{ .Values.metrics.auth.secretKey | quote }}'
+    );
+  });
+
+  it('renders one ServiceMonitor gated by explicit metrics and ServiceMonitor enablement', () => {
+    expect(serviceMonitor).toContain(
+      'if and .Values.serviceMonitor.enabled .Values.metrics.enabled'
+    );
+    expect(serviceMonitor.match(/kind: ServiceMonitor/g)).toHaveLength(1);
+    expect(serviceMonitor).toContain(
+      'fail "metrics.auth.existingSecret is required'
+    );
+  });
+
+  it('selects only the DSPACE Service for the Helm release', () => {
+    expect(serviceMonitor).toContain('selector:');
+    expect(serviceMonitor).toContain('matchLabels:');
+    expect(serviceMonitor).toContain('include "dspace.selectorLabels"');
+    expect(serviceMonitor).toContain('matchNames:');
+    expect(serviceMonitor).toContain('{{ .Release.Namespace }}');
+  });
+
+  it('scrapes the named application port and metrics path with bearer authorization', () => {
+    expect(serviceMonitor).toContain('port: http');
+    expect(serviceMonitor).toContain(
+      'path: {{ .Values.metrics.path | quote }}'
+    );
+    expect(serviceMonitor).toContain('authorization:');
+    expect(serviceMonitor).toContain('type: Bearer');
+    expect(serviceMonitor).toContain('credentials:');
+  });
+
+  it('preserves bounded discovery labels and target metadata hooks', () => {
+    expect(values.serviceMonitor.additionalLabels.release).toBe(
+      'kube-prometheus-stack'
+    );
+    for (const label of [
+      'app',
+      'namespace',
+      'environment',
+      'release',
+      'cluster',
+    ]) {
+      expect(serviceMonitor).toContain(`targetLabel: ${label}`);
+    }
+    expect(serviceMonitor).toContain('targetLabels:');
+    expect(serviceMonitor).toContain('relabelings:');
+  });
+
+  it('does not add a public metrics ingress or observability UI exposure', () => {
+    expect(ingress).not.toMatch(/metrics|prometheus|grafana/i);
+    expect(serviceMonitor).not.toMatch(/kind: Ingress/);
+  });
+
+  it('keeps canonical chart publishing pointed at charts/dspace', () => {
+    expect(workflow).toContain('helm package charts/dspace');
+    expect(workflow).toContain('helm lint charts/dspace');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a canonical, secure Prometheus scrape contract in the packaged `charts/dspace` chart so Sugarkube/staging can opt into authenticated scraping without relying on `deploy/charts/dspace`.
- Ensure metrics are opt-in and safe by default, require operator-provided Secrets for authentication, and avoid exposing unauthenticated metrics via public ingress.
- Preserve bounded metadata (app, environment, namespace, release, cluster) for Prometheus target labels and give operators explicit relabeling hooks.

### Description
- Add opt-in `metrics` and `serviceMonitor` values to `charts/dspace/values.yaml` with safe defaults: `metrics.enabled: false`, `metrics.path: /metrics`, `metrics.auth.existingSecret: ""`, `metrics.auth.secretKey: token`, `serviceMonitor.enabled: false`, `serviceMonitor.interval: 30s`, and `serviceMonitor.scrapeTimeout: 10s`.
- Add `charts/dspace/values.schema.json` to validate the new `metrics` and `serviceMonitor` keys.
- Update `charts/dspace/templates/deployment.yaml` to inject `METRICS_TOKEN` into the container via a `secretKeyRef` only when `metrics.enabled` and `metrics.auth.existingSecret` are set.
- Add `charts/dspace/templates/servicemonitor.yaml` which is rendered only when both `serviceMonitor.enabled` and `metrics.enabled` are true, selects the DSPACE Service by release selector, scrapes the named `http` port at `metrics.path`, and wires bearer-token authorization using Prometheus Operator `authorization.credentials` (Secret name/key), while preserving bounded discovery/relabeling metadata and operator-extensible relabeling hooks.
- Update docs in `docs/charts.md` and `docs/design/observability-v3.1.md`, and add example values in `docs/examples/dspace.values.local-disabled.yaml` (local disabled) and `docs/examples/dspace.values.sugarkube-staging-metrics.yaml` (Sugarkube staging example with a fake Secret name only).
- Add chart contract tests `tests/helmChartMetrics.test.ts` to assert disabled defaults, timeout ordering, Secret-based injection, ServiceMonitor gating, selector correctness, bearer credentials wiring, and absence of a public metrics Ingress.
- No credential values were added to the repo; templates reference Secret names/keys only and do not contain token values.

### Testing
- Ran the focused test suite: `npm run test:root -- tests/helmChartMetrics.test.ts tests/configConsistency.test.ts tests/helmChartReleaseVersion.test.ts`, and all tests passed (46 tests total across those files).
- Ran linting with `npm run lint` which completed successfully.
- Ran chart checks: `helm lint charts/dspace` succeeded and `helm template dspace charts/dspace -f docs/examples/dspace.values.local-disabled.yaml` rendered no `ServiceMonitor`, while `helm template dspace charts/dspace -f docs/examples/dspace.values.sugarkube-staging-metrics.yaml` rendered exactly one `ServiceMonitor` (rendered resources include `ServiceAccount/dspace`, `Service/dspace`, `Deployment/dspace`, `ServiceMonitor/dspace`).
- Validated the rendered ServiceMonitor YAML with `kubeconform -summary -strict -ignore-missing-schemas /tmp/dspace-enabled.yaml` which reported resources Valid and no Invalid resources.
- Attempted full suite `SKIP_E2E=1 npm test` but the long root run was interrupted during the comprehensive run; focused tests + lint + helm/template + kubeconform cover the chart contract and passed.

Files changed (high level): `charts/dspace/values.yaml`, `charts/dspace/values.schema.json` (new), `charts/dspace/templates/deployment.yaml`, `charts/dspace/templates/servicemonitor.yaml` (new), `docs/charts.md`, `docs/design/observability-v3.1.md`, `docs/examples/*` (new), and `tests/helmChartMetrics.test.ts` (new).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f8c6f0dc832f9ae063ec2646a99d)