### PR TITLE
feat(charts): add secure, opt-in Prometheus ServiceMonitor & metrics contract

### DIFF
--- a/charts/dspace/templates/deployment.yaml
+++ b/charts/dspace/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
               value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
             - name: DSPACE_ENV
               value: {{ .Values.environment | default "production" | quote }}
+          {{- if and .Values.metrics.enabled .Values.metrics.auth.existingSecret }}
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.metrics.auth.existingSecret | quote }}
+                  key: {{ .Values.metrics.auth.secretKey | quote }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/charts/dspace/templates/servicemonitor.yaml
+++ b/charts/dspace/templates/servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.serviceMonitor.enabled .Values.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dspace.fullname" . }}
+  labels:
+    {{- include "dspace.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dspace.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/version
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      scheme: http
+      {{- if .Values.metrics.auth.existingSecret }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ .Values.metrics.auth.existingSecret | quote }}
+          key: {{ .Values.metrics.auth.secretKey | quote }}
+      {{- end }}
+      relabelings:
+        - targetLabel: app
+          replacement: {{ include "dspace.name" . | quote }}
+        - targetLabel: environment
+          replacement: {{ .Values.environment | default "production" | quote }}
+        - targetLabel: namespace
+          replacement: {{ .Release.Namespace | quote }}
+        - targetLabel: release
+          replacement: {{ .Release.Name | quote }}
+        {{- if .Values.serviceMonitor.cluster }}
+        - targetLabel: cluster
+          replacement: {{ .Values.serviceMonitor.cluster | quote }}
+        {{- end }}
+        {{- with .Values.serviceMonitor.relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/dspace/values.schema.json
+++ b/charts/dspace/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string", "pattern": "^/.*" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "existingSecret": { "type": "string" },
+            "secretKey": { "type": "string", "minLength": 1 }
+          },
+          "required": ["existingSecret", "secretKey"]
+        }
+      },
+      "required": ["enabled", "path", "auth"]
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "scrapeTimeout": { "type": "string", "pattern": "^[0-9]+(ms|s|m|h)$" },
+        "additionalLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "cluster": { "type": "string" },
+        "relabelings": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": [
+        "enabled",
+        "interval",
+        "scrapeTimeout",
+        "additionalLabels",
+        "relabelings"
+      ]
+    }
+  }
+}

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -12,6 +12,22 @@ service:
   type: ClusterIP
   port: 8080
 
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ""
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: ""
+  relabelings: []
+
 ingress:
   enabled: false
   className: traefik

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -2,11 +2,10 @@
 
 The `charts/dspace` Helm chart deploys the DSPACE application with sensible defaults for
 Traefik-based ingress, HTTP health checks, and optional configuration via ConfigMaps or Secrets.
-It is a lightweight chart intended for direct Helm usage; Flux-managed environments continue to
-use the existing production chart at `deploy/charts/dspace/`, which includes additional features
-like network policies, metrics, and production ingress/TLS automation. The chart uses the
-application container port `8080` by default, matching the `Dockerfile` `EXPOSE` and health check
-settings.
+It is the canonical chart packaged by the GHCR Helm publishing workflow for direct Helm and
+Sugarkube usage; do not rely on the duplicate `deploy/charts/dspace/` tree for canonical release
+evidence. The chart uses the application container port `8080` by default, matching the
+`Dockerfile` `EXPOSE` and health check settings.
 
 ## Key values
 
@@ -26,7 +25,7 @@ settings.
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
   `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-  RuntimeDefault`.
+RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for
@@ -37,6 +36,12 @@ settings.
   (liveness) and `/healthz` (readiness) respectively.
 - `probes.liveness` / `probes.readiness`: Probe timing defaults (`initialDelaySeconds`,
   `periodSeconds`, `timeoutSeconds`, `failureThreshold`).
+- `metrics.enabled`: Enable the application `/metrics` endpoint guard wiring. Defaults to `false`.
+- `metrics.auth.existingSecret` / `metrics.auth.secretKey`: Existing Secret reference used to
+  inject `METRICS_TOKEN`; no token value belongs in chart values.
+- `serviceMonitor.enabled`: Render one Prometheus Operator `ServiceMonitor`. Defaults to `false`.
+- `serviceMonitor.additionalLabels`: Extra labels for discovery, defaulting to
+  `release: kube-prometheus-stack`.
 
 For development, `charts/dspace/values.dev.yaml` enables ingress and sets a placeholder host:
 `dspace-v3.example.dev`. Override this host for your own environment.
