### PR TITLE
ci: make Helm chart publication immutable and fail-closed

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -2,78 +2,120 @@ name: Publish Helm chart
 
 on:
   push:
-    branches:
-      - v3
-      - main
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch to package and publish the chart from
-        required: false
-        default: v3
-        type: choice
-        options:
-          - v3
-          - main
+    tags:
+      - chart-v*
 
 permissions:
   packages: write
   contents: read
 
+concurrency:
+  group: helm-chart-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    outputs:
-      chart_ref: ${{ steps.chart-ref.outputs.chart_ref }}
+    env:
+      CHART_TAG: ${{ github.ref_name }}
+      GHCR_GUARD_USERNAME: ${{ github.actor }}
+      GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub-provided token expression)
+      CHART_REPOSITORY: democratizedspace/charts/dspace
+      SOURCE_REPOSITORY: https://github.com/democratizedspace/dspace
     steps:
-      - name: Checkout
+      - name: Checkout immutable chart tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Validate release coordinates and source revision
+        id: release
+        run: |
+          set -euo pipefail
+          chart_version=$(node -e "const {parse}=require('yaml'); const c=parse(require('fs').readFileSync('charts/dspace/Chart.yaml','utf8')); process.stdout.write(String(c.version ?? ''))")
+          app_version=$(node -e "const {parse}=require('yaml'); const c=parse(require('fs').readFileSync('charts/dspace/Chart.yaml','utf8')); process.stdout.write(String(c.appVersion ?? ''))")
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          [[ "$chart_version" =~ $semver ]] || { echo "Chart version is not strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$app_version" =~ $semver ]] || { echo "Chart appVersion is not strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$CHART_TAG" == "chart-v${chart_version}" ]] || { echo "Tag must equal chart-v<Chart.yaml version>" >&2; exit 1; }
+          [[ "$chart_version" != '3.0.1' ]] || { echo 'Chart version 3.0.1 is permanently tombstoned' >&2; exit 1; }
+          source_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$tag_sha" == "$source_sha" ]] || { echo 'Checked-out HEAD does not match chart tag commit' >&2; exit 1; }
+          source_chart_sha=$(sha256sum charts/dspace/Chart.yaml | awk '{print $1}')
+          printf 'chart_version=%s\napp_version=%s\nsource_sha=%s\nsource_chart_sha=%s\n' "$chart_version" "$app_version" "$source_sha" "$source_chart_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Verify chart version sync
+        run: bash scripts/check-dspace-chart-version.sh
+
+      - name: First fail-closed coordinate guard
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.release.outputs.chart_version }}"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.12.3
 
-      - name: Build chart dependencies
-        run: helm dependency build charts/dspace
-
-      - name: Verify chart version sync
-        run: bash scripts/check-dspace-chart-version.sh
-
-      - name: Lint chart
-        run: helm lint charts/dspace
-
-      - name: Package chart
+      - name: Stage, lint, and package chart
         id: package
+        env:
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
-          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          set -euo pipefail
+          chart_stage="$RUNNER_TEMP/dspace-chart-stage"
           chart_dist="$RUNNER_TEMP/dspace-chart-dist"
-          rm -rf "$chart_dist"
+          rm -rf "$chart_stage" "$chart_dist"
           mkdir -p "$chart_dist"
