### PR TITLE
ci: decouple Helm chart version from application version and validate both coordinate groups

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -48,8 +48,22 @@ jobs:
       - name: Package chart
         id: package
         run: |
-          helm package charts/dspace
-          echo "chart_file=$(ls dspace-*.tgz)" >> "$GITHUB_OUTPUT"
+          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          chart_dist=$(mktemp -d)
+          expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
+          helm package charts/dspace --destination "$chart_dist"
+          mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
+          if [[ ${#chart_files[@]} -ne 1 || "${chart_files[0]}" != "$expected_chart_file" ]]; then
+            printf 'Expected exactly %s; found: %s\n' "$expected_chart_file" "${chart_files[*]:-none}" >&2
+            exit 1
+          fi
+          packaged_version=$(helm show chart "$expected_chart_file" | awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }')
+          packaged_app_version=$(helm show chart "$expected_chart_file" | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }')
+          [[ "$packaged_version" == "$chart_version" ]] || { echo "Packaged chart version '$packaged_version' != '$chart_version'" >&2; exit 1; }
+          [[ "$packaged_app_version" == "$app_version" ]] || { echo "Packaged appVersion '$packaged_app_version' != '$app_version'" >&2; exit 1; }
+          echo "chart_file=$expected_chart_file" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GHCR
         run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
@@ -60,5 +74,4 @@ jobs:
       - name: Export chart reference
         id: chart-ref
         run: |
-          chart_version=$(grep '^version:' charts/dspace/Chart.yaml | awk '{print $2}')
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
-          fetch-depth: 2
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -41,8 +40,6 @@ jobs:
         run: helm dependency build charts/dspace
 
       - name: Verify chart version sync
-        env:
-          DSPACE_VERSION_BASE_REF: HEAD^
         run: bash scripts/check-dspace-chart-version.sh
 
       - name: Lint chart
@@ -53,7 +50,9 @@ jobs:
         run: |
           chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
           app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          chart_dist=$(mktemp -d)
+          chart_dist="$RUNNER_TEMP/dspace-chart-dist"
+          rm -rf "$chart_dist"
+          mkdir -p "$chart_dist"
           expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
           helm package charts/dspace --destination "$chart_dist"
           mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          fetch-depth: 2
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -40,6 +41,8 @@ jobs:
         run: helm dependency build charts/dspace
 
       - name: Verify chart version sync
+        env:
+          DSPACE_VERSION_BASE_REF: HEAD^
         run: bash scripts/check-dspace-chart-version.sh
 
       - name: Lint chart

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,14 @@ must be in the source before the image will work correctly.
 
 ### Semantic Image Tag Publication (release-only)
 
+Application and Helm chart versions are independent coordinate groups. Root/frontend package
+metadata, the root lockfile metadata, `Chart.yaml:appVersion`, and the default semantic image tag
+track the application version. `Chart.yaml:version`, `docs/apps/dspace.version`, and the packaged
+chart filename track the chart version. Keep each group internally consistent, but do not require
+the two versions to match. Branch-SHA tags or digests are immutable deployment evidence; a
+release-only `vX.Y.Z` semantic image tag is a human-readable application coordinate, not proof of
+the deployed image.
+
 `ci-image.yml` has two separate GHCR publish paths, per
 [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727) and the
 [2026-07-23 production version-drift postmortem](outages/2026-07-23-dspace-production-version-drift.md):

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -12,7 +12,9 @@ default, matching the `Dockerfile` `EXPOSE` and health check settings.
 - `replicaCount`: Pod replica count. Defaults to `2` for redundancy.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
-- `image.tag`: Image tag to deploy. Defaults to `v3.1.0`, matching the prepared current package version.
+- `image.tag`: Image tag to deploy. Defaults to the human-readable semantic application tag
+  `v3.1.0`; it is not an immutable deployment coordinate. Use a branch-SHA tag or digest when
+  recording or proving the exact deployed image.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
@@ -146,9 +148,11 @@ For the standard Sugarkube staging and production flow, use the
 Helm commands below remain useful for local clusters, development environments, and manual chart
 inspection.
 
-The chart is published to the GitHub Container Registry on `v3` and `main` pushes. After that
-existing publish workflow has completed successfully and the registry shows `3.1.0`, use this
-installation procedure for the prepared release-candidate version:
+The chart is published to the GitHub Container Registry on `v3` and `main` pushes. Its OCI version
+comes from `Chart.yaml:version` and may differ from the application version in `appVersion` and the
+package files. `docs/apps/dspace.version` pins the chart coordinate. The semantic image tag follows
+the application coordinate, but a branch-SHA tag or digest is required as immutable deployment
+evidence. After the publish workflow has completed successfully, use this installation procedure:
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -14,11 +14,16 @@ setup in their existing runbooks.
 - **Immutable image tags:** `<branch>-<shortsha>`, for example `main-REPLACE_SHORTSHA` or
   `v3-REPLACE_SHORTSHA`
 - **Mutable branch convenience tags:** `<branch>-latest`, for example `main-latest` or `v3-latest`
-- **Version image tag:** `v<package.version>`, for example `v3.1.0`
+- **Application version:** the matching versions in the root/frontend package metadata and
+  `Chart.yaml:appVersion`
+- **Chart version:** the matching `Chart.yaml:version` and `docs/apps/dspace.version`; this may
+  advance independently of the application version
+- **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
+  release and human-readable, but not proof of the deployed image
 
-Use immutable branch-SHA tags for staging, production approvals, and rollback records whenever
-possible. Mutable branch tags are convenient for inspection but should not be the audit record for a
-production deploy.
+Use immutable branch-SHA tags or image digests for staging, production approvals, and rollback
+records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
+be the audit record for a production deploy.
 
 ## Artifact publishing summary
 
@@ -27,7 +32,9 @@ production deploy.
 2. `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to the GHCR OCI chart
    registry for `main` and `v3` pushes, and can also be run manually for those branches.
 3. `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` must stay in sync so Sugarkube helper
-   recipes install the intended chart version.
+   recipes install the intended chart version. Separately, package metadata and
+   `Chart.yaml:appVersion` stay aligned on the application version; neither group must equal the
+   other.
 4. Local Docker builds are for local development and smoke testing only. They are not the normal
    Sugarkube staging or production release path.
 
@@ -74,9 +81,10 @@ just dspace-oci-promote-prod tag=3.1.0
 ```
 
 The bare `3.1.0` value is the existing Sugarkube compatibility/version promote form. The image
-workflow publishes the version image tag as `v3.1.0`; branch-SHA tags such as
-`main-REPLACE_SHORTSHA` or `v3-REPLACE_SHORTSHA` remain the preferred immutable audit path for exact
-image promotion and rollback.
+workflow publishes the release-only semantic application tag as `v3.1.0`; it is human-readable but
+not immutable deployment proof. Branch-SHA tags such as `main-REPLACE_SHORTSHA` or
+`v3-REPLACE_SHORTSHA` (or a digest) are the required audit path for exact image promotion and
+rollback.
 
 or:
 

--- a/scripts/check-dspace-chart-version.sh
+++ b/scripts/check-dspace-chart-version.sh
@@ -74,7 +74,7 @@ package_lock_root_version=$(json_get "$package_lock_file" 'packages..version')
 chart_version=$(yaml_scalar "$chart_file" version || true)
 chart_app_version=$(yaml_scalar "$chart_file" appVersion || true)
 image_tag=$(yaml_nested_scalar "$values_file" image tag || true)
-version_line=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' "$version_file" | head -n1 || true)
+documented_chart_version=$(awk '!/^[[:space:]]*#/ && NF { print }' "$version_file" | tr -d '\r\n')
 expected_image_tag="v${root_package_version}"
 
 failures=0
@@ -97,31 +97,41 @@ expect_semver() {
 }
 
 expect_equal() {
-  local label="$1"
-  local actual="$2"
-  local expected="$3"
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  local expected="$4"
   if [[ -z "$actual" ]]; then
-    echo "Missing $label; expected '$expected'" >&2
+    echo "$group coordinate drift: missing $label; expected '$expected'" >&2
     failures=$((failures + 1))
   elif [[ "$actual" != "$expected" ]]; then
-    echo "$label mismatch: found '$actual', expected '$expected'" >&2
+    echo "$group coordinate drift: $label found '$actual', expected '$expected'" >&2
     failures=$((failures + 1))
   fi
 }
 
 expect_present "root package version" "$root_package_version"
 expect_semver "root package version" "$root_package_version"
-expect_equal "frontend package version" "$frontend_package_version" "$root_package_version"
-expect_equal "package-lock top-level version" "$package_lock_version" "$root_package_version"
-expect_equal 'package-lock packages[""].version' "$package_lock_root_version" "$root_package_version"
-expect_equal "chart version" "$chart_version" "$root_package_version"
-expect_equal "chart appVersion" "$chart_app_version" "$root_package_version"
-expect_equal "chart default image.tag" "$image_tag" "$expected_image_tag"
-expect_equal "docs/apps/dspace.version" "$version_line" "$root_package_version"
+for coordinate in \
+  "frontend package version:$frontend_package_version" \
+  "package-lock top-level version:$package_lock_version" \
+  'package-lock packages[""].version:'"$package_lock_root_version" \
+  "chart appVersion:$chart_app_version"; do
+  label=${coordinate%%:*}
+  actual=${coordinate#*:}
+  expect_semver "$label" "$actual"
+  expect_equal "Application" "$label" "$actual" "$root_package_version"
+done
+expect_equal "Application" "chart default image.tag" "$image_tag" "$expected_image_tag"
+
+expect_present "chart version" "$chart_version"
+expect_semver "chart version" "$chart_version"
+expect_semver "docs/apps/dspace.version" "$documented_chart_version"
+expect_equal "Chart" "docs/apps/dspace.version" "$documented_chart_version" "$chart_version"
 
 if (( failures > 0 )); then
-  echo "DSPACE release coordinates are not aligned." >&2
+  echo "DSPACE release coordinate groups are not aligned." >&2
   exit 1
 fi
 
-echo "DSPACE release coordinates are aligned at ${root_package_version} (${expected_image_tag})."
+echo "DSPACE release coordinates are aligned: application version ${root_package_version} (${expected_image_tag}); chart version ${chart_version}."

--- a/scripts/check-dspace-chart-version.sh
+++ b/scripts/check-dspace-chart-version.sh
@@ -74,7 +74,7 @@ package_lock_root_version=$(json_get "$package_lock_file" 'packages..version')
 chart_version=$(yaml_scalar "$chart_file" version || true)
 chart_app_version=$(yaml_scalar "$chart_file" appVersion || true)
 image_tag=$(yaml_nested_scalar "$values_file" image tag || true)
-documented_chart_version=$(awk '!/^[[:space:]]*#/ && NF { print }' "$version_file" | tr -d '\r\n')
+documented_chart_version=$(awk '!/^[[:space:]]*#/ && NF { sub(/\r$/, ""); print; exit }' "$version_file")
 expected_image_tag="v${root_package_version}"
 
 failures=0
@@ -110,6 +110,16 @@ expect_equal() {
   fi
 }
 
+semver_is_greater() {
+  node -e '
+const [current, previous] = process.argv.slice(1).map((version) => version.split(".").map(Number));
+for (let index = 0; index < 3; index += 1) {
+  if (current[index] !== previous[index]) process.exit(current[index] > previous[index] ? 0 : 1);
+}
+process.exit(1);
+' "$1" "$2"
+}
+
 expect_present "root package version" "$root_package_version"
 expect_semver "root package version" "$root_package_version"
 for coordinate in \
@@ -128,6 +138,32 @@ expect_present "chart version" "$chart_version"
 expect_semver "chart version" "$chart_version"
 expect_semver "docs/apps/dspace.version" "$documented_chart_version"
 expect_equal "Chart" "docs/apps/dspace.version" "$documented_chart_version" "$chart_version"
+
+# Publishing changed application metadata inside an existing chart coordinate would mutate an
+# already-addressed OCI artifact. CI supplies the previous revision so independent application and
+# chart versions remain allowed, while an application bump also requires a new chart version.
+if [[ -n "${DSPACE_VERSION_BASE_REF:-}" ]]; then
+  previous_root_package=$(git -C "$repo_root" show "${DSPACE_VERSION_BASE_REF}:package.json" 2>/dev/null) || {
+    echo "Unable to read application coordinates from base revision '$DSPACE_VERSION_BASE_REF'" >&2
+    exit 1
+  }
+  previous_chart=$(git -C "$repo_root" show "${DSPACE_VERSION_BASE_REF}:charts/dspace/Chart.yaml" 2>/dev/null) || {
+    echo "Unable to read chart coordinates from base revision '$DSPACE_VERSION_BASE_REF'" >&2
+    exit 1
+  }
+  previous_app_version=$(node -e 'const fs = require("node:fs"); console.log(JSON.parse(fs.readFileSync(0, "utf8")).version || "")' <<<"$previous_root_package")
+  previous_chart_version=$(awk '$1 == "version:" { value = $2; gsub(/^"|"$/, "", value); print value; exit }' <<<"$previous_chart")
+
+  if [[ "$root_package_version" != "$previous_app_version" ]]; then
+    if [[ "$chart_version" == "$previous_chart_version" ]]; then
+      echo "Chart coordinate reuse: application version changed from '$previous_app_version' to '$root_package_version', but chart version remains '$chart_version'" >&2
+      failures=$((failures + 1))
+    elif ! semver_is_greater "$chart_version" "$previous_chart_version"; then
+      echo "Chart version must advance when application metadata changes; found '$chart_version' after '$previous_chart_version'" >&2
+      failures=$((failures + 1))
+    fi
+  fi
+fi
 
 if (( failures > 0 )); then
   echo "DSPACE release coordinate groups are not aligned." >&2

--- a/scripts/check-dspace-chart-version.sh
+++ b/scripts/check-dspace-chart-version.sh
@@ -10,8 +10,11 @@ values_file="$repo_root/charts/dspace/values.yaml"
 version_file="$repo_root/docs/apps/dspace.version"
 
 require_file() {
-  if [[ ! -f "$1" ]]; then
-    echo "Required version coordinate file not found: $1" >&2
+  local group="$1"
+  local field="$2"
+  local file="$3"
+  if [[ ! -f "$file" ]]; then
+    echo "$group coordinate missing: $field file not found: $file" >&2
     exit 1
   fi
 }
@@ -63,9 +66,12 @@ yaml_nested_scalar() {
   ' "$file"
 }
 
-for file in "$root_package_file" "$frontend_package_file" "$package_lock_file" "$chart_file" "$values_file" "$version_file"; do
-  require_file "$file"
-done
+require_file "Application" "root package version" "$root_package_file"
+require_file "Application" "frontend package version" "$frontend_package_file"
+require_file "Application" "package-lock versions" "$package_lock_file"
+require_file "Application" "chart appVersion" "$chart_file"
+require_file "Application" "chart default image.tag" "$values_file"
+require_file "Chart" "docs/apps/dspace.version" "$version_file"
 
 root_package_version=$(json_get "$root_package_file" version)
 frontend_package_version=$(json_get "$frontend_package_file" version)
@@ -74,24 +80,31 @@ package_lock_root_version=$(json_get "$package_lock_file" 'packages..version')
 chart_version=$(yaml_scalar "$chart_file" version || true)
 chart_app_version=$(yaml_scalar "$chart_file" appVersion || true)
 image_tag=$(yaml_nested_scalar "$values_file" image tag || true)
-documented_chart_version=$(awk '!/^[[:space:]]*#/ && NF { sub(/\r$/, ""); print; exit }' "$version_file")
 expected_image_tag="v${root_package_version}"
+
+mapfile -t documented_chart_lines < <(awk '!/^[[:space:]]*#/ && NF { print }' "$version_file")
+documented_chart_version=""
+if (( ${#documented_chart_lines[@]} == 1 )); then
+  documented_chart_version=${documented_chart_lines[0]}
+fi
 
 failures=0
 expect_present() {
-  local label="$1"
-  local actual="$2"
+  local group="$1"
+  local label="$2"
+  local actual="$3"
   if [[ -z "$actual" ]]; then
-    echo "Missing $label; expected a non-empty value" >&2
+    echo "$group coordinate missing: $label; expected a non-empty value" >&2
     failures=$((failures + 1))
   fi
 }
 
 expect_semver() {
-  local label="$1"
-  local actual="$2"
-  if [[ -n "$actual" && ! "$actual" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "$label must be a semantic version like 3.1.0; found '$actual'" >&2
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  if [[ -n "$actual" && ! "$actual" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "$group coordinate malformed: $label must be bare X.Y.Z SemVer; found '$actual'" >&2
     failures=$((failures + 1))
   fi
 }
@@ -110,18 +123,8 @@ expect_equal() {
   fi
 }
 
-semver_is_greater() {
-  node -e '
-const [current, previous] = process.argv.slice(1).map((version) => version.split(".").map(Number));
-for (let index = 0; index < 3; index += 1) {
-  if (current[index] !== previous[index]) process.exit(current[index] > previous[index] ? 0 : 1);
-}
-process.exit(1);
-' "$1" "$2"
-}
-
-expect_present "root package version" "$root_package_version"
-expect_semver "root package version" "$root_package_version"
+expect_present "Application" "root package version" "$root_package_version"
+expect_semver "Application" "root package version" "$root_package_version"
 for coordinate in \
   "frontend package version:$frontend_package_version" \
   "package-lock top-level version:$package_lock_version" \
@@ -129,41 +132,20 @@ for coordinate in \
   "chart appVersion:$chart_app_version"; do
   label=${coordinate%%:*}
   actual=${coordinate#*:}
-  expect_semver "$label" "$actual"
+  expect_semver "Application" "$label" "$actual"
   expect_equal "Application" "$label" "$actual" "$root_package_version"
 done
 expect_equal "Application" "chart default image.tag" "$image_tag" "$expected_image_tag"
 
-expect_present "chart version" "$chart_version"
-expect_semver "chart version" "$chart_version"
-expect_semver "docs/apps/dspace.version" "$documented_chart_version"
-expect_equal "Chart" "docs/apps/dspace.version" "$documented_chart_version" "$chart_version"
-
-# Publishing changed application metadata inside an existing chart coordinate would mutate an
-# already-addressed OCI artifact. CI supplies the previous revision so independent application and
-# chart versions remain allowed, while an application bump also requires a new chart version.
-if [[ -n "${DSPACE_VERSION_BASE_REF:-}" ]]; then
-  previous_root_package=$(git -C "$repo_root" show "${DSPACE_VERSION_BASE_REF}:package.json" 2>/dev/null) || {
-    echo "Unable to read application coordinates from base revision '$DSPACE_VERSION_BASE_REF'" >&2
-    exit 1
-  }
-  previous_chart=$(git -C "$repo_root" show "${DSPACE_VERSION_BASE_REF}:charts/dspace/Chart.yaml" 2>/dev/null) || {
-    echo "Unable to read chart coordinates from base revision '$DSPACE_VERSION_BASE_REF'" >&2
-    exit 1
-  }
-  previous_app_version=$(node -e 'const fs = require("node:fs"); console.log(JSON.parse(fs.readFileSync(0, "utf8")).version || "")' <<<"$previous_root_package")
-  previous_chart_version=$(awk '$1 == "version:" { value = $2; gsub(/^"|"$/, "", value); print value; exit }' <<<"$previous_chart")
-
-  if [[ "$root_package_version" != "$previous_app_version" ]]; then
-    if [[ "$chart_version" == "$previous_chart_version" ]]; then
-      echo "Chart coordinate reuse: application version changed from '$previous_app_version' to '$root_package_version', but chart version remains '$chart_version'" >&2
-      failures=$((failures + 1))
-    elif ! semver_is_greater "$chart_version" "$previous_chart_version"; then
-      echo "Chart version must advance when application metadata changes; found '$chart_version' after '$previous_chart_version'" >&2
-      failures=$((failures + 1))
-    fi
-  fi
+expect_present "Chart" "chart version" "$chart_version"
+expect_semver "Chart" "chart version" "$chart_version"
+if (( ${#documented_chart_lines[@]} != 1 )); then
+  echo "Chart coordinate malformed: docs/apps/dspace.version must contain exactly one non-empty, non-comment line; found ${#documented_chart_lines[@]}" >&2
+  failures=$((failures + 1))
+else
+  expect_semver "Chart" "docs/apps/dspace.version" "$documented_chart_version"
 fi
+expect_equal "Chart" "docs/apps/dspace.version" "$documented_chart_version" "$chart_version"
 
 if (( failures > 0 )); then
   echo "DSPACE release coordinate groups are not aligned." >&2

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -2,219 +2,122 @@ import { describe, expect, it } from 'vitest';
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(__dirname, '..');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const coordinatePaths = [
+    'package.json',
+    'frontend/package.json',
+    'package-lock.json',
+    'charts/dspace/Chart.yaml',
+    'charts/dspace/values.yaml',
+    'docs/apps/dspace.version',
+];
 
-const chartPath = join(repoRoot, 'charts', 'dspace', 'Chart.yaml');
-const valuesPath = join(repoRoot, 'charts', 'dspace', 'values.yaml');
-const versionPath = join(repoRoot, 'docs', 'apps', 'dspace.version');
-const packageLockPath = join(repoRoot, 'package-lock.json');
-const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
-const frontendPackageJson = JSON.parse(readFileSync(join(repoRoot, 'frontend', 'package.json'), 'utf8'));
-const packageLockJson = JSON.parse(readFileSync(packageLockPath, 'utf8'));
-
-const copyCoordinateFixture = () => {
-    const fixtureRoot = mkdtempSync(join(tmpdir(), 'dspace-version-'));
-    for (const path of ['package.json', 'package-lock.json', 'frontend/package.json']) {
-        mkdirSync(dirname(join(fixtureRoot, path)), { recursive: true });
-        cpSync(join(repoRoot, path), join(fixtureRoot, path), { recursive: true });
+const fixture = () => {
+    const root = mkdtempSync(join(tmpdir(), 'dspace-version-'));
+    for (const path of coordinatePaths) {
+        mkdirSync(dirname(join(root, path)), { recursive: true });
+        cpSync(join(repoRoot, path), join(root, path));
     }
-    for (const path of ['charts/dspace/Chart.yaml', 'charts/dspace/values.yaml', 'docs/apps/dspace.version']) {
-        mkdirSync(dirname(join(fixtureRoot, path)), { recursive: true });
-        cpSync(join(repoRoot, path), join(fixtureRoot, path), { recursive: true });
-    }
-    return fixtureRoot;
+    return root;
 };
 
-const runGuard = (fixtureRoot: string) =>
-    spawnSync('bash', [join(repoRoot, 'scripts', 'check-dspace-chart-version.sh')], {
-        cwd: repoRoot,
-        env: { ...process.env, DSPACE_VERSION_ROOT: fixtureRoot },
+const runGuard = (root: string) =>
+    spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
+        env: { ...process.env, DSPACE_VERSION_ROOT: root },
         encoding: 'utf8',
     });
 
-const writeChangedText = (path: string, current: string, next: string) => {
+const replace = (root: string, path: string, search: string | RegExp, value: string) => {
+    const file = join(root, path);
+    const current = readFileSync(file, 'utf8');
+    const next = current.replace(search, value);
     expect(next).not.toBe(current);
-    writeFileSync(path, next);
+    writeFileSync(file, next);
 };
 
-const replaceFixtureText = (path: string, search: string | RegExp, replacement: string) => {
-    const current = readFileSync(path, 'utf8');
-    const next = current.replace(search, replacement);
-    writeChangedText(path, current, next);
+const withFixture = (check: (root: string) => void) => {
+    const root = fixture();
+    try {
+        check(root);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
 };
 
-describe('DSPACE release coordinates', () => {
-    const chartContent = readFileSync(chartPath, 'utf8');
-    const valuesContent = readFileSync(valuesPath, 'utf8');
-    const versionContent = readFileSync(versionPath, 'utf8');
-
-    const chartVersionMatch = chartContent.match(/^version:\s*"?([^"\n]+)"?/m);
-    const appVersionMatch = chartContent.match(/^appVersion:\s*"?([^"\n]+)"?/m);
-    const imageTagMatch = valuesContent.match(/^\s*tag:\s*([^\n]+)/m);
-
-    it('sets every authoritative coordinate to the 3.1.0 release candidate metadata', () => {
-        expect(packageJson.version).toBe('3.1.0');
-        expect(frontendPackageJson.version).toBe('3.1.0');
-        expect(packageLockJson.version).toBe('3.1.0');
-        expect(packageLockJson.packages[''].version).toBe('3.1.0');
-        expect(chartVersionMatch?.[1]).toBe('3.1.0');
-        expect(appVersionMatch?.[1]).toBe('3.1.0');
-        expect(imageTagMatch?.[1].trim()).toBe('v3.1.0');
-        expect(versionContent).toMatch(/^3\.1\.0$/m);
-    });
-
-    it('keeps appVersion unprefixed while image.tag uses the human-readable v-prefixed tag', () => {
-        expect(appVersionMatch?.[1]).toBe(packageJson.version);
-        expect(appVersionMatch?.[1].startsWith('v')).toBe(false);
-        expect(imageTagMatch?.[1].trim()).toBe(`v${packageJson.version}`);
-    });
-
-    it('passes the release-coordinate guard for the repository fixture', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const result = runGuard(fixtureRoot);
+describe('independent DSPACE application and chart coordinates', () => {
+    it('passes current repository coordinates and reports both groups', () =>
+        withFixture((root) => {
+            const result = runGuard(root);
             expect(result.status, result.stderr).toBe(0);
-            expect(result.stdout).toContain('DSPACE release coordinates are aligned at 3.1.0');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
+            expect(result.stdout).toContain('application version 3.1.0 (v3.1.0)');
+            expect(result.stdout).toContain('chart version 3.1.0');
+        }));
 
-    it('rejects representative coordinate mismatches without scanning historical docs', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            writeChangedText(
-                join(fixtureRoot, 'docs', 'apps', 'dspace.version'),
-                readFileSync(join(fixtureRoot, 'docs', 'apps', 'dspace.version'), 'utf8'),
-                '3.0.1\n'
-            );
-            const result = runGuard(fixtureRoot);
+    it('permits chart 3.0.2 with application 3.0.1', () =>
+        withFixture((root) => {
+            for (const path of ['package.json', 'frontend/package.json', 'package-lock.json']) {
+                replace(root, path, /"version": "3\.1\.0"/g, '"version": "3.0.1"');
+            }
+            replace(root, 'charts/dspace/Chart.yaml', /^version: 3\.1\.0$/m, 'version: 3.0.2');
+            replace(root, 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "3.0.1"');
+            replace(root, 'charts/dspace/values.yaml', /^\s*tag: v3\.1\.0$/m, '  tag: v3.0.1');
+            writeFileSync(join(root, 'docs/apps/dspace.version'), '3.0.2\n');
+            const result = runGuard(root);
+            expect(result.status, result.stderr).toBe(0);
+            expect(result.stdout).toContain('application version 3.0.1');
+            expect(result.stdout).toContain('chart version 3.0.2');
+        }));
+
+    it.each([
+        ['root package version', 'package.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
+        ['frontend package version', 'frontend/package.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
+        ['package-lock top-level version', 'package-lock.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
+        ['package-lock packages[""].version', 'package-lock.json', /("": \{\n(?:\s*"name"[^\n]*\n)?\s*)"version": "3\.1\.0"/, '$1"version": "3.0.9"'],
+        ['chart appVersion', 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "3.0.9"'],
+        ['chart default image.tag', 'charts/dspace/values.yaml', 'tag: v3.1.0', 'tag: v3.0.9'],
+    ])('rejects application drift in %s', (label, path, search, value) =>
+        withFixture((root) => {
+            replace(root, path, search, value);
+            const result = runGuard(root);
             expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("docs/apps/dspace.version mismatch: found '3.0.1'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
+            expect(result.stderr).toContain('Application coordinate drift:');
+            expect(result.stderr).toContain(label === 'root package version' ? 'frontend package version' : label);
+        }));
 
-
-    it('reports labeled failures when JSON coordinates are missing', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageLockFile = join(fixtureRoot, 'package-lock.json');
-            const current = readFileSync(packageLockFile, 'utf8');
-            const packageLock = JSON.parse(current);
-            expect(packageLock.version).toBe('3.1.0');
-            expect(packageLock.packages[''].version).toBe('3.1.0');
-            delete packageLock.packages[''].version;
-            writeChangedText(packageLockFile, current, `${JSON.stringify(packageLock, null, 2)}\n`);
-
-            const result = runGuard(fixtureRoot);
+    it('rejects chart coordinate drift', () =>
+        withFixture((root) => {
+            writeFileSync(join(root, 'docs/apps/dspace.version'), '3.0.2\n');
+            const result = runGuard(root);
             expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain(
-                `Missing package-lock packages[""].version; expected '3.1.0'`
-            );
-            expect(result.stderr).toContain('DSPACE release coordinates are not aligned.');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
+            expect(result.stderr).toContain('Chart coordinate drift: docs/apps/dspace.version');
+        }));
 
-    it('reports labeled failures when docs/apps/dspace.version has no strict semver line', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            writeChangedText(
-                join(fixtureRoot, 'docs', 'apps', 'dspace.version'),
-                readFileSync(join(fixtureRoot, 'docs', 'apps', 'dspace.version'), 'utf8'),
-                '3.1.0   \n'
-            );
-
-            const result = runGuard(fixtureRoot);
+    it('rejects a v-prefixed appVersion as non-SemVer application metadata', () =>
+        withFixture((root) => {
+            replace(root, 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "v3.1.0"');
+            const result = runGuard(root);
             expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("Missing docs/apps/dspace.version; expected '3.1.0'");
-            expect(result.stderr).toContain('DSPACE release coordinates are not aligned.');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
+            expect(result.stderr).toContain("chart appVersion must be a semantic version");
+            expect(result.stderr).toContain('Application coordinate drift: chart appVersion');
+        }));
+
+    it('uses Chart.yaml version for an exact clean package filename and OCI reference', () => {
+        const workflow = readFileSync(join(repoRoot, '.github/workflows/ci-helm.yml'), 'utf8');
+        expect(workflow).toContain('expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"');
+        expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
+        expect(workflow).toContain('packaged_version=$(helm show chart');
+        expect(workflow).toContain('packaged_app_version=$(helm show chart');
+        expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
+        expect(workflow).not.toMatch(/package\.json[\s\S]*chart_ref=/);
     });
 
-
-    it('reports labeled failures when the package-lock top-level version is missing', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageLockFile = join(fixtureRoot, 'package-lock.json');
-            const current = readFileSync(packageLockFile, 'utf8');
-            const packageLock = JSON.parse(current);
-            expect(packageLock.version).toBe('3.1.0');
-            delete packageLock.version;
-            writeChangedText(packageLockFile, current, `${JSON.stringify(packageLock, null, 2)}\n`);
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("Missing package-lock top-level version; expected '3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('reports malformed JSON coordinate files separately from missing values', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageFile = join(fixtureRoot, 'package.json');
-            writeChangedText(packageFile, readFileSync(packageFile, 'utf8'), '{not json}\n');
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain('Unable to read or parse JSON coordinate file');
-            expect(result.stderr).toContain('package.json');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('rejects a chart appVersion that includes a v prefix', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            replaceFixtureText(
-                join(fixtureRoot, 'charts', 'dspace', 'Chart.yaml'),
-                /^appVersion:\s*"?3\.1\.0"?$/m,
-                'appVersion: "v3.1.0"'
-            );
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("chart appVersion mismatch: found 'v3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('rejects an unprefixed chart default image tag', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            replaceFixtureText(
-                join(fixtureRoot, 'charts', 'dspace', 'values.yaml'),
-                /^(\s*tag:)\s*v3\.1\.0$/m,
-                '$1 3.1.0'
-            );
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("chart default image.tag mismatch: found '3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('continues to ignore historical v3.0.1 documentation outside authoritative coordinates', () => {
-        const stdout = execFileSync('bash', ['scripts/check-dspace-chart-version.sh'], {
-            cwd: repoRoot,
-            encoding: 'utf8',
-        });
-        expect(stdout).toContain('DSPACE release coordinates are aligned at 3.1.0');
-        expect(readFileSync(join(repoRoot, 'docs', 'qa', 'v3.0.1.md'), 'utf8')).toContain('v3.0.1');
-    });
+    it('does not scan historical release records as authoritative coordinates', () =>
+        withFixture((root) => {
+            mkdirSync(join(root, 'docs/qa'), { recursive: true });
+            writeFileSync(join(root, 'docs/qa/v3.0.1.md'), 'historical version v999.999.999\n');
+            expect(runGuard(root).status).toBe(0);
+        }));
 });

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -7,168 +14,224 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const coordinatePaths = [
-    'package.json',
-    'frontend/package.json',
-    'package-lock.json',
-    'charts/dspace/Chart.yaml',
-    'charts/dspace/values.yaml',
-    'docs/apps/dspace.version',
+  'package.json',
+  'frontend/package.json',
+  'package-lock.json',
+  'charts/dspace/Chart.yaml',
+  'charts/dspace/values.yaml',
+  'docs/apps/dspace.version',
 ];
 
 const fixture = () => {
-    const root = mkdtempSync(join(tmpdir(), 'dspace-version-'));
-    for (const path of coordinatePaths) {
-        mkdirSync(dirname(join(root, path)), { recursive: true });
-        cpSync(join(repoRoot, path), join(root, path));
-    }
-    return root;
+  const root = mkdtempSync(join(tmpdir(), 'dspace-version-'));
+  for (const path of coordinatePaths) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    cpSync(join(repoRoot, path), join(root, path));
+  }
+  return root;
 };
 
-const runGuard = (root: string, baseRef?: string) =>
-    spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
-        env: { ...process.env, DSPACE_VERSION_ROOT: root, DSPACE_VERSION_BASE_REF: baseRef },
-        encoding: 'utf8',
-    });
+const runGuard = (root: string) =>
+  spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
+    env: { ...process.env, DSPACE_VERSION_ROOT: root },
+    encoding: 'utf8',
+  });
 
-const replace = (root: string, path: string, search: string | RegExp, value: string) => {
-    const file = join(root, path);
-    const current = readFileSync(file, 'utf8');
-    const next = current.replace(search, value);
-    expect(next).not.toBe(current);
-    writeFileSync(file, next);
+const read = (root: string, path: string) =>
+  readFileSync(join(root, path), 'utf8');
+const replace = (
+  root: string,
+  path: string,
+  search: string | RegExp,
+  value: string
+) => {
+  const file = join(root, path);
+  const current = read(root, path);
+  const next = current.replace(search, value);
+  expect(next).not.toBe(current);
+  writeFileSync(file, next);
 };
-
+const currentVersions = (root: string) => ({
+  application: JSON.parse(read(root, 'package.json')).version as string,
+  chart: read(root, 'charts/dspace/Chart.yaml').match(
+    /^version:\s*"?([^"\s]+)"?$/m
+  )?.[1] as string,
+});
 const withFixture = (check: (root: string) => void) => {
-    const root = fixture();
-    try {
-        check(root);
-    } finally {
-        rmSync(root, { recursive: true, force: true });
-    }
+  const root = fixture();
+  try {
+    check(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 };
 
 describe('independent DSPACE application and chart coordinates', () => {
-    it('passes current repository coordinates and reports both groups', () =>
-        withFixture((root) => {
-            const result = runGuard(root);
-            const packageVersion = JSON.parse(
-                readFileSync(join(root, 'package.json'), 'utf8')
-            ).version;
-            const chartVersion = readFileSync(join(root, 'charts/dspace/Chart.yaml'), 'utf8').match(
-                /^version:\s*"?([^"\s]+)"?$/m
-            )?.[1];
-            expect(result.status, result.stderr).toBe(0);
-            expect(result.stdout).toContain(
-                `application version ${packageVersion} (v${packageVersion})`
-            );
-            expect(result.stdout).toContain(`chart version ${chartVersion}`);
-        }));
+  it('passes current repository coordinates and reports both groups', () =>
+    withFixture((root) => {
+      const { application, chart } = currentVersions(root);
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        `application version ${application} (v${application})`
+      );
+      expect(result.stdout).toContain(`chart version ${chart}`);
+    }));
 
-    it('rejects an application bump that reuses the previous chart coordinate', () => {
-        const root = fixture();
-        try {
-            spawnSync('git', ['init', '-q'], { cwd: root });
-            spawnSync('git', ['add', '.'], { cwd: root });
-            spawnSync(
-                'git',
-                [
-                    '-c',
-                    'user.name=test',
-                    '-c',
-                    'user.email=test@example.com',
-                    'commit',
-                    '-qm',
-                    'base',
-                ],
-                { cwd: root }
-            );
-            for (const path of ['package.json', 'frontend/package.json', 'package-lock.json']) {
-                replace(root, path, /"version": "3\.1\.0"/g, '"version": "3.1.1"');
-            }
-            replace(
-                root,
-                'charts/dspace/Chart.yaml',
-                'appVersion: "3.1.0"',
-                'appVersion: "3.1.1"'
-            );
-            replace(root, 'charts/dspace/values.yaml', 'tag: v3.1.0', 'tag: v3.1.1');
-            const result = runGuard(root, 'HEAD');
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain('Chart coordinate reuse: application version changed');
-        } finally {
-            rmSync(root, { recursive: true, force: true });
-        }
-    });
+  it('permits chart 3.0.2 with application 3.0.1', () =>
+    withFixture((root) => {
+      const { application, chart } = currentVersions(root);
+      for (const path of [
+        'package.json',
+        'frontend/package.json',
+        'package-lock.json',
+      ]) {
+        replace(
+          root,
+          path,
+          new RegExp(`"version": "${application.replaceAll('.', '\\.')}"`, 'g'),
+          '"version": "3.0.1"'
+        );
+      }
+      replace(
+        root,
+        'charts/dspace/Chart.yaml',
+        `version: ${chart}`,
+        'version: 3.0.2'
+      );
+      replace(
+        root,
+        'charts/dspace/Chart.yaml',
+        `appVersion: "${application}"`,
+        'appVersion: "3.0.1"'
+      );
+      replace(
+        root,
+        'charts/dspace/values.yaml',
+        `tag: v${application}`,
+        'tag: v3.0.1'
+      );
+      writeFileSync(join(root, 'docs/apps/dspace.version'), '3.0.2\n');
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('application version 3.0.1');
+      expect(result.stdout).toContain('chart version 3.0.2');
+    }));
 
-    it('reads only the first active chart version documentation line', () =>
-        withFixture((root) => {
-            const current = readFileSync(join(root, 'docs/apps/dspace.version'), 'utf8').trim();
-            writeFileSync(join(root, 'docs/apps/dspace.version'), `${current}\n9.9.9\n`);
-            expect(runGuard(root).status).toBe(0);
-        }));
+  it.each([
+    ['Application', 'root package version', 'package.json', null],
+    ['Chart', 'chart version', 'charts/dspace/Chart.yaml', /^version:.*\n/m],
+  ])('labels a missing %s field', (group, field, path, line) =>
+    withFixture((root) => {
+      if (line) replace(root, path, line, '');
+      else rmSync(join(root, path));
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`${group} coordinate missing: ${field}`);
+    })
+  );
 
-    it('permits chart 3.0.2 with application 3.0.1', () =>
-        withFixture((root) => {
-            for (const path of ['package.json', 'frontend/package.json', 'package-lock.json']) {
-                replace(root, path, /"version": "3\.1\.0"/g, '"version": "3.0.1"');
-            }
-            replace(root, 'charts/dspace/Chart.yaml', /^version: 3\.1\.0$/m, 'version: 3.0.2');
-            replace(root, 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "3.0.1"');
-            replace(root, 'charts/dspace/values.yaml', /^\s*tag: v3\.1\.0$/m, '  tag: v3.0.1');
-            writeFileSync(join(root, 'docs/apps/dspace.version'), '3.0.2\n');
-            const result = runGuard(root);
-            expect(result.status, result.stderr).toBe(0);
-            expect(result.stdout).toContain('application version 3.0.1');
-            expect(result.stdout).toContain('chart version 3.0.2');
-        }));
+  it.each([
+    [
+      'Application',
+      'root package version',
+      'package.json',
+      /"version": "[^"]+"/,
+      '"version": "01.2.3"',
+    ],
+    [
+      'Application',
+      'chart appVersion',
+      'charts/dspace/Chart.yaml',
+      /^appVersion:.*$/m,
+      'appVersion: "v1.2.3"',
+    ],
+    [
+      'Chart',
+      'chart version',
+      'charts/dspace/Chart.yaml',
+      /^version:.*$/m,
+      'version: 1.02.3',
+    ],
+  ])('labels malformed %s field %s', (group, field, path, search, value) =>
+    withFixture((root) => {
+      replace(root, path, search, value);
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        `${group} coordinate malformed: ${field}`
+      );
+    })
+  );
 
-    it.each([
-        ['root package version', 'package.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
-        ['frontend package version', 'frontend/package.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
-        ['package-lock top-level version', 'package-lock.json', /"version": "3\.1\.0"/, '"version": "3.0.9"'],
-        ['package-lock packages[""].version', 'package-lock.json', /("": \{\n(?:\s*"name"[^\n]*\n)?\s*)"version": "3\.1\.0"/, '$1"version": "3.0.9"'],
-        ['chart appVersion', 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "3.0.9"'],
-        ['chart default image.tag', 'charts/dspace/values.yaml', 'tag: v3.1.0', 'tag: v3.0.9'],
-    ])('rejects application drift in %s', (label, path, search, value) =>
-        withFixture((root) => {
-            replace(root, path, search, value);
-            const result = runGuard(root);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain('Application coordinate drift:');
-            expect(result.stderr).toContain(label === 'root package version' ? 'frontend package version' : label);
-        }));
+  it('labels application and chart drift with their fields', () =>
+    withFixture((root) => {
+      const { chart } = currentVersions(root);
+      replace(
+        root,
+        'frontend/package.json',
+        /"version": "[^"]+"/,
+        '"version": "9.9.9"'
+      );
+      writeFileSync(
+        join(root, 'docs/apps/dspace.version'),
+        chart === '8.8.8' ? '8.8.7\n' : '8.8.8\n'
+      );
+      const result = runGuard(root);
+      expect(result.stderr).toContain(
+        'Application coordinate drift: frontend package version'
+      );
+      expect(result.stderr).toContain(
+        'Chart coordinate drift: docs/apps/dspace.version'
+      );
+    }));
 
-    it('rejects chart coordinate drift', () =>
-        withFixture((root) => {
-            writeFileSync(join(root, 'docs/apps/dspace.version'), '3.0.2\n');
-            const result = runGuard(root);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain('Chart coordinate drift: docs/apps/dspace.version');
-        }));
+  it.each([
+    ['', 'found 0'],
+    ['# comment only\n', 'found 0'],
+    ['1.2.3\n2.3.4\n', 'found 2'],
+    [' 1.2.3\n', "found ' 1.2.3'"],
+    ['v1.2.3\n', "found 'v1.2.3'"],
+    ['1.2.3 trailing\n', "found '1.2.3 trailing'"],
+  ])(
+    'rejects malformed docs/apps/dspace.version content %#',
+    (content, detail) =>
+      withFixture((root) => {
+        writeFileSync(join(root, 'docs/apps/dspace.version'), content);
+        const result = runGuard(root);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          'Chart coordinate malformed: docs/apps/dspace.version'
+        );
+        expect(result.stderr).toContain(detail);
+      })
+  );
 
-    it('rejects a v-prefixed appVersion as non-SemVer application metadata', () =>
-        withFixture((root) => {
-            replace(root, 'charts/dspace/Chart.yaml', 'appVersion: "3.1.0"', 'appVersion: "v3.1.0"');
-            const result = runGuard(root);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("chart appVersion must be a semantic version");
-            expect(result.stderr).toContain('Application coordinate drift: chart appVersion');
-        }));
+  it('uses a deterministic clean package destination and chart-derived coordinates', () => {
+    const workflow = readFileSync(
+      join(repoRoot, '.github/workflows/ci-helm.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain('chart_dist="$RUNNER_TEMP/dspace-chart-dist"');
+    expect(workflow).toContain('rm -rf "$chart_dist"');
+    expect(workflow).toContain('mkdir -p "$chart_dist"');
+    expect(workflow).not.toContain('mktemp -d');
+    expect(workflow).toContain(
+      'expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"'
+    );
+    expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
+    expect(workflow).toContain('packaged_version=$(helm show chart');
+    expect(workflow).toContain('packaged_app_version=$(helm show chart');
+    expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
+  });
 
-    it('uses Chart.yaml version for an exact clean package filename and OCI reference', () => {
-        const workflow = readFileSync(join(repoRoot, '.github/workflows/ci-helm.yml'), 'utf8');
-        expect(workflow).toContain('expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"');
-        expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
-        expect(workflow).toContain('packaged_version=$(helm show chart');
-        expect(workflow).toContain('packaged_app_version=$(helm show chart');
-        expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
-        expect(workflow).not.toMatch(/package\.json[\s\S]*chart_ref=/);
-    });
-
-    it('does not scan historical release records as authoritative coordinates', () =>
-        withFixture((root) => {
-            mkdirSync(join(root, 'docs/qa'), { recursive: true });
-            writeFileSync(join(root, 'docs/qa/v3.0.1.md'), 'historical version v999.999.999\n');
-            expect(runGuard(root).status).toBe(0);
-        }));
+  it('does not scan historical release records as authoritative coordinates', () =>
+    withFixture((root) => {
+      mkdirSync(join(root, 'docs/qa'), { recursive: true });
+      writeFileSync(
+        join(root, 'docs/qa/v3.0.1.md'),
+        'historical version v999.999.999\n'
+      );
+      expect(runGuard(root).status).toBe(0);
+    }));
 });

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -24,9 +24,9 @@ const fixture = () => {
     return root;
 };
 
-const runGuard = (root: string) =>
+const runGuard = (root: string, baseRef?: string) =>
     spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
-        env: { ...process.env, DSPACE_VERSION_ROOT: root },
+        env: { ...process.env, DSPACE_VERSION_ROOT: root, DSPACE_VERSION_BASE_REF: baseRef },
         encoding: 'utf8',
     });
 
@@ -51,9 +51,60 @@ describe('independent DSPACE application and chart coordinates', () => {
     it('passes current repository coordinates and reports both groups', () =>
         withFixture((root) => {
             const result = runGuard(root);
+            const packageVersion = JSON.parse(
+                readFileSync(join(root, 'package.json'), 'utf8')
+            ).version;
+            const chartVersion = readFileSync(join(root, 'charts/dspace/Chart.yaml'), 'utf8').match(
+                /^version:\s*"?([^"\s]+)"?$/m
+            )?.[1];
             expect(result.status, result.stderr).toBe(0);
-            expect(result.stdout).toContain('application version 3.1.0 (v3.1.0)');
-            expect(result.stdout).toContain('chart version 3.1.0');
+            expect(result.stdout).toContain(
+                `application version ${packageVersion} (v${packageVersion})`
+            );
+            expect(result.stdout).toContain(`chart version ${chartVersion}`);
+        }));
+
+    it('rejects an application bump that reuses the previous chart coordinate', () => {
+        const root = fixture();
+        try {
+            spawnSync('git', ['init', '-q'], { cwd: root });
+            spawnSync('git', ['add', '.'], { cwd: root });
+            spawnSync(
+                'git',
+                [
+                    '-c',
+                    'user.name=test',
+                    '-c',
+                    'user.email=test@example.com',
+                    'commit',
+                    '-qm',
+                    'base',
+                ],
+                { cwd: root }
+            );
+            for (const path of ['package.json', 'frontend/package.json', 'package-lock.json']) {
+                replace(root, path, /"version": "3\.1\.0"/g, '"version": "3.1.1"');
+            }
+            replace(
+                root,
+                'charts/dspace/Chart.yaml',
+                'appVersion: "3.1.0"',
+                'appVersion: "3.1.1"'
+            );
+            replace(root, 'charts/dspace/values.yaml', 'tag: v3.1.0', 'tag: v3.1.1');
+            const result = runGuard(root, 'HEAD');
+            expect(result.status).not.toBe(0);
+            expect(result.stderr).toContain('Chart coordinate reuse: application version changed');
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('reads only the first active chart version documentation line', () =>
+        withFixture((root) => {
+            const current = readFileSync(join(root, 'docs/apps/dspace.version'), 'utf8').trim();
+            writeFileSync(join(root, 'docs/apps/dspace.version'), `${current}\n9.9.9\n`);
+            expect(runGuard(root).status).toBe(0);
         }));
 
     it('permits chart 3.0.2 with application 3.0.1', () =>

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -164,23 +164,87 @@ describe('independent DSPACE application and chart coordinates', () => {
     })
   );
 
-  it('labels application and chart drift with their fields', () =>
+  it.each([
+    [
+      'root package version',
+      'package.json',
+      'version',
+      'frontend package version',
+    ],
+    [
+      'frontend package version',
+      'frontend/package.json',
+      'version',
+      'frontend package version',
+    ],
+    [
+      'package-lock top-level version',
+      'package-lock.json',
+      'version',
+      'package-lock top-level version',
+    ],
+    [
+      'package-lock packages[""].version',
+      'package-lock.json',
+      'packages',
+      'package-lock packages[""].version',
+    ],
+    [
+      'chart appVersion',
+      'charts/dspace/Chart.yaml',
+      'appVersion',
+      'chart appVersion',
+    ],
+    [
+      'chart default image.tag',
+      'charts/dspace/values.yaml',
+      'image.tag',
+      'chart default image.tag',
+    ],
+  ])(
+    'labels valid application drift in %s',
+    (_coordinate, path, field, diagnostic) =>
+      withFixture((root) => {
+        const { application } = currentVersions(root);
+        const driftVersion = application === '9.8.7' ? '9.8.6' : '9.8.7';
+
+        if (path.endsWith('.json')) {
+          const document = JSON.parse(read(root, path));
+          if (field === 'packages')
+            document.packages[''].version = driftVersion;
+          else document.version = driftVersion;
+          writeFileSync(
+            join(root, path),
+            `${JSON.stringify(document, null, 2)}\n`
+          );
+        } else if (field === 'appVersion') {
+          replace(
+            root,
+            path,
+            /^appVersion:.*$/m,
+            `appVersion: "${driftVersion}"`
+          );
+        } else {
+          replace(root, path, /^(\s*tag:)\s*.*$/m, `$1 v${driftVersion}`);
+        }
+
+        const result = runGuard(root);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `Application coordinate drift: ${diagnostic}`
+        );
+      })
+  );
+
+  it('labels chart drift with its field', () =>
     withFixture((root) => {
       const { chart } = currentVersions(root);
-      replace(
-        root,
-        'frontend/package.json',
-        /"version": "[^"]+"/,
-        '"version": "9.9.9"'
-      );
       writeFileSync(
         join(root, 'docs/apps/dspace.version'),
         chart === '8.8.8' ? '8.8.7\n' : '8.8.8\n'
       );
       const result = runGuard(root);
-      expect(result.stderr).toContain(
-        'Application coordinate drift: frontend package version'
-      );
+      expect(result.status).not.toBe(0);
       expect(result.stderr).toContain(
         'Chart coordinate drift: docs/apps/dspace.version'
       );


### PR DESCRIPTION
## Motivation

Resolve #4729 following the [production version-drift postmortem](https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md) by separating the DSPACE application version from the Helm chart version while preserving strict consistency within each coordinate group.

Closes #4729

## Changes

- Refactor `scripts/check-dspace-chart-version.sh` into two independent validation groups:
  - Application: root and frontend `package.json`, both authoritative root fields in `package-lock.json`, `Chart.yaml:appVersion`, and the default semantic image tag.
  - Chart: `Chart.yaml:version` and `docs/apps/dspace.version`.
- Require strict bare SemVer for both groups, including rejection of `v` prefixes and leading-zero components.
- Require exactly one active, whitespace-clean version line in `docs/apps/dspace.version`.
- Report both coordinates on success and identify the drifting group and field on failure.
- Keep the image tag associated only with the application coordinate. Immutable branch-SHA tags or digests remain the deployment identity.
- Update `.github/workflows/ci-helm.yml` to:
  - derive the package filename and OCI reference from `Chart.yaml:version`;
  - package into a clean `$RUNNER_TEMP` destination;
  - reject missing or ambiguous archives;
  - verify the packaged chart’s `version` and `appVersion`.
- Expand `tests/helmChartReleaseVersion.test.ts` to 22 focused tests covering:
  - current repository coordinates;
  - chart `3.0.2` with application `3.0.1`;
  - valid drift in every application coordinate;
  - chart/documentation drift;
  - prefixed and malformed SemVer;
  - malformed documentation pins;
  - independent package filename derivation;
  - dual-coordinate success output;
  - exclusion of historical release records.
- Update current release documentation to distinguish the application version, chart version, immutable deployment image coordinate, and release-only semantic image tag.

## Scope

This PR does not change existing application or chart version numbers, runtime templates, application behavior, or `.github/workflows/ci-image.yml`. It does not publish or retag images or charts.

Cross-revision chart-bump enforcement is intentionally outside #4729’s current-coordinate consistency guard and remains part of the separate release-policy work tracked by #4728 and #4730. This PR also does not implement #4731’s recovery chart.

## Verification

Local verification:

~~~bash
npm run test:root -- tests/helmChartReleaseVersion.test.ts
# PASS: 22 tests

bash -n scripts/check-dspace-chart-version.sh
# PASS

bash scripts/check-dspace-chart-version.sh
# PASS: application version 3.1.0; chart version 3.1.0

npm run lint
# PASS

npm run type-check
# PASS

npm run build
# PASS

git diff --check
# PASS

git diff 02e1ccc8e859933bcb1e4481d85910ece4ab7a03...HEAD | python3 scripts/scan-secrets.py
# PASS
~~~

`npm run test:ci` was started locally but not completed after the build/build-stamp phase stopped producing output. The latest-head GitHub Actions runs completed successfully instead, including `CI`, `tests`, `ci-sentinel`, `link-check`, `Build and publish GHCR image`, and `Build & Publish Container`.

Helm was unavailable in the local environment, so the following commands were not run locally:

~~~bash
chart_dist="$(mktemp -d)"
helm lint charts/dspace
helm package charts/dspace --destination "$chart_dist"
helm show chart "$chart_dist"/dspace-*.tgz
~~~

The updated Helm publication workflow performs the deterministic package-name and embedded `version`/`appVersion` checks when that publication path runs. No publication step ran for this pull request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a640f1dd3d8832f9066c1459a91f9f8)