### PR TITLE
ci: make Helm chart publication immutable and tag-only (Closes #4728)

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -2,78 +2,115 @@ name: Publish Helm chart
 
 on:
   push:
-    branches:
-      - v3
-      - main
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch to package and publish the chart from
-        required: false
-        default: v3
-        type: choice
-        options:
-          - v3
-          - main
+    tags:
+      - chart-v*
 
 permissions:
   packages: write
   contents: read
 
+concurrency:
+  group: helm-chart-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    outputs:
-      chart_ref: ${{ steps.chart-ref.outputs.chart_ref }}
+    env:
+      CHART_TAG: ${{ github.ref_name }}
+      GHCR_GUARD_USERNAME: ${{ github.actor }}
+      GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (Actions secret reference, not a literal credential)
     steps:
-      - name: Checkout
+      - name: Checkout immutable chart tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Validate tag and source revision
+        id: source
+        run: |
+          set -euo pipefail
+          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          [[ "$chart_version" =~ $semver ]] || { echo "Chart version is not strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$app_version" =~ $semver ]] || { echo "Chart appVersion is not strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$CHART_TAG" == "chart-v${chart_version}" ]] || { echo "Tag must equal chart-v<Chart.yaml version>" >&2; exit 1; }
+          [[ "$chart_version" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
+          source_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Checked-out HEAD does not match chart tag commit" >&2; exit 1; }
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Verify chart version sync
+        run: bash scripts/check-dspace-chart-version.sh
+
+      - name: Guard chart coordinate before packaging
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.source.outputs.chart_version }}"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.12.3
 
-      - name: Build chart dependencies
-        run: helm dependency build charts/dspace
-
-      - name: Verify chart version sync
-        run: bash scripts/check-dspace-chart-version.sh
-
-      - name: Lint chart
-        run: helm lint charts/dspace
-
-      - name: Package chart
+      - name: Stage, lint, and package chart
         id: package
         run: |
-          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          set -euo pipefail
           chart_dist="$RUNNER_TEMP/dspace-chart-dist"
-          rm -rf "$chart_dist"
+          staged_chart="$RUNNER_TEMP/dspace-chart-stage/dspace"
+          rm -rf "$chart_dist" "$(dirname "$staged_chart")"
           mkdir -p "$chart_dist"
-          expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
-          helm package charts/dspace --destination "$chart_dist"
+          source_hash=$(sha256sum charts/dspace/Chart.yaml)
+          node scripts/helm-chart-provenance.mjs stage --source charts/dspace --destination "$staged_chart" --revision "${{ steps.source.outputs.source_sha }}"
+          helm dependency build "$staged_chart"
+          helm lint "$staged_chart"
+          expected_chart_file="$chart_dist/dspace-${{ steps.source.outputs.chart_version }}.tgz"
+          helm package "$staged_chart" --destination "$chart_dist"
           mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