-          expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"
-          helm package charts/dspace --destination "$chart_dist"
-          mapfile -t chart_files < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
-          if [[ ${#chart_files[@]} -ne 1 || "${chart_files[0]}" != "$expected_chart_file" ]]; then
-            printf 'Expected exactly %s; found: %s\n' "$expected_chart_file" "${chart_files[*]:-none}" >&2
-            exit 1
-          fi
-          packaged_version=$(helm show chart "$expected_chart_file" | awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }')
-          packaged_app_version=$(helm show chart "$expected_chart_file" | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }')
-          [[ "$packaged_version" == "$chart_version" ]] || { echo "Packaged chart version '$packaged_version' != '$chart_version'" >&2; exit 1; }
-          [[ "$packaged_app_version" == "$app_version" ]] || { echo "Packaged appVersion '$packaged_app_version' != '$app_version'" >&2; exit 1; }
-          echo "chart_file=$expected_chart_file" >> "$GITHUB_OUTPUT"
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          node scripts/stage-helm-chart.mjs stage --source charts/dspace --destination "$chart_stage" --revision "$SOURCE_SHA"
+          helm dependency build "$chart_stage"
+          helm lint "$chart_stage"
+          helm package "$chart_stage" --destination "$chart_dist"
+          expected="$chart_dist/dspace-${{ steps.release.outputs.chart_version }}.tgz"
+          mapfile -t packages < <(find "$chart_dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
+          [[ ${#packages[@]} -eq 1 && "${packages[0]}" == "$expected" ]] || { echo 'Expected exactly one chart package' >&2; exit 1; }
+          tar -xOf "$expected" dspace/Chart.yaml > "$RUNNER_TEMP/packaged-Chart.yaml"
+          node scripts/stage-helm-chart.mjs verify --chart-yaml "$RUNNER_TEMP/packaged-Chart.yaml" --version "${{ steps.release.outputs.chart_version }}" --app-version "${{ steps.release.outputs.app_version }}" --revision "$SOURCE_SHA"
+          [[ "$(sha256sum charts/dspace/Chart.yaml | awk '{print $1}')" == '${{ steps.release.outputs.source_chart_sha }}' ]] || { echo 'Source Chart.yaml was mutated' >&2; exit 1; }
+          archive_digest="sha256:$(sha256sum "$expected" | awk '{print $1}')"
+          [[ "$archive_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'Invalid archive digest' >&2; exit 1; }
+          printf 'chart_file=%s\narchive_digest=%s\n' "$expected" "$archive_digest" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GHCR
-        run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+        run: helm registry login ghcr.io -u "$GHCR_GUARD_USERNAME" --password-stdin <<< "$GHCR_GUARD_PASSWORD"
 
-      - name: Push chart to GHCR
-        run: helm push ${{ steps.package.outputs.chart_file }} oci://ghcr.io/democratizedspace/charts
+      - name: Final fail-closed coordinate guard
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "${{ steps.release.outputs.chart_version }}"
 
-      - name: Export chart reference
-        id: chart-ref
+      - name: Push chart to GHCR once
+        id: push
         run: |
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${{ steps.package.outputs.chart_version }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          helm push "${{ steps.package.outputs.chart_file }}" oci://ghcr.io/democratizedspace/charts | tee "$RUNNER_TEMP/helm-push.log"
+          push_digest=$(awk '$1 == "Digest:" { print $2 }' "$RUNNER_TEMP/helm-push.log")
+          [[ "$push_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'Helm push did not report one valid OCI digest' >&2; exit 1; }
+          [[ $(grep -c '^Digest:' "$RUNNER_TEMP/helm-push.log") -eq 1 ]] || { echo 'Helm push reported an ambiguous digest' >&2; exit 1; }
+          echo "digest=$push_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Record published OCI digest
+        id: artifact
+        run: node scripts/ghcr-manifest.mjs describe-artifact --owner democratizedspace --repo charts/dspace --tag "${{ steps.release.outputs.chart_version }}"
+
+      - name: Validate evidence and write summary
+        env:
+          OCI_DIGEST: ${{ steps.artifact.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "$OCI_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'Invalid OCI digest' >&2; exit 1; }
+          [[ "$OCI_DIGEST" == '${{ steps.push.outputs.digest }}' ]] || { echo 'Reported and registry OCI digests differ' >&2; exit 1; }
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Helm chart publication evidence
+          - Chart version: `${{ steps.release.outputs.chart_version }}`
+          - Application version: `${{ steps.release.outputs.app_version }}`
+          - Chart release tag: `$CHART_TAG`
+          - Full source SHA: `${{ steps.release.outputs.source_sha }}`
+          - Source repository: `$SOURCE_REPOSITORY`
+          - OCI reference: `oci://ghcr.io/$CHART_REPOSITORY:${{ steps.release.outputs.chart_version }}`
+          - Packaged archive SHA-256: `${{ steps.package.outputs.archive_digest }}`
+          - OCI manifest digest: `$OCI_DIGEST`
+          EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,16 @@ use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
 `scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
 `tests/ghcrManifestGuard.test.ts`.
 
+Helm charts have a separate, tag-only release path in `ci-helm.yml`. Ordinary `main` and `v3`
+pushes never publish charts. An operator must create the exact `chart-v<Chart.yaml:version>` tag on
+the reviewed immutable commit; the workflow verifies the tag resolves to its checked-out `HEAD`.
+It checks the chart coordinate is absent before packaging and again immediately before its single
+push, failing closed on every result except an authoritative GHCR 404. Existing chart coordinates
+cannot be replaced, and chart version `3.0.1` is permanently tombstoned even if GHCR reports it
+absent (`appVersion: 3.0.1` remains valid for a later chart). The staged package records the full
+source SHA in OCI annotations without modifying the tracked chart, and a successful workflow
+summary records the source SHA, archive SHA-256, and OCI manifest digest as release evidence.
+
 ### Smoke Test
 
 The `ci-image.yml` workflow includes a smoke test that:

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -148,11 +148,16 @@ For the standard Sugarkube staging and production flow, use the
 Helm commands below remain useful for local clusters, development environments, and manual chart
 inspection.
 
-The chart is published to the GitHub Container Registry on `v3` and `main` pushes. Its OCI version
-comes from `Chart.yaml:version` and may differ from the application version in `appVersion` and the
-package files. `docs/apps/dspace.version` pins the chart coordinate. The semantic image tag follows
-the application coordinate, but a branch-SHA tag or digest is required as immutable deployment
-evidence. After the publish workflow has completed successfully, use this installation procedure:
+The chart is published to the GitHub Container Registry only from an exact
+`chart-v<Chart.yaml:version>` tag pointing to the reviewed immutable commit. Ordinary `main` and
+`v3` pushes never publish charts. The workflow verifies the source revision, checks twice that the
+OCI coordinate is absent, and refuses to replace any existing chart. Chart version `3.0.1` is
+permanently tombstoned even if it later appears absent; this does not prevent a newer chart from
+retaining `appVersion: 3.0.1`. Its OCI version comes from `Chart.yaml:version` and may differ from
+the application version in `appVersion` and the package files. `docs/apps/dspace.version` pins the
+chart coordinate. Successful workflow summaries record the tag, full source SHA, package SHA-256,
+and OCI manifest digest. After the publish workflow has completed successfully, use this
+installation procedure:
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -20,6 +20,7 @@ setup in their existing runbooks.
   advance independently of the application version
 - **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
   release and human-readable, but not proof of the deployed image
+- **Chart release tag:** exactly `chart-v<chart version>` on the reviewed immutable source commit
 
 Use immutable branch-SHA tags or image digests for staging, production approvals, and rollback
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
@@ -29,14 +30,22 @@ be the audit record for a production deploy.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
-2. `.github/workflows/ci-helm.yml` packages `charts/dspace` and publishes it to the GHCR OCI chart
-   registry for `main` and `v3` pushes, and can also be run manually for those branches.
+2. `.github/workflows/ci-helm.yml` publishes only when an operator pushes the exact
+   `chart-v<Chart.yaml:version>` tag. Point the tag at the reviewed immutable commit whose chart
+   version matches; ordinary `main`/`v3` pushes and manual branch dispatches never publish charts.
+   The workflow refuses to replace an existing coordinate, checks absence twice, and permanently
+   rejects chart `3.0.1` even if it appears absent from GHCR. A later chart may still use
+   `appVersion: 3.0.1`.
 3. `charts/dspace/Chart.yaml` and `docs/apps/dspace.version` must stay in sync so Sugarkube helper
    recipes install the intended chart version. Separately, package metadata and
    `Chart.yaml:appVersion` stay aligned on the application version; neither group must equal the
    other.
 4. Local Docker builds are for local development and smoke testing only. They are not the normal
    Sugarkube staging or production release path.
+
+After chart publication, retain the workflow summary with the exact chart tag, full source SHA,
+packaged archive SHA-256, and OCI manifest digest. These values are the auditable chart publication
+evidence; the chart coordinate cannot be republished or replaced.
 
 ## Deploy staging
 

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -244,14 +244,29 @@ export async function describeManifest({
     };
 }
 
+// Artifact-neutral lookup for single-manifest OCI artifacts such as Helm charts.
+export async function describeArtifact(options) {
+    const token = await fetchGhcrToken(options); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    const manifest = await getManifest({ ...options, token });
+    if (manifest.status !== 'present') {
+        throw new GhcrGuardError('Expected OCI artifact to exist after publish', {
+            code: 'missing-after-publish',
+        });
+    }
+    if (!/^sha256:[0-9a-f]{64}$/.test(manifest.digest)) {
+        throw new GhcrGuardError('OCI artifact manifest digest is malformed', { code: 'malformed' });
+    }
+    return { digest: manifest.digest };
+}
+
 const FLAG_KEYS = new Set(['owner', 'repo', 'tag']);
 
 export function parseArgs(argv) {
     const [subcommand, ...rest] = argv;
 
-    if (subcommand !== 'check-absent' && subcommand !== 'describe') {
+    if (!['check-absent', 'describe', 'describe-artifact'].includes(subcommand)) {
         throw new GhcrGuardError(
-            'Usage: ghcr-manifest.mjs <check-absent|describe> --owner <owner> --repo <repo> --tag <tag>',
+            'Usage: ghcr-manifest.mjs <check-absent|describe|describe-artifact> --owner <owner> --repo <repo> --tag <tag>',
             { code: 'invalid-input' }
         );
     }
@@ -307,6 +322,13 @@ export async function main(argv = process.argv.slice(2)) {
         console.log(
             `GHCR tag ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
         );
+        return;
+    }
+
+    if (subcommand === 'describe-artifact') {
+        const artifact = await describeArtifact({ owner, repo, tag, username, password });
+        writeGithubOutput([['digest', artifact.digest]]);
+        console.log(`Recorded OCI artifact digest for ${owner}/${repo}:${tag}.`);
         return;
     }
 

--- a/scripts/stage-helm-chart.mjs
+++ b/scripts/stage-helm-chart.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { parse, stringify } from 'yaml';
+
+export const SOURCE_REPOSITORY = 'https://github.com/democratizedspace/dspace';
+export const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+export const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function required(value, label, pattern) {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    (pattern && !pattern.test(value))
+  ) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value;
+}
+
+export function readChart(chartYaml) {
+  const document = parse(readFileSync(chartYaml, 'utf8'));
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    throw new Error('Invalid Chart.yaml document');
+  }
+  required(document.name, 'chart name');
+  required(document.version, 'chart version', SEMVER_PATTERN);
+  required(document.appVersion, 'chart appVersion', SEMVER_PATTERN);
+  return document;
+}
+
+export function expectedAnnotations(revision, appVersion) {
+  required(revision, 'full source revision', FULL_SHA_PATTERN);
+  required(appVersion, 'application version', SEMVER_PATTERN);
+  return {
+    'org.opencontainers.image.source': SOURCE_REPOSITORY,
+    'org.opencontainers.image.revision': revision,
+    'org.opencontainers.image.version': appVersion,
+  };
+}
+
+export function stageChart({ source, destination, revision }) {
+  const sourcePath = resolve(required(source, 'source chart path'));
+  const destinationPath = resolve(required(destination, 'staged chart path'));
+  if (
+    !existsSync(join(sourcePath, 'Chart.yaml')) ||
+    lstatSync(sourcePath).isSymbolicLink()
+  ) {
+    throw new Error('Source chart must be a real chart directory');
+  }
+  if (
+    sourcePath === destinationPath ||
+    destinationPath.startsWith(`${sourcePath}/`)
+  ) {
+    throw new Error('Staged chart must be outside the source chart');
+  }
+  const chart = readChart(join(sourcePath, 'Chart.yaml'));
+  const annotations = expectedAnnotations(revision, chart.appVersion);
+  cpSync(sourcePath, destinationPath, {
+    recursive: true,
+    errorOnExist: true,
+    force: false,
+  });
+  const stagedChart = join(destinationPath, 'Chart.yaml');
+  chart.annotations = { ...(chart.annotations || {}), ...annotations };
+  writeFileSync(stagedChart, stringify(chart));
+  return {
+    name: chart.name,
+    version: chart.version,
+    appVersion: chart.appVersion,
+    annotations,
+  };
+}
+
+export function verifyChartMetadata({
+  chartYaml,
+  version,
+  appVersion,
+  revision,
+}) {
+  const chart = readChart(required(chartYaml, 'packaged Chart.yaml path'));
+  if (
+    chart.version !==
+    required(version, 'expected chart version', SEMVER_PATTERN)
+  ) {
+    throw new Error(
+      `Packaged chart version '${chart.version}' does not match '${version}'`
+    );
+  }
+  if (
+    chart.appVersion !==
+    required(appVersion, 'expected appVersion', SEMVER_PATTERN)
+  ) {
+    throw new Error(
+      `Packaged appVersion '${chart.appVersion}' does not match '${appVersion}'`
+    );
+  }
+  for (const [key, value] of Object.entries(
+    expectedAnnotations(revision, appVersion)
+  )) {
+    if (chart.annotations?.[key] !== value)
+      throw new Error(`Invalid provenance annotation ${key}`);
+  }
+  return chart;
+}
+
+function parseArgs(argv) {
+  const [command, ...args] = argv;
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    if (!flag?.startsWith('--') || !args[index + 1])
+      throw new Error(`Invalid argument: ${flag}`);
+    options[flag.slice(2)] = args[index + 1];
+  }
+  return { command, options };
+}
+
+function output(values) {
+  const text =
+    Object.entries(values)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n') + '\n';
+  if (process.env.GITHUB_OUTPUT)
+    writeFileSync(process.env.GITHUB_OUTPUT, text, { flag: 'a' });
+  else process.stdout.write(text);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { command, options } = parseArgs(argv);
+  if (command === 'stage') {
+    const result = stageChart({
+      source: options.source,
+      destination: options.destination,
+      revision: options.revision,
+    });
+    output({
+      chart_name: result.name,
+      chart_version: result.version,
+      app_version: result.appVersion,
+    });
+  } else if (command === 'verify') {
+    verifyChartMetadata({
+      chartYaml: options['chart-yaml'],
+      version: options.version,
+      appVersion: options['app-version'],
+      revision: options.revision,
+    });
+  } else {
+    throw new Error('Usage: stage-helm-chart.mjs <stage|verify> [options]');
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  join(process.cwd(), '.github/workflows/ci-helm.yml'),
+  'utf8'
+);
+
+describe('Helm publication workflow integrity', () => {
+  it('can only be triggered by chart release tags', () => {
+    expect(workflow).toMatch(/push:\n\s+tags:\n\s+- chart-v\*/);
+    expect(workflow).not.toContain('branches:');
+    expect(workflow).not.toContain('workflow_dispatch:');
+    expect(workflow).not.toContain('release:');
+  });
+
+  it('validates exact coordinates, tombstones 3.0.1, and resolves tags to HEAD', () => {
+    expect(workflow).toContain(
+      '[[ "$CHART_TAG" == "chart-v${chart_version}" ]]'
+    );
+    expect(workflow).toContain('[[ "$chart_version" != \'3.0.1\' ]]');
+    expect(workflow).toContain('source_sha=$(git rev-parse HEAD)');
+    expect(workflow).toContain(
+      'tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")'
+    );
+    expect(workflow).toContain('fetch-depth: 0');
+  });
+
+  it('serializes same-tag runs without cancellation', () => {
+    expect(workflow).toContain('group: helm-chart-${{ github.ref_name }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+  });
+
+  it('guards the chart coordinate twice around packaging and pushes exactly once', () => {
+    const guards = [...workflow.matchAll(/ghcr-manifest\.mjs check-absent/g)];
+    expect(guards).toHaveLength(2);
+    expect(workflow.match(/helm push/g)).toHaveLength(1);
+    expect(workflow).not.toContain('continue-on-error');
+    const packageIndex = workflow.indexOf('Stage, lint, and package chart');
+    expect(guards[0].index).toBeLessThan(packageIndex);
+    expect(guards[1].index).toBeGreaterThan(packageIndex);
+    const finalGuardStep = workflow.indexOf(
+      '- name: Final fail-closed coordinate guard'
+    );
+    const pushStep = workflow.indexOf('- name: Push chart to GHCR once');
+    expect(
+      workflow.slice(finalGuardStep, pushStep).match(/- name:/g)
+    ).toHaveLength(1);
+    expect(workflow.match(/--repo charts\/dspace/g)).toHaveLength(3);
+  });
+
+  it('keeps credentials in environment variables and records validated evidence', () => {
+    expect(workflow).toContain(
+      'GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }}'
+    );
+    expect(workflow).toContain('--password-stdin');
+    expect(workflow).not.toMatch(/(?:--password|-p) "?\$\{\{ secrets/);
+    expect(workflow).toContain('^sha256:[0-9a-f]{64}$');
+    for (const field of [
+      'Chart version:',
+      'Application version:',
+      'Chart release tag:',
+      'Full source SHA:',
+      'Source repository:',
+      'OCI reference:',
+      'Packaged archive SHA-256:',
+      'OCI manifest digest:',
+    ])
+      expect(workflow).toContain(field);
+  });
+});

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   GhcrGuardError,
   assertTagAbsent,
+  describeArtifact,
   describeManifest,
   fetchGhcrToken,
   getManifest,
@@ -282,6 +283,27 @@ describe('describeManifest', () => {
   ])('fails closed when %s', async (_description, manifests) => {
     await expect(describeWith(manifests)).rejects.toMatchObject({ code: 'missing-platform' });
   });
+});
+
+describe('describeArtifact', () => {
+  it('supports an artifact-neutral single manifest without weakening image describe', async () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    await expect(describeArtifact({
+      owner: 'o', repo: 'charts/dspace', tag: '3.1.0', username: 'u',
+      password: SECRET_PASSWORD, // scan-secrets: ignore (fixture credential)
+      fetchImpl: fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(200, {}, { 'docker-content-digest': digest }) }),
+    })).resolves.toEqual({ digest });
+  });
+
+  it.each(['sha256:short', `sha256:${'A'.repeat(64)}`, 'not-a-digest'])(
+    'rejects malformed artifact digest %s', async (digest) => {
+      await expect(describeArtifact({
+        owner: 'o', repo: 'charts/dspace', tag: '3.1.0', username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture credential)
+        fetchImpl: fetchFor({ tokenResponse: okToken, manifestResponse: jsonResponse(200, {}, { 'docker-content-digest': digest }) }),
+      })).rejects.toMatchObject({ code: 'malformed' });
+    }
+  );
 });
 
 describe('parseArgs', () => {

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -277,16 +277,16 @@ describe('independent DSPACE application and chart coordinates', () => {
       'utf8'
     );
     expect(workflow).toContain('chart_dist="$RUNNER_TEMP/dspace-chart-dist"');
-    expect(workflow).toContain('rm -rf "$chart_dist"');
+    expect(workflow).toContain('rm -rf "$chart_stage" "$chart_dist"');
     expect(workflow).toContain('mkdir -p "$chart_dist"');
     expect(workflow).not.toContain('mktemp -d');
     expect(workflow).toContain(
-      'expected_chart_file="$chart_dist/dspace-${chart_version}.tgz"'
+      'expected="$chart_dist/dspace-${{ steps.release.outputs.chart_version }}.tgz"'
     );
     expect(workflow).toContain('find "$chart_dist" -maxdepth 1');
-    expect(workflow).toContain('packaged_version=$(helm show chart');
-    expect(workflow).toContain('packaged_app_version=$(helm show chart');
-    expect(workflow).toContain('${{ steps.package.outputs.chart_version }}');
+    expect(workflow).toContain('stage-helm-chart.mjs verify');
+    expect(workflow).toContain('tar -xOf "$expected" dspace/Chart.yaml');
+    expect(workflow).toContain('${{ steps.release.outputs.chart_version }}');
   });
 
   it('does not scan historical release records as authoritative coordinates', () =>

--- a/tests/stageHelmChart.test.ts
+++ b/tests/stageHelmChart.test.ts
@@ -1,0 +1,87 @@
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  SOURCE_REPOSITORY,
+  stageChart,
+  verifyChartMetadata,
+} from '../scripts/stage-helm-chart.mjs';
+
+const roots: string[] = [];
+afterEach(() =>
+  roots
+    .splice(0)
+    .forEach((root) => rmSync(root, { recursive: true, force: true }))
+);
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'chart-stage-'));
+  roots.push(root);
+  const source = join(root, 'source');
+  cpSync(join(process.cwd(), 'charts/dspace'), source, { recursive: true });
+  return { root, source, destination: join(root, 'staged') };
+}
+
+describe('Helm chart provenance staging', () => {
+  it('preserves metadata and annotations, injects provenance, and leaves source unchanged', () => {
+    const { source, destination } = fixture();
+    const sourceYaml = join(source, 'Chart.yaml');
+    const before = readFileSync(sourceYaml, 'utf8');
+    const chart = parse(before);
+    chart.annotations = { 'example.test/existing': 'preserved' };
+    writeFileSync(sourceYaml, `${JSON.stringify(chart)}\n`);
+    const actualBefore = readFileSync(sourceYaml, 'utf8');
+    const revision = 'a'.repeat(40);
+
+    const result = stageChart({ source, destination, revision });
+    const staged = parse(readFileSync(join(destination, 'Chart.yaml'), 'utf8'));
+    expect(staged.description).toBe(chart.description);
+    expect(staged.annotations['example.test/existing']).toBe('preserved');
+    expect(staged.annotations).toMatchObject({
+      'org.opencontainers.image.source': SOURCE_REPOSITORY,
+      'org.opencontainers.image.revision': revision,
+      'org.opencontainers.image.version': result.appVersion,
+    });
+    expect(readFileSync(sourceYaml, 'utf8')).toBe(actualBefore);
+    expect(() =>
+      verifyChartMetadata({
+        chartYaml: join(destination, 'Chart.yaml'),
+        version: result.version,
+        appVersion: result.appVersion,
+        revision,
+      })
+    ).not.toThrow();
+  });
+
+  it.each(['abc1234', 'A'.repeat(40), 'g'.repeat(40), 'a'.repeat(64)])(
+    'rejects malformed or shortened revision %s',
+    (revision) => {
+      const { source, destination } = fixture();
+      expect(() => stageChart({ source, destination, revision })).toThrow(
+        /revision/
+      );
+    }
+  );
+
+  it('rejects mismatched packaged metadata', () => {
+    const { source, destination } = fixture();
+    const revision = 'b'.repeat(40);
+    const result = stageChart({ source, destination, revision });
+    expect(() =>
+      verifyChartMetadata({
+        chartYaml: join(destination, 'Chart.yaml'),
+        version: '9.9.9',
+        appVersion: result.appVersion,
+        revision,
+      })
+    ).toThrow(/version/);
+  });
+});


### PR DESCRIPTION
### Motivation

- Closes #4728 and implements the tag-only, fail-closed Helm chart publication model to prevent repeat-publication (postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md; repeat-publication evidence: run #934 / Actions run 30141535426 pushed `ghcr.io/democratizedspace/charts/dspace:3.1.0`).
- Prevent ordinary `main`/`v3` pushes or manual branch dispatches from publishing charts and ensure every chart publish is tied to an immutable reviewed commit and auditable digests. 
- Provide artifact provenance, double fail-closed existence checks against GHCR, and a small reusable helper to stage/verify chart metadata so published archives include full source SHA annotation without mutating tracked sources. 

### Description

- Replace branch/manual publish triggers with a tag-only trigger in `.github/workflows/ci-helm.yml` so the workflow runs only on `push` tags matching `chart-v*`, checks out the tag with full history, requires `CHART_TAG == chart-v<Chart.yaml version>`, resolves the tag commit to `HEAD`, and adds tag-scoped non-cancelling concurrency. 
- Add two fail-closed GHCR guards using `scripts/ghcr-manifest.mjs` (a pre-package `check-absent` and a pre-push `check-absent`) and a new artifact-neutral `describe-artifact` path; only an authoritative `404` allows publishing and every indeterminate/auth/network/malformed result blocks. 
- Add `scripts/stage-helm-chart.mjs` to stage the chart into a temporary copy, safely parse/serialize YAML, inject OCI provenance annotations (`org.opencontainers.image.*`) with the full source SHA, validate inputs (strict SemVer and 40-hex SHA), and verify packaged `Chart.yaml` and provenance before push. 
- Harden the workflow to create exactly one package, verify the packaged archive SHA-256, record the Helm push-reported OCI digest, reconfirm the registry manifest digest via `describe-artifact`, and write a digest/provenance summary to the GitHub Actions step summary; keep credentials only in `GHCR_GUARD_USERNAME`/`GHCR_GUARD_PASSWORD` and use `--password-stdin`. 
- Add focused regression tests (`tests/ciHelmWorkflow.test.ts`, `tests/stageHelmChart.test.ts`) and extend `scripts/ghcr-manifest.mjs` and its tests to cover artifact-neutral lookups and strict-digest validation; update `AGENTS.md`, `docs/ops/sugarkube-release.md`, and `docs/charts.md` to document the tag-only model and permanent `3.0.1` tombstone. 

### Testing

- Ran `npm run test:root -- tests/ciHelmWorkflow.test.ts tests/ghcrManifestGuard.test.ts tests/helmChartReleaseVersion.test.ts tests/stageHelmChart.test.ts` and the focused integration/unit tests passed (all tests in those files passed). 
- Verified repository helpers and guards with `bash scripts/check-dspace-chart-version.sh`, `npm run lint`, `npm run type-check`, `git diff --check`, and `git diff HEAD | python3 scripts/scan-secrets.py`, all of which succeeded. 
- Per-workflow packaging checks were exercised locally (packaging/inspect steps are present in the workflow) but `helm lint` / `helm package` / `helm show chart` and `actionlint` were not executed in this environment because Helm and actionlint are not installed here. 
- Confirmed no tag was created and no OCI artifact was published, deleted, retagged, or otherwise modified as part of this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642cf1c788832f9b42f80b3132d0c7)