@@ -86,3 +91,59 @@ When installing from the OCI registry, you will not have access to
 `charts/dspace/values.dev.yaml` unless you clone the repository. To customize values, either
 provide your own file with `-f <your-values.yaml>` or use `--set` flags as shown above.
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
+
+## Metrics and Prometheus ServiceMonitor
+
+The canonical chart keeps the metrics scrape contract disabled by default so local installs and
+existing releases do not need a metrics Secret:
+
+```yaml
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ''
+    secretKey: token
+serviceMonitor:
+  enabled: false
+```
+
+For Sugarkube staging, create a Kubernetes Secret out of band and reference only its fake example
+name from values. Do not place the token value in Helm values, rendered templates, docs, or logs.
+The ServiceMonitor uses Prometheus Operator `authorization.credentials` Secret wiring, labels the
+resource for kube-prometheus-stack discovery, selects only the DSPACE Service from this Helm
+release, and scrapes the named `http` application port at `/metrics`:
+
+```yaml
+metrics:
+  enabled: true
+  path: /metrics
+  auth:
+    existingSecret: dspace-metrics-token-example
+    secretKey: token
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube-staging
+  relabelings: []
+```
+
+The chart does not create Prometheus, Grafana, a metrics Ingress, or a separate metrics Service.
+If the public Prefix ingress can reach `/metrics`, the application-side `METRICS_TOKEN` guard is
+still required. Prometheus can scrape with the Secret while unauthenticated public requests should
+receive `401` or another deliberate denial.
+
+Verification examples:
+
+```bash
+# Internal success from a trusted operator shell; keep the token out of command history when possible.
+METRICS_TOKEN="$(kubectl -n dspace get secret dspace-metrics-token-example -o jsonpath='{.data.token}' | base64 -d)"
+kubectl -n dspace run dspace-metrics-check --rm -i --restart=Never --image=curlimages/curl:8.10.1 -- \
+  curl -fsS -H "Authorization: Bearer ${METRICS_TOKEN}" http://dspace:8080/metrics
+
+# Public denial through the normal public ingress.
+curl -i https://dspace-staging.example.com/metrics
+```

--- a/docs/design/observability-v3.1.md
+++ b/docs/design/observability-v3.1.md
@@ -27,7 +27,7 @@ smallest useful v3.1.0 release slice.
 | Metric implementation         | `frontend/src/utils/metrics.js` initializes the shared `prom-client` registry, default process metrics, DSPACE HTTP metrics, dChat metrics, dependency metrics, build info, and instrumentation health. | Implemented source behavior; live evidence pending. | Application source emits the canonical privacy-safe metric families. Staging/prod scrape behavior, chart wiring, dashboards, and alerts still need evidence.    |
 | Local monitoring scaffold     | `infra/monitoring/` contains local Prometheus, Grafana dashboard, and alert examples.                                                                                                                   | Legacy/local scaffold.                              | Useful as reference only; not the canonical Sugarkube release gate. Metric names and thresholds are not sufficient for v3.1.0.                                  |
 | Canonical GHCR chart          | `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` to `oci://ghcr.io/democratizedspace/charts/dspace`.                                                                              | Implemented v3.0.1 path.                            | `charts/dspace` is the canonical chart path for the current GHCR/Sugarkube release path.                                                                        |
-| Canonical chart scrape config | `charts/dspace` has Service, Deployment, and probes, but no ServiceMonitor, metrics service port, PrometheusRule, or scrape values.                                                                     | Missing.                                            | v3.1.0 blocker: add or otherwise identify the canonical scrape configuration before promotion.                                                                  |
+| Canonical chart scrape config | `charts/dspace` has Service, Deployment, probes, disabled-by-default metrics values, existing-Secret `METRICS_TOKEN` wiring, and an opt-in ServiceMonitor.                                              | Implemented chart contract; live evidence pending.  | ServiceMonitor rendering is explicit and uses Prometheus Operator `authorization.credentials` Secret wiring for token-authenticated scrapes.                    |
 | Duplicate chart tree          | `deploy/charts/dspace` contains ServiceMonitor, PrometheusRule, NetworkPolicy, and metrics values, but is not packaged by the GHCR Helm workflow.                                                       | Partial legacy/experimental duplicate.              | Do not update both chart trees blindly. Either migrate the needed scrape contract into `charts/dspace` or explicitly retarget release automation before v3.1.0. |
 | Environment values            | `deploy/env/{dev,int,prod}/values.yaml` exist for the duplicate deploy chart.                                                                                                                           | Legacy/partial.                                     | Not canonical release evidence unless the release path changes and automation points at that chart.                                                             |
 
@@ -59,15 +59,15 @@ Every requirement below is classified as one of:
 
 - [ ] Staging and production expose a Prometheus-compatible DSPACE endpoint for in-cluster
       scraping.
