### PR TITLE
ci: make semantic GHCR image tags release-only and immutable

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -494,15 +494,23 @@ jobs:
 
       - name: Resolve checked-out revision
         id: revision
+        # The release tag is attacker-influenceable (anyone who can publish a release
+        # controls it) and git ref names may contain shell metacharacters such as `"`,
+        # `` ` ``, `$()`, and `;`. Pass it through env and reference it as "$RELEASE_TAG"
+        # data — never interpolate ${{ github.event.release.tag_name }} directly into a
+        # run: script, since GitHub substitutes it into the script's source text before
+        # the shell parses it, which would let a crafted tag execute arbitrary commands.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           full_sha="$(git rev-parse HEAD)"
-          tag_sha="$(git rev-parse "${{ github.event.release.tag_name }}")"
+          tag_sha="$(git rev-parse "$RELEASE_TAG")"
           if [ -z "$full_sha" ]; then
             echo "git rev-parse HEAD returned nothing; refusing to publish." >&2
             exit 1
           fi
           if [ "$full_sha" != "$tag_sha" ]; then
-            echo "Checked-out HEAD ($full_sha) does not match tag ${{ github.event.release.tag_name }} ($tag_sha); refusing to publish." >&2
+            echo "Checked-out HEAD ($full_sha) does not match tag $RELEASE_TAG ($tag_sha); refusing to publish." >&2
             exit 1
           fi
           short_sha="${full_sha:0:7}"
@@ -542,6 +550,10 @@ jobs:
 
       - name: Validate release version coordinates
         id: version
+        # See the "Resolve checked-out revision" step above: pass the attacker-influenceable
+        # release tag through env, never interpolate it directly into this run: script.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           root_version="$(node -p "require('./package.json').version")"
           frontend_version="$(node -p "require('./frontend/package.json').version")"
@@ -552,8 +564,8 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ github.event.release.tag_name }}" != "$expected_tag" ]; then
-            echo "Release tag ${{ github.event.release.tag_name }} does not match expected semantic tag $expected_tag; refusing to publish." >&2
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match expected semantic tag $expected_tag; refusing to publish." >&2
             exit 1
           fi
 

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -632,9 +632,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push semantic release image (attempt 1)
-        id: build_push_1
-        continue-on-error: true
+      - name: Verify corresponding branch-SHA image exists
+        id: branch_sha_evidence
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: |
+          node scripts/ghcr-manifest.mjs describe \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
+
+      - name: Build and push semantic release image
+        id: build_push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -642,9 +652,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
-          tags: |
-            ${{ steps.tags.outputs.branch_sha_tag }}
-            ${{ steps.tags.outputs.semantic_tag }}
+          tags: ${{ steps.tags.outputs.semantic_tag }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ steps.revision.outputs.full_sha }}
@@ -656,38 +664,9 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha,scope=ci-image-semantic-release
           cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      - name: Build and push semantic release image (attempt 2)
-        id: build_push_2
-        if: steps.build_push_1.outcome == 'failure'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: |
-            ${{ steps.tags.outputs.branch_sha_tag }}
-            ${{ steps.tags.outputs.semantic_tag }}
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      - name: Fail if both semantic release pushes failed
-        if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
-        run: exit 1
 
       - name: Build image for SHA verification
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        if: steps.build_push.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -705,7 +684,7 @@ jobs:
           cache-from: type=gha,scope=ci-image-semantic-release
 
       - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        if: steps.build_push.outcome == 'success'
         run: |
           docker run --rm \
             -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
@@ -714,7 +693,7 @@ jobs:
             node /scripts/verify-build-sha.mjs /app/dist
 
       - name: Verify chat build stamp inside image
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        if: steps.build_push.outcome == 'success'
         run: |
           docker run --rm \
             -e VERIFY_REPO_ROOT=/app \
@@ -729,7 +708,7 @@ jobs:
       # writes index_digest/amd64_digest/arm64_digest to $GITHUB_OUTPUT without ever logging
       # the registry credentials used to fetch them.
       - name: Record semantic release evidence
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        if: steps.build_push.outcome == 'success'
         id: evidence
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
@@ -741,7 +720,7 @@ jobs:
             --tag "v${{ steps.version.outputs.version }}"
 
       - name: Summarize semantic release evidence
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        if: steps.build_push.outcome == 'success'
         run: |
           {
             echo "## DSPACE semantic release image"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - v3
       - main
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       branch:
@@ -29,6 +32,9 @@ jobs:
   local-build:
     name: Validate Docker build with host node_modules
     runs-on: ubuntu-latest
+    # Release publication gets its own build in the semantic-release job below; skip the
+    # redundant PR-style validate/smoke pass for release events.
+    if: github.event_name != 'release'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -261,7 +267,11 @@ jobs:
   image:
     name: Build and push image
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Ordinary branch-build publish path. Must never run for release events — that is the
+    # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
+    # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
+    # exclusively by the semantic-release job below.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       image-tag: ${{ steps.tags.outputs.sha_tag }}
     steps:
@@ -318,10 +328,8 @@ jobs:
           tag_prefix="${branch//\//-}"
           sha_tag="ghcr.io/democratizedspace/dspace:${tag_prefix}-${short_sha}"
           latest_tag="ghcr.io/democratizedspace/dspace:${tag_prefix}-latest"
-          version_tag="ghcr.io/democratizedspace/dspace:v${{ steps.version.outputs.version }}"
           echo "sha_tag=${sha_tag}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
-          echo "version_tag=${version_tag}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set image build version
@@ -369,7 +377,6 @@ jobs:
           tags: |
             ${{ steps.tags.outputs.sha_tag }}
             ${{ steps.tags.outputs.latest_tag }}
-            ${{ steps.tags.outputs.version_tag }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ github.sha }}
@@ -395,7 +402,6 @@ jobs:
           tags: |
             ${{ steps.tags.outputs.sha_tag }}
             ${{ steps.tags.outputs.latest_tag }}
-            ${{ steps.tags.outputs.version_tag }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ github.sha }}
@@ -451,7 +457,6 @@ jobs:
         run: |
           sha_tag="${{ steps.tags.outputs.sha_tag }}"
           latest_tag="${{ steps.tags.outputs.latest_tag }}"
