### PR TITLE
ci: make Helm chart publication immutable

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -2,78 +2,128 @@ name: Publish Helm chart
 
 on:
   push:
-    branches:
-      - v3
-      - main
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch to package and publish the chart from
-        required: false
-        default: v3
-        type: choice
-        options:
-          - v3
-          - main
+    tags:
+      - 'chart-v*'
 
 permissions:
   packages: write
   contents: read
 
+concurrency:
+  group: helm-chart-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    outputs:
-      chart_ref: ${{ steps.chart-ref.outputs.chart_ref }}
+    env:
+      CHART_TAG: ${{ github.ref_name }}
+      CHART_SOURCE_DIR: charts/dspace
+      CHART_REPOSITORY: dspace
+      OCI_REPOSITORY: oci://ghcr.io/democratizedspace/charts
+      OCI_REFERENCE_BASE: ghcr.io/democratizedspace/charts/dspace
     steps:
-      - name: Checkout
+      - name: Checkout triggering tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Validate immutable source and stage provenance metadata
+        id: release
+        run: |
+          set -euo pipefail
+          source_revision=$(git rev-parse HEAD)
+          tag_revision=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$source_revision" == "$tag_revision" ]] || { echo 'Checked-out HEAD does not match the chart tag commit' >&2; exit 1; }
+          export SOURCE_REVISION="$source_revision"
+          export CHART_STAGED_DIR="$RUNNER_TEMP/dspace-chart"
+          rm -rf "$CHART_STAGED_DIR"
+          node scripts/helm-chart-release.mjs stage
+          git diff --exit-code -- charts/dspace/Chart.yaml
+          echo "staged_dir=$CHART_STAGED_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse an existing chart coordinate before packaging
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.release.outputs.chartVersion }}"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.12.3
 
-      - name: Build chart dependencies
-        run: helm dependency build charts/dspace
-
-      - name: Verify chart version sync
-        run: bash scripts/check-dspace-chart-version.sh
-
-      - name: Lint chart
-        run: helm lint charts/dspace
-
-      - name: Package chart
-        id: package
+      - name: Verify chart coordinates and lint staged chart
         run: |
-          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          bash scripts/check-dspace-chart-version.sh
+          helm dependency build "${{ steps.release.outputs.staged_dir }}"
+          helm lint "${{ steps.release.outputs.staged_dir }}"
+
+      - name: Package and verify staged chart
+        id: package
+        env:
+          CHART_VERSION: ${{ steps.release.outputs.chartVersion }}
+          APP_VERSION: ${{ steps.release.outputs.appVersion }}
+          SOURCE_REVISION: ${{ steps.release.outputs.revision }}
+        run: |
+          set -euo pipefail
           chart_dist="$RUNNER_TEMP/dspace-chart-dist"
           rm -rf "$chart_dist"
           mkdir -p "$chart_dist"
