### PR TITLE
release: add v3.0.1-compatible recovery chart (dspace 3.0.2) and backport Helm publish guards

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -2,63 +2,160 @@ name: Publish Helm chart
 
 on:
   push:
-    branches:
-      - v3
-      - main
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch to package and publish the chart from
-        required: false
-        default: v3
-        type: choice
-        options:
-          - v3
-          - main
+    tags:
+      - chart-v*
 
 permissions:
   packages: write
   contents: read
 
+concurrency:
+  group: helm-chart-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    outputs:
-      chart_ref: ${{ steps.chart-ref.outputs.chart_ref }}
     steps:
-      - name: Checkout
+      - name: Checkout chart release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Validate tag, versions, and source revision
+        id: release
+        env:
+          CHART_TAG: ${{ github.ref_name }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
+          [[ "$chart_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "Chart version must be strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$app_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "appVersion must be strict X.Y.Z SemVer" >&2; exit 1; }
+          [[ "$CHART_TAG" == "chart-v${chart_version}" ]] || { echo "Tag must equal chart-v${chart_version}; refusing to publish" >&2; exit 1; }
+          [[ "$chart_version" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
+          source_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
+          [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse an existing chart coordinate (pre-package)
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "$CHART_VERSION"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.12.3
 
-      - name: Build chart dependencies
-        run: helm dependency build charts/dspace
-
-      - name: Verify chart version sync
-        run: bash scripts/check-dspace-chart-version.sh
-
-      - name: Lint chart
-        run: helm lint charts/dspace
-
-      - name: Package chart
+      - name: Validate and stage chart provenance
         id: package
+        env:
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+          APP_VERSION: ${{ steps.release.outputs.app_version }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
-          helm package charts/dspace
-          echo "chart_file=$(ls dspace-*.tgz)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          source_hash=$(sha256sum charts/dspace/Chart.yaml)
+          stage="$RUNNER_TEMP/dspace-chart-stage"
+          dist="$RUNNER_TEMP/dspace-chart-dist"
+          rm -rf "$stage" "$dist" && mkdir -p "$dist"
+          node scripts/stage-helm-chart.mjs charts/dspace "$stage" "$SOURCE_SHA"
+          helm dependency build "$stage"
+          bash scripts/check-dspace-chart-version.sh
+          helm lint "$stage"
+          helm package "$stage" --destination "$dist"
+          expected="$dist/dspace-${CHART_VERSION}.tgz"
+          mapfile -t packages < <(find "$dist" -maxdepth 1 -type f -name 'dspace-*.tgz' -print)
+          [[ ${#packages[@]} -eq 1 && "${packages[0]}" == "$expected" ]] || { echo "Expected exactly one package: $expected" >&2; exit 1; }
+          packaged_yaml="$RUNNER_TEMP/dspace-packaged-Chart.yaml"
+          tar -xOf "$expected" dspace/Chart.yaml > "$packaged_yaml"
+          node scripts/stage-helm-chart.mjs verify "$packaged_yaml" "$CHART_VERSION" "$APP_VERSION" "$SOURCE_SHA"
+          [[ "$(sha256sum charts/dspace/Chart.yaml)" == "$source_hash" ]] || { echo "Source Chart.yaml was mutated" >&2; exit 1; }
+          archive_digest="sha256:$(sha256sum "$expected" | awk '{print $1}')"
+          [[ "$archive_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "Invalid package digest" >&2; exit 1; }
+          echo "chart_file=$expected" >> "$GITHUB_OUTPUT"
+          echo "archive_digest=$archive_digest" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GHCR
-        run: helm registry login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+        run: printf '%s' "$GHCR_GUARD_PASSWORD" | helm registry login ghcr.io --username "$GHCR_GUARD_USERNAME" --password-stdin
 
-      - name: Push chart to GHCR
-        run: helm push ${{ steps.package.outputs.chart_file }} oci://ghcr.io/democratizedspace/charts
-
-      - name: Export chart reference
-        id: chart-ref
+      - name: Revalidate tag and source revision before push
+        env:
+          CHART_TAG: ${{ steps.release.outputs.chart_tag }}
+          EVENT_SHA: ${{ github.sha }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
-          chart_version=$(grep '^version:' charts/dspace/Chart.yaml | awk '{print $2}')
-          echo "chart_ref=oci://ghcr.io/democratizedspace/charts/dspace:${chart_version}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          current_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$current_sha" == "$EVENT_SHA" && "$current_sha" == "$SOURCE_SHA" ]] || { echo "Checked-out source changed after initial validation" >&2; exit 1; }
+          [[ "$tag_sha" == "$EVENT_SHA" ]] || { echo "Chart tag moved after initial validation; refusing to publish" >&2; exit 1; }
+
+      - name: Refuse an existing chart coordinate (pre-push)
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "$CHART_VERSION"
+
+      - name: Push chart exactly once
+        id: push
+        env:
+          CHART_FILE: ${{ steps.package.outputs.chart_file }}
+        run: |
+          set -euo pipefail
+          output=$(helm push "$CHART_FILE" oci://ghcr.io/democratizedspace/charts 2>&1)
+          printf '%s\n' "$output"
+          digest=$(printf '%s\n' "$output" | sed -n 's/^Digest: \(sha256:[0-9a-f]\{64\}\)$/\1/p')
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "helm push did not report one valid OCI digest" >&2; exit 1; }
+          echo "oci_digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Write publication evidence
+        env:
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+          APP_VERSION: ${{ steps.release.outputs.app_version }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          CHART_TAG: ${{ steps.release.outputs.chart_tag }}
+          ARCHIVE_DIGEST: ${{ steps.package.outputs.archive_digest }}
+          OCI_DIGEST: ${{ steps.push.outputs.oci_digest }}
+        run: |
+          set -euo pipefail
+          [[ "$ARCHIVE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && "$OCI_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
+          # The tag labels the triggering event; SOURCE_SHA is the authoritative immutable provenance.
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Helm chart publication evidence
+          - Chart version: $CHART_VERSION
+          - Application version: $APP_VERSION
+          - Triggering chart release tag: $CHART_TAG
+          - Full source SHA: $SOURCE_SHA
+          - Source repository: https://github.com/democratizedspace/dspace
+          - OCI reference: oci://ghcr.io/democratizedspace/charts/dspace:$CHART_VERSION
+          - Packaged archive SHA-256: $ARCHIVE_DIGEST
+          - OCI manifest digest: $OCI_DIGEST
+          EOF

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout chart release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.0.0
 
@@ -51,8 +51,11 @@ jobs:
           [[ "$chart_version" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
           source_sha=$(git rev-parse HEAD)
           tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          git fetch --force --no-tags origin refs/heads/release/chart-3.0.x:refs/remotes/origin/release/chart-3.0.x
+          approved_sha=$(git rev-parse refs/remotes/origin/release/chart-3.0.x)
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
           [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
+          [[ "$source_sha" == "$approved_sha" ]] || { echo "Chart tag is not on the approved release/chart-3.0.x revision; refusing to publish" >&2; exit 1; }
           echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
@@ -66,7 +69,7 @@ jobs:
         run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo charts/dspace --tag "$CHART_VERSION"
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.12.3
 
@@ -113,9 +116,15 @@ jobs:
         run: |
           set -euo pipefail
           current_sha=$(git rev-parse HEAD)
-          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          remote_tag_ref="refs/tags/revalidation/${CHART_TAG}"
+          git update-ref -d "$remote_tag_ref" || true
+          git fetch --force --no-tags origin "refs/tags/${CHART_TAG}:${remote_tag_ref}"
+          git fetch --force --no-tags origin refs/heads/release/chart-3.0.x:refs/remotes/origin/release/chart-3.0.x
+          tag_sha=$(git rev-parse "${remote_tag_ref}^{commit}")
+          approved_sha=$(git rev-parse refs/remotes/origin/release/chart-3.0.x)
           [[ "$current_sha" == "$EVENT_SHA" && "$current_sha" == "$SOURCE_SHA" ]] || { echo "Checked-out source changed after initial validation" >&2; exit 1; }
           [[ "$tag_sha" == "$EVENT_SHA" ]] || { echo "Chart tag moved after initial validation; refusing to publish" >&2; exit 1; }
+          [[ "$approved_sha" == "$EVENT_SHA" ]] || { echo "Approved recovery branch moved after initial validation; refusing to publish" >&2; exit 1; }
 
       - name: Refuse an existing chart coordinate (pre-push)
         env:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -22,19 +22,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9.0.0
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --reporter=append-only
+          persist-credentials: false
 
       - name: Validate tag, versions, and source revision
         id: release
@@ -60,6 +48,19 @@ jobs:
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 9.0.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Refuse an existing chart coordinate (pre-package)
         env:

--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.0.1
+version: 3.0.2
 description: Helm chart for deploying the DSPACE application
 type: application
-appVersion: "v3.0.1"
+appVersion: "3.0.1"

--- a/charts/dspace/templates/deployment.yaml
+++ b/charts/dspace/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- $metrics := .Values.metrics | default dict -}}
+{{- $metricsAuth := $metrics.auth | default dict -}}
+{{- if and ($metrics.enabled | default false) (not ($metricsAuth.existingSecret | default "")) }}
+{{- fail "metrics.enabled=true requires metrics.auth.existingSecret so /metrics is authenticated whenever it is served" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +39,15 @@ spec:
               value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
             - name: DSPACE_ENV
               value: {{ .Values.environment | default "production" | quote }}
+            - name: METRICS_ENABLED
+              value: {{ ternary "true" "false" ($metrics.enabled | default false) | quote }}
+          {{- if and ($metrics.enabled | default false) ($metricsAuth.existingSecret | default "") }}
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $metricsAuth.existingSecret | quote }}
+                  key: {{ $metricsAuth.secretKey | default "token" | quote }}
+          {{- end }}
           {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
           {{- end }}

--- a/charts/dspace/templates/deployment.yaml
+++ b/charts/dspace/templates/deployment.yaml
@@ -41,7 +41,14 @@ spec:
               value: {{ .Values.environment | default "production" | quote }}
             - name: METRICS_ENABLED
               value: {{ ternary "true" "false" ($metrics.enabled | default false) | quote }}
-          {{- if and ($metrics.enabled | default false) ($metricsAuth.existingSecret | default "") }}
+          {{- if not ($metrics.enabled | default false) }}
+            # v3.0.1 has no metrics-disable switch. An unpredictable pod-local token
+            # makes /metrics inaccessible when this chart setting is disabled.
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          {{- else if ($metricsAuth.existingSecret | default "") }}
             - name: METRICS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/dspace/templates/servicemonitor.yaml
+++ b/charts/dspace/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- $metrics := .Values.metrics | default dict -}}
+{{- $metricsAuth := $metrics.auth | default dict -}}
+{{- $serviceMonitor := .Values.serviceMonitor | default dict -}}
+{{- if ($serviceMonitor.enabled | default false) }}
+{{- if not ($metrics.enabled | default false) }}
+{{- fail "serviceMonitor.enabled requires metrics.enabled=true so the application metrics endpoint is intentionally configured" }}
+{{- end }}
+{{- if not ($metricsAuth.existingSecret | default "") }}
+{{- fail "serviceMonitor.enabled requires metrics.auth.existingSecret so Prometheus can authenticate to /metrics" }}
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dspace.fullname" . }}
+  labels:
+    {{- include "dspace.labels" . | nindent 4 }}
+    {{- with $serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "dspace.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ $metrics.path | default "/metrics" | quote }}
+      interval: {{ $serviceMonitor.interval | default "30s" | quote }}
+      scrapeTimeout: {{ $serviceMonitor.scrapeTimeout | default "10s" | quote }}
+      bearerTokenSecret: # scan-secrets: ignore (Kubernetes Secret reference field, not secret material)
+        name: {{ $metricsAuth.existingSecret | quote }}
+        key: {{ $metricsAuth.secretKey | default "token" | quote }}
+{{- end }}

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -1,30 +1,46 @@
 replicaCount: 2
 
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 image:
   repository: ghcr.io/democratizedspace/dspace
-  tag: v3.0.1
+  tag: main-1a31a56
   pullPolicy: IfNotPresent
 
 service:
   type: ClusterIP
   port: 8080
 
+# Recovery-safe observability defaults. Templates also tolerate these maps being omitted or null.
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: '' # scan-secrets: ignore (empty Kubernetes Secret name default)
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube
+
 ingress:
   enabled: false
   className: traefik
-  host: ""
+  host: ''
   annotations: {}
   tls:
     enabled: false
-    secretName: ""
+    secretName: ''
 
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
+  name: ''
   automountServiceAccountToken: false
 
 podSecurityContext:
@@ -63,7 +79,7 @@ env: []
 
 resources:
   limits:
-    cpu: "1"
+    cpu: '1'
     memory: 1536Mi
   requests:
     cpu: 500m

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.0.1
+3.0.2

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -26,7 +26,7 @@ settings.
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
   `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-  RuntimeDefault`.
+RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for
@@ -81,3 +81,23 @@ When installing from the OCI registry, you will not have access to
 `charts/dspace/values.dev.yaml` unless you clone the repository. To customize values, either
 provide your own file with `-f <your-values.yaml>` or use `--set` flags as shown above.
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
+
+## v3.0.1 chart-only recovery release
+
+Chart `3.0.2` is a chart-only recovery release for the canonical DSPACE application v3.0.1. It
+defaults to the immutable `main-1a31a56` image built from
+`1a31a569aff2dbeb238e8c2688b9e85140d2077d`; it must never fall back to the mutable `v3.0.1`
+image tag. The chart keeps metrics and ServiceMonitor resources disabled by default and safely
+renders the pre-observability production values contract when `metrics`, `metrics.auth`, or
+`serviceMonitor` is absent or null.
+
+Retain the long-lived `release/chart-3.0.x` branch while v3.0.1 remains an approved rollback
+candidate. After the recovery PR merges into that branch, publication is permitted only by creating
+`chart-v3.0.2` at the exact approved recovery-branch commit. Ordinary branch pushes and manual
+branch dispatches cannot publish this chart. Chart `3.0.1` is permanently tombstoned and must not be
+modified or republished.
+
+Issue #4731 remains open after the implementation PR. Before it can be closed, independently verify
+the single successful publication run and capture its full source SHA, OCI reference, packaged
+archive SHA-256 digest, and OCI manifest digest. Creating or pushing the release tag and changing
+GHCR or deployment state are separate, post-merge operator actions.

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -13,7 +13,7 @@ settings.
 - `replicaCount`: Pod replica count. Defaults to `2` for redundancy.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
-- `image.tag`: Image tag to deploy. Defaults to `v3.0.1`, matching the current package version.
+- `image.tag`: Image tag to deploy. Defaults to immutable recovery image `main-1a31a56`.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
 - `service.port`: Container and service port. Defaults to `8080`.
@@ -26,7 +26,7 @@ settings.
   token automount disabled.
 - `podSecurityContext` / `securityContext`: Hardened defaults with non-root user/group `1000`,
   `runAsNonRoot: true`, dropped capabilities, read-only root filesystem, and `seccompProfile:
-RuntimeDefault`.
+  RuntimeDefault`.
 - `ingress.annotations`: Map of annotations applied to the ingress object.
 - `resources.requests` / `resources.limits`: Default to `500m` CPU / `768Mi` memory requests and
   `1` CPU / `1536Mi` memory limits, matching the production baseline. Override as needed for

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -121,7 +121,6 @@ curl -fsS https://prod.democratized.space/healthz
 
 If rehearsal succeeds and you proceed to production, switch back to `docs/examples/dspace.values.prod.yaml` for the real prod deployment.
 
-
 ## Troubleshooting and cross-environment guardrails
 
 - Use positional Sugarkube env args in operator commands (`just up prod`, `just save-logs prod`)
@@ -166,3 +165,14 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
   - [Sugarkube troubleshooting](https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_troubleshooting.md)
   - [Canonical outage markdown](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
   - [Canonical outage JSON](https://github.com/futuroptimist/sugarkube/blob/main/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+## DSPACE v3.0.1 recovery chart retention
+
+While DSPACE v3.0.1 is an approved production rollback candidate, retain the
+`release/chart-3.0.x` branch. Its chart `3.0.2` manages application v3.0.1 through the immutable
+`main-1a31a56` image. Publish only after the recovery PR merges, by placing `chart-v3.0.2` on the
+exact approved recovery-branch commit. Chart `3.0.1` is permanently tombstoned.
+
+The publication run is not complete evidence until operators capture and independently verify the
+full source SHA, OCI reference, packaged archive digest, and OCI digest. Keep issue #4731 open until
+that exactly-once publication evidence is recorded.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dspace",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "type": "module",
     "description": "A free and open source web-based space exploration idle game",
     "scripts": {

--- a/scripts/check-dspace-chart-version.sh
+++ b/scripts/check-dspace-chart-version.sh
@@ -1,35 +1,155 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-chart_file="charts/dspace/Chart.yaml"
-version_file="docs/apps/dspace.version"
+repo_root="${DSPACE_VERSION_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+root_package_file="$repo_root/package.json"
+frontend_package_file="$repo_root/frontend/package.json"
+package_lock_file="$repo_root/package-lock.json"
+chart_file="$repo_root/charts/dspace/Chart.yaml"
+values_file="$repo_root/charts/dspace/values.yaml"
+version_file="$repo_root/docs/apps/dspace.version"
 
-if [[ ! -f "$chart_file" ]]; then
-  echo "Chart file not found: $chart_file" >&2
+require_file() {
+  local group="$1"
+  local field="$2"
+  local file="$3"
+  if [[ ! -f "$file" ]]; then
+    echo "$group coordinate missing: $field file not found: $file" >&2
+    exit 1
+  fi
+}
+
+json_get() {
+  local file="$1"
+  local expr="$2"
+  node -e '
+const fs = require("node:fs");
+const [file, expr] = process.argv.slice(1);
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(file, "utf8"));
+} catch (error) {
+  console.error(`Unable to read or parse JSON coordinate file ${file}: ${error.message}`);
+  process.exit(2);
+}
+const value = expr.split(".").reduce((current, key) => current?.[key], data);
+console.log(typeof value === "string" && value.length > 0 ? value : "");
+' "$file" "$expr"
+}
+
+yaml_scalar() {
+  local file="$1"
+  local key="$2"
+  awk -v key="$key" '
+    $1 == key ":" {
+      value = $2
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+yaml_nested_scalar() {
+  local file="$1"
+  local parent="$2"
+  local key="$3"
+  awk -v parent="$parent" -v key="$key" '
+    $1 == parent ":" { in_parent = 1; next }
+    in_parent && $0 !~ /^#/ && $0 !~ /^[[:space:]]/ { exit }
+    in_parent && $1 == key ":" {
+      value = $2
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+require_file "Application" "root package version" "$root_package_file"
+require_file "Application" "frontend package version" "$frontend_package_file"
+require_file "Application" "package-lock versions" "$package_lock_file"
+require_file "Application" "chart appVersion" "$chart_file"
+require_file "Application" "chart default image.tag" "$values_file"
+require_file "Chart" "docs/apps/dspace.version" "$version_file"
+
+root_package_version=$(json_get "$root_package_file" version)
+frontend_package_version=$(json_get "$frontend_package_file" version)
+package_lock_version=$(json_get "$package_lock_file" version)
+package_lock_root_version=$(json_get "$package_lock_file" 'packages..version')
+chart_version=$(yaml_scalar "$chart_file" version || true)
+chart_app_version=$(yaml_scalar "$chart_file" appVersion || true)
+image_tag=$(yaml_nested_scalar "$values_file" image tag || true)
+expected_image_tag="main-1a31a56"
+
+mapfile -t documented_chart_lines < <(awk '!/^[[:space:]]*#/ && NF { print }' "$version_file")
+documented_chart_version=""
+if (( ${#documented_chart_lines[@]} == 1 )); then
+  documented_chart_version=${documented_chart_lines[0]}
+fi
+
+failures=0
+expect_present() {
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  if [[ -z "$actual" ]]; then
+    echo "$group coordinate missing: $label; expected a non-empty value" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+expect_semver() {
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  if [[ -n "$actual" && ! "$actual" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "$group coordinate malformed: $label must be bare X.Y.Z SemVer; found '$actual'" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+expect_equal() {
+  local group="$1"
+  local label="$2"
+  local actual="$3"
+  local expected="$4"
+  if [[ -z "$actual" ]]; then
+    echo "$group coordinate drift: missing $label; expected '$expected'" >&2
+    failures=$((failures + 1))
+  elif [[ "$actual" != "$expected" ]]; then
+    echo "$group coordinate drift: $label found '$actual', expected '$expected'" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+expect_present "Application" "root package version" "$root_package_version"
+expect_semver "Application" "root package version" "$root_package_version"
+for coordinate in \
+  "frontend package version:$frontend_package_version" \
+  "package-lock top-level version:$package_lock_version" \
+  'package-lock packages[""].version:'"$package_lock_root_version" \
+  "chart appVersion:$chart_app_version"; do
+  label=${coordinate%%:*}
+  actual=${coordinate#*:}
+  expect_semver "Application" "$label" "$actual"
+  expect_equal "Application" "$label" "$actual" "$root_package_version"
+done
+expect_equal "Application" "chart default image.tag" "$image_tag" "$expected_image_tag"
+
+expect_present "Chart" "chart version" "$chart_version"
+expect_semver "Chart" "chart version" "$chart_version"
+if (( ${#documented_chart_lines[@]} != 1 )); then
+  echo "Chart coordinate malformed: docs/apps/dspace.version must contain exactly one non-empty, non-comment line; found ${#documented_chart_lines[@]}" >&2
+  failures=$((failures + 1))
+else
+  expect_semver "Chart" "docs/apps/dspace.version" "$documented_chart_version"
+fi
+expect_equal "Chart" "docs/apps/dspace.version" "$documented_chart_version" "$chart_version"
+
+if (( failures > 0 )); then
+  echo "DSPACE release coordinate groups are not aligned." >&2
   exit 1
 fi
 
-if [[ ! -f "$version_file" ]]; then
-  echo "Version file not found: $version_file" >&2
-  exit 1
-fi
-
-chart_version=$(grep '^version:' "$chart_file" | awk '{print $2}')
-version_line=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' "$version_file" | head -n1)
-
-if [[ -z "$chart_version" ]]; then
-  echo "Unable to read chart version from $chart_file" >&2
-  exit 1
-fi
-
-if [[ -z "$version_line" ]]; then
-  echo "No semantic version found in $version_file" >&2
-  exit 1
-fi
-
-if [[ "$chart_version" != "$version_line" ]]; then
-  echo "Chart version mismatch: Chart.yaml has '$chart_version' but $version_file has '$version_line'" >&2
-  exit 1
-fi
-
-echo "Chart version is in sync: $chart_version"
+echo "DSPACE release coordinates are aligned: application version ${root_package_version} (${expected_image_tag}); chart version ${chart_version}."

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+
+const REGISTRY_HOST = 'https://ghcr.io';
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const MANIFEST_ACCEPT_HEADER = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ');
+
+export class GhcrGuardError extends Error {
+  constructor(message, { code = 'unknown' } = {}) {
+    super(message);
+    this.name = 'GhcrGuardError';
+    this.code = code;
+  }
+}
+
+function requireField(value, label) {
+  if (!value || typeof value !== 'string') {
+    throw new GhcrGuardError(`Missing required value: ${label}`, {
+      code: 'invalid-input',
+    });
+  }
+  return value;
+}
+
+async function fetchWithTimeout(
+  fetchImpl,
+  url,
+  init,
+  timeoutMs,
+  describeAction
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error && error.name === 'AbortError') {
+      throw new GhcrGuardError(
+        `Timed out after ${timeoutMs}ms while ${describeAction}`,
+        {
+          code: 'timeout',
+        }
+      );
+    }
+    throw new GhcrGuardError(
+      `Network error while ${describeAction}: ${error?.message || error}`,
+      { code: 'network' }
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// GHCR follows the standard Docker Registry v2 auth flow: a Basic-auth request against
+// /token exchanges the workflow's GITHUB_TOKEN for a short-lived Bearer token scoped to
+// read-only access on this one repository.
+export async function fetchGhcrToken({
+  owner,
+  repo,
+  username,
+  password,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  requireField(owner, 'owner');
+  requireField(repo, 'repo');
+  requireField(username, 'username');
+  requireField(password, 'password');
+
+  const scope = `repository:${owner}/${repo}:pull`;
+  const url = `${REGISTRY_HOST}/token?service=ghcr.io&scope=${encodeURIComponent(scope)}`;
+  const basicAuth = Buffer.from(`${username}:${password}`).toString('base64');
+
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    url,
+    { headers: { Authorization: `Basic ${basicAuth}` } },
+    timeoutMs,
+    'requesting a GHCR registry token'
+  );
+
+  if (!response.ok) {
+    const code =
+      response.status === 401 || response.status === 403
+        ? 'auth'
+        : 'indeterminate';
+    throw new GhcrGuardError(
+      `GHCR token request failed with status ${response.status}`,
+      {
+        code,
+      }
+    );
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new GhcrGuardError('GHCR token response was not valid JSON', {
+      code: 'malformed',
+    });
+  }
+
+  if (!body || typeof body.token !== 'string' || body.token.length === 0) {
+    throw new GhcrGuardError('GHCR token response did not include a token', {
+      code: 'malformed',
+    });
+  }
+
+  return body.token;
+}
+
+// Returns { status: 'absent' } only on an authoritative registry 404. Every other outcome
+// (found, auth failure, network failure, timeout, unexpected status, malformed body) is
+// surfaced to the caller as either status: 'present' or a thrown GhcrGuardError, so callers
+// can fail closed rather than assume absence.
+export async function getManifest({
+  owner,
+  repo,
+  tag,
+  token,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  requireField(owner, 'owner');
+  requireField(repo, 'repo');
+  requireField(tag, 'tag');
+  requireField(token, 'token');
+
+  const url = `${REGISTRY_HOST}/v2/${owner}/${repo}/manifests/${encodeURIComponent(tag)}`;
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    url,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: MANIFEST_ACCEPT_HEADER,
+      },
+    },
+    timeoutMs,
+    'requesting the GHCR manifest'
+  );
+
+  if (response.status === 404) {
+    return { status: 'absent' };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new GhcrGuardError(
+      `GHCR manifest request was denied with status ${response.status}`,
+      {
+        code: 'auth',
+      }
+    );
+  }
+
+  if (!response.ok) {
+    throw new GhcrGuardError(
+      `GHCR manifest request returned an indeterminate status ${response.status}`,
+      { code: 'indeterminate' }
+    );
+  }
+
+  const digest = response.headers.get('docker-content-digest') || '';
+  if (!digest) {
+    throw new GhcrGuardError(
+      'GHCR manifest response was missing a Docker-Content-Digest header',
+      { code: 'malformed' }
+    );
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new GhcrGuardError('GHCR manifest response body was not valid JSON', {
+      code: 'malformed',
+    });
+  }
+
+  const manifests = Array.isArray(body?.manifests)
+    ? body.manifests
+        .filter(
+          (entry) => entry && entry.platform && typeof entry.digest === 'string'
+        )
+        .map((entry) => ({
+          architecture: entry.platform.architecture,
+          os: entry.platform.os,
+          digest: entry.digest,
+        }))
+    : [];
+
+  return { status: 'present', digest, manifests };
+}
+
+// Fails closed: resolves only when the registry authoritatively reports the tag as absent.
+export async function assertTagAbsent({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const registryAuth = await fetchGhcrToken({
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+  const manifest = await getManifest({
+    owner,
+    repo,
+    tag,
+    token: registryAuth, // scan-secrets: ignore (short-lived registry token plumbing)
+    fetchImpl,
+    timeoutMs,
+  });
+
+  if (manifest.status === 'present') {
+    throw new GhcrGuardError(
+      `Artifact ${owner}/${repo}:${tag} already exists in GHCR with digest ${manifest.digest}; refusing to overwrite it`,
+      { code: 'exists' }
+    );
+  }
+
+  return manifest;
+}
+
+// Used only after a successful push, to record evidence. 'present' is the expected outcome
+// here; any other outcome is a hard failure.
+export async function describeManifest({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const registryAuth = await fetchGhcrToken({
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+  const manifest = await getManifest({
+    owner,
+    repo,
+    tag,
+    token: registryAuth, // scan-secrets: ignore (short-lived registry token plumbing)
+    fetchImpl,
+    timeoutMs,
+  });
+
+  if (manifest.status !== 'present') {
+    throw new GhcrGuardError(
+      `Expected GHCR tag ${owner}/${repo}:${tag} to exist after publish, but the registry reported it as absent`,
+      { code: 'missing-after-publish' }
+    );
+  }
+
+  const findDigest = (architecture) =>
+    manifest.manifests.find(
+      (entry) =>
+        entry.os === 'linux' &&
+        entry.architecture === architecture &&
+        typeof entry.digest === 'string' &&
+        entry.digest.trim().length > 0
+    )?.digest;
+
+  const amd64Digest = findDigest('amd64');
+  const arm64Digest = findDigest('arm64');
+  if (!amd64Digest || !arm64Digest) {
+    throw new GhcrGuardError(
+      `GHCR tag ${owner}/${repo}:${tag} does not contain non-empty digests for both required platforms linux/amd64 and linux/arm64`,
+      { code: 'missing-platform' }
+    );
+  }
+
+  return {
+    indexDigest: manifest.digest,
+    amd64Digest,
+    arm64Digest,
+  };
+}
+
+const FLAG_KEYS = new Set(['owner', 'repo', 'tag']);
+
+export function parseArgs(argv) {
+  const [subcommand, ...rest] = argv;
+
+  if (subcommand !== 'check-absent' && subcommand !== 'describe') {
+    throw new GhcrGuardError(
+      'Usage: ghcr-manifest.mjs <check-absent|describe> --owner <owner> --repo <repo> --tag <tag>',
+      { code: 'invalid-input' }
+    );
+  }
+
+  const options = {};
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    const key = flag?.startsWith('--') ? flag.slice(2) : '';
+    if (!FLAG_KEYS.has(key)) {
+      throw new GhcrGuardError(`Unrecognized argument: ${flag}`, {
+        code: 'invalid-input',
+      });
+    }
+    const value = rest[i + 1];
+    if (!value) {
+      throw new GhcrGuardError(`Missing value for --${key}`, {
+        code: 'invalid-input',
+      });
+    }
+    options[key] = value;
+    i += 1;
+  }
+
+  return {
+    subcommand,
+    owner: requireField(options.owner, '--owner'),
+    repo: requireField(options.repo, '--repo'),
+    tag: requireField(options.tag, '--tag'),
+  };
+}
+
+function writeGithubOutput(entries) {
+  const content =
+    entries.map(([key, value]) => `${key}=${value}`).join('\n') + '\n';
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    appendFileSync(outputPath, content);
+  } else {
+    console.log(JSON.stringify(Object.fromEntries(entries), null, 2));
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const { subcommand, owner, repo, tag } = parseArgs(argv);
+
+  // Credentials are read only from the environment, never from CLI args, so they can't
+  // leak through process listings or workflow logs that echo the invoked command.
+  const username = process.env.GHCR_GUARD_USERNAME || '';
+  const password = process.env.GHCR_GUARD_PASSWORD || ''; // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+  if (!username || !password) {
+    throw new GhcrGuardError(
+      'GHCR_GUARD_USERNAME and GHCR_GUARD_PASSWORD must both be set',
+      {
+        code: 'invalid-input',
+      }
+    );
+  }
+
+  if (subcommand === 'check-absent') {
+    await assertTagAbsent({ owner, repo, tag, username, password });
+    console.log(
+      `GHCR artifact ${owner}/${repo}:${tag} is not present (registry returned 404); safe to publish.`
+    );
+    return;
+  }
+
+  const digests = await describeManifest({
+    owner,
+    repo,
+    tag,
+    username,
+    password,
+  });
+  writeGithubOutput([
+    ['index_digest', digests.indexDigest],
+    ['amd64_digest', digests.amd64Digest],
+    ['arm64_digest', digests.arm64Digest],
+  ]);
+  console.log(`Recorded GHCR digests for ${owner}/${repo}:${tag}.`);
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isDirectRun) {
+  main().catch((error) => {
+    const message =
+      error instanceof GhcrGuardError
+        ? error.message
+        : `Unexpected error: ${error?.message || error}`;
+    console.error(message);
+    process.exit(1);
+  });
+}

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 const REGISTRY_HOST = 'https://ghcr.io';
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -386,7 +387,7 @@ export async function main(argv = process.argv.slice(2)) {
 }
 
 const isDirectRun =
-  process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectRun) {
   main().catch((error) => {
     const message =

--- a/scripts/stage-helm-chart.mjs
+++ b/scripts/stage-helm-chart.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { cpSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parse, stringify } from 'yaml';
 
 export const SOURCE_REPOSITORY = 'https://github.com/democratizedspace/dspace';
@@ -105,7 +106,10 @@ export function main(argv = process.argv.slice(2)) {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   try {
     main();
   } catch (error) {

--- a/scripts/stage-helm-chart.mjs
+++ b/scripts/stage-helm-chart.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parse, stringify } from 'yaml';
+
+export const SOURCE_REPOSITORY = 'https://github.com/democratizedspace/dspace';
+const FULL_SHA = /^[0-9a-f]{40}$/;
+const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+
+function required(value, label, pattern) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`Invalid ${label}: expected ${pattern}`);
+  }
+  return value;
+}
+
+export function stageChart({ sourceDir, destinationDir, revision }) {
+  if (!sourceDir || !destinationDir || sourceDir === destinationDir) {
+    throw new Error(
+      'Distinct sourceDir and destinationDir values are required'
+    );
+  }
+  required(revision, 'full source revision', FULL_SHA);
+  const sourceYaml = join(sourceDir, 'Chart.yaml');
+  const chart = parse(readFileSync(sourceYaml, 'utf8'));
+  if (!chart || typeof chart !== 'object')
+    throw new Error('Chart.yaml must contain a YAML map');
+  required(chart.version, 'chart version', SEMVER);
+  required(String(chart.appVersion), 'appVersion', SEMVER);
+  if (
+    chart.annotations !== undefined &&
+    (chart.annotations === null ||
+      typeof chart.annotations !== 'object' ||
+      Array.isArray(chart.annotations))
+  ) {
+    throw new Error('Chart.yaml annotations must be a YAML map');
+  }
+
+  mkdirSync(dirname(destinationDir), { recursive: true });
+  cpSync(sourceDir, destinationDir, { recursive: true, errorOnExist: true });
+  chart.annotations = { ...(chart.annotations || {}) };
+  chart.annotations['org.opencontainers.image.source'] = SOURCE_REPOSITORY;
+  chart.annotations['org.opencontainers.image.revision'] = revision;
+  chart.annotations['org.opencontainers.image.version'] = String(
+    chart.appVersion
+  );
+  writeFileSync(join(destinationDir, 'Chart.yaml'), stringify(chart));
+  return {
+    version: chart.version,
+    appVersion: String(chart.appVersion),
+    source: SOURCE_REPOSITORY,
+  };
+}
+
+export function verifyChart({ chartYaml, version, appVersion, revision }) {
+  required(version, 'chart version', SEMVER);
+  required(appVersion, 'appVersion', SEMVER);
+  required(revision, 'full source revision', FULL_SHA);
+  const chart = parse(readFileSync(chartYaml, 'utf8'));
+  if (!chart || typeof chart !== 'object' || Array.isArray(chart))
+    throw new Error('Chart.yaml must contain a YAML map');
+  if (
+    !chart.annotations ||
+    typeof chart.annotations !== 'object' ||
+    Array.isArray(chart.annotations)
+  )
+    throw new Error('Chart.yaml annotations must be a YAML map');
+  const expectedAnnotations = {
+    'org.opencontainers.image.source': SOURCE_REPOSITORY,
+    'org.opencontainers.image.revision': revision,
+    'org.opencontainers.image.version': appVersion,
+  };
+  if (String(chart.version) !== version)
+    throw new Error('Packaged Chart.yaml version mismatch');
+  if (String(chart.appVersion) !== appVersion)
+    throw new Error('Packaged Chart.yaml appVersion mismatch');
+  for (const [key, value] of Object.entries(expectedAnnotations)) {
+    if (chart.annotations[key] !== value)
+      throw new Error(`Packaged Chart.yaml ${key} mismatch`);
+  }
+  return { version, appVersion, ...expectedAnnotations };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  if (argv[0] === 'verify') {
+    if (argv.length !== 5)
+      throw new Error(
+        'Usage: stage-helm-chart.mjs verify <Chart.yaml> <version> <appVersion> <full-revision>'
+      );
+    process.stdout.write(
+      `${JSON.stringify(verifyChart({ chartYaml: argv[1], version: argv[2], appVersion: argv[3], revision: argv[4] }))}\n`
+    );
+    return;
+  }
+  if (argv.length !== 3) {
+    throw new Error(
+      'Usage: stage-helm-chart.mjs <source-dir> <destination-dir> <full-revision>'
+    );
+  }
+  const result = stageChart({
+    sourceDir: argv[0],
+    destinationDir: argv[1],
+    revision: argv[2],
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/tests/changelogDocsReleaseChecklist.test.ts
+++ b/tests/changelogDocsReleaseChecklist.test.ts
@@ -26,19 +26,19 @@ describe('April 1, 2026 changelog release checklist', () => {
     expect(content).not.toMatch(/💯/);
   });
 
-  it('keeps rc.6 SHA/range gate open until immutable tag proof is attached', () => {
+  it('records immutable remote-tag proof and closes the rc.6 SHA/range identity gate', () => {
     const content = readFileSync(qaChecklistPath, 'utf8');
 
     expect(content).toContain(
-      '- [ ] QA signoff confirms the audited commit delta above resolves to the immutable rc.6 SHA and'
+      '- [x] QA signoff confirms the audited commit delta above resolves to the immutable rc.6 SHA and'
     );
     expect(content).toMatch(/SHA\/range resolution gate only/i);
-    expect(content).toMatch(/origin.*unavailable|no configured `origin`/i);
-    expect(content).toMatch(/must attach remote tag/i);
     expect(content).toMatch(/git ls-remote --tags origin v3\.0\.1-rc\.6/i);
     expect(content).toContain('8a1fa6ca2b4206c3e481da6b8f02c912b56dfdb0');
-    expect(content).not.toMatch(/resolves to `8a1fa6ca.*` in this checkout/i);
-    expect(content).not.toMatch(/git rev-parse v3\.0\.1-rc\.6` resolves/i);
+    expect(content).toMatch(/closes the tag\/SHA\/range identity gate only/i);
+    expect(content).toMatch(
+      /separate staging, candidate-specific, production promotion, rollback, and closeout gates/i
+    );
     expect(content).toMatch(
       /Completed custom quests move into the Completed Quests section/
     );
@@ -50,7 +50,7 @@ describe('April 1, 2026 changelog release checklist', () => {
     const content = readFileSync(changelogPath, 'utf8');
 
     expect(content).toContain(
-      '## June 1, 2026 — DSPACE v3.0.1 (patch addendum)'
+      '## May 21, 2026 — DSPACE v3.0.1 (patch addendum)'
     );
     expect(content).toContain('### Reader guide and verification routes');
     expect(content).toContain('The player-visible route checks for v3.0.1');

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -17,6 +16,18 @@ const step = (name: string) =>
   steps.find((candidate) => candidate.name === name);
 
 describe('chart publication workflow integrity', () => {
+  it.each([
+    ['stage-helm-chart.mjs', 'Usage: stage-helm-chart.mjs'],
+    ['ghcr-manifest.mjs', 'Usage: ghcr-manifest.mjs'],
+  ])('runs %s when invoked through a relative CLI path', (script, usage) => {
+    const result = spawnSync('node', [`scripts/${script}`], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(usage);
+  });
+
   it('publishes only for chart-v* tag pushes, never branches or manual dispatch', () => {
     expect(workflow.on).toEqual({ push: { tags: ['chart-v*'] } });
     expect(text).not.toContain('workflow_dispatch');
@@ -42,6 +53,14 @@ describe('chart publication workflow integrity', () => {
     expect(release.run).toContain('git rev-parse "${CHART_TAG}^{commit}"');
     expect(release.run).toContain('"$source_sha" == "$EVENT_SHA"');
     expect(release.run).toContain('"$source_sha" == "$tag_sha"');
+    expect(release.run).toContain('refs/heads/release/chart-3.0.x');
+    expect(release.run).toContain('"$source_sha" == "$approved_sha"');
+  });
+
+  it('pins every package-authorized action to an immutable commit', () => {
+    for (const actionStep of steps.filter((candidate) => candidate.uses)) {
+      expect(actionStep.uses).toMatch(/^[^@]+@[0-9a-f]{40}$/);
+    }
   });
 
   it('enforces strict matching versions and tombstones chart 3.0.1 before registry access', () => {
@@ -64,8 +83,14 @@ describe('chart publication workflow integrity', () => {
     const finalGuard = step('Refuse an existing chart coordinate (pre-push)');
     const push = step('Push chart exactly once');
     expect(revalidation.env.EVENT_SHA).toBe('${{ github.sha }}');
-    expect(revalidation.run).toContain('git rev-parse "${CHART_TAG}^{commit}"');
+    expect(revalidation.run).toContain(
+      'git fetch --force --no-tags origin "refs/tags/${CHART_TAG}:${remote_tag_ref}"'
+    );
+    expect(revalidation.run).toContain(
+      'git rev-parse "${remote_tag_ref}^{commit}"'
+    );
     expect(revalidation.run).toContain('"$tag_sha" == "$EVENT_SHA"');
+    expect(revalidation.run).toContain('"$approved_sha" == "$EVENT_SHA"');
     expect(steps.indexOf(revalidation)).toBe(steps.indexOf(finalGuard) - 1);
     expect(steps.indexOf(finalGuard)).toBe(steps.indexOf(push) - 1);
   });

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+const text = readFileSync(
+  join(process.cwd(), '.github/workflows/ci-helm.yml'),
+  'utf8'
+);
+const workflow = parse(text) as any;
+const job = workflow.jobs.publish;
+const steps = job.steps as any[];
+const step = (name: string) =>
+  steps.find((candidate) => candidate.name === name);
+
+describe('chart publication workflow integrity', () => {
+  it('publishes only for chart-v* tag pushes, never branches or manual dispatch', () => {
+    expect(workflow.on).toEqual({ push: { tags: ['chart-v*'] } });
+    expect(text).not.toContain('workflow_dispatch');
+    expect(text).not.toMatch(/branches:\s*\n\s*- (main|v3)/);
+  });
+
+  it('serializes same-tag runs without cancellation', () => {
+    expect(workflow.concurrency.group).toBe('helm-chart-${{ github.ref }}');
+    expect(workflow.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('binds checkout to the event SHA and rejects a subsequently moved tag', () => {
+    const checkout = steps.find((candidate) =>
+      candidate.uses?.startsWith('actions/checkout')
+    );
+    expect(checkout.with.ref).toBe('${{ github.sha }}');
+    expect(checkout.with['fetch-depth']).toBe(0);
+    const release = step('Validate tag, versions, and source revision');
+    expect(release.env.CHART_TAG).toBe('${{ github.ref_name }}');
+    expect(text.match(/github\.ref_name/g)).toHaveLength(1);
+    expect(release.env.EVENT_SHA).toBe('${{ github.sha }}');
+    expect(release.run).toContain('git rev-parse HEAD');
+    expect(release.run).toContain('git rev-parse "${CHART_TAG}^{commit}"');
+    expect(release.run).toContain('"$source_sha" == "$EVENT_SHA"');
+    expect(release.run).toContain('"$source_sha" == "$tag_sha"');
+  });
+
+  it('enforces strict matching versions and tombstones chart 3.0.1 before registry access', () => {
+    const releaseIndex = steps.indexOf(
+      step('Validate tag, versions, and source revision')
+    );
+    const guardIndex = steps.indexOf(
+      step('Refuse an existing chart coordinate (pre-package)')
+    );
+    expect(steps[releaseIndex].run).toContain(
+      '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
+    );
+    expect(steps[releaseIndex].run).toContain('chart-v${chart_version}');
+    expect(steps[releaseIndex].run).toContain('chart_version" != "3.0.1');
+    expect(releaseIndex).toBeLessThan(guardIndex);
+  });
+
+  it('revalidates the peeled tag against the push SHA immediately before the final guard', () => {
+    const revalidation = step('Revalidate tag and source revision before push');
+    const finalGuard = step('Refuse an existing chart coordinate (pre-push)');
+    const push = step('Push chart exactly once');
+    expect(revalidation.env.EVENT_SHA).toBe('${{ github.sha }}');
+    expect(revalidation.run).toContain('git rev-parse "${CHART_TAG}^{commit}"');
+    expect(revalidation.run).toContain('"$tag_sha" == "$EVENT_SHA"');
+    expect(steps.indexOf(revalidation)).toBe(steps.indexOf(finalGuard) - 1);
+    expect(steps.indexOf(finalGuard)).toBe(steps.indexOf(push) - 1);
+  });
+
+  it('targets the chart repository twice, before packaging and immediately before push', () => {
+    const guards = steps.filter((candidate) =>
+      candidate.run?.includes('check-absent')
+    );
+    expect(guards).toHaveLength(2);
+    for (const guard of guards) {
+      expect(guard.run).toContain('--repo charts/dspace');
+      expect(guard.run).toContain('--tag "$CHART_VERSION"');
+      expect(guard.env.GHCR_GUARD_PASSWORD).toBe('${{ secrets.GITHUB_TOKEN }}');
+    }
+    const packageIndex = steps.indexOf(
+      step('Validate and stage chart provenance')
+    );
+    const pushIndex = steps.indexOf(step('Push chart exactly once'));
+    expect(steps.indexOf(guards[0])).toBeLessThan(packageIndex);
+    expect(steps.indexOf(guards[1])).toBe(pushIndex - 1);
+  });
+
+  it('has one unsuppressed helm push and records validated provenance evidence', () => {
+    expect(text.match(/^\s*output=\$\(helm push /gm)).toHaveLength(1);
+    const push = step('Push chart exactly once').run;
+    expect(push).not.toMatch(/retry|continue-on-error|\|\| true/);
+    expect(push).toContain('^sha256:[0-9a-f]{64}$');
+    const summary = step('Write publication evidence').run;
+    for (const field of [
+      'Chart version',
+      'Application version',
+      'Triggering chart release tag',
+      'Full source SHA',
+      'Source repository',
+      'OCI reference',
+      'Packaged archive SHA-256',
+      'OCI manifest digest',
+    ]) {
+      expect(summary).toContain(field);
+    }
+    expect(summary).toContain(
+      'SOURCE_SHA is the authoritative immutable provenance'
+    );
+  });
+
+  it('keeps credentials in environment variables and stdin', () => {
+    expect(text).not.toContain('-p "${{ secrets.GITHUB_TOKEN }}"');
+    expect(step('Authenticate to GHCR').run).toContain('--password-stdin');
+    expect(step('Authenticate to GHCR').env).toEqual({
+      GHCR_GUARD_USERNAME: '${{ github.actor }}',
+      GHCR_GUARD_PASSWORD: '${{ secrets.GITHUB_TOKEN }}', // scan-secrets: ignore -- workflow expression, not a credential
+    });
+  });
+
+  it('installs Node and YAML dependencies before staging', () => {
+    expect(step('Setup Node.js').with['node-version']).toBe(20);
+    expect(step('Setup pnpm').with.version).toBe('9.0.0');
+    expect(step('Install dependencies').run).toBe(
+      'pnpm install --frozen-lockfile --reporter=append-only'
+    );
+    expect(steps.indexOf(step('Install dependencies'))).toBeLessThan(
+      steps.indexOf(step('Validate and stage chart provenance'))
+    );
+  });
+
+  it('verifies the safely extracted packaged Chart.yaml with the YAML helper', () => {
+    const packaging = step('Validate and stage chart provenance').run;
+    expect(packaging).toContain('tar -xOf "$expected" dspace/Chart.yaml');
+    expect(packaging).toContain('stage-helm-chart.mjs verify');
+    expect(packaging).not.toContain('value()');
+  });
+});
+
+describe('immutable chart tag peeling', () => {
+  const withRepository = (
+    run: (root: string, first: string, second: string) => void
+  ) => {
+    const root = mkdtempSync(join(tmpdir(), 'helm-tag-'));
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+    try {
+      git('init', '-q');
+      git('config', 'user.name', 'Test');
+      git('config', 'user.email', 'test@example.invalid');
+      execFileSync(
+        'sh',
+        ['-c', 'echo one > file && git add file && git commit -qm one'],
+        { cwd: root }
+      );
+      const first = git('rev-parse', 'HEAD');
+      execFileSync('sh', ['-c', 'echo two > file && git commit -qam two'], {
+        cwd: root,
+      });
+      run(root, first, git('rev-parse', 'HEAD'));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+  const validate = (root: string, eventSha: string, tag: string) =>
+    spawnSync(
+      'bash',
+      [
+        '-c',
+        'source_sha=$(git rev-parse HEAD); tag_sha=$(git rev-parse "${CHART_TAG}^{commit}"); [[ "$source_sha" == "$EVENT_SHA" && "$source_sha" == "$tag_sha" ]]',
+      ],
+      {
+        cwd: root,
+        env: { ...process.env, EVENT_SHA: eventSha, CHART_TAG: tag },
+      }
+    );
+
+  it.each([['lightweight'], ['annotated']])(
+    'peels a %s tag to the event commit',
+    (kind) =>
+      withRepository((root, first) => {
+        const args =
+          kind === 'annotated'
+            ? ['tag', '-a', 'chart-v1.2.3', '-m', 'release', first]
+            : ['tag', 'chart-v1.2.3', first];
+        execFileSync('git', args, { cwd: root });
+        execFileSync('git', ['checkout', '-q', first], { cwd: root });
+        expect(validate(root, first, 'chart-v1.2.3').status).toBe(0);
+      })
+  );
+
+  it('rejects a tag moved away from the checked-out event commit', () =>
+    withRepository((root, first, second) => {
+      execFileSync('git', ['tag', 'chart-v1.2.3', second], { cwd: root });
+      execFileSync('git', ['checkout', '-q', first], { cwd: root });
+      expect(validate(root, first, 'chart-v1.2.3').status).not.toBe(0);
+    }));
+});

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -45,6 +45,7 @@ describe('chart publication workflow integrity', () => {
     );
     expect(checkout.with.ref).toBe('${{ github.sha }}');
     expect(checkout.with['fetch-depth']).toBe(0);
+    expect(checkout.with['persist-credentials']).toBe(false);
     const release = step('Validate tag, versions, and source revision');
     expect(release.env.CHART_TAG).toBe('${{ github.ref_name }}');
     expect(text.match(/github\.ref_name/g)).toHaveLength(1);
@@ -55,6 +56,27 @@ describe('chart publication workflow integrity', () => {
     expect(release.run).toContain('"$source_sha" == "$tag_sha"');
     expect(release.run).toContain('refs/heads/release/chart-3.0.x');
     expect(release.run).toContain('"$source_sha" == "$approved_sha"');
+  });
+
+  it('authorizes the source before setup or repository-controlled execution', () => {
+    const checkoutIndex = steps.indexOf(step('Checkout chart release tag'));
+    const releaseIndex = steps.indexOf(
+      step('Validate tag, versions, and source revision')
+    );
+    const nodeIndex = steps.indexOf(step('Setup Node.js'));
+    const pnpmIndex = steps.indexOf(step('Setup pnpm'));
+    const installIndex = steps.indexOf(step('Install dependencies'));
+
+    expect(releaseIndex).toBe(checkoutIndex + 1);
+    expect(releaseIndex).toBeLessThan(nodeIndex);
+    expect(releaseIndex).toBeLessThan(pnpmIndex);
+    expect(releaseIndex).toBeLessThan(installIndex);
+
+    const release = steps[releaseIndex].run;
+    expect(release).toContain('refs/heads/release/chart-3.0.x');
+    expect(release).toContain('"$source_sha" == "$EVENT_SHA"');
+    expect(release).toContain('"$source_sha" == "$tag_sha"');
+    expect(release).toContain('"$source_sha" == "$approved_sha"');
   });
 
   it('pins every package-authorized action to an immutable commit', () => {
@@ -153,6 +175,9 @@ describe('chart publication workflow integrity', () => {
     );
     expect(steps.indexOf(step('Install dependencies'))).toBeLessThan(
       steps.indexOf(step('Validate and stage chart provenance'))
+    );
+    expect(steps.indexOf(step('Install dependencies'))).toBeLessThan(
+      steps.indexOf(step('Refuse an existing chart coordinate (pre-package)'))
     );
   });
 

--- a/tests/fixtures/helm/dspace-v3.0.1-null-metrics-values.yaml
+++ b/tests/fixtures/helm/dspace-v3.0.1-null-metrics-values.yaml
@@ -1,0 +1,3 @@
+# Helm upgrades may retain explicitly null maps from historical stored values.
+metrics: null
+serviceMonitor: null

--- a/tests/fixtures/helm/dspace-v3.0.1-production-values.yaml
+++ b/tests/fixtures/helm/dspace-v3.0.1-production-values.yaml
@@ -1,0 +1,18 @@
+# Deterministic representation of the stored pre-observability v3.0.1 production values.
+replicaCount: 2
+image:
+  repository: ghcr.io/democratizedspace/dspace
+  tag: v3.0.1
+  pullPolicy: Always
+service:
+  type: ClusterIP
+  port: 8080
+environment: production
+ingress:
+  enabled: true
+  className: traefik
+  host: democratized.space
+  annotations: {}
+  tls:
+    enabled: true
+    secretName: dspace-tls

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GhcrGuardError,
+  assertTagAbsent,
+  describeManifest,
+  fetchGhcrToken,
+  getManifest,
+  parseArgs,
+} from '../scripts/ghcr-manifest.mjs';
+
+const SECRET_PASSWORD = 'super-secret-token-value-do-not-leak'; // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+) {
+  const lowered = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => lowered[name.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+function malformedJsonResponse(
+  status: number,
+  headers: Record<string, string> = {}
+) {
+  const lowered = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => lowered[name.toLowerCase()] ?? null },
+    json: async () => {
+      throw new Error('Unexpected token in JSON');
+    },
+  };
+}
+
+function fetchFor({
+  tokenResponse,
+  manifestResponse,
+}: {
+  tokenResponse: any;
+  manifestResponse?: any;
+}) {
+  return async (url: string) => {
+    if (url.includes('/token')) {
+      return tokenResponse;
+    }
+    if (url.includes('/manifests/')) {
+      return manifestResponse;
+    }
+    throw new Error(`Unexpected fetch call to ${url}`);
+  };
+}
+
+function hangingFetch() {
+  return (_url: string, init: { signal: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        const error = new Error('The operation was aborted');
+        error.name = 'AbortError';
+        reject(error);
+      });
+    });
+}
+
+const okToken = jsonResponse(200, { token: 'fake-bearer-token' }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+
+describe('fetchGhcrToken', () => {
+  it('throws a network GhcrGuardError when the request fails', async () => {
+    const fetchImpl = async () => {
+      throw new Error('getaddrinfo ENOTFOUND ghcr.io');
+    };
+
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'network' });
+  });
+
+  it('classifies a 401 as an auth failure and never leaks the password', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: jsonResponse(401, { message: 'denied' }),
+    });
+
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(GhcrGuardError);
+      expect((error as GhcrGuardError).code).toBe('auth');
+      expect((error as Error).message).not.toContain(SECRET_PASSWORD);
+      return true;
+    });
+  });
+
+  it('classifies a 500 as indeterminate', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: jsonResponse(500, { message: 'boom' }),
+    });
+
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'indeterminate' });
+  });
+
+  it('fails closed on a timeout', async () => {
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        fetchImpl: hangingFetch(),
+        timeoutMs: 20,
+      })
+    ).rejects.toMatchObject({ code: 'timeout' });
+  });
+
+  it('fails closed on a malformed (non-JSON) token response', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: malformedJsonResponse(200) });
+
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+
+  it('fails closed when the token response has no token field', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: jsonResponse(200, { not_a_token: true }), // scan-secrets: ignore (test placeholder, not credential material)
+    }); // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+
+    await expect(
+      fetchGhcrToken({
+        owner: 'o',
+        repo: 'r',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+});
+
+describe('getManifest', () => {
+  it('reports an authoritative 404 as absent', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(404, {}),
+    });
+    // getManifest is tested directly with a raw token, bypassing the token exchange.
+    const result = await getManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      token: 't', // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+      fetchImpl: async (url: string) => fetchImpl(url),
+    });
+    expect(result).toEqual({ status: 'absent' });
+  });
+
+  it('reports a 200 with a digest as present and parses per-platform digests', async () => {
+    const body = {
+      manifests: [
+        {
+          platform: { architecture: 'amd64', os: 'linux' },
+          digest: 'sha256:amd64digest',
+        },
+        {
+          platform: { architecture: 'arm64', os: 'linux' },
+          digest: 'sha256:arm64digest',
+        },
+      ],
+    };
+    const fetchImpl = async () =>
+      jsonResponse(200, body, {
+        'docker-content-digest': 'sha256:indexdigest',
+      });
+
+    const result = await getManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      token: 't', // scan-secrets: ignore (test placeholder, not credential material)
+      fetchImpl,
+    }); // scan-secrets: ignore (fixture token; no real secret literal)
+    expect(result.status).toBe('present');
+    expect(result.digest).toBe('sha256:indexdigest');
+    expect(result.manifests).toEqual([
+      { architecture: 'amd64', os: 'linux', digest: 'sha256:amd64digest' },
+      { architecture: 'arm64', os: 'linux', digest: 'sha256:arm64digest' },
+    ]);
+  });
+
+  it('fails closed on 401/403', async () => {
+    const fetchImpl = async () => jsonResponse(403, {});
+    await expect(
+      getManifest({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        token: 't', // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture token; no real secret literal)
+    ).rejects.toMatchObject({ code: 'auth' });
+  });
+
+  it('fails closed on an indeterminate status', async () => {
+    const fetchImpl = async () => jsonResponse(502, {});
+    await expect(
+      getManifest({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        token: 't', // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture token; no real secret literal)
+    ).rejects.toMatchObject({ code: 'indeterminate' });
+  });
+
+  it('fails closed when a 200 response is missing the digest header', async () => {
+    const fetchImpl = async () => jsonResponse(200, { manifests: [] });
+    await expect(
+      getManifest({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        token: 't', // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture token; no real secret literal)
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+
+  it('fails closed on a malformed manifest body', async () => {
+    const fetchImpl = async () =>
+      malformedJsonResponse(200, {
+        'docker-content-digest': 'sha256:indexdigest',
+      });
+    await expect(
+      getManifest({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        token: 't', // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture token; no real secret literal)
+    ).rejects.toMatchObject({ code: 'malformed' });
+  });
+});
+
+describe('assertTagAbsent', () => {
+  it('resolves when the registry authoritatively reports the tag absent', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(404, {}),
+    });
+    await expect(
+      assertTagAbsent({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).resolves.toEqual({ status: 'absent' });
+  });
+
+  it('throws (fails closed) when the tag already exists, including the digest but never the password', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(
+        200,
+        { manifests: [] },
+        { 'docker-content-digest': 'sha256:existingdigest' }
+      ),
+    });
+
+    await expect(
+      assertTagAbsent({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toSatisfy((error: unknown) => {
+      const message = (error as Error).message;
+      expect((error as GhcrGuardError).code).toBe('exists');
+      expect(message).toContain('sha256:existingdigest');
+      expect(message).not.toContain(SECRET_PASSWORD);
+      return true;
+    });
+  });
+
+  it('fails closed when the token request itself is denied', async () => {
+    const fetchImpl = fetchFor({ tokenResponse: jsonResponse(401, {}) });
+    await expect(
+      assertTagAbsent({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'auth' });
+  });
+});
+
+describe('describeManifest', () => {
+  function describeWith(manifests: unknown) {
+    return describeManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      username: 'u',
+      password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+      fetchImpl: fetchFor({
+        tokenResponse: okToken,
+        manifestResponse: jsonResponse(
+          200,
+          { manifests },
+          { 'docker-content-digest': 'sha256:indexdigest' }
+        ),
+      }),
+    });
+  }
+
+  it('returns index/amd64/arm64 digests for a published multi-arch tag', async () => {
+    const body = {
+      manifests: [
+        {
+          platform: { architecture: 'amd64', os: 'linux' },
+          digest: 'sha256:amd64digest',
+        },
+        {
+          platform: { architecture: 'arm64', os: 'linux' },
+          digest: 'sha256:arm64digest',
+        },
+      ],
+    };
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(200, body, {
+        'docker-content-digest': 'sha256:indexdigest',
+      }),
+    });
+
+    const result = await describeManifest({
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+      username: 'u',
+      password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      indexDigest: 'sha256:indexdigest',
+      amd64Digest: 'sha256:amd64digest',
+      arm64Digest: 'sha256:arm64digest',
+    });
+  });
+
+  it('fails when the tag unexpectedly does not exist after a publish', async () => {
+    const fetchImpl = fetchFor({
+      tokenResponse: okToken,
+      manifestResponse: jsonResponse(404, {}),
+    });
+    await expect(
+      describeManifest({
+        owner: 'o',
+        repo: 'r',
+        tag: 'v1.0.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (test placeholder, not credential material)
+        fetchImpl,
+      }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    ).rejects.toMatchObject({ code: 'missing-after-publish' });
+  });
+
+  it.each([
+    [
+      'linux/amd64 is missing',
+      [
+        {
+          platform: { architecture: 'arm64', os: 'linux' },
+          digest: 'sha256:arm64digest',
+        },
+      ],
+    ],
+    [
+      'linux/arm64 is missing',
+      [
+        {
+          platform: { architecture: 'amd64', os: 'linux' },
+          digest: 'sha256:amd64digest',
+        },
+      ],
+    ],
+    [
+      'a non-Linux entry uses a required architecture',
+      [
+        {
+          platform: { architecture: 'amd64', os: 'windows' },
+          digest: 'sha256:wrongos',
+        },
+        {
+          platform: { architecture: 'arm64', os: 'linux' },
+          digest: 'sha256:arm64digest',
+        },
+      ],
+    ],
+    ['the response is a single-image manifest', undefined],
+    ['the manifest list is empty', []],
+    [
+      'a required platform has an empty digest',
+      [
+        { platform: { architecture: 'amd64', os: 'linux' }, digest: '' },
+        {
+          platform: { architecture: 'arm64', os: 'linux' },
+          digest: 'sha256:arm64digest',
+        },
+      ],
+    ],
+  ])('fails closed when %s', async (_description, manifests) => {
+    await expect(describeWith(manifests)).rejects.toMatchObject({
+      code: 'missing-platform',
+    });
+  });
+});
+
+describe('parseArgs', () => {
+  it('rejects a missing subcommand', () => {
+    expect(() => parseArgs([])).toThrow(/Usage: ghcr-manifest\.mjs/);
+  });
+
+  it('rejects an unknown subcommand', () => {
+    expect(() => parseArgs(['delete-everything'])).toThrow(
+      /Usage: ghcr-manifest\.mjs/
+    );
+  });
+
+  it('rejects a missing --owner/--repo/--tag', () => {
+    expect(() => parseArgs(['check-absent', '--owner', 'o'])).toThrow(/--repo/);
+  });
+
+  it('rejects an unrecognized flag', () => {
+    expect(() =>
+      parseArgs([
+        'check-absent',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--tag',
+        'v1.0.0',
+        '--bogus',
+        'x',
+      ])
+    ).toThrow(/Unrecognized argument/);
+  });
+
+  it('parses a fully specified check-absent invocation', () => {
+    expect(
+      parseArgs([
+        'check-absent',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--tag',
+        'v1.0.0',
+      ])
+    ).toEqual({
+      subcommand: 'check-absent',
+      owner: 'o',
+      repo: 'r',
+      tag: 'v1.0.0',
+    });
+  });
+});

--- a/tests/helmChartRecovery.test.ts
+++ b/tests/helmChartRecovery.test.ts
@@ -55,7 +55,10 @@ describe('v3.0.1-compatible recovery chart', () => {
       'tests/fixtures/helm/dspace-v3.0.1-null-metrics-values.yaml',
     ]);
     expect(manifest).not.toContain('kind: ServiceMonitor');
-    expect(manifest).not.toContain('METRICS_TOKEN');
+    expect(deploymentEnv(manifest)).toContainEqual({
+      name: 'METRICS_TOKEN',
+      valueFrom: { fieldRef: { fieldPath: 'metadata.uid' } },
+    });
     expect(deploymentEnv(manifest)).toContainEqual({
       name: 'METRICS_ENABLED',
       value: 'false',

--- a/tests/helmChartRecovery.test.ts
+++ b/tests/helmChartRecovery.test.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+const render = (args: string[] = []) =>
+  execFileSync(
+    'helm',
+    ['template', 'dspace', 'charts/dspace', '--namespace', 'dspace', ...args],
+    { encoding: 'utf8' }
+  );
+
+const documents = (manifest: string) =>
+  manifest
+    .split(/^---$/m)
+    .map((document) => document.trim())
+    .filter(Boolean)
+    .map((document) => YAML.parse(document));
+
+const deploymentEnv = (manifest: string) =>
+  documents(manifest).find((document) => document.kind === 'Deployment').spec
+    .template.spec.containers[0].env;
+
+describe('v3.0.1-compatible recovery chart', () => {
+  it('reports chart 3.0.2 and application 3.0.1 with an immutable default image', () => {
+    const chart = YAML.parse(readFileSync('charts/dspace/Chart.yaml', 'utf8'));
+    const values = YAML.parse(
+      readFileSync('charts/dspace/values.yaml', 'utf8')
+    );
+    expect(chart.version).toBe('3.0.2');
+    expect(String(chart.appVersion)).toBe('3.0.1');
+    expect(values.image.tag).toBe('main-1a31a56');
+    expect(values.image.tag).not.toBe('v3.0.1');
+    expect(render()).toContain('ghcr.io/democratizedspace/dspace:main-1a31a56');
+  });
+
+  it('renders stored pre-observability production values with an immutable override', () => {
+    const manifest = render([
+      '-f',
+      'tests/fixtures/helm/dspace-v3.0.1-production-values.yaml',
+      '--set-string',
+      'image.tag=main-1a31a56',
+    ]);
+    expect(manifest).toContain('ghcr.io/democratizedspace/dspace:main-1a31a56');
+    expect(manifest).not.toContain('kind: ServiceMonitor');
+    expect(deploymentEnv(manifest)).toContainEqual({
+      name: 'METRICS_ENABLED',
+      value: 'false',
+    });
+  });
+
+  it('safely renders explicitly null metrics-related maps', () => {
+    const manifest = render([
+      '-f',
+      'tests/fixtures/helm/dspace-v3.0.1-null-metrics-values.yaml',
+    ]);
+    expect(manifest).not.toContain('kind: ServiceMonitor');
+    expect(manifest).not.toContain('METRICS_TOKEN');
+    expect(deploymentEnv(manifest)).toContainEqual({
+      name: 'METRICS_ENABLED',
+      value: 'false',
+    });
+  });
+
+  it('renders authenticated metrics and its existing Secret reference only when enabled', () => {
+    const manifest = render([
+      '--set',
+      'metrics.enabled=true',
+      '--set',
+      'metrics.auth.existingSecret=dspace-metrics-token', // scan-secrets: ignore (fixture Secret name)
+      '--set',
+      'serviceMonitor.enabled=true',
+    ]);
+    const serviceMonitor = documents(manifest).find(
+      (document) => document.kind === 'ServiceMonitor'
+    );
+    expect(serviceMonitor.spec.endpoints[0].bearerTokenSecret).toEqual({
+      name: 'dspace-metrics-token',
+      key: 'token',
+    });
+    expect(deploymentEnv(manifest)).toContainEqual({
+      name: 'METRICS_TOKEN',
+      valueFrom: {
+        secretKeyRef: { name: 'dspace-metrics-token', key: 'token' },
+      },
+    });
+  });
+});

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -1,28 +1,428 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { parse, stringify } from 'yaml';
+import {
+  SOURCE_REPOSITORY,
+  stageChart,
+  verifyChart,
+} from '../scripts/stage-helm-chart.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(__dirname, '..');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const coordinatePaths = [
+  'package.json',
+  'frontend/package.json',
+  'package-lock.json',
+  'charts/dspace/Chart.yaml',
+  'charts/dspace/values.yaml',
+  'docs/apps/dspace.version',
+];
 
-const chartPath = join(repoRoot, 'charts', 'dspace', 'Chart.yaml');
-const valuesPath = join(repoRoot, 'charts', 'dspace', 'values.yaml');
-const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+const fixture = () => {
+  const root = mkdtempSync(join(tmpdir(), 'dspace-version-'));
+  for (const path of coordinatePaths) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    cpSync(join(repoRoot, path), join(root, path));
+  }
+  return root;
+};
 
-describe('charts/dspace release metadata', () => {
-    const chartContent = readFileSync(chartPath, 'utf8');
-    const valuesContent = readFileSync(valuesPath, 'utf8');
+const runGuard = (root: string) =>
+  spawnSync('bash', [join(repoRoot, 'scripts/check-dspace-chart-version.sh')], {
+    env: { ...process.env, DSPACE_VERSION_ROOT: root },
+    encoding: 'utf8',
+  });
 
-    const appVersionMatch = chartContent.match(/appVersion:\s*"?([^"\n]+)"?/);
-    const imageTagMatch = valuesContent.match(/^\s*tag:\s*([^\n]+)/m);
+const read = (root: string, path: string) =>
+  readFileSync(join(root, path), 'utf8');
+const replace = (
+  root: string,
+  path: string,
+  search: string | RegExp,
+  value: string
+) => {
+  const file = join(root, path);
+  const current = read(root, path);
+  const next = current.replace(search, value);
+  expect(next).not.toBe(current);
+  writeFileSync(file, next);
+};
+const currentVersions = (root: string) => ({
+  application: JSON.parse(read(root, 'package.json')).version as string,
+  chart: read(root, 'charts/dspace/Chart.yaml').match(
+    /^version:\s*"?([^"\s]+)"?$/m
+  )?.[1] as string,
+});
+const withFixture = (check: (root: string) => void) => {
+  const root = fixture();
+  try {
+    check(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
 
-    it('keeps appVersion aligned with the default image tag and package release', () => {
-        expect(appVersionMatch?.[1], 'appVersion should be defined in Chart.yaml').toBe(
-            `v${packageJson.version}`,
+describe('independent DSPACE application and chart coordinates', () => {
+  it('passes current repository coordinates and reports both groups', () =>
+    withFixture((root) => {
+      const { application, chart } = currentVersions(root);
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        `application version ${application} (main-1a31a56)`
+      );
+      expect(result.stdout).toContain(`chart version ${chart}`);
+    }));
+
+  it('permits chart 3.0.2 with application 3.0.1', () =>
+    withFixture((root) => {
+      expect(currentVersions(root)).toEqual({
+        application: '3.0.1',
+        chart: '3.0.2',
+      });
+      const result = runGuard(root);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('application version 3.0.1');
+      expect(result.stdout).toContain('chart version 3.0.2');
+    }));
+
+  it.each([
+    ['Application', 'root package version', 'package.json', null],
+    ['Chart', 'chart version', 'charts/dspace/Chart.yaml', /^version:.*\n/m],
+  ])('labels a missing %s field', (group, field, path, line) =>
+    withFixture((root) => {
+      if (line) replace(root, path, line, '');
+      else rmSync(join(root, path));
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`${group} coordinate missing: ${field}`);
+    })
+  );
+
+  it.each([
+    [
+      'Application',
+      'root package version',
+      'package.json',
+      /"version": "[^"]+"/,
+      '"version": "01.2.3"',
+    ],
+    [
+      'Application',
+      'chart appVersion',
+      'charts/dspace/Chart.yaml',
+      /^appVersion:.*$/m,
+      'appVersion: "v1.2.3"',
+    ],
+    [
+      'Chart',
+      'chart version',
+      'charts/dspace/Chart.yaml',
+      /^version:.*$/m,
+      'version: 1.02.3',
+    ],
+  ])('labels malformed %s field %s', (group, field, path, search, value) =>
+    withFixture((root) => {
+      replace(root, path, search, value);
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        `${group} coordinate malformed: ${field}`
+      );
+    })
+  );
+
+  it.each([
+    [
+      'root package version',
+      'package.json',
+      'version',
+      'frontend package version',
+    ],
+    [
+      'frontend package version',
+      'frontend/package.json',
+      'version',
+      'frontend package version',
+    ],
+    [
+      'package-lock top-level version',
+      'package-lock.json',
+      'version',
+      'package-lock top-level version',
+    ],
+    [
+      'package-lock packages[""].version',
+      'package-lock.json',
+      'packages',
+      'package-lock packages[""].version',
+    ],
+    [
+      'chart appVersion',
+      'charts/dspace/Chart.yaml',
+      'appVersion',
+      'chart appVersion',
+    ],
+    [
+      'chart default image.tag',
+      'charts/dspace/values.yaml',
+      'image.tag',
+      'chart default image.tag',
+    ],
+  ])(
+    'labels valid application drift in %s',
+    (_coordinate, path, field, diagnostic) =>
+      withFixture((root) => {
+        const { application } = currentVersions(root);
+        const driftVersion = application === '9.8.7' ? '9.8.6' : '9.8.7';
+
+        if (path.endsWith('.json')) {
+          const document = JSON.parse(read(root, path));
+          if (field === 'packages')
+            document.packages[''].version = driftVersion;
+          else document.version = driftVersion;
+          writeFileSync(
+            join(root, path),
+            `${JSON.stringify(document, null, 2)}\n`
+          );
+        } else if (field === 'appVersion') {
+          replace(
+            root,
+            path,
+            /^appVersion:.*$/m,
+            `appVersion: "${driftVersion}"`
+          );
+        } else {
+          replace(root, path, /^(\s*tag:)\s*.*$/m, `$1 v${driftVersion}`);
+        }
+
+        const result = runGuard(root);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `Application coordinate drift: ${diagnostic}`
         );
-        expect(imageTagMatch?.[1].trim(), 'image.tag should be defined in values.yaml').toBe(
-            `v${packageJson.version}`,
+      })
+  );
+
+  it('labels chart drift with its field', () =>
+    withFixture((root) => {
+      const { chart } = currentVersions(root);
+      writeFileSync(
+        join(root, 'docs/apps/dspace.version'),
+        chart === '8.8.8' ? '8.8.7\n' : '8.8.8\n'
+      );
+      const result = runGuard(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        'Chart coordinate drift: docs/apps/dspace.version'
+      );
+    }));
+
+  it.each([
+    ['', 'found 0'],
+    ['# comment only\n', 'found 0'],
+    ['1.2.3\n2.3.4\n', 'found 2'],
+    [' 1.2.3\n', "found ' 1.2.3'"],
+    ['v1.2.3\n', "found 'v1.2.3'"],
+    ['1.2.3 trailing\n', "found '1.2.3 trailing'"],
+  ])(
+    'rejects malformed docs/apps/dspace.version content %#',
+    (content, detail) =>
+      withFixture((root) => {
+        writeFileSync(join(root, 'docs/apps/dspace.version'), content);
+        const result = runGuard(root);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          'Chart coordinate malformed: docs/apps/dspace.version'
         );
-    });
+        expect(result.stderr).toContain(detail);
+      })
+  );
+
+  it('uses a deterministic clean package destination and chart-derived coordinates', () => {
+    const workflow = readFileSync(
+      join(repoRoot, '.github/workflows/ci-helm.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain('dist="$RUNNER_TEMP/dspace-chart-dist"');
+    expect(workflow).toContain('rm -rf "$stage" "$dist"');
+    expect(workflow).toContain('mkdir -p "$dist"');
+    expect(workflow).not.toContain('mktemp -d');
+    expect(workflow).toContain('expected="$dist/dspace-${CHART_VERSION}.tgz"');
+    expect(workflow).toContain('find "$dist" -maxdepth 1');
+    expect(workflow).toContain('stage-helm-chart.mjs verify');
+    expect(workflow).toContain('${{ steps.release.outputs.chart_version }}');
+  });
+
+  it('does not scan historical release records as authoritative coordinates', () =>
+    withFixture((root) => {
+      mkdirSync(join(root, 'docs/qa'), { recursive: true });
+      writeFileSync(
+        join(root, 'docs/qa/v3.0.1.md'),
+        'historical version v999.999.999\n'
+      );
+      expect(runGuard(root).status).toBe(0);
+    }));
+});
+
+describe('staged Helm chart provenance', () => {
+  const revision = '0123456789abcdef0123456789abcdef01234567';
+  const chartFixture = (run: (source: string, staged: string) => void) => {
+    const root = mkdtempSync(join(tmpdir(), 'stage-chart-'));
+    const source = join(root, 'source');
+    const staged = join(root, 'staged');
+    mkdirSync(source);
+    writeFileSync(
+      join(source, 'Chart.yaml'),
+      'apiVersion: v2\nname: dspace\nversion: 4.5.6\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+    );
+    try {
+      run(source, staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  it('preserves metadata, adds provenance, verifies it, and leaves source unchanged', () =>
+    chartFixture((source, staged) => {
+      const before = readFileSync(join(source, 'Chart.yaml'), 'utf8');
+      stageChart({ sourceDir: source, destinationDir: staged, revision });
+      const stagedYaml = join(staged, 'Chart.yaml');
+      const chart = parse(readFileSync(stagedYaml, 'utf8'));
+      expect(chart.description).toBe('retained');
+      expect(chart.annotations['example.org/existing']).toBe('retained');
+      expect(
+        verifyChart({
+          chartYaml: stagedYaml,
+          version: '4.5.6',
+          appVersion: '3.1.0',
+          revision,
+        })
+      ).toMatchObject({
+        'org.opencontainers.image.source': SOURCE_REPOSITORY,
+      });
+      expect(readFileSync(join(source, 'Chart.yaml'), 'utf8')).toBe(before);
+    }));
+
+  it.each(['01.2.3', '1.2', 'v1.2.3', '1.2.3-rc.1', '1.2.3+build'])(
+    'rejects non-strict chart SemVer %s',
+    (version) =>
+      chartFixture((source, staged) => {
+        replace(source, 'Chart.yaml', 'version: 4.5.6', `version: ${version}`);
+        expect(() =>
+          stageChart({ sourceDir: source, destinationDir: staged, revision })
+        ).toThrow(/chart version/);
+      })
+  );
+
+  it.each(['01.2.3', '1.2', 'v1.2.3', '1.2.3-rc.1', '1.2.3+build'])(
+    'rejects non-strict appVersion %s',
+    (appVersion) =>
+      chartFixture((source, staged) => {
+        replace(
+          source,
+          'Chart.yaml',
+          'appVersion: "3.1.0"',
+          `appVersion: "${appVersion}"`
+        );
+        expect(() =>
+          stageChart({ sourceDir: source, destinationDir: staged, revision })
+        ).toThrow(/appVersion/);
+      })
+  );
+
+  it.each(['abc', `${revision.slice(0, -1)}Z`, revision.slice(1)])(
+    'rejects malformed revision %s',
+    (value) =>
+      chartFixture((source, staged) => {
+        expect(() =>
+          stageChart({
+            sourceDir: source,
+            destinationDir: staged,
+            revision: value,
+          })
+        ).toThrow(/full source revision/);
+      })
+  );
+
+  it.each(['text', '[]', 'null'])(
+    'rejects non-mapping annotations: %s',
+    (annotations) =>
+      chartFixture((source, staged) => {
+        replace(
+          source,
+          'Chart.yaml',
+          /annotations:[\s\S]*$/,
+          `annotations: ${annotations}\n`
+        );
+        expect(() =>
+          stageChart({ sourceDir: source, destinationDir: staged, revision })
+        ).toThrow(/annotations must be a YAML map/);
+      })
+  );
+
+  it.each([
+    ['version', 'version: 4.5.6', 'version: 4.5.7'],
+    ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
+    ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
+    ['revision', revision, 'f'.repeat(40)],
+    [
+      'application version',
+      'org.opencontainers.image.version: 3.1.0',
+      'org.opencontainers.image.version: 3.1.1',
+    ],
+  ])('rejects tampered packaged %s metadata', (_field, search, value) =>
+    chartFixture((source, staged) => {
+      const before = readFileSync(join(source, 'Chart.yaml'), 'utf8');
+      stageChart({ sourceDir: source, destinationDir: staged, revision });
+      replace(staged, 'Chart.yaml', search, value);
+      expect(() =>
+        verifyChart({
+          chartYaml: join(staged, 'Chart.yaml'),
+          version: '4.5.6',
+          appVersion: '3.1.0',
+          revision,
+        })
+      ).toThrow(/mismatch/);
+      expect(readFileSync(join(source, 'Chart.yaml'), 'utf8')).toBe(before);
+    })
+  );
+
+  it.each([
+    ['missing', 'org.opencontainers.image.revision', undefined],
+    ['wrong', 'org.opencontainers.image.revision', 'f'.repeat(40)],
+  ])(
+    'rejects a %s provenance annotation despite a matching top-level lookalike',
+    (_case, annotation, annotationValue) =>
+      chartFixture((source, staged) => {
+        stageChart({ sourceDir: source, destinationDir: staged, revision });
+        const chartYaml = join(staged, 'Chart.yaml');
+        const chart = parse(readFileSync(chartYaml, 'utf8'));
+        chart[annotation] = revision;
+        if (annotationValue === undefined) {
+          delete chart.annotations[annotation];
+        } else {
+          chart.annotations[annotation] = annotationValue;
+        }
+        writeFileSync(chartYaml, stringify(chart));
+        expect(() =>
+          verifyChart({
+            chartYaml,
+            version: '4.5.6',
+            appVersion: '3.1.0',
+            revision,
+          })
+        ).toThrow(/revision mismatch/);
+      })
+  );
 });


### PR DESCRIPTION
### Motivation

- Implements the repository portion of #4731.
- Creates an immutable chart-only recovery release for canonical DSPACE v3.0.1 without importing later application behavior.
- Backports safeguards against chart replacement, tag movement, unapproved recovery artifacts, and pre-authorization lifecycle execution.
- Supports pre-observability production values, including omitted or null observability maps.

### Branch and release scope

- Targets the long-lived `release/chart-3.0.x` branch.
- The branch is based on canonical v3.0.1 commit `1a31a569aff2dbeb238e8c2688b9e85140d2077d`.
- Current PR head: `fe12d0018953d2c16665e2cf842613f823fef809`.
- This PR does not change DSPACE application behavior or publish an application image.
- Merging does not create a Git tag or publish, delete, replace, or retag an OCI artifact.
- Issue #4731 remains open until chart `3.0.2` is published exactly once and the evidence is independently verified.

### Changes

#### Recovery chart

- Set `charts/dspace/Chart.yaml` to chart version `3.0.2` and `appVersion: "3.0.1"`.
- Align `docs/apps/dspace.version` with chart version `3.0.2`.
- Keep the application package coordinate at canonical version `3.0.1`.
- Default to immutable image tag `main-1a31a56`; the chart cannot fall back to mutable `v3.0.1`.
- Add fixtures for pre-observability production values and explicitly null `metrics`, `metrics.auth`, and `serviceMonitor` maps.
- Keep metrics and ServiceMonitor disabled by default.
- When metrics are disabled, protect the v3.0.1 `/metrics` handler with the pod UID because that application version has no native metrics-disable switch.
- When metrics are enabled, require an existing Kubernetes Secret and render authenticated ServiceMonitor configuration.

#### Immutable publication path

- Publish only from pushed `chart-v*` tags; branch pushes and manual dispatches cannot publish.
- Pin checkout to the immutable push-event SHA.
- Disable persisted checkout credentials.
- Authorize the event SHA, peeled tag SHA, and approved `release/chart-3.0.x` tip immediately after checkout, before Node/pnpm setup or repository lifecycle execution.
- Keep the public approved-branch fetch fail-closed under `set -euo pipefail`.
- Require strict bare `X.Y.Z` chart and application versions and an exact `chart-v<chartVersion>` tag.
- Permanently tombstone chart version `3.0.1`.
- Re-fetch and revalidate the live remote tag and approved recovery branch immediately before publication.
- Pin package-authorized third-party actions to reviewed commit SHAs.
- Perform fail-closed GHCR absence checks before packaging and immediately before the single `helm push`.
- Stage chart provenance without modifying tracked `Chart.yaml`.
- Verify packaged version, appVersion, source repository, and full source revision using YAML-aware parsing.
- Record the packaged archive SHA-256 and OCI manifest digest in the workflow summary.
- Keep registry credentials step-scoped and pass the Helm password through stdin.
- Support relative CLI invocation for both Node publication helpers.

#### Tests and documentation

- Add focused coverage for release-coordinate validation, strict SemVer, provenance staging and verification, fail-closed GHCR behavior, relative CLI execution, tag peeling and movement, approved-branch enforcement, remote-ref refresh, immutable action pins, source-authorization ordering, disabled credential persistence, and publication ordering.
- Add Helm rendering coverage for immutable recovery defaults, historical production values, explicit-null maps, disabled metrics authentication, and enabled authenticated metrics/ServiceMonitor behavior.
- Document the recovery chart, permanent `3.0.1` tombstone, branch-retention policy, exactly-once publication procedure, and required evidence.
- Correct stale v3.0.1 release-checklist assertions to match the completed rc.6 identity evidence and canonical May 21 patch-addendum date.

### Verification

Targeted verification performed during implementation:

- `bash scripts/check-dspace-chart-version.sh`
- `helm lint charts/dspace`
- Historical production-values render with `image.tag=main-1a31a56`
- Explicit-null metrics-values render
- Authenticated metrics and ServiceMonitor render
- Focused recovery-chart, workflow, GHCR guard, and release-coordinate Vitest suites
- `npx vitest run --config vitest.config.mts tests/changelogDocsReleaseChecklist.test.ts` — 3 tests passed
- `npx vitest run --config vitest.config.mts tests/ciHelmWorkflow.test.ts --maxWorkers=1` — 17 tests passed
- `node scripts/link-check.mjs`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `git diff --check`
- Secret scan of the recovery-branch diff

The final task environment did not have `actionlint` installed, so it did not rerun that local command after the final workflow-ordering change. The latest-head `ci-sentinel` run is the authoritative workflow-integrity result.

Latest-head GitHub Actions runs, all of which must succeed before merge:

- `ci-sentinel`: https://github.com/democratizedspace/dspace/actions/runs/30149488943
- `tests`: https://github.com/democratizedspace/dspace/actions/runs/30149488999
- `Build & Publish Container`: https://github.com/democratizedspace/dspace/actions/runs/30149488954

### Post-merge publication

After this PR merges into `release/chart-3.0.x`:

1. Create `chart-v3.0.2` at the exact approved recovery-branch tip.
2. Allow the immutable chart workflow to publish the coordinate once.
3. Capture the full source SHA, OCI reference, packaged archive digest, and OCI manifest digest.
4. Verify a second publication cannot overwrite `3.0.2`.
5. Record the evidence in #4731 before closing it.

Refs #4731

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64556b58e4832f873f865bd02d6fb9)