-          version_tag="${{ steps.tags.outputs.version_tag }}"
           {
             echo "## DSPACE image tags"
             echo
@@ -461,10 +466,281 @@ jobs:
             echo "| --- | --- | --- |"
             echo "| Immutable image tag | \`${sha_tag##*:}\` | \`${sha_tag}\` |"
             echo "| Mutable branch convenience tag | \`${latest_tag##*:}\` | \`${latest_tag}\` |"
-            echo "| Version image tag | \`${version_tag##*:}\` | \`${version_tag}\` |"
             echo "| Short SHA | \`${{ steps.tags.outputs.short_sha }}\` | n/a |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if both image pushes failed
         if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
         run: exit 1
+
+  semantic-release:
+    name: Publish semantic release image tag
+    runs-on: ubuntu-latest
+    # Single canonical semantic-publication event for DSPACE #4727: a published GitHub
+    # release. Deliberately not also triggered by a `push: tags: v*` event — creating a
+    # release normally creates its tag too, so triggering on both would race and turn
+    # every ordinary release into an expected "tag already exists" failure. See
+    # outages/2026-07-23-dspace-production-version-drift.md and AGENTS.md.
+    if: github.event_name == 'release' && github.event.action == 'published'
+    concurrency:
+      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Resolve checked-out revision
+        id: revision
+        run: |
+          full_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-parse "${{ github.event.release.tag_name }}")"
+          if [ -z "$full_sha" ]; then
+            echo "git rev-parse HEAD returned nothing; refusing to publish." >&2
+            exit 1
+          fi
+          if [ "$full_sha" != "$tag_sha" ]; then
+            echo "Checked-out HEAD ($full_sha) does not match tag ${{ github.event.release.tag_name }} ($tag_sha); refusing to publish." >&2
+            exit 1
+          fi
+          short_sha="${full_sha:0:7}"
+          echo "full_sha=${full_sha}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve eligible source branch
+        id: branch
+        run: |
+          # Do not trust github.sha for this event (it can reflect the default branch, not
+          # the tagged commit). Everything downstream keys off steps.revision.outputs.full_sha
+          # (git rev-parse HEAD after checkout), not github.sha.
+          git fetch origin main v3 --quiet
+          full_sha="${{ steps.revision.outputs.full_sha }}"
+          matched="$(git branch -r --contains "$full_sha" | sed 's/^[* ]*//' | grep -E '^origin/(main|v3)$' | head -n1 | sed 's#^origin/##')"
+          if [ -z "$matched" ]; then
+            echo "Tagged commit $full_sha is not reachable from origin/main or origin/v3; refusing to publish." >&2
+            exit 1
+          fi
+          echo "branch=${matched}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+          run_install: false
+
+      - name: Verify pnpm is on PATH
+        run: |
+          command -v pnpm
+          pnpm --version
+
+      - name: Validate release version coordinates
+        id: version
+        run: |
+          root_version="$(node -p "require('./package.json').version")"
+          frontend_version="$(node -p "require('./frontend/package.json').version")"
+          expected_tag="v${root_version}"
+
+          if [ "$root_version" != "$frontend_version" ]; then
+            echo "Root package version ($root_version) does not match frontend package version ($frontend_version); refusing to publish." >&2
+            exit 1
+          fi
+
+          if [ "${{ github.event.release.tag_name }}" != "$expected_tag" ]; then
+            echo "Release tag ${{ github.event.release.tag_name }} does not match expected semantic tag $expected_tag; refusing to publish." >&2
+            exit 1
+          fi
+
+          echo "version=${root_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Build and verify chat build stamp
+        run: |
+          pnpm run build
+          pnpm run verify:chat-build-stamp
+
+      - name: Define image tags
+        id: tags
+        run: |
+          branch_sha_tag="ghcr.io/democratizedspace/dspace:${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
+          semantic_tag="ghcr.io/democratizedspace/dspace:v${{ steps.version.outputs.version }}"
+          echo "branch_sha_tag=${branch_sha_tag}" >> "$GITHUB_OUTPUT"
+          echo "semantic_tag=${semantic_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set image build version
+        id: build_version
+        run: |
+          build_version="v${{ steps.version.outputs.version }}+${{ steps.revision.outputs.short_sha }}"
+          echo "value=${build_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set image metadata
+        id: metadata
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "created=${created}" >> "$GITHUB_OUTPUT"
+          echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
+
+      # Fail-closed guard: only an authoritative "not found" result from GHCR permits
+      # publication. Auth, network, timeout, malformed-response, and any other status are
+      # treated as hard failures by scripts/ghcr-manifest.mjs. Running inside this job's
+      # tag-scoped concurrency group means the check happens only after this run has
+      # exclusive access to that group, so it cannot race a second publish attempt.
+      - name: Refuse to overwrite an existing semantic tag
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: |
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "v${{ steps.version.outputs.version }}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push semantic release image (attempt 1)
+        id: build_push_1
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ${{ steps.tags.outputs.branch_sha_tag }}
+            ${{ steps.tags.outputs.semantic_tag }}
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha,scope=ci-image-semantic-release
+          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
+
+      - name: Build and push semantic release image (attempt 2)
+        id: build_push_2
+        if: steps.build_push_1.outcome == 'failure'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ${{ steps.tags.outputs.branch_sha_tag }}
+            ${{ steps.tags.outputs.semantic_tag }}
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha,scope=ci-image-semantic-release
+          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
+
+      - name: Fail if both semantic release pushes failed
+        if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
+        run: exit 1
+
+      - name: Build image for SHA verification
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+          cache-from: type=gha,scope=ci-image-semantic-release
+
+      - name: Assert build SHA is baked into frontend bundle
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
+            -v "$PWD/scripts:/scripts:ro" \
+            dspace-verify:latest \
+            node /scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD/scripts:/scripts:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /scripts/verify-chat-build-stamp.mjs
+
+      # Records index + per-platform digests as evidence. 'present' is the expected outcome
+      # of this second registry call (the tag was just pushed above); scripts/ghcr-manifest.mjs
+      # writes index_digest/amd64_digest/arm64_digest to $GITHUB_OUTPUT without ever logging
+      # the registry credentials used to fetch them.
+      - name: Record semantic release evidence
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        id: evidence
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: |
+          node scripts/ghcr-manifest.mjs describe \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "v${{ steps.version.outputs.version }}"
+
+      - name: Summarize semantic release evidence
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        run: |
+          {
+            echo "## DSPACE semantic release image"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Semantic version | \`v${{ steps.version.outputs.version }}\` |"
+            echo "| Full Git SHA | \`${{ steps.revision.outputs.full_sha }}\` |"
+            echo "| Immutable branch-SHA tag | \`${{ steps.tags.outputs.branch_sha_tag }}\` |"
+            echo "| Semantic tag | \`${{ steps.tags.outputs.semantic_tag }}\` |"
+            echo "| Image index digest | \`${{ steps.evidence.outputs.index_digest }}\` |"
+            echo "| linux/amd64 digest | \`${{ steps.evidence.outputs.amd64_digest }}\` |"
+            echo "| linux/arm64 digest | \`${{ steps.evidence.outputs.arm64_digest }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -568,6 +568,14 @@ jobs:
             exit 1
           fi
 
+          # DSPACE release coordinates use the same strict X.Y.Z convention enforced by
+          # scripts/check-dspace-chart-version.sh. Validate before exposing package data as
+          # a step output so shell metacharacters and multiline values fail closed.
+          if [[ ! "$root_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Package version is not a supported semantic version; refusing to publish." >&2
+            exit 1
+          fi
+
           if [ "$RELEASE_TAG" != "$expected_tag" ]; then
             echo "Release tag $RELEASE_TAG does not match expected semantic tag $expected_tag; refusing to publish." >&2
             exit 1
@@ -585,16 +593,23 @@ jobs:
 
       - name: Define image tags
         id: tags
+        env:
+          SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
+          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          branch_sha_tag="ghcr.io/democratizedspace/dspace:${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
-          semantic_tag="ghcr.io/democratizedspace/dspace:v${{ steps.version.outputs.version }}"
+          branch_sha_tag="ghcr.io/democratizedspace/dspace:${SOURCE_BRANCH}-${SHORT_SHA}"
+          semantic_tag="ghcr.io/democratizedspace/dspace:v${RELEASE_VERSION}"
           echo "branch_sha_tag=${branch_sha_tag}" >> "$GITHUB_OUTPUT"
           echo "semantic_tag=${semantic_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Set image build version
         id: build_version
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
         run: |
-          build_version="v${{ steps.version.outputs.version }}+${{ steps.revision.outputs.short_sha }}"
+          build_version="v${RELEASE_VERSION}+${SHORT_SHA}"
           echo "value=${build_version}" >> "$GITHUB_OUTPUT"
 
       - name: Set image metadata
@@ -615,11 +630,12 @@ jobs:
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
           GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           node scripts/ghcr-manifest.mjs check-absent \
             --owner democratizedspace \
             --repo dspace \
-            --tag "v${{ steps.version.outputs.version }}"
+            --tag "v${RELEASE_VERSION}"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -718,24 +734,29 @@ jobs:
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
           GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           node scripts/ghcr-manifest.mjs describe \
             --owner democratizedspace \
             --repo dspace \
-            --tag "v${{ steps.version.outputs.version }}"
+            --tag "v${RELEASE_VERSION}"
 
       - name: Summarize semantic release evidence
         if: steps.build_push.outcome == 'success'
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          BRANCH_SHA_TAG: ${{ steps.tags.outputs.branch_sha_tag }}
+          SEMANTIC_TAG: ${{ steps.tags.outputs.semantic_tag }}
         run: |
           {
             echo "## DSPACE semantic release image"
             echo
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| Semantic version | \`v${{ steps.version.outputs.version }}\` |"
+            echo "| Semantic version | \`v${RELEASE_VERSION}\` |"
             echo "| Full Git SHA | \`${{ steps.revision.outputs.full_sha }}\` |"
-            echo "| Immutable branch-SHA tag | \`${{ steps.tags.outputs.branch_sha_tag }}\` |"
-            echo "| Semantic tag | \`${{ steps.tags.outputs.semantic_tag }}\` |"
+            echo "| Immutable branch-SHA tag | \`${BRANCH_SHA_TAG}\` |"
+            echo "| Semantic tag | \`${SEMANTIC_TAG}\` |"
             echo "| Image index digest | \`${{ steps.evidence.outputs.index_digest }}\` |"
             echo "| linux/amd64 digest | \`${{ steps.evidence.outputs.amd64_digest }}\` |"
             echo "| linux/arm64 digest | \`${{ steps.evidence.outputs.arm64_digest }}\` |"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -647,6 +647,45 @@ jobs:
             --repo dspace \
             --tag "${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
 
+      - name: Build image for SHA verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha,scope=ci-image-semantic-release
+
+      - name: Assert build SHA is baked into frontend bundle
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
+            -v "$PWD/scripts:/scripts:ro" \
+            dspace-verify:latest \
+            node /scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD/scripts:/scripts:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /scripts/verify-chat-build-stamp.mjs
+
       - name: Build and push semantic release image
         id: build_push
         uses: docker/build-push-action@v6
@@ -668,44 +707,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha,scope=ci-image-semantic-release
           cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      - name: Build image for SHA verification
-        if: steps.build_push.outcome == 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          cache-from: type=gha,scope=ci-image-semantic-release
-
-      - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        if: steps.build_push.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
 
       # Records index + per-platform digests as evidence. 'present' is the expected outcome
       # of this second registry call (the tag was just pushed above); scripts/ghcr-manifest.mjs

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -504,7 +504,11 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           full_sha="$(git rev-parse HEAD)"
-          tag_sha="$(git rev-parse "$RELEASE_TAG")"
+          # Peel to the commit form: for annotated/signed tags, "git rev-parse <tag>" alone
+          # resolves the tag *object*'s own SHA, not the commit it points at, which would
+          # reject every legitimate release cut from such a tag even though checkout
+          # correctly left HEAD on the tagged commit.
+          tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           if [ -z "$full_sha" ]; then
             echo "git rev-parse HEAD returned nothing; refusing to publish." >&2
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,33 @@ The root `Dockerfile` builds the production image:
 **Important**: The Docker build uses the current PR code, so any SSR safety fixes
 must be in the source before the image will work correctly.
 
+### Semantic Image Tag Publication (release-only)
+
+`ci-image.yml` has two separate GHCR publish paths, per
+[DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727) and the
+[2026-07-23 production version-drift postmortem](outages/2026-07-23-dspace-production-version-drift.md):
+
+- **Ordinary branch pushes** to `main`/`v3` (the `image` job) publish only
+  `<branch>-<short-sha>` (immutable) and `<branch>-latest` (explicitly mutable
+  convenience tag). This job must never compute or publish a `vX.Y.Z` tag — that
+  is exactly the bug that let a stale `package.json` version cause `v3.0.1` to
+  keep moving in production.
+- **A published GitHub release** (`on.release.types: [published]`, the
+  `semantic-release` job) is the single canonical event allowed to publish
+  `vX.Y.Z`. Do not also add a `push: tags: v*` trigger for this — creating a
+  release normally creates its tag too, so both firing would race and turn
+  every ordinary release into an expected "tag already exists" failure.
+
+The `semantic-release` job checks out `github.event.release.tag_name` explicitly
+and uses `git rev-parse HEAD` (not `github.sha`, which is not guaranteed to be
+the tagged commit on a `release` event) as the source revision everywhere,
+validates the tag against `v<root package.json version>` (and that the root and
+frontend versions agree), and queries GHCR for the tag before publishing —
+failing closed on any non-404 outcome, including auth, network, timeout, and
+malformed-response errors — inside a job-level `concurrency` group keyed on the
+tag so two publish attempts can't race. See `scripts/ghcr-manifest.mjs` and
+`tests/ciImageWorkflow.test.ts` / `tests/ghcrManifestGuard.test.ts`.
+
 ### Smoke Test
 
 The `ci-image.yml` workflow includes a smoke test that:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,11 +332,14 @@ The `semantic-release` job checks out `github.event.release.tag_name` explicitly
 and uses `git rev-parse HEAD` (not `github.sha`, which is not guaranteed to be
 the tagged commit on a `release` event) as the source revision everywhere,
 validates the tag against `v<root package.json version>` (and that the root and
-frontend versions agree), and queries GHCR for the tag before publishing —
-failing closed on any non-404 outcome, including auth, network, timeout, and
-malformed-response errors — inside a job-level `concurrency` group keyed on the
-tag so two publish attempts can't race. See `scripts/ghcr-manifest.mjs` and
-`tests/ciImageWorkflow.test.ts` / `tests/ghcrManifestGuard.test.ts`.
+frontend versions agree), verifies the corresponding `<branch>-<short-sha>` artifact by
+reading its GHCR manifest without republishing or retagging it, and queries GHCR for the
+semantic tag before publishing — failing closed on any non-404 outcome, including auth,
+network, timeout, and malformed-response errors — inside a job-level `concurrency` group
+keyed on the tag so two publication runs can't race. The semantic publication step must
+use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
+`scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
+`tests/ghcrManifestGuard.test.ts`.
 
 ### Smoke Test
 

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+
+const REGISTRY_HOST = 'https://ghcr.io';
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const MANIFEST_ACCEPT_HEADER = [
+    'application/vnd.oci.image.index.v1+json',
+    'application/vnd.docker.distribution.manifest.list.v2+json',
+    'application/vnd.oci.image.manifest.v1+json',
+    'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ');
+
+export class GhcrGuardError extends Error {
+    constructor(message, { code = 'unknown' } = {}) {
+        super(message);
+        this.name = 'GhcrGuardError';
+        this.code = code;
+    }
+}
+
+function requireField(value, label) {
+    if (!value || typeof value !== 'string') {
+        throw new GhcrGuardError(`Missing required value: ${label}`, { code: 'invalid-input' });
+    }
+    return value;
+}
+
+async function fetchWithTimeout(fetchImpl, url, init, timeoutMs, describeAction) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (error) {
+        if (error && error.name === 'AbortError') {
+            throw new GhcrGuardError(`Timed out after ${timeoutMs}ms while ${describeAction}`, {
+                code: 'timeout',
+            });
+        }
+        throw new GhcrGuardError(
+            `Network error while ${describeAction}: ${error?.message || error}`,
+            { code: 'network' }
+        );
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+// GHCR follows the standard Docker Registry v2 auth flow: a Basic-auth request against
+// /token exchanges the workflow's GITHUB_TOKEN for a short-lived Bearer token scoped to
+// read-only access on this one repository.
+export async function fetchGhcrToken({
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+    requireField(owner, 'owner');
+    requireField(repo, 'repo');
+    requireField(username, 'username');
+    requireField(password, 'password');
+
+    const scope = `repository:${owner}/${repo}:pull`;
+    const url = `${REGISTRY_HOST}/token?service=ghcr.io&scope=${encodeURIComponent(scope)}`;
+    const basicAuth = Buffer.from(`${username}:${password}`).toString('base64');
+
+    const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        { headers: { Authorization: `Basic ${basicAuth}` } },
+        timeoutMs,
+        'requesting a GHCR registry token'
+    );
+
+    if (!response.ok) {
+        const code = response.status === 401 || response.status === 403 ? 'auth' : 'indeterminate';
+        throw new GhcrGuardError(`GHCR token request failed with status ${response.status}`, {
+            code,
+        });
+    }
+
+    let body;
+    try {
+        body = await response.json();
+    } catch (error) {
+        throw new GhcrGuardError('GHCR token response was not valid JSON', { code: 'malformed' });
+    }
+
+    if (!body || typeof body.token !== 'string' || body.token.length === 0) {
+        throw new GhcrGuardError('GHCR token response did not include a token', {
+            code: 'malformed',
+        });
+    }
+
+    return body.token;
+}
+
+// Returns { status: 'absent' } only on an authoritative registry 404. Every other outcome
+// (found, auth failure, network failure, timeout, unexpected status, malformed body) is
+// surfaced to the caller as either status: 'present' or a thrown GhcrGuardError, so callers
+// can fail closed rather than assume absence.
+export async function getManifest({
+    owner,
+    repo,
+    tag,
+    token,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+    requireField(owner, 'owner');
+    requireField(repo, 'repo');
+    requireField(tag, 'tag');
+    requireField(token, 'token');
+
+    const url = `${REGISTRY_HOST}/v2/${owner}/${repo}/manifests/${encodeURIComponent(tag)}`;
+    const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: MANIFEST_ACCEPT_HEADER,
+            },
+        },
+        timeoutMs,
+        'requesting the GHCR manifest'
+    );
+
+    if (response.status === 404) {
+        return { status: 'absent' };
+    }
+
+    if (response.status === 401 || response.status === 403) {
+        throw new GhcrGuardError(`GHCR manifest request was denied with status ${response.status}`, {
+            code: 'auth',
+        });
+    }
+
+    if (!response.ok) {
+        throw new GhcrGuardError(
+            `GHCR manifest request returned an indeterminate status ${response.status}`,
+            { code: 'indeterminate' }
+        );
+    }
+
+    const digest = response.headers.get('docker-content-digest') || '';
+    if (!digest) {
+        throw new GhcrGuardError(
+            'GHCR manifest response was missing a Docker-Content-Digest header',
+            { code: 'malformed' }
+        );
+    }
+
+    let body;
+    try {
+        body = await response.json();
+    } catch (error) {
+        throw new GhcrGuardError('GHCR manifest response body was not valid JSON', {
+            code: 'malformed',
+        });
+    }
+
+    const manifests = Array.isArray(body?.manifests)
+        ? body.manifests
+              .filter((entry) => entry && entry.platform && typeof entry.digest === 'string')
+              .map((entry) => ({
+                  architecture: entry.platform.architecture,
+                  os: entry.platform.os,
+                  digest: entry.digest,
+              }))
+        : [];
+
+    return { status: 'present', digest, manifests };
+}
+
+// Fails closed: resolves only when the registry authoritatively reports the tag as absent.
+export async function assertTagAbsent({
+    owner,
+    repo,
+    tag,
+    username,
+    password,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs });
+    const manifest = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
+
+    if (manifest.status === 'present') {
+        throw new GhcrGuardError(
+            `Semantic tag ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
+            { code: 'exists' }
+        );
+    }
+
+    return manifest;
+}
+
+// Used only after a successful push, to record evidence. 'present' is the expected outcome
+// here; any other outcome is a hard failure.
+export async function describeManifest({
+    owner,
+    repo,
+    tag,
+    username,
+    password,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs });
+    const manifest = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
+
+    if (manifest.status !== 'present') {
+        throw new GhcrGuardError(
+            `Expected GHCR tag ${owner}/${repo}:${tag} to exist after publish, but the registry reported it as absent`,
+            { code: 'missing-after-publish' }
+        );
+    }
+
+    const findDigest = (architecture) =>
+        manifest.manifests.find((entry) => entry.architecture === architecture)?.digest || '';
+
+    return {
+        indexDigest: manifest.digest,
+        amd64Digest: findDigest('amd64'),
+        arm64Digest: findDigest('arm64'),
+    };
+}
+
+const FLAG_KEYS = new Set(['owner', 'repo', 'tag']);
+
+export function parseArgs(argv) {
+    const [subcommand, ...rest] = argv;
+
+    if (subcommand !== 'check-absent' && subcommand !== 'describe') {
+        throw new GhcrGuardError(
+            'Usage: ghcr-manifest.mjs <check-absent|describe> --owner <owner> --repo <repo> --tag <tag>',
+            { code: 'invalid-input' }
+        );
+    }
+
+    const options = {};
+    for (let i = 0; i < rest.length; i += 1) {
+        const flag = rest[i];
+        const key = flag?.startsWith('--') ? flag.slice(2) : '';
+        if (!FLAG_KEYS.has(key)) {
+            throw new GhcrGuardError(`Unrecognized argument: ${flag}`, { code: 'invalid-input' });
+        }
+        const value = rest[i + 1];
+        if (!value) {
+            throw new GhcrGuardError(`Missing value for --${key}`, { code: 'invalid-input' });
+        }
+        options[key] = value;
+        i += 1;
+    }
+
+    return {
+        subcommand,
+        owner: requireField(options.owner, '--owner'),
+        repo: requireField(options.repo, '--repo'),
+        tag: requireField(options.tag, '--tag'),
+    };
+}
+
+function writeGithubOutput(entries) {
+    const content = entries.map(([key, value]) => `${key}=${value}`).join('\n') + '\n';
+    const outputPath = process.env.GITHUB_OUTPUT;
+    if (outputPath) {
+        appendFileSync(outputPath, content);
+    } else {
+        console.log(JSON.stringify(Object.fromEntries(entries), null, 2));
+    }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+    const { subcommand, owner, repo, tag } = parseArgs(argv);
+
+    // Credentials are read only from the environment, never from CLI args, so they can't
+    // leak through process listings or workflow logs that echo the invoked command.
+    const username = process.env.GHCR_GUARD_USERNAME || '';
+    const password = process.env.GHCR_GUARD_PASSWORD || '';
+    if (!username || !password) {
+        throw new GhcrGuardError('GHCR_GUARD_USERNAME and GHCR_GUARD_PASSWORD must both be set', {
+            code: 'invalid-input',
+        });
+    }
+
+    if (subcommand === 'check-absent') {
+        await assertTagAbsent({ owner, repo, tag, username, password });
+        console.log(
+            `GHCR tag ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
+        );
+        return;
+    }
+
+    const digests = await describeManifest({ owner, repo, tag, username, password });
+    writeGithubOutput([
+        ['index_digest', digests.indexDigest],
+        ['amd64_digest', digests.amd64Digest],
+        ['arm64_digest', digests.arm64Digest],
+    ]);
+    console.log(`Recorded GHCR digests for ${owner}/${repo}:${tag}.`);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isDirectRun) {
+    main().catch((error) => {
+        const message =
+            error instanceof GhcrGuardError
+                ? error.message
+                : `Unexpected error: ${error?.message || error}`;
+        console.error(message);
+        process.exit(1);
+    });
+}

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -220,12 +220,27 @@ export async function describeManifest({
     }
 
     const findDigest = (architecture) =>
-        manifest.manifests.find((entry) => entry.architecture === architecture)?.digest || '';
+        manifest.manifests.find(
+            (entry) =>
+                entry.os === 'linux' &&
+                entry.architecture === architecture &&
+                typeof entry.digest === 'string' &&
+                entry.digest.trim().length > 0
+        )?.digest;
+
+    const amd64Digest = findDigest('amd64');
+    const arm64Digest = findDigest('arm64');
+    if (!amd64Digest || !arm64Digest) {
+        throw new GhcrGuardError(
+            `GHCR tag ${owner}/${repo}:${tag} does not contain non-empty digests for both required platforms linux/amd64 and linux/arm64`,
+            { code: 'missing-platform' }
+        );
+    }
 
     return {
         indexDigest: manifest.digest,
-        amd64Digest: findDigest('amd64'),
-        arm64Digest: findDigest('arm64'),
+        amd64Digest,
+        arm64Digest,
     };
 }
 

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -185,7 +185,7 @@ export async function assertTagAbsent({
     fetchImpl = fetch,
     timeoutMs = DEFAULT_TIMEOUT_MS,
 }) {
-    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs });
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     const manifest = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
 
     if (manifest.status === 'present') {
@@ -209,7 +209,7 @@ export async function describeManifest({
     fetchImpl = fetch,
     timeoutMs = DEFAULT_TIMEOUT_MS,
 }) {
-    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs });
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     const manifest = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
 
     if (manifest.status !== 'present') {
@@ -280,7 +280,7 @@ export async function main(argv = process.argv.slice(2)) {
     // Credentials are read only from the environment, never from CLI args, so they can't
     // leak through process listings or workflow logs that echo the invoked command.
     const username = process.env.GHCR_GUARD_USERNAME || '';
-    const password = process.env.GHCR_GUARD_PASSWORD || '';
+    const password = process.env.GHCR_GUARD_PASSWORD || ''; // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     if (!username || !password) {
         throw new GhcrGuardError('GHCR_GUARD_USERNAME and GHCR_GUARD_PASSWORD must both be set', {
             code: 'invalid-input',

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -26,7 +26,8 @@ function findSteps(job: any): any[] {
 
 function findStepsUsing(job: any, actionPrefix: string): any[] {
   return findSteps(job).filter(
-    (step) => typeof step.uses === 'string' && step.uses.startsWith(actionPrefix)
+    (step) =>
+      typeof step.uses === 'string' && step.uses.startsWith(actionPrefix)
   );
 }
 
@@ -64,7 +65,9 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(serialized).not.toMatch(/version_tag/);
     // Guards against the historical bug directly: no step should build a tag string of the
     // shape ghcr.io/.../dspace:v<package-version> in this job.
-    expect(serialized).not.toMatch(/ghcr\.io\/democratizedspace\/dspace:v\$\{\{/);
+    expect(serialized).not.toMatch(
+      /ghcr\.io\/democratizedspace\/dspace:v\$\{\{/
+    );
   });
 
   it('still publishes the immutable branch-SHA tag and the mutable branch convenience tag', () => {
@@ -112,7 +115,9 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
 
   it('exists and is gated on a published release, not an ordinary push', () => {
     expect(job).toBeTruthy();
-    expect(job.if).toBe("github.event_name == 'release' && github.event.action == 'published'");
+    expect(job.if).toBe(
+      "github.event_name == 'release' && github.event.action == 'published'"
+    );
   });
 
   it('serializes semantic publication with a concurrency group keyed on the tag', () => {
@@ -147,7 +152,9 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
       }
       expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
       if (step.run.includes('RELEASE_TAG')) {
-        expect(step.env?.RELEASE_TAG).toBe('${{ github.event.release.tag_name }}');
+        expect(step.env?.RELEASE_TAG).toBe(
+          '${{ github.event.release.tag_name }}'
+        );
       }
     }
   });
@@ -161,18 +168,24 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
 
     const pushIndex = stepIndex(
       job,
-      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
+      (step) =>
+        step.uses?.startsWith('docker/build-push-action') &&
+        step.with?.push === true
     );
     const versionIndex = stepIndex(job, (step) => step.id === 'version');
     expect(versionIndex).toBeGreaterThanOrEqual(0);
     expect(versionIndex).toBeLessThan(pushIndex);
   });
 
-  it('runs the GHCR existence guard before any push, and fails closed', () => {
-    const guardIndex = stepIndex(job, (step) => step.run?.includes('ghcr-manifest.mjs check-absent'));
+  it('runs the semantic absence guard before publication, and fails closed', () => {
+    const guardIndex = stepIndex(job, (step) =>
+      step.run?.includes('ghcr-manifest.mjs check-absent')
+    );
     const pushIndex = stepIndex(
       job,
-      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
+      (step) =>
+        step.uses?.startsWith('docker/build-push-action') &&
+        step.with?.push === true
     );
     expect(guardIndex).toBeGreaterThanOrEqual(0);
     expect(pushIndex).toBeGreaterThan(guardIndex);
@@ -188,15 +201,67 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     }
   });
 
-  it('publishes only the immutable branch-SHA tag and the semantic tag, never a mutable "latest" tag', () => {
+  it('contains exactly one semantic publication step that pushes only the semantic tag', () => {
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
+      (step) => step.with?.push === true
+    );
+    expect(pushSteps).toHaveLength(1);
+    const [pushStep] = pushSteps;
+    expect(pushStep.name).toBe('Build and push semantic release image');
+    expect(pushStep.id).toBe('build_push');
+    expect(pushStep.with.tags).toBe('${{ steps.tags.outputs.semantic_tag }}');
+    expect(pushStep.with.tags).not.toContain('branch_sha_tag');
+    expect(pushStep.with.tags).not.toMatch(/latest/);
+    expect(pushStep['continue-on-error']).toBeUndefined();
+  });
+
+  it('has no second-attempt or retry path for semantic publication', () => {
+    const serialized = JSON.stringify(job);
+    expect(serialized).not.toMatch(/attempt 1|attempt 2|retry/i);
+    expect(serialized).not.toContain('build_push_1');
+    expect(serialized).not.toContain('build_push_2');
+    expect(serialized).not.toMatch(/outcome == 'failure'/);
+  });
+
+  it('lets publication failure terminate the job without conditional recovery', () => {
+    const pushStep = findStepsUsing(job, 'docker/build-push-action').find(
+      (step) => step.with?.push === true
+    );
+    expect(pushStep).toBeTruthy();
+    expect(pushStep.if).toBeUndefined();
+    expect(pushStep['continue-on-error']).toBeUndefined();
+    const laterSteps = findSteps(job).slice(
+      findSteps(job).indexOf(pushStep) + 1
+    );
+    for (const step of laterSteps) {
+      expect(step.if ?? '').not.toMatch(
+        /failure\(\)|outcome == 'failure'|always\(\)/
+      );
+    }
+  });
+
+  it('verifies and summarizes the branch-SHA coordinate without pushing it', () => {
+    const branchDescribeStep = findSteps(job).find(
+      (step) => step.id === 'branch_sha_evidence'
+    );
+    expect(branchDescribeStep).toBeTruthy();
+    expect(branchDescribeStep.run).toContain('ghcr-manifest.mjs describe');
+    expect(branchDescribeStep.run).toContain('steps.branch.outputs.branch');
+    expect(branchDescribeStep.run).toContain(
+      'steps.revision.outputs.short_sha'
+    );
+
     const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
       (step) => step.with?.push === true
     );
     for (const step of pushSteps) {
-      expect(step.with.tags).toContain('steps.tags.outputs.branch_sha_tag');
-      expect(step.with.tags).toContain('steps.tags.outputs.semantic_tag');
-      expect(step.with.tags).not.toMatch(/latest/);
+      expect(JSON.stringify(step.with)).not.toContain('branch_sha_tag');
     }
+
+    const summaryStep = findSteps(job).find((step) =>
+      step.run?.includes('GITHUB_STEP_SUMMARY')
+    );
+    expect(summaryStep.run).toContain('steps.tags.outputs.branch_sha_tag');
   });
 
   it('records the required evidence in the workflow summary without leaking credentials', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -132,6 +132,26 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     expect(serialized).not.toContain('${{ github.sha }}');
   });
 
+  it('never interpolates the attacker-influenceable release tag directly into a shell script', () => {
+    // Git tag names can contain shell metacharacters ("`, $(), ;). GitHub substitutes
+    // ${{ }} expressions into a run: script's source text before the shell parses it, so
+    // interpolating the raw tag there would let a crafted release tag execute commands with
+    // this job's packages:write/actions:write token. The tag may only reach a `run:` step by
+    // way of an `env:` var (assigned as data, not concatenated into the script) — never as a
+    // literal ${{ github.event.release.tag_name }} expression inside `run:` text. Using it as
+    // a structured action input (checkout's `ref:`, `concurrency.group`) is fine, since those
+    // aren't shell-interpolation contexts.
+    for (const step of findSteps(job)) {
+      if (typeof step.run !== 'string') {
+        continue;
+      }
+      expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
+      if (step.run.includes('RELEASE_TAG')) {
+        expect(step.env?.RELEASE_TAG).toBe('${{ github.event.release.tag_name }}');
+      }
+    }
+  });
+
   it('validates the release tag against v<root package version> before any push', () => {
     const versionStep = findSteps(job).find((step) => step.id === 'version');
     expect(versionStep.run).toMatch(/root_version/);

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -137,6 +137,16 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     expect(serialized).not.toContain('${{ github.sha }}');
   });
 
+  it('peels the release tag to its commit before comparing to HEAD', () => {
+    // "git rev-parse <tag>" alone resolves an annotated/signed tag's own object SHA, not
+    // the commit it points at, which would reject every legitimate release cut from such a
+    // tag even though checkout correctly left HEAD on the tagged commit. The "^{commit}"
+    // peeling suffix is required so both lightweight and annotated/signed tags compare
+    // correctly against HEAD.
+    const revisionStep = findSteps(job).find((step) => step.id === 'revision');
+    expect(revisionStep.run).toMatch(/\$\{RELEASE_TAG\}\^\{commit\}|\$RELEASE_TAG\^\{commit\}/);
+  });
+
   it('never interpolates the attacker-influenceable release tag directly into a shell script', () => {
     // Git tag names can contain shell metacharacters ("`, $(), ;). GitHub substitutes
     // ${{ }} expressions into a run: script's source text before the shell parses it, so

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const workflowPath = join(repoRoot, '.github', 'workflows', 'ci-image.yml');
+const contents = readFileSync(workflowPath, 'utf8');
+const workflow = parse(contents) as {
+  on: Record<string, any>;
+  jobs: Record<string, any>;
+};
+
+function asArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function findSteps(job: any): any[] {
+  return asArray(job?.steps).filter((step) => step && typeof step === 'object');
+}
+
+function findStepsUsing(job: any, actionPrefix: string): any[] {
+  return findSteps(job).filter(
+    (step) => typeof step.uses === 'string' && step.uses.startsWith(actionPrefix)
+  );
+}
+
+function stepIndex(job: any, predicate: (step: any) => boolean): number {
+  return findSteps(job).findIndex(predicate);
+}
+
+describe('ci-image.yml triggers', () => {
+  it('keeps ordinary branch coverage on main and v3, with no tag-push trigger', () => {
+    expect(workflow.on.push.branches).toEqual(['v3', 'main']);
+    expect(workflow.on.pull_request.branches).toEqual(['v3', 'main']);
+    expect(workflow.on.push.tags).toBeUndefined();
+  });
+
+  it('has exactly one canonical semantic-publication event: a published release', () => {
+    expect(workflow.on.release).toBeTruthy();
+    expect(workflow.on.release.types).toContain('published');
+    // No push.tags trigger alongside release: published — that combination would race
+    // and turn every ordinary release into an expected duplicate-publication failure.
+    expect(workflow.on.push.tags).toBeUndefined();
+  });
+});
+
+describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
+  const job = workflow.jobs.image;
+
+  it('never runs for release events', () => {
+    expect(job.if).toContain("github.event_name == 'push'");
+    expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(job.if).not.toMatch(/release/);
+  });
+
+  it('never computes or publishes a semantic version tag', () => {
+    const serialized = JSON.stringify(job);
+    expect(serialized).not.toMatch(/version_tag/);
+    // Guards against the historical bug directly: no step should build a tag string of the
+    // shape ghcr.io/.../dspace:v<package-version> in this job.
+    expect(serialized).not.toMatch(/ghcr\.io\/democratizedspace\/dspace:v\$\{\{/);
+  });
+
+  it('still publishes the immutable branch-SHA tag and the mutable branch convenience tag', () => {
+    const tagsStep = findSteps(job).find((step) => step.id === 'tags');
+    expect(tagsStep.run).toMatch(/sha_tag=/);
+    expect(tagsStep.run).toMatch(/latest_tag=/);
+
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action');
+    const realPushSteps = pushSteps.filter((step) => step.with?.push === true);
+    expect(realPushSteps.length).toBeGreaterThan(0);
+    for (const step of realPushSteps) {
+      expect(step.with.tags).toContain('steps.tags.outputs.sha_tag');
+      expect(step.with.tags).toContain('steps.tags.outputs.latest_tag');
+    }
+  });
+
+  it('keeps multi-arch publication for both supported architectures', () => {
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
+      (step) => step.with?.push === true
+    );
+    for (const step of pushSteps) {
+      expect(step.with.platforms).toBe('linux/amd64,linux/arm64');
+    }
+  });
+});
+
+describe('ci-image.yml "local-build" job (PR path)', () => {
+  const job = workflow.jobs['local-build'];
+
+  it('never pushes an image', () => {
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action');
+    expect(pushSteps.length).toBeGreaterThan(0);
+    for (const step of pushSteps) {
+      expect(step.with.push).toBe(false);
+    }
+  });
+
+  it('does not run redundantly for release events', () => {
+    expect(job.if).toBe("github.event_name != 'release'");
+  });
+});
+
+describe('ci-image.yml "semantic-release" job (release-only publish path)', () => {
+  const job = workflow.jobs['semantic-release'];
+
+  it('exists and is gated on a published release, not an ordinary push', () => {
+    expect(job).toBeTruthy();
+    expect(job.if).toBe("github.event_name == 'release' && github.event.action == 'published'");
+  });
+
+  it('serializes semantic publication with a concurrency group keyed on the tag', () => {
+    expect(job.concurrency).toBeTruthy();
+    expect(job.concurrency.group).toContain('github.event.release.tag_name');
+    expect(job.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('checks out the tagged commit explicitly rather than trusting the default ref', () => {
+    const checkoutStep = findStepsUsing(job, 'actions/checkout')[0];
+    expect(checkoutStep.with.ref).toContain('github.event.release.tag_name');
+  });
+
+  it('uses the checked-out git rev-parse HEAD as the source revision, never github.sha', () => {
+    const serialized = JSON.stringify(job);
+    expect(serialized).toMatch(/git rev-parse HEAD/);
+    expect(serialized).not.toContain('${{ github.sha }}');
+  });
+
+  it('validates the release tag against v<root package version> before any push', () => {
+    const versionStep = findSteps(job).find((step) => step.id === 'version');
+    expect(versionStep.run).toMatch(/root_version/);
+    expect(versionStep.run).toMatch(/frontend_version/);
+    expect(versionStep.run).toMatch(/expected_tag="v\$\{root_version\}"/);
+    expect(versionStep.run).toMatch(/refusing to publish/);
+
+    const pushIndex = stepIndex(
+      job,
+      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
+    );
+    const versionIndex = stepIndex(job, (step) => step.id === 'version');
+    expect(versionIndex).toBeGreaterThanOrEqual(0);
+    expect(versionIndex).toBeLessThan(pushIndex);
+  });
+
+  it('runs the GHCR existence guard before any push, and fails closed', () => {
+    const guardIndex = stepIndex(job, (step) => step.run?.includes('ghcr-manifest.mjs check-absent'));
+    const pushIndex = stepIndex(
+      job,
+      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
+    );
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(pushIndex).toBeGreaterThan(guardIndex);
+  });
+
+  it('keeps multi-arch publication for both supported architectures', () => {
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
+      (step) => step.with?.push === true
+    );
+    expect(pushSteps.length).toBeGreaterThan(0);
+    for (const step of pushSteps) {
+      expect(step.with.platforms).toBe('linux/amd64,linux/arm64');
+    }
+  });
+
+  it('publishes only the immutable branch-SHA tag and the semantic tag, never a mutable "latest" tag', () => {
+    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
+      (step) => step.with?.push === true
+    );
+    for (const step of pushSteps) {
+      expect(step.with.tags).toContain('steps.tags.outputs.branch_sha_tag');
+      expect(step.with.tags).toContain('steps.tags.outputs.semantic_tag');
+      expect(step.with.tags).not.toMatch(/latest/);
+    }
+  });
+
+  it('records the required evidence in the workflow summary without leaking credentials', () => {
+    const summaryStep = findSteps(job).find((step) =>
+      step.run?.includes('GITHUB_STEP_SUMMARY')
+    );
+    expect(summaryStep).toBeTruthy();
+    const summary = summaryStep.run as string;
+    expect(summary).toMatch(/Semantic version/);
+    expect(summary).toMatch(/Full Git SHA/);
+    expect(summary).toMatch(/Immutable branch-SHA tag/);
+    expect(summary).toMatch(/Semantic tag/);
+    expect(summary).toMatch(/Image index digest/);
+    expect(summary).toMatch(/linux\/amd64 digest/);
+    expect(summary).toMatch(/linux\/arm64 digest/);
+    expect(summary).not.toMatch(/GITHUB_TOKEN/);
+    expect(summary).not.toMatch(/password/i);
+  });
+
+  it('passes registry credentials only through env, never inline in a run script', () => {
+    const guardStep = findSteps(job).find((step) =>
+      step.run?.includes('ghcr-manifest.mjs check-absent')
+    );
+    const evidenceStep = findSteps(job).find((step) =>
+      step.run?.includes('ghcr-manifest.mjs describe')
+    );
+    for (const step of [guardStep, evidenceStep]) {
+      expect(step.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
+      expect(step.run).not.toContain('secrets.GITHUB_TOKEN');
+    }
+  });
+});

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -187,6 +187,73 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     expect(versionIndex).toBeLessThan(pushIndex);
   });
 
+  it('validates package versions before emitting the version output', () => {
+    const versionStep = findSteps(job).find((step) => step.id === 'version');
+    const validation = '[[ ! "$root_version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]';
+    expect(versionStep.run).toContain(validation);
+    expect(versionStep.run.indexOf(validation)).toBeLessThan(
+      versionStep.run.indexOf(
+        'echo "version=${root_version}" >> "$GITHUB_OUTPUT"'
+      )
+    );
+
+    const supportedVersion = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+    expect(supportedVersion.test('3.1.0')).toBe(true);
+    for (const maliciousVersion of [
+      '3.1.$(touch /tmp/pwned)',
+      '3.1.`id`',
+      '3.1.0\nmalicious=value',
+    ]) {
+      expect(supportedVersion.test(maliciousVersion)).toBe(false);
+    }
+  });
+
+  it('passes version-derived shell values through env instead of run expressions', () => {
+    const rawVersionExpression = '${{ steps.version.outputs.version }}';
+    for (const step of findSteps(job)) {
+      if (typeof step.run === 'string') {
+        expect(step.run).not.toContain(rawVersionExpression);
+      }
+    }
+
+    const expectedEnvReferences = [
+      ['tags', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
+      ['build_version', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
+      [undefined, 'RELEASE_VERSION', '"v${RELEASE_VERSION}"'],
+    ];
+    for (const [id, envName, shellReference] of expectedEnvReferences) {
+      const matchingSteps = findSteps(job).filter(
+        (step) =>
+          (id === undefined || step.id === id) &&
+          step.env?.[envName] === rawVersionExpression &&
+          step.run?.includes(shellReference)
+      );
+      expect(matchingSteps.length).toBeGreaterThan(0);
+    }
+
+    const summaryStep = findSteps(job).find((step) =>
+      step.run?.includes('GITHUB_STEP_SUMMARY')
+    );
+    expect(summaryStep.env.RELEASE_VERSION).toBe(rawVersionExpression);
+    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
+      '${{ steps.tags.outputs.branch_sha_tag }}'
+    );
+    expect(summaryStep.env.SEMANTIC_TAG).toBe(
+      '${{ steps.tags.outputs.semantic_tag }}'
+    );
+    expect(summaryStep.run).toContain('${RELEASE_VERSION}');
+    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
+    expect(summaryStep.run).toContain('${SEMANTIC_TAG}');
+
+    const semanticRegistrySteps = findSteps(job).filter((step) =>
+      step.run?.includes('--tag "v${RELEASE_VERSION}"')
+    );
+    expect(semanticRegistrySteps).toHaveLength(2);
+    for (const step of semanticRegistrySteps) {
+      expect(step.env.RELEASE_VERSION).toBe(rawVersionExpression);
+    }
+  });
+
   it('runs the semantic absence guard before publication, and fails closed', () => {
     const guardIndex = stepIndex(job, (step) =>
       step.run?.includes('ghcr-manifest.mjs check-absent')
@@ -300,7 +367,10 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     const summaryStep = findSteps(job).find((step) =>
       step.run?.includes('GITHUB_STEP_SUMMARY')
     );
-    expect(summaryStep.run).toContain('steps.tags.outputs.branch_sha_tag');
+    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
+      '${{ steps.tags.outputs.branch_sha_tag }}'
+    );
+    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
   });
 
   it('records the required evidence in the workflow summary without leaking credentials', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -233,6 +233,35 @@ describe('ci-image.yml "semantic-release" job (release-only publish path)', () =
     expect(serialized).not.toMatch(/outcome == 'failure'/);
   });
 
+  it('completes local image verification before the sole semantic publication', () => {
+    const steps = findSteps(job);
+    const pushIndex = steps.findIndex(
+      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
+    );
+    const verificationBuildIndex = steps.findIndex(
+      (step) => step.name === 'Build image for SHA verification'
+    );
+    const shaAssertionIndex = steps.findIndex(
+      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
+    );
+    const chatStampIndex = steps.findIndex(
+      (step) => step.name === 'Verify chat build stamp inside image'
+    );
+
+    expect(verificationBuildIndex).toBeGreaterThanOrEqual(0);
+    expect(shaAssertionIndex).toBeGreaterThan(verificationBuildIndex);
+    expect(chatStampIndex).toBeGreaterThan(shaAssertionIndex);
+    expect(pushIndex).toBeGreaterThan(chatStampIndex);
+
+    for (const index of [verificationBuildIndex, shaAssertionIndex, chatStampIndex]) {
+      expect(steps[index].if).toBeUndefined();
+      expect(steps[index]['continue-on-error']).toBeUndefined();
+    }
+
+    expect(steps[verificationBuildIndex].with['build-args']).toBe(steps[pushIndex].with['build-args']);
+    expect(steps[verificationBuildIndex].with.labels).toBe(steps[pushIndex].with.labels);
+  });
+
   it('lets publication failure terminate the job without conditional recovery', () => {
     const pushStep = findStepsUsing(job, 'docker/build-push-action').find(
       (step) => step.with?.push === true

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GhcrGuardError,
+  assertTagAbsent,
+  describeManifest,
+  fetchGhcrToken,
+  getManifest,
+  parseArgs,
+} from '../scripts/ghcr-manifest.mjs';
+
+const SECRET_PASSWORD = 'super-secret-token-value-do-not-leak';
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const lowered = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => lowered[name.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+function malformedJsonResponse(status: number, headers: Record<string, string> = {}) {
+  const lowered = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => lowered[name.toLowerCase()] ?? null },
+    json: async () => {
+      throw new Error('Unexpected token in JSON');
+    },
+  };
+}
+
+function fetchFor({ tokenResponse, manifestResponse }: { tokenResponse: any; manifestResponse?: any }) {
+  return async (url: string) => {
+    if (url.includes('/token')) {
+      return tokenResponse;
+    }
+    if (url.includes('/manifests/')) {
+      return manifestResponse;
+    }
+    throw new Error(`Unexpected fetch call to ${url}`);
+  };
+}
+
+function hangingFetch() {
+  return (_url: string, init: { signal: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const error = new Error('The operation was aborted');
+        error.name = 'AbortError';
+        reject(error);
+      });
+    });
+}
+
+const okToken = jsonResponse(200, { token: 'fake-bearer-token' });
+
+describe('fetchGhcrToken', () => {
+  it('throws a network GhcrGuardError when the request fails', async () => {
+    const fetchImpl = async () => {
+      throw new Error('getaddrinfo ENOTFOUND ghcr.io');
+    };
+
+    await expect(
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'network' });
+  });
+
+  it('classifies a 401 as an auth failure and never leaks the password', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(401, { message: 'denied' }) });
+
+    await expect(
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(GhcrGuardError);
+      expect((error as GhcrGuardError).code).toBe('auth');
+      expect((error as Error).message).not.toContain(SECRET_PASSWORD);
+      return true;
+    });
+  });
+
+  it('classifies a 500 as indeterminate', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(500, { message: 'boom' }) });
+
+    await expect(
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'indeterminate' });
+  });
+
+  it('fails closed on a timeout', async () => {
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD,
+        fetchImpl: hangingFetch(),
+        timeoutMs: 20,
+      })
+    ).rejects.toMatchObject({ code: 'timeout' });
+  });
+
+  it('fails closed on a malformed (non-JSON) token response', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: malformedJsonResponse(200) });
+
+    await expect(
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+
+  it('fails closed when the token response has no token field', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(200, { not_a_token: true }) });
+
+    await expect(
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+});
+
+describe('getManifest', () => {
+  it('reports an authoritative 404 as absent', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(404, {}) });
+    // getManifest is tested directly with a raw token, bypassing the token exchange.
+    const result = await getManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      token: 't',
+      fetchImpl: async (url: string) => fetchImpl(url),
+    });
+    expect(result).toEqual({ status: 'absent' });
+  });
+
+  it('reports a 200 with a digest as present and parses per-platform digests', async () => {
+    const body = {
+      manifests: [
+        { platform: { architecture: 'amd64', os: 'linux' }, digest: 'sha256:amd64digest' },
+        { platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:arm64digest' },
+      ],
+    };
+    const fetchImpl = async () =>
+      jsonResponse(200, body, { 'docker-content-digest': 'sha256:indexdigest' });
+
+    const result = await getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl });
+    expect(result.status).toBe('present');
+    expect(result.digest).toBe('sha256:indexdigest');
+    expect(result.manifests).toEqual([
+      { architecture: 'amd64', os: 'linux', digest: 'sha256:amd64digest' },
+      { architecture: 'arm64', os: 'linux', digest: 'sha256:arm64digest' },
+    ]);
+  });
+
+  it('fails closed on 401/403', async () => {
+    const fetchImpl = async () => jsonResponse(403, {});
+    await expect(
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+    ).rejects.toMatchObject({ code: 'auth' });
+  });
+
+  it('fails closed on an indeterminate status', async () => {
+    const fetchImpl = async () => jsonResponse(502, {});
+    await expect(
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+    ).rejects.toMatchObject({ code: 'indeterminate' });
+  });
+
+  it('fails closed when a 200 response is missing the digest header', async () => {
+    const fetchImpl = async () => jsonResponse(200, { manifests: [] });
+    await expect(
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+
+  it('fails closed on a malformed manifest body', async () => {
+    const fetchImpl = async () =>
+      malformedJsonResponse(200, { 'docker-content-digest': 'sha256:indexdigest' });
+    await expect(
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+});
+
+describe('assertTagAbsent', () => {
+  it('resolves when the registry authoritatively reports the tag absent', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(404, {}) });
+    await expect(
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).resolves.toEqual({ status: 'absent' });
+  });
+
+  it('throws (fails closed) when the tag already exists, including the digest but never the password', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(200, { manifests: [] }, { 'docker-content-digest': 'sha256:existingdigest' }),
+    });
+
+    await expect(
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toSatisfy((error: unknown) => {
+      const message = (error as Error).message;
+      expect((error as GhcrGuardError).code).toBe('exists');
+      expect(message).toContain('sha256:existingdigest');
+      expect(message).not.toContain(SECRET_PASSWORD);
+      return true;
+    });
+  });
+
+  it('fails closed when the token request itself is denied', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(401, {}) });
+    await expect(
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'auth' });
+  });
+});
+
+describe('describeManifest', () => {
+  it('returns index/amd64/arm64 digests for a published multi-arch tag', async () => {
+    const body = {
+      manifests: [
+        { platform: { architecture: 'amd64', os: 'linux' }, digest: 'sha256:amd64digest' },
+        { platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:arm64digest' },
+      ],
+    };
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(200, body, { 'docker-content-digest': 'sha256:indexdigest' }),
+    });
+
+    const result = await describeManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      username: 'u',
+      password: SECRET_PASSWORD,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      indexDigest: 'sha256:indexdigest',
+      amd64Digest: 'sha256:amd64digest',
+      arm64Digest: 'sha256:arm64digest',
+    });
+  });
+
+  it('fails when the tag unexpectedly does not exist after a publish', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(404, {}) });
+    await expect(
+      describeManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+    ).rejects.toMatchObject({ code: 'missing-after-publish' });
+  });
+});
+
+describe('parseArgs', () => {
+  it('rejects a missing subcommand', () => {
+    expect(() => parseArgs([])).toThrow(/Usage: ghcr-manifest\.mjs/);
+  });
+
+  it('rejects an unknown subcommand', () => {
+    expect(() => parseArgs(['delete-everything'])).toThrow(/Usage: ghcr-manifest\.mjs/);
+  });
+
+  it('rejects a missing --owner/--repo/--tag', () => {
+    expect(() => parseArgs(['check-absent', '--owner', 'o'])).toThrow(/--repo/);
+  });
+
+  it('rejects an unrecognized flag', () => {
+    expect(() => parseArgs(['check-absent', '--owner', 'o', '--repo', 'r', '--tag', 'v1.0.0', '--bogus', 'x'])).toThrow(
+      /Unrecognized argument/
+    );
+  });
+
+  it('parses a fully specified check-absent invocation', () => {
+    expect(parseArgs(['check-absent', '--owner', 'o', '--repo', 'r', '--tag', 'v1.0.0'])).toEqual({
+      subcommand: 'check-absent',
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+    });
+  });
+});

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -8,7 +8,7 @@ import {
   parseArgs,
 } from '../scripts/ghcr-manifest.mjs';
 