-          if [[ ${#chart_files[@]} -ne 1 || "${chart_files[0]}" != "$expected_chart_file" ]]; then
-            printf 'Expected exactly %s; found: %s\n' "$expected_chart_file" "${chart_files[*]:-none}" >&2
-            exit 1
-          fi
-          packaged_version=$(helm show chart "$expected_chart_file" | awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }')
-          packaged_app_version=$(helm show chart "$expected_chart_file" | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }')
-          [[ "$packaged_version" == "$chart_version" ]] || { echo "Packaged chart version '$packaged_version' != '$chart_version'" >&2; exit 1; }
-          [[ "$packaged_app_version" == "$app_version" ]] || { echo "Packaged appVersion '$packaged_app_version' != '$app_version'" >&2; exit 1; }
+          [[ ${#chart_files[@]} -eq 1 && "${chart_files[0]}" == "$expected_chart_file" ]] || { echo "Expected exactly $expected_chart_file" >&2; exit 1; }
+          helm show chart "$expected_chart_file" | node scripts/helm-chart-provenance.mjs verify --version "${{ steps.source.outputs.chart_version }}" --app-version "${{ steps.source.outputs.app_version }}" --revision "${{ steps.source.outputs.source_sha }}"
+          [[ "$(sha256sum charts/dspace/Chart.yaml)" == "$source_hash" ]] || { echo "Source Chart.yaml was mutated" >&2; exit 1; }
+          archive_digest="sha256:$(sha256sum "$expected_chart_file" | awk '{print $1}')"
+          [[ "$archive_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
           echo "chart_file=$expected_chart_file" >> "$GITHUB_OUTPUT"
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "archive_digest=$archive_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Guard chart coordinate immediately before push
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.source.outputs.chart_version }}"
 
       - name: Authenticate to GHCR
-        run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+        run: printf '%s' "$GHCR_GUARD_PASSWORD" | helm registry login ghcr.io --username "$GHCR_GUARD_USERNAME" --password-stdin
 
-      - name: Push chart to GHCR
-        run: helm push ${{ steps.package.outputs.chart_file }} oci://ghcr.io/democratizedspace/charts
-
-      - name: Export chart reference
-        id: chart-ref
+      - name: Push chart to GHCR once
+        id: push
         run: |
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"
+          push_output=$(helm push "${{ steps.package.outputs.chart_file }}" oci://ghcr.io/democratizedspace/charts)
+          printf '%s\n' "$push_output"
+          reported_digest=$(printf '%s\n' "$push_output" | awk '$1 == "Digest:" { print $2 }')
+          [[ "$reported_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "reported_digest=$reported_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Record OCI digest
+        id: oci
+        run: node scripts/ghcr-manifest.mjs describe-artifact --owner democratizedspace --repo charts/dspace --tag "${{ steps.source.outputs.chart_version }}"
+
+      - name: Write publication evidence
+        run: |
+          [[ "${{ steps.package.outputs.archive_digest }}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${{ steps.oci.outputs.digest }}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${{ steps.push.outputs.reported_digest }}" == "${{ steps.oci.outputs.digest }}" ]]
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Helm chart publication evidence
+          - Chart version: ${{ steps.source.outputs.chart_version }}
+          - appVersion: ${{ steps.source.outputs.app_version }}
+          - Chart release tag: $CHART_TAG
+          - Full source SHA: ${{ steps.source.outputs.source_sha }}
+          - Source repository: https://github.com/democratizedspace/dspace
+          - OCI reference: oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.source.outputs.chart_version }}
+          - Packaged archive SHA-256: ${{ steps.package.outputs.archive_digest }}
+          - OCI manifest digest: ${{ steps.oci.outputs.digest }}
+          EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,15 @@ use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
 `scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
 `tests/ghcrManifestGuard.test.ts`.
 
+Helm chart publication is independent and is allowed only from a pushed tag exactly matching
+`chart-v<charts/dspace/Chart.yaml version>`. Ordinary `main` and `v3` pushes and manual dispatches
+never publish charts. The tag must identify the reviewed immutable commit; the workflow resolves
+both the checked-out `HEAD` and the tag's peeled commit, refuses any existing chart coordinate,
+and permanently tombstones chart version `3.0.1`. It checks GHCR before packaging and again
+immediately before its single push. A successful run records the full source SHA, staged OCI
+provenance, package SHA-256, and OCI manifest digest in the workflow summary. Never recreate a
+published chart coordinate or use an application release event to publish a chart.
+
 ### Smoke Test
 
 The `ci-image.yml` workflow includes a smoke test that:

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -148,10 +148,18 @@ For the standard Sugarkube staging and production flow, use the
 Helm commands below remain useful for local clusters, development environments, and manual chart
 inspection.
 
-The chart is published to the GitHub Container Registry on `v3` and `main` pushes. Its OCI version
-comes from `Chart.yaml:version` and may differ from the application version in `appVersion` and the
-package files. `docs/apps/dspace.version` pins the chart coordinate. The semantic image tag follows
-the application coordinate, but a branch-SHA tag or digest is required as immutable deployment
+The chart is published to GitHub Container Registry only when an operator pushes the exact tag
+`chart-v<chart-version>` (for example, `chart-v3.1.0`). That tag must point to the reviewed immutable
+commit whose `charts/dspace/Chart.yaml:version` matches it. Ordinary `main` and `v3` pushes never
+publish charts, and an existing chart coordinate cannot be replaced. Chart version `3.0.1` is
+permanently tombstoned and cannot be republished even if GHCR later reports it absent; a later chart
+may still legitimately use application `appVersion: 3.0.1`.
+
+The OCI version comes from `Chart.yaml:version` and may differ from the application version in
+`appVersion` and the package files. `docs/apps/dspace.version` pins the chart coordinate. The
+successful chart workflow summary records the full source SHA, packaged archive SHA-256, OCI
+manifest digest, and provenance coordinates for audit. The semantic image tag follows the
+application coordinate, but a branch-SHA tag or digest is required as immutable image deployment
 evidence. After the publish workflow has completed successfully, use this installation procedure:
 
 ```bash

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -20,6 +20,8 @@ setup in their existing runbooks.
   advance independently of the application version
 - **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
   release and human-readable, but not proof of the deployed image
+- **Chart release tag:** exactly `chart-v<chart version>`, for example `chart-v3.1.0`; it must point
+  to the reviewed immutable commit whose `Chart.yaml:version` matches
 
 Use immutable branch-SHA tags or image digests for staging, production approvals, and rollback
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
@@ -29,14 +31,23 @@ be the audit record for a production deploy.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
-2. `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to the GHCR OCI chart
-   registry for `main` and `v3` pushes, and can also be run manually for those branches.
+2. `.github/workflows/ci-helm.yml` packages `charts/dspace` only for a pushed tag exactly matching
+   `chart-v<Chart.yaml version>`. Ordinary `main` and `v3` pushes and manual dispatches never
+   publish charts. The workflow refuses to replace an existing coordinate, checks for existence
+   both before packaging and immediately before its single push, and permanently rejects chart
+   version `3.0.1` even if that coordinate later appears absent. A later chart may retain
+   `appVersion: 3.0.1`.
 3. `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` must stay in sync so Sugarkube helper
    recipes install the intended chart version. Separately, package metadata and
    `Chart.yaml:appVersion` stay aligned on the application version; neither group must equal the
    other.
 4. Local Docker builds are for local development and smoke testing only. They are not the normal
    Sugarkube staging or production release path.
+
+Before chart publication, review the exact commit, ensure its chart coordinate is ready, and create
+the matching `chart-v<chart-version>` tag at that commit. Do not reuse or move a chart release tag.
+After a successful run, retain the workflow summary: it provides the chart tag, full source SHA,
+source repository, OCI reference, package SHA-256, and OCI manifest digest as audit evidence.
 
 ## Deploy staging
 

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -190,7 +190,7 @@ export async function assertTagAbsent({
 
     if (manifest.status === 'present') {
         throw new GhcrGuardError(
-            `Semantic tag ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
+            `Artifact coordinate ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
             { code: 'exists' }
         );
     }
@@ -244,14 +244,29 @@ export async function describeManifest({
     };
 }
 
+// Artifact-neutral evidence lookup for single-manifest artifacts such as Helm charts.
+export async function describeArtifact(options) {
+    const token = await fetchGhcrToken(options); // scan-secrets: ignore (env credential plumbing)
+    const manifest = await getManifest({ ...options, token });
+    if (manifest.status !== 'present') {
+        throw new GhcrGuardError('Expected GHCR artifact to exist, but it was absent', {
+            code: 'missing-after-publish',
+        });
+    }
+    if (!/^sha256:[0-9a-f]{64}$/.test(manifest.digest)) {
+        throw new GhcrGuardError('GHCR artifact digest was malformed', { code: 'malformed' });
+    }
+    return { digest: manifest.digest };
+}
+
 const FLAG_KEYS = new Set(['owner', 'repo', 'tag']);
 
 export function parseArgs(argv) {
     const [subcommand, ...rest] = argv;
 
-    if (subcommand !== 'check-absent' && subcommand !== 'describe') {
+    if (!['check-absent', 'describe', 'describe-artifact'].includes(subcommand)) {
         throw new GhcrGuardError(
-            'Usage: ghcr-manifest.mjs <check-absent|describe> --owner <owner> --repo <repo> --tag <tag>',
+            'Usage: ghcr-manifest.mjs <check-absent|describe|describe-artifact> --owner <owner> --repo <repo> --tag <tag>',
             { code: 'invalid-input' }
         );
     }
@@ -307,6 +322,13 @@ export async function main(argv = process.argv.slice(2)) {
         console.log(
             `GHCR tag ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
         );
+        return;
+    }
+
+    if (subcommand === 'describe-artifact') {
+        const artifact = await describeArtifact({ owner, repo, tag, username, password });
+        writeGithubOutput([['digest', artifact.digest]]);
+        console.log(`Recorded GHCR digest for ${owner}/${repo}:${tag}.`);
         return;
     }
 

--- a/scripts/helm-chart-provenance.mjs
+++ b/scripts/helm-chart-provenance.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parse, stringify } from 'yaml';
+
+export const SOURCE_REPOSITORY = 'https://github.com/democratizedspace/dspace';
+export const STRICT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+export const FULL_REVISION = /^[0-9a-f]{40}$/;
+
+function requireValue(value, label, pattern) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`Invalid ${label}: expected ${pattern}`);
+  }
+  return value;
+}
+
+export function readChartMetadata(chartYaml) {
+  const chart = parse(chartYaml);
+  if (!chart || typeof chart !== 'object' || Array.isArray(chart)) {
+    throw new Error('Chart metadata must be a YAML mapping');
+  }
+  requireValue(chart.version, 'chart version', STRICT_SEMVER);
+  requireValue(chart.appVersion, 'chart appVersion', STRICT_SEMVER);
+  return chart;
+}
+
+export function stampChartMetadata(chartYaml, revision) {
+  requireValue(revision, 'full source revision', FULL_REVISION);
+  const chart = readChartMetadata(chartYaml);
+  chart.annotations = {
+    ...(chart.annotations && typeof chart.annotations === 'object'
+      ? chart.annotations
+      : {}),
+    'org.opencontainers.image.source': SOURCE_REPOSITORY,
+    'org.opencontainers.image.revision': revision,
+    'org.opencontainers.image.version': chart.appVersion,
+  };
+  return stringify(chart, { lineWidth: 0 });
+}
+
+export function verifyChartProvenance(
+  chartYaml,
+  { version, appVersion, revision }
+) {
+  requireValue(version, 'expected chart version', STRICT_SEMVER);
+  requireValue(appVersion, 'expected appVersion', STRICT_SEMVER);
+  requireValue(revision, 'full source revision', FULL_REVISION);
+  const chart = readChartMetadata(chartYaml);
+  const expected = {
+    version,
+    appVersion,
+    source: SOURCE_REPOSITORY,
+    revision,
+  };
+  const actual = {
+    version: chart.version,
+    appVersion: chart.appVersion,
+    source: chart.annotations?.['org.opencontainers.image.source'],
+    revision: chart.annotations?.['org.opencontainers.image.revision'],
+  };
+  if (chart.annotations?.['org.opencontainers.image.version'] !== appVersion) {
+    throw new Error(
+      'Packaged chart application-version annotation does not match'
+    );
+  }
+  for (const key of Object.keys(expected)) {
+    if (actual[key] !== expected[key])
+      throw new Error(`Packaged chart ${key} does not match`);
+  }
+  return chart;
+}
+
+function args(argv) {
+  const [command, ...rest] = argv;
+  const values = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    if (!flag?.startsWith('--') || !rest[index + 1])
+      throw new Error(`Invalid argument: ${flag}`);
+    values[flag.slice(2)] = rest[index + 1];
+  }
+  return { command, values };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { command, values } = args(argv);
+  if (command === 'stage') {
+    if (!values.source || !values.destination)
+      throw new Error('stage requires --source and --destination');
+    const sourceYaml = readFileSync(join(values.source, 'Chart.yaml'), 'utf8');
+    readChartMetadata(sourceYaml);
+    mkdirSync(dirname(values.destination), { recursive: true });
+    cpSync(values.source, values.destination, { recursive: true });
+    writeFileSync(
+      join(values.destination, 'Chart.yaml'),
+      stampChartMetadata(sourceYaml, values.revision)
+    );
+    return;
+  }
+  if (command === 'verify') {
+    verifyChartProvenance(readFileSync(0, 'utf8'), {
+      version: values.version,
+      appVersion: values['app-version'],
+      revision: values.revision,
+    });
+    return;
+  }
+  throw new Error('Usage: helm-chart-provenance.mjs <stage|verify> ...');
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error?.message || error);
+    process.exit(1);
+  }
+}

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  join(process.cwd(), '.github/workflows/ci-helm.yml'),
+  'utf8'
+);
+
+describe('Helm publication workflow integrity', () => {
+  it('has only the chart-specific tag trigger, not branches, dispatch, or releases', () => {
+    expect(workflow).toMatch(/push:\n\s+tags:\n\s+- chart-v\*/);
+    expect(workflow).not.toMatch(/branches:|workflow_dispatch:|release:/);
+  });
+
+  it('validates the attacker-controlled tag via environment and resolves annotated or lightweight tags', () => {
+    expect(workflow).toContain('CHART_TAG: ${{ github.ref_name }}');
+    expect(workflow).toContain('"$CHART_TAG" == "chart-v${chart_version}"');
+    expect(workflow).toContain('git rev-parse "${CHART_TAG}^{commit}"');
+    expect(workflow).toContain('source_sha=$(git rev-parse HEAD)');
+    expect(workflow).toContain('fetch-depth: 0');
+    expect(workflow).not.toContain('${{ github.ref_name }}^{commit}');
+  });
+
+  it('tombstones 3.0.1 before both fail-closed checks against the chart repository', () => {
+    const tombstone = workflow.indexOf('chart_version" != "3.0.1');
+    const packageStep = workflow.indexOf('Stage, lint, and package chart');
+    const checks = [
+      ...workflow.matchAll(
+        /ghcr-manifest\.mjs check-absent --owner democratizedspace --repo charts\/dspace/g
+      ),
+    ].map((m) => m.index!);
+    expect(checks).toHaveLength(2);
+    expect(tombstone).toBeLessThan(checks[0]);
+    expect(checks[0]).toBeLessThan(packageStep);
+    expect(checks[1]).toBeGreaterThan(packageStep);
+    expect(
+      workflow.slice(checks[1], workflow.indexOf('Push chart to GHCR once'))
+    ).not.toContain('helm package');
+  });
+
+  it('serializes same-tag runs without cancellation and pushes exactly once without suppression', () => {
+    expect(workflow).toContain('group: helm-chart-${{ github.ref_name }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow.match(/helm push/g)).toHaveLength(1);
+    expect(workflow).not.toMatch(/continue-on-error|\|\|\s*true|retry/);
+  });
+
+  it('stages provenance, validates digests, summarizes evidence, and keeps credentials out of arguments', () => {
+    expect(workflow).toContain('helm-chart-provenance.mjs stage');
+    expect(workflow).toContain('helm-chart-provenance.mjs verify');
+    expect(workflow).toContain('sha256sum charts/dspace/Chart.yaml');
+    expect(workflow.match(/\^sha256:\[0-9a-f\]\{64\}\$/g)).toHaveLength(4);
+    expect(workflow).toContain('steps.push.outputs.reported_digest');
+    for (const field of [
+      'Chart version',
+      'appVersion',
+      'Chart release tag',
+      'Full source SHA',
+      'Source repository',
+      'OCI reference',
+      'Packaged archive SHA-256',
+      'OCI manifest digest',
+    ]) {
+      expect(workflow).toContain(field);
+    }
+    expect(workflow).toContain('--password-stdin');
+    expect(workflow).not.toContain('-p "${{ secrets.GITHUB_TOKEN }}"');
+  });
+});

--- a/tests/helmChartProvenance.test.ts
+++ b/tests/helmChartProvenance.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  SOURCE_REPOSITORY,
+  stampChartMetadata,
+  verifyChartProvenance,
+} from '../scripts/helm-chart-provenance.mjs';
+import { parse } from 'yaml';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const source = `apiVersion: v2
+name: dspace
+version: 4.2.1
+appVersion: "3.1.0"
+description: preserved
+annotations:
+  example.test/preserved: yes
+`;
+
+describe('Helm chart provenance metadata', () => {
+  it('preserves chart fields and annotations while stamping exact provenance', () => {
+    const chart = parse(stampChartMetadata(source, revision));
+    expect(chart.description).toBe('preserved');
+    expect(chart.annotations['example.test/preserved']).toBe('yes');
+    expect(chart.annotations).toMatchObject({
+      'org.opencontainers.image.source': SOURCE_REPOSITORY,
+      'org.opencontainers.image.revision': revision,
+      'org.opencontainers.image.version': '3.1.0',
+    });
+    expect(() =>
+      verifyChartProvenance(stampChartMetadata(source, revision), {
+        version: '4.2.1',
+        appVersion: '3.1.0',
+        revision,
+      })
+    ).not.toThrow();
+  });
+
+  it.each(['abc1234', `${revision}0`, revision.toUpperCase(), 'not-a-sha'])(
+    'rejects malformed or non-full revision %s',
+    (invalid) =>
+      expect(() => stampChartMetadata(source, invalid)).toThrow(
+        /full source revision/
+      )
+  );
+
+  it('rejects malformed chart coordinates and provenance mismatches', () => {
+    expect(() =>
+      stampChartMetadata(source.replace('4.2.1', 'v4.2.1'), revision)
+    ).toThrow();
+    expect(() =>
+      verifyChartProvenance(stampChartMetadata(source, revision), {
+        version: '4.2.0',
+        appVersion: '3.1.0',
+        revision,
+      })
+    ).toThrow(/version does not match/);
+  });
+
+  it('does not modify source content while producing staged metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'chart-provenance-'));
+    const file = join(root, 'Chart.yaml');
+    try {
+      writeFileSync(file, source);
+      stampChartMetadata(readFileSync(file, 'utf8'), revision);
+      expect(readFileSync(file, 'utf8')).toBe(source);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -281,12 +281,11 @@ describe('independent DSPACE application and chart coordinates', () => {
     expect(workflow).toContain('mkdir -p "$chart_dist"');
     expect(workflow).not.toContain('mktemp -d');
     expect(workflow).toContain(
-      'expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"'
+      'expected_chart_file="$chart_dist/dspace-${{ steps.source.outputs.chart_version }}.tgz"'
     );
     expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
-    expect(workflow).toContain('packaged_version=$(helm show chart');
-    expect(workflow).toContain('packaged_app_version=$(helm show chart');
-    expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
+    expect(workflow).toContain('helm show chart "$expected_chart_file"');
+    expect(workflow).toContain('${{ steps.source.outputs.chart_version }}');
   });
 
   it('does not scan historical release records as authoritative coordinates', () =>


### PR DESCRIPTION
### Motivation

- Prevent accidental or repeat Helm chart publication from ordinary branch pushes (the repeat-publication path that republished `ghcr.io/democratizedspace/charts/dspace:3.1.0` in run #934 / https://github.com/democratizedspace/dspace/actions/runs/30141535426).  
- Ensure chart publication is explicit, auditable, and fail-closed by tying it to an immutable source commit and disallowing overwrite of existing chart coordinates.  
- Add artifact provenance and strong registry-guard checks so only an authoritative 404 permits publication and reported digests are validated.  
- Permanently tombstone chart version `3.0.1` to close the repeat-republication vector described in the postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md.

### Description

- Replace the branch-triggered Helm workflow with a tag-only trigger by changing `.github/workflows/ci-helm.yml` to run only on `push: tags: [chart-v*]`, use tag-scoped concurrency `group: helm-chart-${{ github.ref_name }}` and `cancel-in-progress: false`, and check out full history (`fetch-depth: 0`).  
- Validate the pushed tag at runtime: require `chart-v<Chart.yaml version>` (strict `X.Y.Z` SemVer), peel annotated/lightweight tags, resolve `git rev-parse HEAD` and `${CHART_TAG}^{commit}` and require an exact match, and reject `chart version == 3.0.1` up-front (tombstone).  
- Add two fail-closed registry existence guards using `scripts/ghcr-manifest.mjs` against `democratizedspace/charts/dspace:<chartVersion>`: one before packaging and one immediately before the single `helm push`; only an authoritative `404` permits progress and any indeterminate outcome blocks.  
- Add `scripts/helm-chart-provenance.mjs` to stage a temporary copy of `charts/dspace`, stamp it with safe OCI provenance annotations (`org.opencontainers.image.source`, `org.opencontainers.image.revision` (full 40-char SHA), `org.opencontainers.image.version`), preserve original `Chart.yaml`, and provide a `verify` helper to validate packaged provenance.  
- Package from the staged copy, verify exactly one expected `dspace-<version>.tgz` is produced, confirm chart `version` and `appVersion` and provenance annotations, compute the archive SHA-256, perform a single `helm push`, capture the `helm push` reported digest, call the GHCR read-only descriptor to get the authoritative manifest digest, validate formats (`sha256:[0-9a-f]{64}`) and that reported digest equals manifest digest, and write a compact publication evidence summary to the GitHub Actions summary (chart version, appVersion, chart tag, full source SHA, source repo, OCI reference, packaged SHA-256, OCI manifest digest).  
- Keep credentials out of command-line arguments by passing registry credentials only via `GHCR_GUARD_USERNAME` / `GHCR_GUARD_PASSWORD` (and `--password-stdin` for `helm registry login`).  
- Extend `scripts/ghcr-manifest.mjs` with an artifact-neutral `describe-artifact` path while preserving existing image multi-arch `describe` behavior and tests.  
- Add focused tests: `tests/ciHelmWorkflow.test.ts` (workflow integrity and tag-only model), `tests/helmChartProvenance.test.ts` (provenance staging/verify), and adapt `tests/helmChartReleaseVersion.test.ts` to the new workflow variables.  
- Update operator guidance and docs: `docs/charts.md`, `docs/ops/sugarkube-release.md`, and `AGENTS.md` to describe the new `chart-v<version>` tag-only release model, tombstone behavior, and the evidence recorded by successful runs.

### Testing

- Ran the focused unit/workflow tests: `npm run test:root -- tests/ciHelmWorkflow.test.ts tests/ghcrManifestGuard.test.ts tests/helmChartReleaseVersion.test.ts tests/helmChartProvenance.test.ts`, and all tests passed (62 tests).  
- Ran chart/check helpers: `bash scripts/check-dspace-chart-version.sh` — passed.  
- Performed static checks: `npm run lint` — passed, `npm run type-check` — passed, and `npm run build` completed (was executed as part of `test:ci` pre-build).  
- Verified packaging/provenance flow locally up to the point that requires `helm`: staged a provenance copy and ran the `verify` helper; however `helm` is not installed in this environment so `helm lint`, `helm package`, and `helm show chart` full local validation could not be executed here (`helm: command not found`).  
- Confirmed registry-guard tests via `tests/ghcrManifestGuard.test.ts` exercised timeouts, auth, malformed and 404 behaviors and passed.  
- Confirmed no sensitive credentials were placed in command arguments or logs; `GHCR_GUARD_PASSWORD` is read from `secrets.GITHUB_TOKEN` only via env and `--password-stdin`.  

Notes and constraints

- This PR implements the tag-only chart publication model, double fail-closed GHCR checks, the `3.0.1` tombstone, provenance stamping, single `helm push` with digest validation, and documentation updates.  
- Environment limitations: `helm` and `actionlint` were not available in this runner, so local `helm`-driven lint/package/show checks could not be executed here; CI will run these in GitHub-hosted runners that have those tools available.  
- No Git tags were created and no OCI artifacts were pushed, deleted, retagged, or otherwise modified while verifying this change.  

Administrative

- Closes #4728.  
- Postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md.  
- Repeat-publication evidence: run #934 — https://github.com/democratizedspace/dspace/actions/runs/30141535426.  
- Verification summary included above; commit for this change is `ci: make Helm chart publication immutable` (contained in this PR).  

If you want, I can (in a follow-up PR) add a small operator-facing checklist / release template that documents the exact steps to create a `chart-v<version>` tag at the intended immutable commit and run the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642cd7049c832f86234addf3fbbc69)