### PR TITLE
Decouple Helm chart and application version coordinates

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -48,17 +48,35 @@ jobs:
       - name: Package chart
         id: package
         run: |
-          helm package charts/dspace
-          echo "chart_file=$(ls dspace-*.tgz)" >> "$GITHUB_OUTPUT"
+          chart_version=$(awk '$1 == "version:" { print $2; exit }' charts/dspace/Chart.yaml)
+          chart_app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          chart_dist="$RUNNER_TEMP/dspace-chart-dist"
+          rm -rf "$chart_dist"
+          mkdir -p "$chart_dist"
+          helm package charts/dspace --destination "$chart_dist"
+
+          expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
+          mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
+          if [[ ${#chart_files[@]} -ne 1 || "${chart_files[0]:-}" != "$expected_chart_file" ]]; then
+            printf 'Expected exactly %s; found: %s\n' "$expected_chart_file" "${chart_files[*]:-(none)}" >&2
+            exit 1
+          fi
+
+          packaged_chart=$(helm show chart "$expected_chart_file")
+          packaged_version=$(awk '$1 == "version:" { print $2; exit }' <<<"$packaged_chart")
+          packaged_app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' <<<"$packaged_chart")
+          [[ "$packaged_version" == "$chart_version" ]] || { echo "Packaged chart version mismatch" >&2; exit 1; }
+          [[ "$packaged_app_version" == "$chart_app_version" ]] || { echo "Packaged chart appVersion mismatch" >&2; exit 1; }
+          echo "chart_file=$expected_chart_file" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GHCR
         run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Push chart to GHCR
-        run: helm push ${{ steps.package.outputs.chart_file }} oci://ghcr.io/democratizedspace/charts
+        run: helm push "${{ steps.package.outputs.chart_file }}" oci://ghcr.io/democratizedspace/charts
 
       - name: Export chart reference
         id: chart-ref
         run: |
-          chart_version=$(grep '^version:' charts/dspace/Chart.yaml | awk '{print $2}')
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,13 @@ must be in the source before the image will work correctly.
 
 ### Semantic Image Tag Publication (release-only)
 
+DSPACE has two independent release coordinate groups. The application version is shared by the
+root and frontend packages, root `package-lock.json` metadata, `Chart.yaml` `appVersion`, and the
+default semantic image tag. The Helm chart version is shared only by `Chart.yaml` `version`,
+`docs/apps/dspace.version`, and the packaged chart filename/reference. Both are bare SemVer, but
+they need not be equal. Immutable branch-SHA tags or digests prove deployment identity; a
+release-only `vX.Y.Z` image tag is a human-readable application coordinate, not immutable proof.
+
 `ci-image.yml` has two separate GHCR publish paths, per
 [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727) and the
 [2026-07-23 production version-drift postmortem](outages/2026-07-23-dspace-production-version-drift.md):

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -12,7 +12,10 @@ default, matching the `Dockerfile` `EXPOSE` and health check settings.
 - `replicaCount`: Pod replica count. Defaults to `2` for redundancy.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
-- `image.tag`: Image tag to deploy. Defaults to `v3.1.0`, matching the prepared current package version.
+- `image.tag`: Image tag to deploy. Defaults to `v3.1.0`, matching the application version rather
+  than the independently versioned chart. For immutable deployment evidence, override it with a
+  branch-SHA tag or digest; the release-only semantic tag is a human-readable application
+  coordinate.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
@@ -162,3 +165,8 @@ When installing from the OCI registry, you will not have access to
 `charts/dspace/values.dev.yaml` unless you clone the repository. To customize values, either
 provide your own file with `-f <your-values.yaml>` or use `--set` flags as shown above.
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
+The `--version` argument selects the independent Helm chart version (`Chart.yaml` `version` and
+`docs/apps/dspace.version`). It need not equal the application version in `Chart.yaml` `appVersion`
+or the `image.tag`. The chart package is named `dspace-<chart-version>.tgz`; application releases
+continue to use `v<application-version>` only as a human-readable semantic image tag. Production
+approvals and rollbacks should record an immutable branch-SHA image tag or digest.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -16,6 +16,14 @@ setup in their existing runbooks.
 - **Mutable branch convenience tags:** `<branch>-latest`, for example `main-latest` or `v3-latest`
 - **Version image tag:** `v<package.version>`, for example `v3.1.0`
 
+The application and chart have independent bare-SemVer coordinates. The application coordinate is
+the package version, chart `appVersion`, and semantic image version. The chart coordinate is
+`Chart.yaml` `version`, `docs/apps/dspace.version`, and the OCI chart version/package filename. A
+chart-only change increments only the chart coordinate. Neither coordinate proves which image bytes
+are deployed: use a branch-SHA tag or image digest for that immutable evidence. The release-only
+semantic image tag is human-readable application release metadata and is deliberately not the
+deployment audit coordinate.
+
 Use immutable branch-SHA tags for staging, production approvals, and rollback records whenever
 possible. Mutable branch tags are convenient for inspection but should not be the audit record for a
 production deploy.
@@ -26,8 +34,9 @@ production deploy.
    `v3` pushes, and can also be run manually for those branches.
 2. `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to the GHCR OCI chart
    registry for `main` and `v3` pushes, and can also be run manually for those branches.
-3. `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` must stay in sync so Sugarkube helper
-   recipes install the intended chart version.
+3. `charts/dspace/Chart.yaml` `version` and `docs/apps/dspace.version` must stay in sync so
+   Sugarkube helper recipes install the intended chart version. `Chart.yaml` `appVersion` instead
+   stays in the independent application coordinate group.
 4. Local Docker builds are for local development and smoke testing only. They are not the normal
    Sugarkube staging or production release path.
 

--- a/scripts/check-dspace-chart-version.sh
+++ b/scripts/check-dspace-chart-version.sh
@@ -97,31 +97,35 @@ expect_semver() {
 }
 
 expect_equal() {
-  local label="$1"
-  local actual="$2"
-  local expected="$3"
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  local expected="$4"
   if [[ -z "$actual" ]]; then
-    echo "Missing $label; expected '$expected'" >&2
+    echo "$group coordinate drift: missing $label; expected '$expected'" >&2
     failures=$((failures + 1))
   elif [[ "$actual" != "$expected" ]]; then
-    echo "$label mismatch: found '$actual', expected '$expected'" >&2
+    echo "$group coordinate drift: $label found '$actual', expected '$expected'" >&2
     failures=$((failures + 1))
   fi
 }
 
-expect_present "root package version" "$root_package_version"
-expect_semver "root package version" "$root_package_version"
-expect_equal "frontend package version" "$frontend_package_version" "$root_package_version"
-expect_equal "package-lock top-level version" "$package_lock_version" "$root_package_version"
-expect_equal 'package-lock packages[""].version' "$package_lock_root_version" "$root_package_version"
-expect_equal "chart version" "$chart_version" "$root_package_version"
-expect_equal "chart appVersion" "$chart_app_version" "$root_package_version"
-expect_equal "chart default image.tag" "$image_tag" "$expected_image_tag"
-expect_equal "docs/apps/dspace.version" "$version_line" "$root_package_version"
+expect_present "application root package version" "$root_package_version"
+expect_semver "application root package version" "$root_package_version"
+expect_semver "application chart appVersion" "$chart_app_version"
+expect_equal "Application" "frontend package version" "$frontend_package_version" "$root_package_version"
+expect_equal "Application" "package-lock top-level version" "$package_lock_version" "$root_package_version"
+expect_equal "Application" 'package-lock packages[""].version' "$package_lock_root_version" "$root_package_version"
+expect_equal "Application" "chart appVersion" "$chart_app_version" "$root_package_version"
+expect_equal "Application" "chart default image.tag" "$image_tag" "$expected_image_tag"
+
+expect_present "chart version" "$chart_version"
+expect_semver "chart version" "$chart_version"
+expect_equal "Chart" "docs/apps/dspace.version" "$version_line" "$chart_version"
 
 if (( failures > 0 )); then
-  echo "DSPACE release coordinates are not aligned." >&2
+  echo "DSPACE release coordinate validation failed." >&2
   exit 1
 fi
 
-echo "DSPACE release coordinates are aligned at ${root_package_version} (${expected_image_tag})."
+echo "DSPACE release coordinates are valid: application version ${root_package_version} (${expected_image_tag}); chart version ${chart_version}."

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -1,220 +1,212 @@
 import { describe, expect, it } from 'vitest';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(__dirname, '..');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const coordinatePaths = [
+  'package.json',
+  'package-lock.json',
+  'frontend/package.json',
+  'charts/dspace/Chart.yaml',
+  'charts/dspace/values.yaml',
+  'docs/apps/dspace.version',
+];
 
-const chartPath = join(repoRoot, 'charts', 'dspace', 'Chart.yaml');
-const valuesPath = join(repoRoot, 'charts', 'dspace', 'values.yaml');
-const versionPath = join(repoRoot, 'docs', 'apps', 'dspace.version');
-const packageLockPath = join(repoRoot, 'package-lock.json');
-const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
-const frontendPackageJson = JSON.parse(readFileSync(join(repoRoot, 'frontend', 'package.json'), 'utf8'));
-const packageLockJson = JSON.parse(readFileSync(packageLockPath, 'utf8'));
-
-const copyCoordinateFixture = () => {
-    const fixtureRoot = mkdtempSync(join(tmpdir(), 'dspace-version-'));
-    for (const path of ['package.json', 'package-lock.json', 'frontend/package.json']) {
-        mkdirSync(dirname(join(fixtureRoot, path)), { recursive: true });
-        cpSync(join(repoRoot, path), join(fixtureRoot, path), { recursive: true });
-    }
-    for (const path of ['charts/dspace/Chart.yaml', 'charts/dspace/values.yaml', 'docs/apps/dspace.version']) {
-        mkdirSync(dirname(join(fixtureRoot, path)), { recursive: true });
-        cpSync(join(repoRoot, path), join(fixtureRoot, path), { recursive: true });
-    }
-    return fixtureRoot;
+const fixture = () => {
+  const root = mkdtempSync(join(tmpdir(), 'dspace-version-'));
+  for (const path of coordinatePaths) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    cpSync(join(repoRoot, path), join(root, path));
+  }
+  return root;
 };
 
-const runGuard = (fixtureRoot: string) =>
-    spawnSync('bash', [join(repoRoot, 'scripts', 'check-dspace-chart-version.sh')], {
-        cwd: repoRoot,
-        env: { ...process.env, DSPACE_VERSION_ROOT: fixtureRoot },
-        encoding: 'utf8',
-    });
+const runGuard = (root: string) =>
+  spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
+    env: { ...process.env, DSPACE_VERSION_ROOT: root },
+    encoding: 'utf8',
+  });
 
-const writeChangedText = (path: string, current: string, next: string) => {
-    expect(next).not.toBe(current);
-    writeFileSync(path, next);
+const replace = (
+  root: string,
+  path: string,
+  search: string | RegExp,
+  value: string
+) => {
+  const file = join(root, path);
+  const current = readFileSync(file, 'utf8');
+  const next = current.replace(search, value);
+  expect(next).not.toBe(current);
+  writeFileSync(file, next);
 };
 
-const replaceFixtureText = (path: string, search: string | RegExp, replacement: string) => {
-    const current = readFileSync(path, 'utf8');
-    const next = current.replace(search, replacement);
-    writeChangedText(path, current, next);
+const withFixture = (test: (root: string) => void) => {
+  const root = fixture();
+  try {
+    test(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 };
 
 describe('DSPACE release coordinates', () => {
-    const chartContent = readFileSync(chartPath, 'utf8');
-    const valuesContent = readFileSync(valuesPath, 'utf8');
-    const versionContent = readFileSync(versionPath, 'utf8');
+  it('passes the current repository coordinates and reports both groups', () =>
+    withFixture((root) => {
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('application version 3.1.0 (v3.1.0)');
+      expect(result.stdout).toContain('chart version 3.1.0');
+    }));
 
-    const chartVersionMatch = chartContent.match(/^version:\s*"?([^"\n]+)"?/m);
-    const appVersionMatch = chartContent.match(/^appVersion:\s*"?([^"\n]+)"?/m);
-    const imageTagMatch = valuesContent.match(/^\s*tag:\s*([^\n]+)/m);
+  it('permits chart 3.0.2 with application and appVersion 3.0.1', () =>
+    withFixture((root) => {
+      for (const path of [
+        'package.json',
+        'frontend/package.json',
+        'package-lock.json',
+      ]) {
+        replace(root, path, /"version": "3\.1\.0"/g, '"version": "3.0.1"');
+      }
+      replace(
+        root,
+        'charts/dspace/Chart.yaml',
+        /^version: 3\.1\.0$/m,
+        'version: 3.0.2'
+      );
+      replace(
+        root,
+        'charts/dspace/Chart.yaml',
+        /appVersion: "3\.1\.0"/,
+        'appVersion: "3.0.1"'
+      );
+      replace(
+        root,
+        'charts/dspace/values.yaml',
+        /(tag:) v3\.1\.0/,
+        '$1 v3.0.1'
+      );
+      replace(root, 'docs/apps/dspace.version', /^3\.1\.0$/m, '3.0.2');
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('application version 3.0.1');
+      expect(result.stdout).toContain('chart version 3.0.2');
+    }));
 
-    it('sets every authoritative coordinate to the 3.1.0 release candidate metadata', () => {
-        expect(packageJson.version).toBe('3.1.0');
-        expect(frontendPackageJson.version).toBe('3.1.0');
-        expect(packageLockJson.version).toBe('3.1.0');
-        expect(packageLockJson.packages[''].version).toBe('3.1.0');
-        expect(chartVersionMatch?.[1]).toBe('3.1.0');
-        expect(appVersionMatch?.[1]).toBe('3.1.0');
-        expect(imageTagMatch?.[1].trim()).toBe('v3.1.0');
-        expect(versionContent).toMatch(/^3\.1\.0$/m);
-    });
+  it.each([
+    [
+      'frontend/package.json',
+      /"version": "3\.1\.0"/,
+      '"version": "3.0.9"',
+      'frontend package version',
+    ],
+    [
+      'package-lock.json',
+      /^  "version": "3\.1\.0",/m,
+      '  "version": "3.0.9",',
+      'package-lock top-level version',
+    ],
+    [
+      'package-lock.json',
+      /("": \{\n      "name": "dspace",\n      )"version": "3\.1\.0"/,
+      '$1"version": "3.0.9"',
+      'package-lock packages[""].version',
+    ],
+    [
+      'charts/dspace/Chart.yaml',
+      /appVersion: "3\.1\.0"/,
+      'appVersion: "3.0.9"',
+      'chart appVersion',
+    ],
+    [
+      'charts/dspace/values.yaml',
+      /(tag:) v3\.1\.0/,
+      '$1 v3.0.9',
+      'chart default image.tag',
+    ],
+  ])('rejects application drift in %s', (path, search, value, label) =>
+    withFixture((root) => {
+      replace(root, path, search, value);
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`Application coordinate drift: ${label}`);
+    })
+  );
 
-    it('keeps appVersion unprefixed while image.tag uses the human-readable v-prefixed tag', () => {
-        expect(appVersionMatch?.[1]).toBe(packageJson.version);
-        expect(appVersionMatch?.[1].startsWith('v')).toBe(false);
-        expect(imageTagMatch?.[1].trim()).toBe(`v${packageJson.version}`);
-    });
+  it('rejects root application package drift from the remaining application coordinates', () =>
+    withFixture((root) => {
+      replace(
+        root,
+        'package.json',
+        /"version": "3\.1\.0"/,
+        '"version": "3.0.9"'
+      );
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        'Application coordinate drift: frontend package version'
+      );
+    }));
 
-    it('passes the release-coordinate guard for the repository fixture', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const result = runGuard(fixtureRoot);
-            expect(result.status, result.stderr).toBe(0);
-            expect(result.stdout).toContain('DSPACE release coordinates are aligned at 3.1.0');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
+  it('rejects chart coordinate drift', () =>
+    withFixture((root) => {
+      replace(root, 'docs/apps/dspace.version', /^3\.1\.0$/m, '3.0.2');
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        'Chart coordinate drift: docs/apps/dspace.version'
+      );
+    }));
 
-    it('rejects representative coordinate mismatches without scanning historical docs', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            writeChangedText(
-                join(fixtureRoot, 'docs', 'apps', 'dspace.version'),
-                readFileSync(join(fixtureRoot, 'docs', 'apps', 'dspace.version'), 'utf8'),
-                '3.0.1\n'
-            );
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("docs/apps/dspace.version mismatch: found '3.0.1'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
+  it('rejects a v-prefixed appVersion as non-SemVer application metadata', () =>
+    withFixture((root) => {
+      replace(
+        root,
+        'charts/dspace/Chart.yaml',
+        /appVersion: "3\.1\.0"/,
+        'appVersion: "v3.1.0"'
+      );
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        'application chart appVersion must be a semantic version'
+      );
+      expect(result.stderr).toContain(
+        'Application coordinate drift: chart appVersion'
+      );
+    }));
 
+  it('derives the package filename and OCI reference from the independent chart version', () => {
+    const workflow = readFileSync(
+      join(repoRoot, '.github/workflows/ci-helm.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain(
+      'expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"'
+    );
+    expect(workflow).toContain('charts/dspace/Chart.yaml');
+    expect(workflow).toContain('steps.package.outputs.chart_version');
+    expect(workflow).not.toMatch(/package\.json[\s\S]*expected_chart_file/);
+    expect(workflow).toContain('helm show chart "$expected_chart_file"');
+  });
 
-    it('reports labeled failures when JSON coordinates are missing', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageLockFile = join(fixtureRoot, 'package-lock.json');
-            const current = readFileSync(packageLockFile, 'utf8');
-            const packageLock = JSON.parse(current);
-            expect(packageLock.version).toBe('3.1.0');
-            expect(packageLock.packages[''].version).toBe('3.1.0');
-            delete packageLock.packages[''].version;
-            writeChangedText(packageLockFile, current, `${JSON.stringify(packageLock, null, 2)}\n`);
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain(
-                `Missing package-lock packages[""].version; expected '3.1.0'`
-            );
-            expect(result.stderr).toContain('DSPACE release coordinates are not aligned.');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('reports labeled failures when docs/apps/dspace.version has no strict semver line', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            writeChangedText(
-                join(fixtureRoot, 'docs', 'apps', 'dspace.version'),
-                readFileSync(join(fixtureRoot, 'docs', 'apps', 'dspace.version'), 'utf8'),
-                '3.1.0   \n'
-            );
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("Missing docs/apps/dspace.version; expected '3.1.0'");
-            expect(result.stderr).toContain('DSPACE release coordinates are not aligned.');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-
-    it('reports labeled failures when the package-lock top-level version is missing', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageLockFile = join(fixtureRoot, 'package-lock.json');
-            const current = readFileSync(packageLockFile, 'utf8');
-            const packageLock = JSON.parse(current);
-            expect(packageLock.version).toBe('3.1.0');
-            delete packageLock.version;
-            writeChangedText(packageLockFile, current, `${JSON.stringify(packageLock, null, 2)}\n`);
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("Missing package-lock top-level version; expected '3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('reports malformed JSON coordinate files separately from missing values', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            const packageFile = join(fixtureRoot, 'package.json');
-            writeChangedText(packageFile, readFileSync(packageFile, 'utf8'), '{not json}\n');
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain('Unable to read or parse JSON coordinate file');
-            expect(result.stderr).toContain('package.json');
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('rejects a chart appVersion that includes a v prefix', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            replaceFixtureText(
-                join(fixtureRoot, 'charts', 'dspace', 'Chart.yaml'),
-                /^appVersion:\s*"?3\.1\.0"?$/m,
-                'appVersion: "v3.1.0"'
-            );
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("chart appVersion mismatch: found 'v3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('rejects an unprefixed chart default image tag', () => {
-        const fixtureRoot = copyCoordinateFixture();
-        try {
-            replaceFixtureText(
-                join(fixtureRoot, 'charts', 'dspace', 'values.yaml'),
-                /^(\s*tag:)\s*v3\.1\.0$/m,
-                '$1 3.1.0'
-            );
-
-            const result = runGuard(fixtureRoot);
-            expect(result.status).not.toBe(0);
-            expect(result.stderr).toContain("chart default image.tag mismatch: found '3.1.0'");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
-        }
-    });
-
-    it('continues to ignore historical v3.0.1 documentation outside authoritative coordinates', () => {
-        const stdout = execFileSync('bash', ['scripts/check-dspace-chart-version.sh'], {
-            cwd: repoRoot,
-            encoding: 'utf8',
-        });
-        expect(stdout).toContain('DSPACE release coordinates are aligned at 3.1.0');
-        expect(readFileSync(join(repoRoot, 'docs', 'qa', 'v3.0.1.md'), 'utf8')).toContain('v3.0.1');
-    });
+  it('does not scan historical release records as authoritative coordinates', () =>
+    withFixture((root) => {
+      mkdirSync(join(root, 'docs', 'qa'), { recursive: true });
+      writeFileSync(
+        join(root, 'docs', 'qa', 'historical.md'),
+        'chart version 0.0.1\n'
+      );
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+    }));
 });


### PR DESCRIPTION
### Motivation

- The production incident showed chart/package coordinates and application/image coordinates were conflated, causing release-integrity drift and operator confusion.  
- The goal is to validate two independent, strict bare-SemVer coordinate groups (application vs chart) so chart-only bumps do not force application version changes while still failing on any authoritative-coordinate drift.  

### Description

- Refactor `scripts/check-dspace-chart-version.sh` to validate two independent coordinate groups: an Application group (root `package.json`, `frontend/package.json`, `package-lock.json` top-level and packages[''] version, `Chart.yaml:appVersion`, and the default semantic image tag) and a Chart group (`Chart.yaml:version` and `docs/apps/dspace.version`), require bare SemVer for both groups, and emit labeled group/field failures on drift.  
- Update `.github/workflows/ci-helm.yml` to derive package filename and OCI chart reference from `Chart.yaml:version`, package into a clean temp directory, require exactly `dspace-<chart-version>.tgz`, and verify the packaged chart’s embedded `version` and `appVersion` before publishing.  
- Add and rework `tests/helmChartReleaseVersion.test.ts` fixtures to prove: current coordinates pass; chart 3.0.2 with application/appVersion 3.0.1 passes; application-coordinate drifts fail; chart-coordinate drifts fail; `v`-prefixed `appVersion` fails; packaged filename is derived from chart version; historical docs are ignored.  
- Update operator-facing docs (`docs/ops/sugarkube-release.md`, `docs/charts.md`) and `AGENTS.md` to explicitly distinguish application version, Helm chart version, immutable branch-SHA/digest as deployment evidence, and human-readable release-only semantic image tags.  
- Preserve all runtime behavior, existing version numbers, `ci-image.yml` release-only semantic-image behavior, and historical records; CI will remain authoritative for the Helm packaging proof.  

### Testing

- `npm run test:root -- tests/helmChartReleaseVersion.test.ts` — PASS (12 tests passed).  
- `bash scripts/check-dspace-chart-version.sh` — PASS (printed: "DSPACE release coordinates are valid: application version 3.1.0 (v3.1.0); chart version 3.1.0.").  
- `bash -n scripts/check-dspace-chart-version.sh` — PASS (syntax OK).  
- `npm run lint` — PASS.  
- `npm run type-check` — PASS.  
- `npm run build` — PASS.  
- `git diff --check` and `git diff | python3 scripts/scan-secrets.py` — PASS (no whitespace or secret issues).  
- Helm packaging/`helm show chart` local verification — NOT RUN here because `helm` is not installed in the execution environment; the package filename/embedded-metadata verification is enforced in `ci-helm.yml` where Helm is available.  

Closes #4729

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a640f223af0832f9dd551c74672b91e)