-const SECRET_PASSWORD = 'super-secret-token-value-do-not-leak';
+const SECRET_PASSWORD = 'super-secret-token-value-do-not-leak'; // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
 
 function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
   const lowered = Object.fromEntries(
@@ -59,7 +59,7 @@ function hangingFetch() {
     });
 }
 
-const okToken = jsonResponse(200, { token: 'fake-bearer-token' });
+const okToken = jsonResponse(200, { token: 'fake-bearer-token' }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
 
 describe('fetchGhcrToken', () => {
   it('throws a network GhcrGuardError when the request fails', async () => {
@@ -68,7 +68,7 @@ describe('fetchGhcrToken', () => {
     };
 
     await expect(
-      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'network' });
   });
 
@@ -76,7 +76,7 @@ describe('fetchGhcrToken', () => {
     const fetchImpl = fetchFor({ tokenResponse: jsonResponse(401, { message: 'denied' }) });
 
     await expect(
-      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toSatisfy((error: unknown) => {
       expect(error).toBeInstanceOf(GhcrGuardError);
       expect((error as GhcrGuardError).code).toBe('auth');
@@ -89,7 +89,7 @@ describe('fetchGhcrToken', () => {
     const fetchImpl = fetchFor({ tokenResponse: jsonResponse(500, { message: 'boom' }) });
 
     await expect(
-      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'indeterminate' });
   });
 
@@ -99,7 +99,7 @@ describe('fetchGhcrToken', () => {
         owner: 'o',
         repo: 'r',
         username: 'u',
-        password: SECRET_PASSWORD,
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
         fetchImpl: hangingFetch(),
         timeoutMs: 20,
       })
@@ -110,15 +110,15 @@ describe('fetchGhcrToken', () => {
     const fetchImpl = fetchFor({ tokenResponse: malformedJsonResponse(200) });
 
     await expect(
-      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'malformed' });
   });
 
   it('fails closed when the token response has no token field', async () => {
-    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(200, { not_a_token: true }) });
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(200, { not_a_token: true }) }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
 
     await expect(
-      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'malformed' });
   });
 });
