### PR TITLE
ci: add fail-closed full release consistency gate (Refs #4730)

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -22,19 +22,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --reporter=append-only
+          persist-credentials: false
 
       - name: Validate tag, versions, and source revision
         id: release
@@ -57,6 +45,25 @@ jobs:
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Apply reusable release-coordinate policy
+        env:
+          CHART_TAG: ${{ steps.release.outputs.chart_tag }}
+          SOURCE_REVISION: ${{ steps.release.outputs.source_sha }}
+        run: node scripts/check-release-consistency.mjs chart-candidate
 
       - name: Refuse an existing chart coordinate (pre-package)
         env:
@@ -123,6 +130,14 @@ jobs:
           digest=$(printf '%s\n' "$output" | sed -n 's/^Digest: \(sha256:[0-9a-f]\{64\}\)$/\1/p')
           [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "helm push did not report one valid OCI digest" >&2; exit 1; }
           echo "oci_digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Verify published chart coordinates and provenance
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
+          SOURCE_REVISION: ${{ steps.release.outputs.source_sha }}
+          EXPECTED_CHART_DIGEST: ${{ steps.push.outputs.oci_digest }}
+        run: node scripts/check-release-consistency.mjs chart-published
 
       - name: Write publication evidence
         env:

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -491,6 +491,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve checked-out revision
         id: revision
@@ -541,223 +542,77 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-          run_install: false
-
-      - name: Verify pnpm is on PATH
-        run: |
-          command -v pnpm
-          pnpm --version
-
-      - name: Validate release version coordinates
-        id: version
-        # See the "Resolve checked-out revision" step above: pass the attacker-influenceable
-        # release tag through env, never interpolate it directly into this run: script.
+      - name: Validate complete release and immutable prerequisites
+        id: consistency
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          root_version="$(node -p "require('./package.json').version")"
-          frontend_version="$(node -p "require('./frontend/package.json').version")"
-          expected_tag="v${root_version}"
-
-          if [ "$root_version" != "$frontend_version" ]; then
-            echo "Root package version ($root_version) does not match frontend package version ($frontend_version); refusing to publish." >&2
-            exit 1
-          fi
-
-          # DSPACE release coordinates use the same strict X.Y.Z convention enforced by
-          # scripts/check-dspace-chart-version.sh. Validate before exposing package data as
-          # a step output so shell metacharacters and multiline values fail closed.
-          if [[ ! "$root_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version is not a supported semantic version; refusing to publish." >&2
-            exit 1
-          fi
-
-          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
-            echo "Release tag $RELEASE_TAG does not match expected semantic tag $expected_tag; refusing to publish." >&2
-            exit 1
-          fi
-
-          echo "version=${root_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --reporter=append-only
-
-      - name: Build and verify chat build stamp
-        run: |
-          pnpm run build
-          pnpm run verify:chat-build-stamp
-
-      - name: Define image tags
-        id: tags
-        env:
+          SOURCE_REVISION: ${{ steps.revision.outputs.full_sha }}
           SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          branch_sha_tag="ghcr.io/democratizedspace/dspace:${SOURCE_BRANCH}-${SHORT_SHA}"
-          semantic_tag="ghcr.io/democratizedspace/dspace:v${RELEASE_VERSION}"
-          echo "branch_sha_tag=${branch_sha_tag}" >> "$GITHUB_OUTPUT"
-          echo "semantic_tag=${semantic_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image build version
-        id: build_version
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-        run: |
-          build_version="v${RELEASE_VERSION}+${SHORT_SHA}"
-          echo "value=${build_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image metadata
-        id: metadata
-        env:
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          echo "created=${created}" >> "$GITHUB_OUTPUT"
-          echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
-
-      # Fail-closed guard: only an authoritative "not found" result from GHCR permits
-      # publication. Auth, network, timeout, malformed-response, and any other status are
-      # treated as hard failures by scripts/ghcr-manifest.mjs. Running inside this job's
-      # tag-scoped concurrency group means the check happens only after this run has
-      # exclusive access to that group, so it cannot race a second publish attempt.
-      - name: Refuse to overwrite an existing semantic tag
-        env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node scripts/ghcr-manifest.mjs check-absent \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
+        run: node scripts/check-release-consistency.mjs pre-semantic
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
-        with:
-          platforms: arm64
+          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Verify corresponding branch-SHA image exists
-        id: branch_sha_evidence
+      # Revalidate absence immediately before the sole mutation. The tag-scoped
+      # concurrency group prevents two release runs from racing this operation.
+      - name: Final semantic-coordinate absence check
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo dspace --tag "$RELEASE_TAG"
+
+      - name: Create exact semantic alias once
+        id: alias
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
+          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
         run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "ghcr.io/democratizedspace/dspace:${RELEASE_TAG}" \
+            "ghcr.io/democratizedspace/dspace:${SOURCE_BRANCH}-${SHORT_SHA}"
 
-      - name: Build image for SHA verification
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-
-      - name: Assert build SHA is baked into frontend bundle
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Build and push semantic release image
-        id: build_push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: ${{ steps.tags.outputs.semantic_tag }}
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      # Records index + per-platform digests as evidence. 'present' is the expected outcome
-      # of this second registry call (the tag was just pushed above); scripts/ghcr-manifest.mjs
-      # writes index_digest/amd64_digest/arm64_digest to $GITHUB_OUTPUT without ever logging
-      # the registry credentials used to fetch them.
-      - name: Record semantic release evidence
-        if: steps.build_push.outcome == 'success'
+      - name: Verify alias and emit release manifest
         id: evidence
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SOURCE_REVISION: ${{ steps.revision.outputs.full_sha }}
+          SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
+          RELEASE_MANIFEST_PATH: dspace-release-manifest.json
+        run: node scripts/check-release-consistency.mjs post-semantic
 
-      - name: Summarize semantic release evidence
-        if: steps.build_push.outcome == 'success'
+      - name: Upload release consistency manifest
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: dspace-release-manifest
+          path: dspace-release-manifest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize full release evidence
         env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          BRANCH_SHA_TAG: ${{ steps.tags.outputs.branch_sha_tag }}
-          SEMANTIC_TAG: ${{ steps.tags.outputs.semantic_tag }}
+          SOURCE_REVISION: ${{ steps.revision.outputs.full_sha }}
         run: |
-          {
-            echo "## DSPACE semantic release image"
-            echo
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Semantic version | \`v${RELEASE_VERSION}\` |"
-            echo "| Full Git SHA | \`${{ steps.revision.outputs.full_sha }}\` |"
-            echo "| Immutable branch-SHA tag | \`${BRANCH_SHA_TAG}\` |"
-            echo "| Semantic tag | \`${SEMANTIC_TAG}\` |"
-            echo "| Image index digest | \`${{ steps.evidence.outputs.index_digest }}\` |"
-            echo "| linux/amd64 digest | \`${{ steps.evidence.outputs.amd64_digest }}\` |"
-            echo "| linux/arm64 digest | \`${{ steps.evidence.outputs.arm64_digest }}\` |"
-          } >> "$GITHUB_STEP_SUMMARY"
+          node - <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const m = require('./dspace-release-manifest.json');
+          console.log('## DSPACE full release consistency evidence');
+          console.log(`- Full source SHA: ${m.sourceRevision}`);
+          console.log(`- Immutable image: ghcr.io/democratizedspace/dspace:${m.imageTag}@${m.imageDigest}`);
+          console.log(`- linux/amd64 digest: ${m.platformDigests['linux/amd64']}`);
+          console.log(`- linux/arm64 digest: ${m.platformDigests['linux/arm64']}`);
+          console.log(`- Semantic evidence tag: ${m.semanticImageTag}@${m.imageDigest}`);
+          console.log(`- Immutable chart: oci://ghcr.io/democratizedspace/charts/dspace:${m.chartVersion}@${m.chartDigest}`);
+          NODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,3 +432,13 @@ Run `npm test` to verify configuration stays in sync.
 - [Codex Prompt Upgrader](https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/upgrader.md)
 - [AGENTS.md Spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6)
 - [Agents.md Guide](https://agentsmd.net/)
+
+## Full-release consistency invariant
+
+A full release uses one approved commit for the `vX.Y.Z` and `chart-v<chartVersion>` tags,
+the immutable branch-SHA image, both required image platform revision labels, and Helm provenance.
+Publish the branch-SHA image first, the immutable chart second, and the GitHub release/semantic
+image alias last. The semantic tag must be an exact digest alias and must never be rebuilt or
+overwritten. Deployments and release manifests always select the immutable branch-SHA image.
+`scripts/check-release-consistency.mjs` is the shared fail-closed policy implementation; workflow
+YAML must not duplicate or weaken it.

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -173,3 +173,13 @@ When installing from the OCI registry, you will not have access to
 `charts/dspace/values.dev.yaml` unless you clone the repository. To customize values, either
 provide your own file with `-f <your-values.yaml>` or use `--set` flags as shown above.
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
+
+## Full-release relationship
+
+For a full application release, publication is deliberately ordered: first publish and verify the
+immutable `<branch>-<shortsha>` image, then publish and verify this chart from the same full commit,
+and only then publish the GitHub release. The release workflow verifies the chart's OCI digest,
+chart version, `appVersion`, and `org.opencontainers.image.revision` before it creates any semantic
+image coordinate. A missing or mismatched artifact stops safely; publish the missing immutable
+prerequisite and rerun while the semantic tag remains absent. Existing chart versions are never
+overwritten.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -154,3 +154,23 @@ just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 
 Until those generic recipes are available in Sugarkube, keep using the mature DSPACE-specific
 commands documented above.
+
+## Fail-closed full-release order and manifest
+
+1. Publish and verify the multi-platform immutable `<branch>-<shortsha>` image.
+2. Publish and verify `chart-v<chartVersion>` from that exact full source commit.
+3. Publish the `v<applicationVersion>` GitHub release. Its workflow confirms the semantic image
+   coordinate is absent, creates one exact registry alias of the approved immutable image index,
+   verifies digest equality, and uploads `dspace-release-manifest.json` in the deterministic
+   `dspace-release-manifest` workflow artifact.
+
+The JSON records `applicationVersion`, the complete `sourceRevision`, immutable `imageTag` and
+`imageDigest`, required platform digests, `chartVersion`, and `chartDigest`. It intentionally has no
+deployment environment, approver, runtime, or promotion fields. The semantic tag is human-readable
+release evidence only: equality with the immutable index digest is enforced, but deployments and
+downstream manifests continue to use the immutable branch-SHA coordinate.
+
+Publishing out of order fails before semantic mutation. Supply the missing immutable prerequisite
+and rerun, provided the semantic coordinate was not created. Authentication, timeout, malformed
+registry data, existing coordinates, provenance mismatches, and digest mismatches all fail closed;
+neither semantic image tags nor chart coordinates are moved or overwritten.

--- a/scripts/check-release-consistency.mjs
+++ b/scripts/check-release-consistency.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
+import {
+  assertTagAbsent,
+  describeManifest,
+  inspectChart,
+  inspectImage,
+} from './ghcr-manifest.mjs';
+
+export const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+export const SHA = /^[0-9a-f]{40}$/;
+export const DIGEST = /^sha256:[0-9a-f]{64}$/;
+const required = (ok, message) => {
+  if (!ok) throw new Error(message);
+};
+const json = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+export function validateLocalCoordinates(input) {
+  const {
+    applicationVersion,
+    frontendVersion,
+    lockfileVersion,
+    chartVersion,
+    chartAppVersion,
+    releaseTag,
+    chartTag,
+    sourceRevision,
+    releaseTagRevision,
+    chartTagRevision,
+    branch,
+    imageTag,
+  } = input;
+  for (const [name, value] of [
+    ['application version', applicationVersion],
+    ['frontend version', frontendVersion],
+    ['lockfile version', lockfileVersion],
+    ['chart version', chartVersion],
+    ['chart appVersion', chartAppVersion],
+  ])
+    required(SEMVER.test(value), `${name} must be strict bare X.Y.Z SemVer`);
+  required(
+    applicationVersion === frontendVersion &&
+      applicationVersion === lockfileVersion,
+    'Root, frontend, and lockfile application versions must agree'
+  );
+  required(
+    chartAppVersion === applicationVersion,
+    'Chart appVersion must equal application version'
+  );
+  required(
+    releaseTag === `v${applicationVersion}`,
+    'Release tag does not match application version'
+  );
+  required(
+    chartTag === `chart-v${chartVersion}`,
+    'Chart tag does not match chart version'
+  );
+  required(
+    SHA.test(sourceRevision),
+    'Approved source revision must be a full 40-character SHA'
+  );
+  required(
+    releaseTagRevision === sourceRevision,
+    'Release tag does not peel to approved source revision'
+  );
+  required(
+    chartTagRevision === sourceRevision,
+    'Chart tag does not peel to approved source revision'
+  );
+  required(
+    branch === 'main' || branch === 'v3',
+    'Source must be reachable from main or v3'
+  );
+  required(
+    imageTag === `${branch}-${sourceRevision.slice(0, 7)}`,
+    'Deployment image tag must be the derived immutable branch-SHA tag'
+  );
+  return input;
+}
+
+export function validateImage(image, sourceRevision) {
+  required(
+    DIGEST.test(image?.indexDigest || ''),
+    'Immutable image index digest is invalid'
+  );
+  for (const arch of ['amd64', 'arm64']) {
+    required(
+      image?.platforms?.[arch],
+      `Image is missing required platform linux/${arch}`
+    );
+    required(
+      image.platforms[arch].revision === sourceRevision,
+      `linux/${arch} image revision label does not match approved source revision`
+    );
+    required(
+      DIGEST.test(image.platforms[arch].manifestDigest || ''),
+      `linux/${arch} manifest digest is invalid`
+    );
+  }
+  return image;
+}
+
+export function validateChartArtifact(chart, expected) {
+  required(
+    chart && chart.present !== false,
+    'Expected chart artifact is missing'
+  );
+  required(
+    chart.version === expected.chartVersion,
+    'Published chart version mismatch'
+  );
+  required(
+    chart.appVersion === expected.applicationVersion,
+    'Published chart appVersion mismatch'
+  );
+  required(
+    chart.revision === expected.sourceRevision,
+    'Published chart source revision mismatch'
+  );
+  required(
+    DIGEST.test(chart.digest || ''),
+    'Published chart digest is invalid'
+  );
+  return chart;
+}
+
+export function createReleaseManifest({ coordinates, image, chart }) {
+  validateLocalCoordinates(coordinates);
+  validateImage(image, coordinates.sourceRevision);
+  validateChartArtifact(chart, coordinates);
+  return {
+    schemaVersion: 1,
+    app: 'dspace',
+    applicationVersion: coordinates.applicationVersion,
+    sourceRevision: coordinates.sourceRevision,
+    imageTag: coordinates.imageTag,
+    imageDigest: image.indexDigest,
+    platformDigests: {
+      'linux/amd64': image.platforms.amd64.manifestDigest,
+      'linux/arm64': image.platforms.arm64.manifestDigest,
+    },
+    semanticImageTag: coordinates.releaseTag,
+    chartVersion: coordinates.chartVersion,
+    chartDigest: chart.digest,
+  };
+}
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+function loadLocal() {
+  const root = json('package.json'),
+    frontend = json('frontend/package.json'),
+    lock = json('package-lock.json');
+  const chart = parseYaml(readFileSync('charts/dspace/Chart.yaml', 'utf8'));
+  const sourceRevision =
+    process.env.SOURCE_REVISION || git('rev-parse', 'HEAD');
+  const branch = process.env.SOURCE_BRANCH || '';
+  const releaseTag = process.env.RELEASE_TAG || '';
+  const chartTag = process.env.CHART_TAG || `chart-v${chart.version}`;
+  return validateLocalCoordinates({
+    applicationVersion: root.version,
+    frontendVersion: frontend.version,
+    lockfileVersion: lock.packages?.['']?.version || lock.version,
+    chartVersion: String(chart.version),
+    chartAppVersion: String(chart.appVersion),
+    releaseTag,
+    chartTag,
+    sourceRevision,
+    releaseTagRevision: git('rev-parse', `${releaseTag}^{commit}`),
+    chartTagRevision: git('rev-parse', `${chartTag}^{commit}`),
+    branch,
+    imageTag: `${branch}-${sourceRevision.slice(0, 7)}`,
+  });
+}
+
+export function verifyLocalFixtures() {
+  const sha = 'a'.repeat(40),
+    digest = `sha256:${'b'.repeat(64)}`;
+  const coordinates = {
+    applicationVersion: '3.1.0',
+    frontendVersion: '3.1.0',
+    lockfileVersion: '3.1.0',
+    chartVersion: '4.0.0',
+    chartAppVersion: '3.1.0',
+    releaseTag: 'v3.1.0',
+    chartTag: 'chart-v4.0.0',
+    sourceRevision: sha,
+    releaseTagRevision: sha,
+    chartTagRevision: sha,
+    branch: 'main',
+    imageTag: 'main-aaaaaaa',
+  };
+  const image = {
+    indexDigest: digest,
+    platforms: {
+      amd64: { revision: sha, manifestDigest: digest },
+      arm64: { revision: sha, manifestDigest: digest },
+    },
+  };
+  const chart = {
+    version: '4.0.0',
+    appVersion: '3.1.0',
+    revision: sha,
+    digest,
+  };
+  const first = JSON.stringify(
+    createReleaseManifest({ coordinates, image, chart })
+  );
+  required(
+    first ===
+      JSON.stringify(createReleaseManifest({ coordinates, image, chart })),
+    'Manifest output is not deterministic'
+  );
+  console.log('Local release-consistency fixtures passed.');
+}
+
+async function main(argv) {
+  if (argv.length === 1 && argv[0] === '--verify-local-fixtures')
+    return verifyLocalFixtures();
+  const mode = argv[0];
+  if (mode === 'chart-candidate' && argv.length === 1) {
+    const root = json('package.json');
+    const frontend = json('frontend/package.json');
+    const lock = json('package-lock.json');
+    const chart = parseYaml(readFileSync('charts/dspace/Chart.yaml', 'utf8'));
+    const version = String(chart.version);
+    required(
+      SEMVER.test(version) && version !== '3.0.1',
+      'Chart version is invalid or tombstoned'
+    );
+    required(
+      SEMVER.test(String(chart.appVersion)),
+      'Chart appVersion must be strict bare SemVer'
+    );
+    required(
+      root.version === frontend.version &&
+        root.version === (lock.packages?.['']?.version || lock.version) &&
+        root.version === String(chart.appVersion),
+      'Application metadata and chart appVersion must agree'
+    );
+    required(
+      readFileSync('docs/apps/dspace.version', 'utf8').trim() === version,
+      'Chart version and docs/apps/dspace.version must agree'
+    );
+    required(
+      process.env.CHART_TAG === `chart-v${version}`,
+      'Chart tag does not match chart version'
+    );
+    required(
+      process.env.SOURCE_REVISION ===
+        git('rev-parse', `${process.env.CHART_TAG}^{commit}`),
+      'Chart tag does not peel to approved source revision'
+    );
+    console.log('Chart release candidate coordinates are consistent.');
+    return;
+  }
+  if (mode === 'chart-published' && argv.length === 1) {
+    const root = json('package.json');
+    const chartYaml = parseYaml(
+      readFileSync('charts/dspace/Chart.yaml', 'utf8')
+    );
+    const credentials = {
+      owner: 'democratizedspace',
+      username: process.env.GHCR_GUARD_USERNAME,
+      password: process.env.GHCR_GUARD_PASSWORD, // scan-secrets: ignore (environment credential plumbing)
+    };
+    const chart = validateChartArtifact(
+      await inspectChart({
+        ...credentials,
+        repo: 'charts/dspace',
+        tag: String(chartYaml.version),
+      }),
+      {
+        chartVersion: String(chartYaml.version),
+        applicationVersion: root.version,
+        sourceRevision: process.env.SOURCE_REVISION,
+      }
+    );
+    required(
+      chart.digest === process.env.EXPECTED_CHART_DIGEST,
+      'Published chart digest does not match helm push evidence'
+    );
+    console.log(`Verified published chart ${chart.version}@${chart.digest}.`);
+    return;
+  }
+  required(
+    ['pre-semantic', 'post-semantic'].includes(mode) && argv.length === 1,
+    'Usage: check-release-consistency.mjs --verify-local-fixtures | <pre-semantic|post-semantic>'
+  );
+  const coordinates = loadLocal();
+  const credentials = {
+    owner: 'democratizedspace',
+    username: process.env.GHCR_GUARD_USERNAME,
+    password: process.env.GHCR_GUARD_PASSWORD, // scan-secrets: ignore (environment credential plumbing)
+  };
+  const image = validateImage(
+    await inspectImage({
+      ...credentials,
+      repo: 'dspace',
+      tag: coordinates.imageTag,
+    }),
+    coordinates.sourceRevision
+  );
+  const chart = validateChartArtifact(
+    await inspectChart({
+      ...credentials,
+      repo: 'charts/dspace',
+      tag: coordinates.chartVersion,
+    }),
+    coordinates
+  );
+  if (mode === 'pre-semantic') {
+    await assertTagAbsent({
+      ...credentials,
+      repo: 'dspace',
+      tag: coordinates.releaseTag,
+    });
+    return;
+  }
+  const semantic = await describeManifest({
+    ...credentials,
+    repo: 'dspace',
+    tag: coordinates.releaseTag,
+  });
+  required(
+    semantic.indexDigest === image.indexDigest,
+    'Semantic and immutable image index digests differ'
+  );
+  const manifest = createReleaseManifest({ coordinates, image, chart });
+  const output =
+    process.env.RELEASE_MANIFEST_PATH ||
+    `dspace-release-v${coordinates.applicationVersion}.json`;
+  writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Validated and wrote ${output}`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`)
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -3,6 +3,7 @@ import { appendFileSync } from 'node:fs';
 
 const REGISTRY_HOST = 'https://ghcr.io';
 const DEFAULT_TIMEOUT_MS = 15000;
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 
 const MANIFEST_ACCEPT_HEADER = [
     'application/vnd.oci.image.index.v1+json',
@@ -172,7 +173,45 @@ export async function getManifest({
               }))
         : [];
 
-    return { status: 'present', digest, manifests };
+    return { status: 'present', digest, manifests, body };
+}
+
+export async function getBlob({ owner, repo, digest, token, fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    requireField(digest, 'digest');
+    const response = await fetchWithTimeout(fetchImpl,
+        `${REGISTRY_HOST}/v2/${owner}/${repo}/blobs/${encodeURIComponent(digest)}`,
+        { headers: { Authorization: `Bearer ${token}` } }, timeoutMs, 'requesting a GHCR blob');
+    if (response.status === 401 || response.status === 403)
+        throw new GhcrGuardError(`GHCR blob request was denied with status ${response.status}`, { code: 'auth' });
+    if (!response.ok) throw new GhcrGuardError(`GHCR blob request returned an indeterminate status ${response.status}`, { code: 'indeterminate' });
+    try { return await response.json(); } catch { throw new GhcrGuardError('GHCR blob response was not valid JSON', { code: 'malformed' }); }
+}
+
+export async function inspectImage({ owner, repo, tag, username, password, fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs }); // scan-secrets: ignore (environment credential plumbing; no literal secret)
+    const index = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
+    if (index.status !== 'present') throw new GhcrGuardError(`Required immutable image ${owner}/${repo}:${tag} is missing`, { code: 'missing-image' });
+    const platforms = {};
+    for (const architecture of ['amd64', 'arm64']) {
+        const descriptor = index.manifests.find((m) => m.os === 'linux' && m.architecture === architecture);
+        if (!descriptor) throw new GhcrGuardError(`Image is missing required platform linux/${architecture}`, { code: 'missing-platform' });
+        const manifest = await getManifest({ owner, repo, tag: descriptor.digest, token, fetchImpl, timeoutMs });
+        const configDigest = manifest.body?.config?.digest;
+        if (manifest.status !== 'present' || typeof configDigest !== 'string') throw new GhcrGuardError(`Malformed linux/${architecture} manifest`, { code: 'malformed' });
+        const config = await getBlob({ owner, repo, digest: configDigest, token, fetchImpl, timeoutMs });
+        platforms[architecture] = { manifestDigest: descriptor.digest, configDigest, revision: config?.config?.Labels?.['org.opencontainers.image.revision'] };
+    }
+    return { indexDigest: index.digest, platforms };
+}
+
+export async function inspectChart({ owner, repo, tag, username, password, fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    const token = await fetchGhcrToken({ owner, repo, username, password, fetchImpl, timeoutMs }); // scan-secrets: ignore (environment credential plumbing; no literal secret)
+    const manifest = await getManifest({ owner, repo, tag, token, fetchImpl, timeoutMs });
+    if (manifest.status !== 'present') return { present: false };
+    const configDigest = manifest.body?.config?.digest;
+    if (!DIGEST_PATTERN.test(manifest.digest) || typeof configDigest !== 'string') throw new GhcrGuardError('Malformed Helm OCI manifest', { code: 'malformed' });
+    const config = await getBlob({ owner, repo, digest: configDigest, token, fetchImpl, timeoutMs });
+    return { present: true, digest: manifest.digest, version: String(config?.version || ''), appVersion: String(config?.appVersion || ''), revision: config?.annotations?.['org.opencontainers.image.revision'] };
 }
 
 // Fails closed: resolves only when the registry authoritatively reports the tag as absent.

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -112,294 +112,64 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
 
 describe('ci-image.yml "semantic-release" job (release-only publish path)', () => {
   const job = workflow.jobs['semantic-release'];
-
-  it('exists and is gated on a published release, not an ordinary push', () => {
-    expect(job).toBeTruthy();
-    expect(job.if).toBe(
-      "github.event_name == 'release' && github.event.action == 'published'"
-    );
-  });
-
-  it('serializes semantic publication with a concurrency group keyed on the tag', () => {
-    expect(job.concurrency).toBeTruthy();
+  const steps = findSteps(job);
+  it('is release-only and serializes the event-controlled tag', () => {
+    expect(job.if).toContain("github.event_name == 'release'");
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
-    expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
-
-  it('checks out the tagged commit explicitly rather than trusting the default ref', () => {
-    const checkoutStep = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkoutStep.with.ref).toContain('github.event.release.tag_name');
+  it('authorizes checkout before setup or repository lifecycle execution', () => {
+    const authorization = stepIndex(job, (step) => step.id === 'revision');
+    expect(authorization).toBeLessThan(
+      stepIndex(job, (step) => step.uses?.startsWith('actions/setup-node'))
+    );
+    expect(JSON.stringify(job)).not.toContain('pnpm install');
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    expect(checkout.with['persist-credentials']).toBe(false);
   });
-
-  it('uses the checked-out git rev-parse HEAD as the source revision, never github.sha', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).toMatch(/git rev-parse HEAD/);
-    expect(serialized).not.toContain('${{ github.sha }}');
+  it('uses the reusable gate before and after one exact alias operation, with no rebuild', () => {
+    const gates = steps.filter((step) =>
+      step.run?.includes('check-release-consistency.mjs')
+    );
+    expect(gates).toHaveLength(2);
+    const aliases = steps.filter((step) =>
+      step.run?.includes('docker buildx imagetools create')
+    );
+    expect(aliases).toHaveLength(1);
+    expect(stepIndex(job, (step) => step === gates[0])).toBeLessThan(
+      stepIndex(job, (step) => step === aliases[0])
+    );
+    expect(stepIndex(job, (step) => step === aliases[0])).toBeLessThan(
+      stepIndex(job, (step) => step === gates[1])
+    );
+    expect(findStepsUsing(job, 'docker/build-push-action')).toHaveLength(0);
   });
-
-  it('peels the release tag to its commit before comparing to HEAD', () => {
-    // "git rev-parse <tag>" alone resolves an annotated/signed tag's own object SHA, not
-    // the commit it points at, which would reject every legitimate release cut from such a
-    // tag even though checkout correctly left HEAD on the tagged commit. The "^{commit}"
-    // peeling suffix is required so both lightweight and annotated/signed tags compare
-    // correctly against HEAD.
-    const revisionStep = findSteps(job).find((step) => step.id === 'revision');
-    expect(revisionStep.run).toMatch(/\$\{RELEASE_TAG\}\^\{commit\}|\$RELEASE_TAG\^\{commit\}/);
+  it('revalidates absence immediately before the mutation', () => {
+    const alias = stepIndex(job, (step) =>
+      step.run?.includes('imagetools create')
+    );
+    expect(steps[alias - 1].run).toContain('ghcr-manifest.mjs check-absent');
   });
-
-  it('never interpolates the attacker-influenceable release tag directly into a shell script', () => {
-    // Git tag names can contain shell metacharacters ("`, $(), ;). GitHub substitutes
-    // ${{ }} expressions into a run: script's source text before the shell parses it, so
-    // interpolating the raw tag there would let a crafted release tag execute commands with
-    // this job's packages:write/actions:write token. The tag may only reach a `run:` step by
-    // way of an `env:` var (assigned as data, not concatenated into the script) — never as a
-    // literal ${{ github.event.release.tag_name }} expression inside `run:` text. Using it as
-    // a structured action input (checkout's `ref:`, `concurrency.group`) is fine, since those
-    // aren't shell-interpolation contexts.
-    for (const step of findSteps(job)) {
-      if (typeof step.run !== 'string') {
-        continue;
-      }
+  it('uploads a deterministic manifest with an immutable pinned action and summarizes all digests', () => {
+    const upload = findStepsUsing(job, 'actions/upload-artifact')[0];
+    expect(upload.uses).toMatch(/@[0-9a-f]{40}$/);
+    expect(upload.with.name).toBe('dspace-release-manifest');
+    expect(upload.with.path).toBe('dspace-release-manifest.json');
+    const summary = steps.find((step) =>
+      step.run?.includes('GITHUB_STEP_SUMMARY')
+    ).run;
+    for (const field of [
+      'sourceRevision',
+      'imageDigest',
+      'linux/amd64',
+      'linux/arm64',
+      'chartDigest',
+    ])
+      expect(summary).toContain(field);
+  });
+  it('passes event tag and credentials as environment data', () => {
+    for (const step of steps.filter((step) => typeof step.run === 'string')) {
       expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
-      if (step.run.includes('RELEASE_TAG')) {
-        expect(step.env?.RELEASE_TAG).toBe(
-          '${{ github.event.release.tag_name }}'
-        );
-      }
-    }
-  });
-
-  it('validates the release tag against v<root package version> before any push', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    expect(versionStep.run).toMatch(/root_version/);
-    expect(versionStep.run).toMatch(/frontend_version/);
-    expect(versionStep.run).toMatch(/expected_tag="v\$\{root_version\}"/);
-    expect(versionStep.run).toMatch(/refusing to publish/);
-
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
-    );
-    const versionIndex = stepIndex(job, (step) => step.id === 'version');
-    expect(versionIndex).toBeGreaterThanOrEqual(0);
-    expect(versionIndex).toBeLessThan(pushIndex);
-  });
-
-  it('validates package versions before emitting the version output', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    const validation = '[[ ! "$root_version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]';
-    expect(versionStep.run).toContain(validation);
-    expect(versionStep.run.indexOf(validation)).toBeLessThan(
-      versionStep.run.indexOf(
-        'echo "version=${root_version}" >> "$GITHUB_OUTPUT"'
-      )
-    );
-
-    const supportedVersion = /^[0-9]+\.[0-9]+\.[0-9]+$/;
-    expect(supportedVersion.test('3.1.0')).toBe(true);
-    for (const maliciousVersion of [
-      '3.1.$(touch /tmp/pwned)',
-      '3.1.`id`',
-      '3.1.0\nmalicious=value',
-    ]) {
-      expect(supportedVersion.test(maliciousVersion)).toBe(false);
-    }
-  });
-
-  it('passes version-derived shell values through env instead of run expressions', () => {
-    const rawVersionExpression = '${{ steps.version.outputs.version }}';
-    for (const step of findSteps(job)) {
-      if (typeof step.run === 'string') {
-        expect(step.run).not.toContain(rawVersionExpression);
-      }
-    }
-
-    const expectedEnvReferences = [
-      ['tags', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      ['build_version', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      [undefined, 'RELEASE_VERSION', '"v${RELEASE_VERSION}"'],
-    ];
-    for (const [id, envName, shellReference] of expectedEnvReferences) {
-      const matchingSteps = findSteps(job).filter(
-        (step) =>
-          (id === undefined || step.id === id) &&
-          step.env?.[envName] === rawVersionExpression &&
-          step.run?.includes(shellReference)
-      );
-      expect(matchingSteps.length).toBeGreaterThan(0);
-    }
-
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.env.SEMANTIC_TAG).toBe(
-      '${{ steps.tags.outputs.semantic_tag }}'
-    );
-    expect(summaryStep.run).toContain('${RELEASE_VERSION}');
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
-    expect(summaryStep.run).toContain('${SEMANTIC_TAG}');
-
-    const semanticRegistrySteps = findSteps(job).filter((step) =>
-      step.run?.includes('--tag "v${RELEASE_VERSION}"')
-    );
-    expect(semanticRegistrySteps).toHaveLength(2);
-    for (const step of semanticRegistrySteps) {
-      expect(step.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    }
-  });
-
-  it('runs the semantic absence guard before publication, and fails closed', () => {
-    const guardIndex = stepIndex(job, (step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
-    );
-    expect(guardIndex).toBeGreaterThanOrEqual(0);
-    expect(pushIndex).toBeGreaterThan(guardIndex);
-  });
-
-  it('keeps multi-arch publication for both supported architectures', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps.length).toBeGreaterThan(0);
-    for (const step of pushSteps) {
-      expect(step.with.platforms).toBe('linux/amd64,linux/arm64');
-    }
-  });
-
-  it('contains exactly one semantic publication step that pushes only the semantic tag', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps).toHaveLength(1);
-    const [pushStep] = pushSteps;
-    expect(pushStep.name).toBe('Build and push semantic release image');
-    expect(pushStep.id).toBe('build_push');
-    expect(pushStep.with.tags).toBe('${{ steps.tags.outputs.semantic_tag }}');
-    expect(pushStep.with.tags).not.toContain('branch_sha_tag');
-    expect(pushStep.with.tags).not.toMatch(/latest/);
-    expect(pushStep['continue-on-error']).toBeUndefined();
-  });
-
-  it('has no second-attempt or retry path for semantic publication', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).not.toMatch(/attempt 1|attempt 2|retry/i);
-    expect(serialized).not.toContain('build_push_1');
-    expect(serialized).not.toContain('build_push_2');
-    expect(serialized).not.toMatch(/outcome == 'failure'/);
-  });
-
-  it('completes local image verification before the sole semantic publication', () => {
-    const steps = findSteps(job);
-    const pushIndex = steps.findIndex(
-      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
-    );
-    const verificationBuildIndex = steps.findIndex(
-      (step) => step.name === 'Build image for SHA verification'
-    );
-    const shaAssertionIndex = steps.findIndex(
-      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
-    );
-    const chatStampIndex = steps.findIndex(
-      (step) => step.name === 'Verify chat build stamp inside image'
-    );
-
-    expect(verificationBuildIndex).toBeGreaterThanOrEqual(0);
-    expect(shaAssertionIndex).toBeGreaterThan(verificationBuildIndex);
-    expect(chatStampIndex).toBeGreaterThan(shaAssertionIndex);
-    expect(pushIndex).toBeGreaterThan(chatStampIndex);
-
-    for (const index of [verificationBuildIndex, shaAssertionIndex, chatStampIndex]) {
-      expect(steps[index].if).toBeUndefined();
-      expect(steps[index]['continue-on-error']).toBeUndefined();
-    }
-
-    expect(steps[verificationBuildIndex].with['build-args']).toBe(steps[pushIndex].with['build-args']);
-    expect(steps[verificationBuildIndex].with.labels).toBe(steps[pushIndex].with.labels);
-  });
-
-  it('lets publication failure terminate the job without conditional recovery', () => {
-    const pushStep = findStepsUsing(job, 'docker/build-push-action').find(
-      (step) => step.with?.push === true
-    );
-    expect(pushStep).toBeTruthy();
-    expect(pushStep.if).toBeUndefined();
-    expect(pushStep['continue-on-error']).toBeUndefined();
-    const laterSteps = findSteps(job).slice(
-      findSteps(job).indexOf(pushStep) + 1
-    );
-    for (const step of laterSteps) {
-      expect(step.if ?? '').not.toMatch(
-        /failure\(\)|outcome == 'failure'|always\(\)/
-      );
-    }
-  });
-
-  it('verifies and summarizes the branch-SHA coordinate without pushing it', () => {
-    const branchDescribeStep = findSteps(job).find(
-      (step) => step.id === 'branch_sha_evidence'
-    );
-    expect(branchDescribeStep).toBeTruthy();
-    expect(branchDescribeStep.run).toContain('ghcr-manifest.mjs describe');
-    expect(branchDescribeStep.run).toContain('steps.branch.outputs.branch');
-    expect(branchDescribeStep.run).toContain(
-      'steps.revision.outputs.short_sha'
-    );
-
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    for (const step of pushSteps) {
-      expect(JSON.stringify(step.with)).not.toContain('branch_sha_tag');
-    }
-
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
-  });
-
-  it('records the required evidence in the workflow summary without leaking credentials', () => {
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep).toBeTruthy();
-    const summary = summaryStep.run as string;
-    expect(summary).toMatch(/Semantic version/);
-    expect(summary).toMatch(/Full Git SHA/);
-    expect(summary).toMatch(/Immutable branch-SHA tag/);
-    expect(summary).toMatch(/Semantic tag/);
-    expect(summary).toMatch(/Image index digest/);
-    expect(summary).toMatch(/linux\/amd64 digest/);
-    expect(summary).toMatch(/linux\/arm64 digest/);
-    expect(summary).not.toMatch(/GITHUB_TOKEN/);
-    expect(summary).not.toMatch(/password/i);
-  });
-
-  it('passes registry credentials only through env, never inline in a run script', () => {
-    const guardStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const evidenceStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs describe')
-    );
-    for (const step of [guardStep, evidenceStep]) {
-      expect(step.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
-      expect(step.run).not.toContain('secrets.GITHUB_TOKEN');
+      expect(step.run).not.toContain('${{ secrets.GITHUB_TOKEN }}');
     }
   });
 });

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createReleaseManifest,
+  validateChartArtifact,
+  validateImage,
+  validateLocalCoordinates,
+} from '../scripts/check-release-consistency.mjs';
+
+const sha = 'a'.repeat(40);
+const digest = `sha256:${'b'.repeat(64)}`;
+const coordinates = {
+  applicationVersion: '3.1.0',
+  frontendVersion: '3.1.0',
+  lockfileVersion: '3.1.0',
+  chartVersion: '4.2.0',
+  chartAppVersion: '3.1.0',
+  releaseTag: 'v3.1.0',
+  chartTag: 'chart-v4.2.0',
+  sourceRevision: sha,
+  releaseTagRevision: sha,
+  chartTagRevision: sha,
+  branch: 'main',
+  imageTag: 'main-aaaaaaa',
+};
+const image = {
+  indexDigest: digest,
+  platforms: {
+    amd64: { revision: sha, manifestDigest: digest },
+    arm64: { revision: sha, manifestDigest: digest },
+  },
+};
+const chart = { version: '4.2.0', appVersion: '3.1.0', revision: sha, digest };
+
+describe('release consistency policy', () => {
+  it('accepts independently versioned coordinates and emits stable required fields', () => {
+    const manifest = createReleaseManifest({ coordinates, image, chart });
+    expect(manifest).toMatchObject({
+      applicationVersion: '3.1.0',
+      chartVersion: '4.2.0',
+      sourceRevision: sha,
+      imageTag: 'main-aaaaaaa',
+      imageDigest: digest,
+      chartDigest: digest,
+    });
+    expect(JSON.stringify(manifest)).toBe(
+      JSON.stringify(createReleaseManifest({ coordinates, image, chart }))
+    );
+  });
+  it.each([
+    ['frontendVersion', '3.1.1'],
+    ['lockfileVersion', '3.1.1'],
+    ['chartAppVersion', '3.1.1'],
+    ['releaseTagRevision', 'c'.repeat(40)],
+    ['chartTagRevision', 'c'.repeat(40)],
+    ['imageTag', 'main-latest'],
+    ['imageTag', 'v3.1.0'],
+    ['imageTag', 'bad tag'],
+  ])('rejects mismatched %s', (key, value) =>
+    expect(() =>
+      validateLocalCoordinates({ ...coordinates, [key]: value })
+    ).toThrow()
+  );
+  it('rejects a missing platform and a wrong revision label', () => {
+    expect(() =>
+      validateImage(
+        { ...image, platforms: { amd64: image.platforms.amd64 } },
+        sha
+      )
+    ).toThrow(/arm64/);
+    expect(() =>
+      validateImage(
+        {
+          ...image,
+          platforms: {
+            ...image.platforms,
+            arm64: { ...image.platforms.arm64, revision: 'c'.repeat(40) },
+          },
+        },
+        sha
+      )
+    ).toThrow(/arm64/);
+  });
+  it.each([
+    [{ present: false }, /missing/],
+    [{ ...chart, version: '9.0.0' }, /version/],
+    [{ ...chart, appVersion: '9.0.0' }, /appVersion/],
+    [{ ...chart, revision: 'c'.repeat(40) }, /revision/],
+    [{ ...chart, digest: 'latest' }, /digest/],
+  ])('rejects invalid chart evidence', (candidate, message) =>
+    expect(() => validateChartArtifact(candidate as any, coordinates)).toThrow(
+      message
+    )
+  );
+});


### PR DESCRIPTION
### Motivation

- Reproduce the release-integrity follow-up for Refs #4730 and the 2026-07-23 production version-drift postmortem by adding a single reusable, fail-closed gate that proves the tag, source commit, application metadata, immutable image, semantic alias, Helm chart provenance, and emitted manifest all describe the same approved release.
- Prevent future semantic-tag / chart-coordinate drift by requiring immutable evidence and a deterministic publication ordering before any semantic mutation is created.

### Description

- Add `scripts/check-release-consistency.mjs`, a reusable Node policy command that validates local coordinates, resolves peeled tag commits, enforces strict `X.Y.Z` semantics, and composes the deterministic release manifest JSON. It supports a network-free fixture mode via `--verify-local-fixtures`.
- Extend `scripts/ghcr-manifest.mjs` to inspect OCI image indexes, per-platform manifests/configs, image config labels (`org.opencontainers.image.revision`), Helm OCI manifests, and to fetch blobs for provenance assertions used by the policy.
- Integrate the gate into CI workflows: the image `semantic-release` job now performs a `pre-semantic` check, creates one bounded exact alias with `docker buildx imagetools create` (no rebuild), and runs a `post-semantic` verification that emits `dspace-release-manifest.json` which is uploaded as an artifact; the chart `publish` job invokes the reusable `chart-candidate` and `chart-published` checks while preserving the double absence checks and a single `helm push`.
- Implement one deterministic manifest format (minimum fields: `applicationVersion`, `sourceRevision`, `imageTag`, `imageDigest`, `chartVersion`, `chartDigest`, plus platform digests) and ensure manifest generation/validation is deterministic and fail-closed.
- Add focused deterministic tests `tests/releaseConsistency.test.ts` and update `tests/ciImageWorkflow.test.ts` to assert the new workflows, plus documentation updates in `docs/ops/sugarkube-release.md`, `docs/charts.md`, and `AGENTS.md` describing the required publication order and invariants.
- Preserve existing policies: semantic publication remains release-only, chart/image versions remain independently versioned, chart coordinate immutability and tombstoning are preserved, and no external tags/artifacts were created, modified, or deleted by these changes.

### Testing

- Ran `bash scripts/check-dspace-chart-version.sh` and it succeeded.
- Ran `node scripts/check-release-consistency.mjs --verify-local-fixtures` and it succeeded.
- Ran CI-focused test subset: `npm run test:root -- tests/releaseConsistency.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts tests/ghcrManifestGuard.test.ts tests/helmChartReleaseVersion.test.ts` and all tests passed (115 tests).
- Ran `npm run lint` and `npm run type-check` and both completed successfully; static checks (`git diff --check`, `scripts/scan-secrets.py` on diff) passed after adding credential redaction annotations to avoid false positives.
- Not run here due to environment/time limits: full `npm run test:ci`, `node scripts/link-check.mjs` and `actionlint` against modified workflows (note: workflows pin the upload action to a commit SHA as required). These should be run in CI or a fuller environment as final verification.

No GitHub releases, GHCR artifacts, chart coordinates, or deployments were created, overwritten, or mutated as part of this change; the gate is implemented and wired into workflows but will only operate in real publication runs (release / chart tag pushes) where credentials are provided by CI. Remaining operational evidence required to close #4730: perform a genuine post-merge release run to produce the `dspace-release-manifest.json` artifact and confirm the semantic alias digest equality in the live registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a647204b1e4832f8f4f750a2586a3f2)