-          expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
-          helm package charts/dspace --destination "$chart_dist"
-          mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
-          if [[ ${#chart_files[@]} -ne 1 || "${chart_files[0]}" != "$expected_chart_file" ]]; then
-            printf 'Expected exactly %s; found: %s\n' "$expected_chart_file" "${chart_files[*]:-none}" >&2
-            exit 1
-          fi
-          packaged_version=$(helm show chart "$expected_chart_file" | awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }')
-          packaged_app_version=$(helm show chart "$expected_chart_file" | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }')
-          [[ "$packaged_version" == "$chart_version" ]] || { echo "Packaged chart version '$packaged_version' != '$chart_version'" >&2; exit 1; }
-          [[ "$packaged_app_version" == "$app_version" ]] || { echo "Packaged appVersion '$packaged_app_version' != '$app_version'" >&2; exit 1; }
-          echo "chart_file=$expected_chart_file" >> "$GITHUB_OUTPUT"
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          helm package "${{ steps.release.outputs.staged_dir }}" --destination "$chart_dist"
+          expected="$chart_dist/dspace-${CHART_VERSION}.tgz"
+          mapfile -t packages < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
+          [[ ${#packages[@]} -eq 1 && "${packages[0]}" == "$expected" ]] || { echo 'Expected exactly one correctly named chart package' >&2; exit 1; }
+          CHART_ARCHIVE="$expected" node scripts/helm-chart-release.mjs verify-package
+          git diff --exit-code -- charts/dspace/Chart.yaml
+          archive_digest="sha256:$(sha256sum "$expected" | cut -d' ' -f1)"
+          DIGEST_VALUE="$archive_digest" DIGEST_LABEL='packaged archive digest' node scripts/helm-chart-release.mjs validate-digest
+          echo "chart_file=$expected" >> "$GITHUB_OUTPUT"
+          echo "archive_digest=$archive_digest" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GHCR
-        run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+        run: helm registry login ghcr.io -u "$GHCR_USERNAME" --password-stdin <<<"$GHCR_PASSWORD"
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
 
-      - name: Push chart to GHCR
-        run: helm push ${{ steps.package.outputs.chart_file }} oci://ghcr.io/democratizedspace/charts
+      - name: Refuse an existing chart coordinate immediately before push
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.release.outputs.chartVersion }}"
 
-      - name: Export chart reference
-        id: chart-ref
+      - name: Push chart once and capture digest
+        id: push
+        env:
+          CHART_FILE: ${{ steps.package.outputs.chart_file }}
         run: |
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          push_output=$(helm push "$CHART_FILE" "$OCI_REPOSITORY" 2>&1)
+          printf '%s\n' "$push_output"
+          oci_digest=$(printf '%s\n' "$push_output" | sed -nE 's/^Digest: (sha256:[0-9a-f]{64})$/\1/p')
+          [[ $(printf '%s\n' "$oci_digest" | sed '/^$/d' | wc -l) -eq 1 ]] || { echo 'helm push did not report exactly one valid OCI digest' >&2; exit 1; }
+          DIGEST_VALUE="$oci_digest" DIGEST_LABEL='OCI manifest digest' node scripts/helm-chart-release.mjs validate-digest
+          echo "oci_digest=$oci_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Record publication evidence
+        env:
+          CHART_VERSION: ${{ steps.release.outputs.chartVersion }}
+          APP_VERSION: ${{ steps.release.outputs.appVersion }}
+          SOURCE_REVISION: ${{ steps.release.outputs.revision }}
+          ARCHIVE_DIGEST: ${{ steps.package.outputs.archive_digest }}
+          OCI_DIGEST: ${{ steps.push.outputs.oci_digest }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Helm chart publication evidence
+
+          - Chart version: \`$CHART_VERSION\`
+          - appVersion: \`$APP_VERSION\`
+          - Chart release tag: \`$CHART_TAG\`
+          - Full source SHA: \`$SOURCE_REVISION\`
+          - Source repository: \`https://github.com/democratizedspace/dspace\`
+          - OCI reference: \`$OCI_REFERENCE_BASE:$CHART_VERSION\`
+          - Packaged archive SHA-256: \`$ARCHIVE_DIGEST\`
+          - OCI manifest digest: \`$OCI_DIGEST\`
+          EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,15 @@ use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
 `scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
 `tests/ghcrManifestGuard.test.ts`.
 
+Helm chart publication is separate and tag-only. `.github/workflows/ci-helm.yml` may publish only
+from an exact `chart-v<Chart.yaml version>` tag pointing at the reviewed immutable commit; ordinary
+`main` and `v3` pushes never publish charts. The workflow must reject an existing chart coordinate,
+check once before packaging and again immediately before its single push, and permanently reject
+chart version `3.0.1` even if the registry reports it absent. It stages OCI source/revision/version
+annotations without changing the tracked chart. Its successful summary is the audit record for the
+full source SHA, packaged archive digest, and OCI manifest digest. Never create a chart tag until the
+chart version and commit have been reviewed.
+
 ### Smoke Test
 
 The `ci-image.yml` workflow includes a smoke test that:

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -7,6 +7,21 @@ Helm publishing workflow. Do not use `deploy/charts/dspace/` as release evidence
 automation is intentionally migrated. The chart uses the application container port `8080` by
 default, matching the `Dockerfile` `EXPOSE` and health check settings.
 
+## Publishing releases
+
+Charts publish only when an operator pushes an exact `chart-v<chart-version>` tag. The tag must
+point to the reviewed immutable commit whose `charts/dspace/Chart.yaml` version matches the tag;
+ordinary `main` and `v3` pushes never publish charts. Before creating the tag, confirm that the
+coordinate is new: the workflow fails closed unless GHCR authoritatively reports it absent both
+before packaging and immediately before its one push. Existing coordinates cannot be replaced.
+Chart version `3.0.1` is permanently tombstoned and cannot be published again, even if it appears
+absent; a later chart may still use `appVersion: 3.0.1`.
+
+The workflow packages a temporary staged copy and adds OCI source, full source-revision, and
+application-version annotations without modifying the tracked chart. A successful workflow summary
+records the chart tag and versions, immutable source SHA, OCI reference, packaged archive SHA-256,
+and OCI manifest digest as publication evidence.
+
 ## Key values
 
 - `replicaCount`: Pod replica count. Defaults to `2` for redundancy.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -18,6 +18,7 @@ setup in their existing runbooks.
   `Chart.yaml:appVersion`
 - **Chart version:** the matching `Chart.yaml:version` and `docs/apps/dspace.version`; this may
   advance independently of the application version
+- **Chart release tag:** exact `chart-v<chart version>`, pointing to the reviewed immutable commit
 - **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
   release and human-readable, but not proof of the deployed image
 
@@ -29,8 +30,13 @@ be the audit record for a production deploy.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
-2. `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to the GHCR OCI chart
-   registry for `main` and `v3` pushes, and can also be run manually for those branches.
+2. `.github/workflows/ci-helm.yml` packages and publishes `charts/dspace` only when an operator
+   pushes an exact `chart-v<Chart.yaml version>` tag at the reviewed immutable commit. Ordinary
+   `main`/`v3` pushes and mutable-branch manual dispatches never publish charts. The workflow checks
+   twice that the coordinate is absent and never replaces an existing coordinate. Chart `3.0.1` is
+   permanently tombstoned even if it later appears absent (later charts may retain
+   `appVersion: 3.0.1`). Its successful summary records the full source SHA plus package and OCI
+   digests as auditable publication evidence.
 3. `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` must stay in sync so Sugarkube helper
    recipes install the intended chart version. Separately, package metadata and
    `Chart.yaml:appVersion` stay aligned on the application version; neither group must equal the

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -190,7 +190,7 @@ export async function assertTagAbsent({
 
     if (manifest.status === 'present') {
         throw new GhcrGuardError(
-            `Semantic tag ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
+            `Artifact ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
             { code: 'exists' }
         );
     }
@@ -214,7 +214,7 @@ export async function describeManifest({
 
     if (manifest.status !== 'present') {
         throw new GhcrGuardError(
-            `Expected GHCR tag ${owner}/${repo}:${tag} to exist after publish, but the registry reported it as absent`,
+            `Expected GHCR artifact ${owner}/${repo}:${tag} to exist after publish, but the registry reported it as absent`,
             { code: 'missing-after-publish' }
         );
     }
@@ -232,7 +232,7 @@ export async function describeManifest({
     const arm64Digest = findDigest('arm64');
     if (!amd64Digest || !arm64Digest) {
         throw new GhcrGuardError(
-            `GHCR tag ${owner}/${repo}:${tag} does not contain non-empty digests for both required platforms linux/amd64 and linux/arm64`,
+            `GHCR image ${owner}/${repo}:${tag} does not contain non-empty digests for both required platforms linux/amd64 and linux/arm64`,
             { code: 'missing-platform' }
         );
     }
@@ -305,7 +305,7 @@ export async function main(argv = process.argv.slice(2)) {
     if (subcommand === 'check-absent') {
         await assertTagAbsent({ owner, repo, tag, username, password });
         console.log(
-            `GHCR tag ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
+            `GHCR artifact ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
         );
         return;
     }

--- a/scripts/helm-chart-release.mjs
+++ b/scripts/helm-chart-release.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { parse, stringify } from 'yaml';
+
+export const SOURCE_REPOSITORY = 'https://github.com/democratizedspace/dspace';
+export const TOMBSTONED_CHART_VERSION = '3.0.1';
+const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const REVISION = /^[0-9a-f]{40}$/;
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+
+function requireMatch(value, pattern, label) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`${label} is invalid: ${value || '<empty>'}`);
+  }
+  return value;
+}
+
+export function validateChartRelease({
+  chartVersion,
+  appVersion,
+  chartTag,
+  revision,
+}) {
+  requireMatch(chartVersion, SEMVER, 'chart version');
+  requireMatch(appVersion, SEMVER, 'appVersion');
+  requireMatch(revision, REVISION, 'source revision');
+  if (chartVersion === TOMBSTONED_CHART_VERSION) {
+    throw new Error(
+      `Chart version ${TOMBSTONED_CHART_VERSION} is permanently tombstoned`
+    );
+  }
+  if (chartTag !== `chart-v${chartVersion}`) {
+    throw new Error(`chart tag must equal chart-v${chartVersion}`);
+  }
+  return { chartVersion, appVersion, chartTag, revision };
+}
+
+export function readChart(chartPath) {
+  const chart = parse(readFileSync(chartPath, 'utf8'));
+  if (!chart || typeof chart !== 'object' || Array.isArray(chart)) {
+    throw new Error('Chart.yaml must contain a YAML mapping');
+  }
+  return chart;
+}
+
+export function stageChart({ sourceDir, stagedDir, chartTag, revision }) {
+  const sourceChartPath = `${sourceDir}/Chart.yaml`;
+  const original = readFileSync(sourceChartPath, 'utf8');
+  const chart = readChart(sourceChartPath);
+  validateChartRelease({
+    chartVersion: chart.version,
+    appVersion: String(chart.appVersion),
+    chartTag,
+    revision,
+  });
+  cpSync(sourceDir, stagedDir, { recursive: true, errorOnExist: true });
+  chart.annotations = {
+    ...(chart.annotations || {}),
+    'org.opencontainers.image.source': SOURCE_REPOSITORY,
+    'org.opencontainers.image.revision': revision,
+    'org.opencontainers.image.version': String(chart.appVersion),
+  };
+  writeFileSync(`${stagedDir}/Chart.yaml`, stringify(chart));
+  if (readFileSync(sourceChartPath, 'utf8') !== original) {
+    throw new Error('Source Chart.yaml was mutated while staging');
+  }
+  return { chartVersion: chart.version, appVersion: String(chart.appVersion) };
+}
+
+export function validateDigest(value, label) {
+  return requireMatch(value, DIGEST, label);
+}
+
+export function verifyPackage({ archive, chartVersion, appVersion, revision }) {
+  if (!existsSync(archive))
+    throw new Error(`Expected chart archive does not exist: ${archive}`);
+  const shown = spawnSync('helm', ['show', 'chart', archive], {
+    encoding: 'utf8',
+  });
+  if (shown.status !== 0)
+    throw new Error(`helm show chart failed: ${shown.stderr.trim()}`);
+  const chart = parse(shown.stdout);
+  const expectedAnnotations = {
+    'org.opencontainers.image.source': SOURCE_REPOSITORY,
+    'org.opencontainers.image.revision': revision,
+    'org.opencontainers.image.version': appVersion,
+  };
+  if (
+    chart.version !== chartVersion ||
+    String(chart.appVersion) !== appVersion
+  ) {
+    throw new Error(
+      'Packaged chart coordinates do not match the validated source chart'
+    );
+  }
+  for (const [key, value] of Object.entries(expectedAnnotations)) {
+    if (chart.annotations?.[key] !== value)
+      throw new Error(`Packaged annotation ${key} is invalid`);
+  }
+  return chart;
+}
+
+function output(entries) {
+  const body =
+    Object.entries(entries)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n') + '\n';
+  if (process.env.GITHUB_OUTPUT)
+    writeFileSync(process.env.GITHUB_OUTPUT, body, { flag: 'a' });
+  else process.stdout.write(body);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const command = argv[0];
+  if (command === 'stage') {
+    const chartTag = process.env.CHART_TAG || '';
+    const revision = process.env.SOURCE_REVISION || '';
+    const sourceDir = process.env.CHART_SOURCE_DIR || 'charts/dspace';
+    const stagedDir = process.env.CHART_STAGED_DIR || '';
+    if (!stagedDir) throw new Error('CHART_STAGED_DIR is required');
+    const coordinates = stageChart({
+      sourceDir,
+      stagedDir,
+      chartTag,
+      revision,
+    });
+    output({ ...coordinates, chartTag, revision });
+    return;
+  }
+  if (command === 'verify-package') {
+    verifyPackage({
+      archive: process.env.CHART_ARCHIVE || '',
+      chartVersion: process.env.CHART_VERSION || '',
+      appVersion: process.env.APP_VERSION || '',
+      revision: process.env.SOURCE_REVISION || '',
+    });
+    return;
+  }
+  if (command === 'validate-digest') {
+    validateDigest(
+      process.env.DIGEST_VALUE || '',
+      process.env.DIGEST_LABEL || 'digest'
+    );
+    return;
+  }
+  throw new Error(
+    'Usage: helm-chart-release.mjs <stage|verify-package|validate-digest>'
+  );
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync('.github/workflows/ci-helm.yml', 'utf8');
+
+describe('immutable Helm chart publication workflow', () => {
+  it('is triggered only by chart-specific tags, never branches or manual dispatch', () => {
+    expect(workflow).toMatch(/push:\n\s+tags:\n\s+- 'chart-v\*'/);
+    expect(workflow).not.toMatch(/branches:|workflow_dispatch:|release:/);
+  });
+
+  it('checks out and verifies the triggering tag commit with full history', () => {
+    expect(workflow).toContain('ref: ${{ github.ref }}');
+    expect(workflow).toContain('fetch-depth: 0');
+    expect(workflow).toContain('source_revision=$(git rev-parse HEAD)');
+    expect(workflow).toContain(
+      'tag_revision=$(git rev-parse "${CHART_TAG}^{commit}")'
+    );
+    expect(workflow).toContain('[[ "$source_revision" == "$tag_revision" ]]');
+    expect(workflow).toContain('CHART_TAG: ${{ github.ref_name }}');
+  });
+
+  it('serializes same-tag runs without cancelling an active publication', () => {
+    expect(workflow).toContain('group: helm-chart-${{ github.ref_name }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+  });
+
+  it('guards the charts/dspace coordinate before packaging and immediately before one push', () => {
+    const guards = [
+      ...workflow.matchAll(
+        /ghcr-manifest\.mjs check-absent --owner democratizedspace --repo charts\/dspace/g
+      ),
+    ];
+    expect(guards).toHaveLength(2);
+    const packageAt = workflow.indexOf('helm package');
+    const pushAt = workflow.indexOf('helm push');
+    expect(guards[0].index).toBeLessThan(packageAt);
+    expect(guards[1].index).toBeGreaterThan(packageAt);
+    expect(guards[1].index).toBeLessThan(pushAt);
+    expect(workflow.match(/push_output=\$\(helm push/g)).toHaveLength(1);
+    expect(workflow).not.toMatch(/continue-on-error|retry|--password\s/);
+  });
+
+  it('stages provenance, validates both digests, and records complete evidence', () => {
+    expect(workflow).toContain('helm-chart-release.mjs stage');
+    expect(workflow).toContain('helm-chart-release.mjs verify-package');
+    expect(
+      workflow.match(/helm-chart-release\.mjs validate-digest/g)
+    ).toHaveLength(2);
+    for (const field of [
+      'Chart version:',
+      'appVersion:',
+      'Chart release tag:',
+      'Full source SHA:',
+      'Source repository:',
+      'OCI reference:',
+      'Packaged archive SHA-256:',
+      'OCI manifest digest:',
+    ])
+      expect(workflow).toContain(field);
+    expect(workflow).toContain(
+      'git diff --exit-code -- charts/dspace/Chart.yaml'
+    );
+  });
+
+  it('passes registry credentials only through guarded environment variables', () => {
+    expect(workflow.match(/GHCR_GUARD_USERNAME:/g)).toHaveLength(2);
+    expect(workflow.match(/GHCR_GUARD_PASSWORD:/g)).toHaveLength(2); // scan-secrets: ignore (asserts an environment variable name, not a credential)
+    expect(workflow).not.toMatch(/ghcr-manifest\.mjs[^\n]*(password|username)/);
+  });
+});

--- a/tests/helmChartReleaseMetadata.test.ts
+++ b/tests/helmChartReleaseMetadata.test.ts
@@ -1,0 +1,100 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+import {
+  SOURCE_REPOSITORY,
+  stageChart,
+  validateChartRelease,
+  validateDigest,
+} from '../scripts/helm-chart-release.mjs';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+
+describe('Helm chart release metadata', () => {
+  it('preserves chart metadata and annotations, injects provenance, and leaves the source unchanged', () => {
+    const root = mkdtempSync(join(tmpdir(), 'chart-stage-'));
+    const sourceDir = join(root, 'source');
+    const stagedDir = join(root, 'staged');
+    try {
+      mkdirSync(sourceDir);
+      const original = `apiVersion: v2\nname: dspace\ndescription: keep me\ntype: application\nversion: 3.0.2\nappVersion: "3.0.1"\nannotations:\n  example.com/existing: retained\n`;
+      writeFileSync(join(sourceDir, 'Chart.yaml'), original);
+      stageChart({ sourceDir, stagedDir, chartTag: 'chart-v3.0.2', revision });
+      expect(readFileSync(join(sourceDir, 'Chart.yaml'), 'utf8')).toBe(
+        original
+      );
+      const staged = parse(readFileSync(join(stagedDir, 'Chart.yaml'), 'utf8'));
+      expect(staged.description).toBe('keep me');
+      expect(staged.annotations['example.com/existing']).toBe('retained');
+      expect(staged.annotations['org.opencontainers.image.source']).toBe(
+        SOURCE_REPOSITORY
+      );
+      expect(staged.annotations['org.opencontainers.image.revision']).toBe(
+        revision
+      );
+      expect(staged.annotations['org.opencontainers.image.version']).toBe(
+        '3.0.1'
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('requires strict coordinates, an exact tag, and a full lowercase source revision', () => {
+    const valid = {
+      chartVersion: '3.0.2',
+      appVersion: '3.0.1',
+      chartTag: 'chart-v3.0.2',
+      revision,
+    };
+    expect(() => validateChartRelease(valid)).not.toThrow();
+    expect(() =>
+      validateChartRelease({ ...valid, chartTag: 'chart-v3.0.3' })
+    ).toThrow(/must equal/);
+    expect(() =>
+      validateChartRelease({ ...valid, chartVersion: '3.0' })
+    ).toThrow(/chart version/);
+    expect(() =>
+      validateChartRelease({ ...valid, revision: revision.slice(0, 12) })
+    ).toThrow(/source revision/);
+    expect(() =>
+      validateChartRelease({ ...valid, revision: revision.toUpperCase() })
+    ).toThrow(/source revision/);
+  });
+
+  it('permanently tombstones chart 3.0.1 without rejecting a later chart whose appVersion is 3.0.1', () => {
+    expect(() =>
+      validateChartRelease({
+        chartVersion: '3.0.1',
+        appVersion: '9.9.9',
+        chartTag: 'chart-v3.0.1',
+        revision,
+      })
+    ).toThrow(/tombstoned/);
+    expect(() =>
+      validateChartRelease({
+        chartVersion: '3.0.2',
+        appVersion: '3.0.1',
+        chartTag: 'chart-v3.0.2',
+        revision,
+      })
+    ).not.toThrow();
+  });
+
+  it('strictly validates lowercase SHA-256 digests', () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    expect(validateDigest(digest, 'digest')).toBe(digest);
+    expect(() =>
+      validateDigest(`sha256:${'A'.repeat(64)}`, 'digest')
+    ).toThrow();
+    expect(() => validateDigest('sha256:abc', 'digest')).toThrow();
+  });
+});

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -281,12 +281,11 @@ describe('independent DSPACE application and chart coordinates', () => {
     expect(workflow).toContain('mkdir -p "$chart_dist"');
     expect(workflow).not.toContain('mktemp -d');
     expect(workflow).toContain(
-      'expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"'
+      'expected="$chart_dist/dspace-${CHART_VERSION}.tgz"'
     );
     expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
-    expect(workflow).toContain('packaged_version=$(helm show chart');
-    expect(workflow).toContain('packaged_app_version=$(helm show chart');
-    expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
+    expect(workflow).toContain('helm-chart-release.mjs verify-package');
+    expect(workflow).toContain('${{ steps.release.outputs.chartVersion }}');
   });
 
   it('does not scan historical release records as authoritative coordinates', () =>


### PR DESCRIPTION
### Motivation

- Close the repeat-publication path that allowed ordinary `main`/`v3` workflow runs to republish chart coordinates (Closes #4728).  Evidence: the repeat-publication run `#934` (https://github.com/democratizedspace/dspace/actions/runs/30141535426) is the concrete incident motivating this change and the referenced postmortem is https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md.  
- Ensure Helm chart publication is explicit, immutable, and auditable by restricting publication to an exact `chart-v<Chart.yaml version>` tag and by failing closed on any registry uncertainty.  
- Prevent accidental or attacker-influenceable overwrites of existing chart coordinates and permanently tombstone the problematic `3.0.1` chart version.  

### Description

- Replace branch/manual publish triggers with tag-only publication by changing `.github/workflows/ci-helm.yml` to `on: push: tags: ['chart-v*']`, add tag-scoped `concurrency` with `cancel-in-progress: false`, check out the triggering tag with full history and require `git rev-parse HEAD` to match the peeled tag commit, and require at runtime that the tag equals `chart-v<chartVersion>`.  
- Add `scripts/helm-chart-release.mjs` to stage a temporary copy of `charts/dspace`, inject OCI provenance annotations (`org.opencontainers.image.source`, `org.opencontainers.image.revision`, `org.opencontainers.image.version`), validate strict SemVer and full lowercase 40-char commit SHA provenance, verify packaged coordinates/annotations without mutating source `Chart.yaml`, and strictly validate `sha256:` digests.  
- Enforce two fail-closed GHCR existence checks (using `scripts/ghcr-manifest.mjs`) targeting `democratizedspace/charts/dspace:<chartVersion>`: one before packaging and one immediately before the single `helm push`; hard-reject any indeterminate outcome (auth, timeout, network, malformed, present manifest, or missing digest), and forbid re-publication of chart version `3.0.1`.  
- Perform a single `helm push` with no retries or continue-on-error paths, parse the pushed output to capture the OCI manifest digest, compute the packaged `.tgz` `sha256` and validate both digests, and write a GitHub Actions step summary containing chart version, `appVersion`, chart release tag, full source SHA, repository, OCI reference, packaged archive SHA-256, and OCI manifest digest.  
- Add focused regression tests: `tests/ciHelmWorkflow.test.ts` (workflow invariants), `tests/helmChartReleaseMetadata.test.ts` (staging/annotation/digest helpers), and small updates to chart/version tests; update docs (`docs/charts.md`, `docs/ops/sugarkube-release.md`) and `AGENTS.md` to document the tag-only release model and the `3.0.1` tombstone.  

### Testing

- Ran the focused unit/regression suite: `npm run test:root -- tests/ciHelmWorkflow.test.ts tests/ghcrManifestGuard.test.ts tests/helmChartReleaseVersion.test.ts tests/helmChartReleaseMetadata.test.ts`, and all tests passed (60 tests).  
- Ran `bash scripts/check-dspace-chart-version.sh` which passed.  
- Ran `npm run lint` and `npm run type-check` which passed.  
- Ran `npm run build` as part of CI test phases which completed successfully for the verification steps performed.  
- Ran repo integrity checks: `git diff --check` and `git diff main...HEAD | python3 scripts/scan-secrets.py` which passed; added `# scan-secrets: ignore` comments where workflow secret references are required.  
- Not executed in this environment: `helm lint charts/dspace`, local `helm package` / `helm show chart`, and `actionlint .github/workflows/ci-helm.yml` because `helm` and `actionlint` are not installed here; those are documented as required verifications for operators with Helm available.  

Notes and assurances

- This PR implements the tag-only release model, the double fail-closed existence checks, the permanent tombstone of chart version `3.0.1`, and artifact provenance + digest-summary behavior required by the issue.  
- No Git tag was created as part of this work and no OCI artifact was published, deleted, retagged, or otherwise modified during verification.  
- Follow-ups: operator-run verification in a CI environment with `helm` and `actionlint` installed is recommended to exercise `helm lint`, `helm package` end-to-end, and to run the workflow against a dry-run tag in a controlled environment before operator tag publishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642cdffc88832fab61d9791f1bb249)