@@ -131,7 +131,7 @@ describe('getManifest', () => {
       owner: 'o',
       repo: 'r',
       tag: 'v1.0.0',
-      token: 't',
+      token: 't', // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
       fetchImpl: async (url: string) => fetchImpl(url),
     });
     expect(result).toEqual({ status: 'absent' });
@@ -147,7 +147,7 @@ describe('getManifest', () => {
     const fetchImpl = async () =>
       jsonResponse(200, body, { 'docker-content-digest': 'sha256:indexdigest' });
 
-    const result = await getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl });
+    const result = await getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl }); // scan-secrets: ignore (fixture token; no real secret literal)
     expect(result.status).toBe('present');
     expect(result.digest).toBe('sha256:indexdigest');
     expect(result.manifests).toEqual([
@@ -159,21 +159,21 @@ describe('getManifest', () => {
   it('fails closed on 401/403', async () => {
     const fetchImpl = async () => jsonResponse(403, {});
     await expect(
-      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl }) // scan-secrets: ignore (fixture token; no real secret literal)
     ).rejects.toMatchObject({ code: 'auth' });
   });
 
   it('fails closed on an indeterminate status', async () => {
     const fetchImpl = async () => jsonResponse(502, {});
     await expect(
-      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl }) // scan-secrets: ignore (fixture token; no real secret literal)
     ).rejects.toMatchObject({ code: 'indeterminate' });
   });
 
   it('fails closed when a 200 response is missing the digest header', async () => {
     const fetchImpl = async () => jsonResponse(200, { manifests: [] });
     await expect(
-      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl }) // scan-secrets: ignore (fixture token; no real secret literal)
     ).rejects.toMatchObject({ code: 'malformed' });
   });
 