-- [ ] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
-- [ ] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
+- [x] The canonical scrape configuration is in, or explicitly referenced by, `charts/dspace`.
+- [x] The canonical chart renders a ServiceMonitor or equivalent discovery mechanism compatible
       with Sugarkube's Prometheus operator labels.
 - [ ] Discovery labels include the Sugarkube-compatible monitoring release label selected by the
       cluster operator, plus stable app labels for `app=dspace`, namespace, environment, cluster,
       and Helm release identity through metric labels or Prometheus relabeling.
 - [ ] Authentication and network behavior allow Prometheus in the cluster to scrape metrics without
       exposing a privileged metrics surface publicly.
-- [ ] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
+- [x] If `METRICS_TOKEN` remains the endpoint guard, the ServiceMonitor or equivalent scrape config
       includes tested bearer-token Secret wiring; if a cluster-only metrics service or NetworkPolicy
       is used instead, public ingress must not route to `/metrics`.
 - [x] Application source exposes release/build identity with bounded labels:

--- a/tests/helmChartMetrics.test.ts
+++ b/tests/helmChartMetrics.test.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseAllDocuments } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const chartPath = join(repoRoot, 'charts', 'dspace');
+
+function helmAvailable() {
+  try {
+    execFileSync('helm', ['version', '--short'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function render(extraValues = '') {
+  if (!helmAvailable()) return [] as any[];
+  const args = ['template', 'dspace', chartPath, '--namespace', 'dspace'];
+  if (extraValues) {
+    const dir = mkdtempSync(join(tmpdir(), 'dspace-chart-'));
+    const file = join(dir, 'values.yaml');
+    writeFileSync(file, extraValues);
+    args.push('-f', file);
+  }
+  const output = execFileSync('helm', args, { encoding: 'utf8' });
+  return parseAllDocuments(output)
+    .map((doc) => doc.toJSON())
+    .filter(Boolean) as any[];
+}
+
+describe('canonical dspace Helm metrics scrape contract', () => {
+  it('declares safe disabled-by-default metrics and ServiceMonitor values', () => {
+    const values = readFileSync(join(chartPath, 'values.yaml'), 'utf8');
+    expect(values).toMatch(/metrics:\n\s+enabled: false\n\s+path: \/metrics/);
+    expect(values).toMatch(/auth:\n\s+existingSecret: ""\n\s+secretKey: token/);
+    expect(values).toMatch(
+      /serviceMonitor:\n\s+enabled: false\n\s+interval: 30s\n\s+scrapeTimeout: 10s/
+    );
+    expect(values).toMatch(
+      /additionalLabels:\n\s+release: kube-prometheus-stack/
+    );
+    expect(existsSync(join(chartPath, 'values.schema.json'))).toBe(true);
+  });
+
+  it('uses Prometheus Operator authorization Secret wiring and no inline token values', () => {
+    const serviceMonitor = readFileSync(
+      join(chartPath, 'templates', 'servicemonitor.yaml'),
+      'utf8'
+    );
+    expect(serviceMonitor).toContain('authorization:');
+    expect(serviceMonitor).toContain('credentials:');
+    expect(serviceMonitor).toContain(
+      'name: {{ .Values.metrics.auth.existingSecret | quote }}'
+    );
+    expect(serviceMonitor).toContain(
+      'key: {{ .Values.metrics.auth.secretKey | quote }}'
+    );
+    expect(serviceMonitor).not.toContain('bearerToken:');
+    expect(serviceMonitor).not.toContain('bearerTokenSecret:');
+  });
+
+  it('injects METRICS_TOKEN only from an existing SecretKeyRef', () => {
+    const deployment = readFileSync(
+      join(chartPath, 'templates', 'deployment.yaml'),
+      'utf8'
+    );
+    expect(deployment).toContain('METRICS_TOKEN');
+    expect(deployment).toContain('secretKeyRef:');
+    expect(deployment).toContain(
+      'name: {{ .Values.metrics.auth.existingSecret | quote }}'
+    );
+    expect(deployment).toContain(
+      'key: {{ .Values.metrics.auth.secretKey | quote }}'
+    );
+    expect(deployment).not.toMatch(/METRICS_TOKEN[\s\S]{0,120}value:/);
+  });
+
+  it('documents local disabled and Sugarkube staging examples plus verification commands', () => {
+    const docs = readFileSync(join(repoRoot, 'docs', 'charts.md'), 'utf8');
+    expect(docs).toContain('`metrics.enabled`:');
+    expect(docs).toContain('dspace-metrics-token-example');
+    expect(docs).toContain(
+      'curl -fsS -H "Authorization: Bearer ${METRICS_TOKEN}"'
+    );
+    expect(docs).toContain(
+      'curl -i https://dspace-staging.example.com/metrics'
+    );
+  });
+
+  it('renders exactly one secure ServiceMonitor and no metrics Ingress when enabled', () => {
+    const manifests = render(
+      `metrics:\n  enabled: true\n  auth:\n    existingSecret: dspace-metrics-token-example\nserviceMonitor:\n  enabled: true\n  cluster: sugarkube-staging\ningress:\n  enabled: true\n  host: dspace-staging.example.com\n`
+    );
+    if (manifests.length === 0) return;
+    const serviceMonitors = manifests.filter(
+      (manifest) => manifest.kind === 'ServiceMonitor'
+    );
+    expect(serviceMonitors).toHaveLength(1);
+    const serviceMonitor = serviceMonitors[0];
+    expect(serviceMonitor.metadata.labels.release).toBe(
+      'kube-prometheus-stack'
+    );
+    expect(serviceMonitor.spec.selector.matchLabels).toEqual({
+      'app.kubernetes.io/name': 'dspace',
+      'app.kubernetes.io/instance': 'dspace',
+    });
+    expect(serviceMonitor.spec.endpoints[0]).toMatchObject({
+      port: 'http',
+      path: '/metrics',
+      interval: '30s',
+      scrapeTimeout: '10s',
+      authorization: {
+        type: 'Bearer',
+        credentials: { name: 'dspace-metrics-token-example', key: 'token' },
+      },
+    });
+    const ingresses = manifests.filter(
+      (manifest) => manifest.kind === 'Ingress'
+    );
+    expect(ingresses).toHaveLength(1);
+    expect(ingresses[0].metadata.name).toBe('dspace');
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a canonical, secure Prometheus scrape contract in `charts/dspace` so Sugarkube/staging can discover DSPACE metrics without exposing them publicly.  
- Enforce token-based scraping using an existing Kubernetes Secret wired via `secretKeyRef` and Prometheus Operator `authorization.credentials` so no token values live in chart values, templates, docs, or logs.  
- Keep defaults safe and backward-compatible by disabling metrics and ServiceMonitor rendering unless explicitly enabled.

### Description

- Added opt-in values and safe defaults in `charts/dspace/values.yaml` for `metrics` (disabled, `path: /metrics`, `auth.existingSecret`, `auth.secretKey`) and `serviceMonitor` (disabled, `interval: 30s`, `scrapeTimeout: 10s`, `additionalLabels: { release: kube-prometheus-stack }`).
- Inject `METRICS_TOKEN` into the app container only when `metrics.enabled` is `true` and `metrics.auth.existingSecret` is set, using a `secretKeyRef` in `charts/dspace/templates/deployment.yaml`.  
- Render a Prometheus Operator `ServiceMonitor` only when `serviceMonitor.enabled` and `metrics.enabled` are true, selecting the release-scoped DSPACE `Service`, scraping the named application port at the configured metrics path, wiring bearer-token auth via `authorization.credentials` (Prometheus Operator secret wiring), and preserving bounded app/environment/namespace/release/cluster metadata via `targetLabels` and relabelings in `charts/dspace/templates/servicemonitor.yaml`.  
- Added `charts/dspace/values.schema.json` for validation, updated `docs/charts.md` and `docs/design/observability-v3.1.md` with examples and verification commands (local disabled, Sugarkube staging), and added `tests/helmChartMetrics.test.ts` to assert defaults, Secret wiring, selector/label correctness, and enabled rendering behavior.

### Testing

- Ran `helm lint charts/dspace` which passed.  
- Rendered templates with metrics disabled via `helm template dspace charts/dspace --namespace dspace` which produced no `ServiceMonitor`, and rendered with metrics+ServiceMonitor enabled via `helm template ... --set metrics.enabled=true --set metrics.auth.existingSecret=dspace-metrics-token-example --set serviceMonitor.enabled=true --set serviceMonitor.cluster=sugarkube-staging` which produced exactly one `ServiceMonitor`.  
- Validated rendered manifests with `kubeconform -strict -ignore-missing-schemas /tmp/dspace-enabled.yaml` which succeeded, and verified no token values appear in values/templates/docs output.  
- Ran chart contract tests with Vitest: `npx vitest run --config vitest.config.mts tests/helmChartMetrics.test.ts tests/chartResourcesDefaults.test.ts` and both tests passed.  
- Notes about full test run: `npm test -- --runInBand` was attempted but the full root unit test phase took too long in this environment and was interrupted; the focused helm/chart tests above completed successfully.

Files changed (high level): `charts/dspace/values.yaml`, `charts/dspace/values.schema.json`, `charts/dspace/templates/servicemonitor.yaml`, `charts/dspace/templates/deployment.yaml` (env injection), `docs/charts.md`, `docs/design/observability-v3.1.md`, and `tests/helmChartMetrics.test.ts`.

Residual notes: the Prometheus Operator `authorization.credentials` wiring was chosen for compatibility with the pinned kube-prometheus-stack; maintainers should confirm cluster Prometheus Operator versions if migrating the monitoring stack later. The change does not touch `deploy/charts/dspace` or CI publishing workflows, and the canonical `charts/dspace` packaging path remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f8d47964832f8d2e4690b896b46b)