@@ -181,7 +181,7 @@ describe('getManifest', () => {
     const fetchImpl = async () =>
       malformedJsonResponse(200, { 'docker-content-digest': 'sha256:indexdigest' });
     await expect(
-      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl })
+      getManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', token: 't', fetchImpl }) // scan-secrets: ignore (fixture token; no real secret literal)
     ).rejects.toMatchObject({ code: 'malformed' });
   });
 });
@@ -190,7 +190,7 @@ describe('assertTagAbsent', () => {
   it('resolves when the registry authoritatively reports the tag absent', async () => {
     const fetchImpl = fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(404, {}) });
     await expect(
-      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).resolves.toEqual({ status: 'absent' });
   });
 
@@ -201,7 +201,7 @@ describe('assertTagAbsent', () => {
     });
 
     await expect(
-      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toSatisfy((error: unknown) => {
       const message = (error as Error).message;
       expect((error as GhcrGuardError).code).toBe('exists');
@@ -214,7 +214,7 @@ describe('assertTagAbsent', () => {
   it('fails closed when the token request itself is denied', async () => {
     const fetchImpl = fetchFor({ tokenResponse: jsonResponse(401, {}) });
     await expect(
-      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      assertTagAbsent({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'auth' });
   });
 });
@@ -237,7 +237,7 @@ describe('describeManifest', () => {
       repo: 'r',
       tag: 'v1.0.0',
       username: 'u',
-      password: SECRET_PASSWORD,
+      password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
       fetchImpl,
     });
 
@@ -251,7 +251,7 @@ describe('describeManifest', () => {
   it('fails when the tag unexpectedly does not exist after a publish', async () => {
     const fetchImpl = fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(404, {}) });
     await expect(
-      describeManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl })
+      describeManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'missing-after-publish' });
   });
 });

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -220,6 +220,17 @@ describe('assertTagAbsent', () => {
 });
 
 describe('describeManifest', () => {
+  function describeWith(manifests: unknown) {
+    return describeManifest({
+      owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u',
+      password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+      fetchImpl: fetchFor({
+        tokenResponse: okToken,
+        manifestResponse: jsonResponse(200, { manifests }, { 'docker-content-digest': 'sha256:indexdigest' }),
+      }),
+    });
+  }
+
   it('returns index/amd64/arm64 digests for a published multi-arch tag', async () => {
     const body = {
       manifests: [
@@ -253,6 +264,23 @@ describe('describeManifest', () => {
     await expect(
       describeManifest({ owner: 'o', repo: 'r', tag: 'v1.0.0', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
     ).rejects.toMatchObject({ code: 'missing-after-publish' });
+  });
+
+  it.each([
+    ['linux/amd64 is missing', [{ platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:arm64digest' }]],
+    ['linux/arm64 is missing', [{ platform: { architecture: 'amd64', os: 'linux' }, digest: 'sha256:amd64digest' }]],
+    ['a non-Linux entry uses a required architecture', [
+      { platform: { architecture: 'amd64', os: 'windows' }, digest: 'sha256:wrongos' },
+      { platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:arm64digest' },
+    ]],
+    ['the response is a single-image manifest', undefined],
+    ['the manifest list is empty', []],
+    ['a required platform has an empty digest', [
+      { platform: { architecture: 'amd64', os: 'linux' }, digest: '' },
+      { platform: { architecture: 'arm64', os: 'linux' }, digest: 'sha256:arm64digest' },
+    ]],
+  ])('fails closed when %s', async (_description, manifests) => {
+    await expect(describeWith(manifests)).rejects.toMatchObject({ code: 'missing-platform' });
   });
 });
 


### PR DESCRIPTION
## Refs

- Refs #4727
- Postmortem: [outages/2026-07-23-dspace-production-version-drift.md](https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md)

## Incident context

Ordinary eligible branch builds previously republished `v<package.json version>`. Because the package version remained `3.0.1` while `main` advanced, later source revisions could move `v3.0.1`.

Production referenced that semantic tag with `image.pullPolicy=Always`. Resolving the moved tag during pod creation or restart is the strongest evidence-supported mechanism for the July 23 production drift, although the exact workflow run, tag movement, and activation event were not captured.

## What changed

`.github/workflows/ci-image.yml` now separates branch and semantic publication:

- The ordinary `image` job runs only for eligible `push` and `workflow_dispatch` events. It publishes `<branch>-<short-sha>` and the explicitly mutable `<branch>-latest`; it no longer computes or publishes `vX.Y.Z`.
- The new `semantic-release` job runs only for a published GitHub release. It performs one semantic publication attempt and pushes only `vX.Y.Z`.
- PR builds remain build-only and never authenticate to GHCR or publish images.

A second `push: tags: v*` trigger was intentionally not added. Publishing a GitHub release normally accompanies creation of its tag; using both events would create competing publication attempts.

## Release validation and immutability controls

Before semantic publication, the release job:

1. Checks out `github.event.release.tag_name`.
2. Peels lightweight, annotated, or signed tags to their target commit with `^{commit}` and verifies that target against `git rev-parse HEAD`.
3. Resolves an eligible source branch (`main` or `v3`) containing the tagged commit.
4. Requires matching root and frontend package versions.
5. Requires the package version to use the project-supported strict `X.Y.Z` format.
6. Requires the release tag to equal `v<package version>`.
7. Verifies that the corresponding immutable `<branch>-<short-sha>` image already exists as a multi-architecture image containing both `linux/amd64` and `linux/arm64`; it does not republish or retag that coordinate.
8. Queries GHCR and permits semantic publication only when the registry authoritatively reports the semantic tag absent.
9. Builds and verifies a local image using the same revision-sensitive build arguments and labels as the publication build, including frontend SHA and chat-build-stamp checks.
10. Performs one `linux/amd64,linux/arm64` push containing only the semantic tag.
11. Records the semantic version, full Git SHA, branch-SHA coordinate, semantic tag, image-index digest, and both platform digests in the workflow summary.

`scripts/ghcr-manifest.mjs` performs the GHCR registry requests without a new dependency. Authentication failures, network errors, timeouts, malformed responses, unexpected statuses, existing semantic tags, missing tags when evidence is required, and missing required platform digests all fail closed.

Publication attempts from this workflow are serialized per semantic tag with `cancel-in-progress: false`, preventing two runs of the canonical workflow from racing each other.

## Shell-safety controls

Release tags and package-version-derived values are treated as data rather than interpolated directly into Bash source:

- The release tag enters shell steps through `env: RELEASE_TAG`.
- Package versions are validated before being written to `GITHUB_OUTPUT`.
- Version-derived tags, build versions, registry arguments, and summary fields enter shell steps through environment variables.
- Structured action inputs remain GitHub expressions where no shell parsing occurs.

These controls address both Greptile shell-injection findings, including the recurring package-version variant reported after the initial release-tag fix.

## Documentation and tests

- `AGENTS.md` documents the release-only semantic publication contract.
- `tests/ciImageWorkflow.test.ts` covers trigger separation, branch-build restrictions, release validation, annotated-tag peeling, shell-safety invariants, publication ordering, branch-SHA immutability, single-attempt semantic publication, multi-architecture output, and summary evidence.
- `tests/ghcrManifestGuard.test.ts` covers authoritative absence, existing tags, authentication and network failures, timeouts, malformed responses, credential non-disclosure, argument validation, digest extraction, and failure when either required architecture is missing.

## Verification

The final security patch completed these focused checks:

~~~bash
npm run test:root -- tests/ciImageWorkflow.test.ts  # 26 passed
npm run lint
npm run type-check
node scripts/link-check.mjs
git diff --check
git diff main...HEAD | python3 scripts/scan-secrets.py
~~~

The secret scan completed cleanly on the final diff.

The final local `npm run test:ci` invocation completed the build and chat-build-stamp stages, but its long-running root suite detached from the local command runner. The authoritative full-suite and container results are the latest-head GitHub Actions checks and must complete successfully before merge.

`actionlint` was unavailable in the final task environment. An earlier run for this PR reported only two pre-existing `shellcheck SC2129` suggestions in the unchanged ordinary `image` job and no new workflow errors.

## No operational mutation

This PR does not create or move a Git tag, create a GitHub release, publish an image, or deploy anything. Its PR-event workflow runs do not mutate GHCR state.

## Remaining operational closure

This PR continues to use `Refs #4727` because the following acceptance evidence requires controlled post-merge branch and release runs:

- [ ] An ordinary `main` or `v3` build leaves semantic tags unchanged.
- [ ] A genuine matching release publishes its semantic tag exactly once.
- [ ] A duplicate attempt for that semantic tag fails before publication.
- [ ] GHCR evidence confirms the protected semantic tag did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)