### PR TITLE
ci: add end-to-end release-coordinate consistency gate (Refs #4730)

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -22,6 +22,26 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate tag, versions, and source revision
+        id: release
+        env:
+          CHART_TAG: ${{ github.ref_name }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          source_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
+          [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
+          node scripts/check-release-consistency.mjs --verify-chart-local
+          chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
+          app_version="$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -35,28 +55,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --reporter=append-only
-
-      - name: Validate tag, versions, and source revision
-        id: release
-        env:
-          CHART_TAG: ${{ github.ref_name }}
-          EVENT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          [[ "$chart_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "Chart version must be strict X.Y.Z SemVer" >&2; exit 1; }
-          [[ "$app_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "appVersion must be strict X.Y.Z SemVer" >&2; exit 1; }
-          [[ "$CHART_TAG" == "chart-v${chart_version}" ]] || { echo "Tag must equal chart-v${chart_version}; refusing to publish" >&2; exit 1; }
-          [[ "$chart_version" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
-          source_sha=$(git rev-parse HEAD)
-          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
-          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
-          [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
-          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Refuse an existing chart coordinate (pre-package)
         env:
@@ -123,6 +121,17 @@ jobs:
           digest=$(printf '%s\n' "$output" | sed -n 's/^Digest: \(sha256:[0-9a-f]\{64\}\)$/\1/p')
           [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "helm push did not report one valid OCI digest" >&2; exit 1; }
           echo "oci_digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Verify published chart coordinates
+        id: published_chart
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+          APPLICATION_VERSION: ${{ steps.release.outputs.app_version }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          EXPECTED_CHART_DIGEST: ${{ steps.push.outputs.oci_digest }}
+        run: node scripts/check-release-consistency.mjs --verify-chart
 
       - name: Write publication evidence
         env:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -24,12 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-
-      - name: Validate tag, versions, and source revision
+      - name: Authorize chart release source
         id: release
         env:
           CHART_TAG: ${{ github.ref_name }}
@@ -40,13 +35,22 @@ jobs:
           tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
           [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
-          node scripts/check-release-consistency.mjs --verify-chart-local
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           app_version="$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Validate chart release coordinates
+        env:
+          CHART_TAG: ${{ steps.release.outputs.chart_tag }}
+        run: node scripts/check-release-consistency.mjs --verify-chart-local
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -24,6 +24,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
       - name: Validate tag, versions, and source revision
         id: release
         env:
@@ -42,11 +47,6 @@ jobs:
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -279,6 +279,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.branch) || github.ref }}
+          persist-credentials: false
 
       - name: Ensure build SHA is present
         run: |
@@ -322,8 +323,10 @@ jobs:
 
       - name: Define image tags
         id: tags
+        env:
+          SOURCE_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
-          branch="${{ github.event.inputs.branch || github.ref_name }}"
+          branch="$SOURCE_BRANCH"
           full_sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short=7 HEAD)"
           tag_prefix="${branch//\//-}"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -474,290 +474,157 @@ jobs:
         run: exit 1
 
   semantic-release:
-    name: Publish semantic release image tag
+    name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    # Single canonical semantic-publication event for DSPACE #4727: a published GitHub
-    # release. Deliberately not also triggered by a `push: tags: v*` event — creating a
-    # release normally creates its tag too, so triggering on both would race and turn
-    # every ordinary release into an expected "tag already exists" failure. See
-    # outages/2026-07-23-dspace-production-version-drift.md and AGENTS.md.
     if: github.event_name == 'release' && github.event.action == 'published'
     concurrency:
       group: dspace-semantic-image-${{ github.event.release.tag_name }}
       cancel-in-progress: false
     steps:
-      - name: Checkout tagged commit
+      - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Resolve checked-out revision
-        id: revision
-        # The release tag is attacker-influenceable (anyone who can publish a release
-        # controls it) and git ref names may contain shell metacharacters such as `"`,
-        # `` ` ``, `$()`, and `;`. Pass it through env and reference it as "$RELEASE_TAG"
-        # data — never interpolate ${{ github.event.release.tag_name }} directly into a
-        # run: script, since GitHub substitutes it into the script's source text before
-        # the shell parses it, which would let a crafted tag execute arbitrary commands.
+      # Authorize event-controlled source data before setup, dependency installation, or
+      # any repository-controlled lifecycle command. Tag names are passed only through env.
+      - name: Authorize release source
+        id: source
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          full_sha="$(git rev-parse HEAD)"
-          # Peel to the commit form: for annotated/signed tags, "git rev-parse <tag>" alone
-          # resolves the tag *object*'s own SHA, not the commit it points at, which would
-          # reject every legitimate release cut from such a tag even though checkout
-          # correctly left HEAD on the tagged commit.
+          set -euo pipefail
+          source_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
-          if [ -z "$full_sha" ]; then
-            echo "git rev-parse HEAD returned nothing; refusing to publish." >&2
-            exit 1
-          fi
-          if [ "$full_sha" != "$tag_sha" ]; then
-            echo "Checked-out HEAD ($full_sha) does not match tag $RELEASE_TAG ($tag_sha); refusing to publish." >&2
-            exit 1
-          fi
-          short_sha="${full_sha:0:7}"
-          echo "full_sha=${full_sha}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Release tag/source mismatch" >&2; exit 1; }
+          git fetch https://github.com/democratizedspace/dspace.git main:refs/remotes/origin/main v3:refs/remotes/origin/v3 --quiet
+          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^(origin/)?(main|v3)$' | head -n1 | sed 's#^origin/##')"
+          [[ "$source_branch" == main || "$source_branch" == v3 ]] || { echo "Unsupported release source" >&2; exit 1; }
+          chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
+          chart_tag="chart-v${chart_version}"
+          git rev-parse "${chart_tag}^{commit}" >/dev/null
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "source_branch=$source_branch" >> "$GITHUB_OUTPUT"
+          echo "chart_tag=$chart_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve eligible source branch
-        id: branch
-        run: |
-          # Do not trust github.sha for this event (it can reflect the default branch, not
-          # the tagged commit). Everything downstream keys off steps.revision.outputs.full_sha
-          # (git rev-parse HEAD after checkout), not github.sha.
-          git fetch origin main v3 --quiet
-          full_sha="${{ steps.revision.outputs.full_sha }}"
-          matched="$(git branch -r --contains "$full_sha" | sed 's/^[* ]*//' | grep -E '^origin/(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          if [ -z "$matched" ]; then
-            echo "Tagged commit $full_sha is not reachable from origin/main or origin/v3; refusing to publish." >&2
-            exit 1
-          fi
-          echo "branch=${matched}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-          run_install: false
-
-      - name: Verify pnpm is on PATH
-        run: |
-          command -v pnpm
-          pnpm --version
-
-      - name: Validate release version coordinates
-        id: version
-        # See the "Resolve checked-out revision" step above: pass the attacker-influenceable
-        # release tag through env, never interpolate it directly into this run: script.
+      - name: Validate all local release coordinates
+        id: coordinates
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          root_version="$(node -p "require('./package.json').version")"
-          frontend_version="$(node -p "require('./frontend/package.json').version")"
-          expected_tag="v${root_version}"
+          CHART_TAG: ${{ steps.source.outputs.chart_tag }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+        run: node scripts/check-release-consistency.mjs --verify-local
 
-          if [ "$root_version" != "$frontend_version" ]; then
-            echo "Root package version ($root_version) does not match frontend package version ($frontend_version); refusing to publish." >&2
-            exit 1
-          fi
-
-          # DSPACE release coordinates use the same strict X.Y.Z convention enforced by
-          # scripts/check-dspace-chart-version.sh. Validate before exposing package data as
-          # a step output so shell metacharacters and multiline values fail closed.
-          if [[ ! "$root_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version is not a supported semantic version; refusing to publish." >&2
-            exit 1
-          fi
-
-          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
-            echo "Release tag $RELEASE_TAG does not match expected semantic tag $expected_tag; refusing to publish." >&2
-            exit 1
-          fi
-
-          echo "version=${root_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --reporter=append-only
-
-      - name: Build and verify chat build stamp
-        run: |
-          pnpm run build
-          pnpm run verify:chat-build-stamp
-
-      - name: Define image tags
-        id: tags
-        env:
-          SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          branch_sha_tag="ghcr.io/democratizedspace/dspace:${SOURCE_BRANCH}-${SHORT_SHA}"
-          semantic_tag="ghcr.io/democratizedspace/dspace:v${RELEASE_VERSION}"
-          echo "branch_sha_tag=${branch_sha_tag}" >> "$GITHUB_OUTPUT"
-          echo "semantic_tag=${semantic_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image build version
-        id: build_version
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-        run: |
-          build_version="v${RELEASE_VERSION}+${SHORT_SHA}"
-          echo "value=${build_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image metadata
-        id: metadata
-        env:
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          echo "created=${created}" >> "$GITHUB_OUTPUT"
-          echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
-
-      # Fail-closed guard: only an authoritative "not found" result from GHCR permits
-      # publication. Auth, network, timeout, malformed-response, and any other status are
-      # treated as hard failures by scripts/ghcr-manifest.mjs. Running inside this job's
-      # tag-scoped concurrency group means the check happens only after this run has
-      # exclusive access to that group, so it cannot race a second publish attempt.
-      - name: Refuse to overwrite an existing semantic tag
+      - name: Refuse an existing semantic tag (preflight)
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node scripts/ghcr-manifest.mjs check-absent \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SEMANTIC_TAG: v${{ steps.coordinates.outputs.applicationVersion }}
+        run: node scripts/check-release-consistency.mjs --pre-semantic
+
+      - name: Verify immutable image provenance
+        id: immutable_image
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          IMAGE_TAG: ${{ steps.coordinates.outputs.imageTag }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: node scripts/check-release-consistency.mjs --verify-image
+
+      - name: Verify published chart provenance
+        id: chart
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          CHART_VERSION: ${{ steps.coordinates.outputs.chartVersion }}
+          APPLICATION_VERSION: ${{ steps.coordinates.outputs.applicationVersion }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: node scripts/check-release-consistency.mjs --verify-chart
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
-        with:
-          platforms: arm64
+          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Verify corresponding branch-SHA image exists
-        id: branch_sha_evidence
+      # Revalidate immediately before the sole mutation. Never rebuild an application in
+      # this path: create an exact registry alias of the approved immutable index.
+      - name: Refuse an existing semantic tag (final)
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SEMANTIC_TAG: v${{ steps.coordinates.outputs.applicationVersion }}
+        run: node scripts/check-release-consistency.mjs --pre-semantic
+
+      - name: Publish semantic alias exactly once
+        env:
+          IMAGE_TAG: ${{ steps.coordinates.outputs.imageTag }}
+          IMAGE_DIGEST: ${{ steps.immutable_image.outputs.indexDigest }}
+          SEMANTIC_TAG: v${{ steps.coordinates.outputs.applicationVersion }}
         run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "ghcr.io/democratizedspace/dspace:${SEMANTIC_TAG}" \
+            "ghcr.io/democratizedspace/dspace:${IMAGE_TAG}@${IMAGE_DIGEST}"
 
-      - name: Build image for SHA verification
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-
-      - name: Assert build SHA is baked into frontend bundle
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Build and push semantic release image
-        id: build_push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: ${{ steps.tags.outputs.semantic_tag }}
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      # Records index + per-platform digests as evidence. 'present' is the expected outcome
-      # of this second registry call (the tag was just pushed above); scripts/ghcr-manifest.mjs
-      # writes index_digest/amd64_digest/arm64_digest to $GITHUB_OUTPUT without ever logging
-      # the registry credentials used to fetch them.
-      - name: Record semantic release evidence
-        if: steps.build_push.outcome == 'success'
-        id: evidence
+      - name: Verify semantic alias digest equality
+        id: semantic_image
         env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          IMAGE_TAG: v${{ steps.coordinates.outputs.applicationVersion }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          EXPECTED_IMAGE_DIGEST: ${{ steps.immutable_image.outputs.indexDigest }}
+        run: node scripts/check-release-consistency.mjs --verify-image
 
-      - name: Summarize semantic release evidence
-        if: steps.build_push.outcome == 'success'
+      - name: Emit and validate release manifest
         env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          BRANCH_SHA_TAG: ${{ steps.tags.outputs.branch_sha_tag }}
-          SEMANTIC_TAG: ${{ steps.tags.outputs.semantic_tag }}
+          APPLICATION_VERSION: ${{ steps.coordinates.outputs.applicationVersion }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          IMAGE_TAG: ${{ steps.coordinates.outputs.imageTag }}
+          IMAGE_DIGEST: ${{ steps.immutable_image.outputs.indexDigest }}
+          CHART_VERSION: ${{ steps.coordinates.outputs.chartVersion }}
+          CHART_DIGEST: ${{ steps.chart.outputs.chartDigest }}
+          SEMANTIC_TAG: v${{ steps.coordinates.outputs.applicationVersion }}
+          RELEASE_MANIFEST_PATH: dspace-release-manifest.json
         run: |
-          {
-            echo "## DSPACE semantic release image"
-            echo
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Semantic version | \`v${RELEASE_VERSION}\` |"
-            echo "| Full Git SHA | \`${{ steps.revision.outputs.full_sha }}\` |"
-            echo "| Immutable branch-SHA tag | \`${BRANCH_SHA_TAG}\` |"
-            echo "| Semantic tag | \`${SEMANTIC_TAG}\` |"
-            echo "| Image index digest | \`${{ steps.evidence.outputs.index_digest }}\` |"
-            echo "| linux/amd64 digest | \`${{ steps.evidence.outputs.amd64_digest }}\` |"
-            echo "| linux/arm64 digest | \`${{ steps.evidence.outputs.arm64_digest }}\` |"
-          } >> "$GITHUB_STEP_SUMMARY"
+          node scripts/check-release-consistency.mjs --emit-manifest
+          node scripts/check-release-consistency.mjs --validate-manifest
+
+      - name: Upload release manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dspace-release-manifest
+          path: dspace-release-manifest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Write complete release evidence
+        env:
+          APPLICATION_VERSION: ${{ steps.coordinates.outputs.applicationVersion }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          IMAGE_TAG: ${{ steps.coordinates.outputs.imageTag }}
+          IMAGE_DIGEST: ${{ steps.immutable_image.outputs.indexDigest }}
+          AMD64_DIGEST: ${{ steps.immutable_image.outputs.amd64Digest }}
+          ARM64_DIGEST: ${{ steps.immutable_image.outputs.arm64Digest }}
+          CHART_VERSION: ${{ steps.coordinates.outputs.chartVersion }}
+          CHART_DIGEST: ${{ steps.chart.outputs.chartDigest }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Full release consistency evidence
+          - Application version: $APPLICATION_VERSION
+          - Full source SHA: $SOURCE_SHA
+          - Immutable image: ghcr.io/democratizedspace/dspace:$IMAGE_TAG@$IMAGE_DIGEST
+          - linux/amd64 manifest: $AMD64_DIGEST
+          - linux/arm64 manifest: $ARM64_DIGEST
+          - Semantic evidence alias: ghcr.io/democratizedspace/dspace:v$APPLICATION_VERSION@$IMAGE_DIGEST
+          - Immutable chart: oci://ghcr.io/democratizedspace/charts/dspace:$CHART_VERSION@$CHART_DIGEST
+          - Release manifest artifact: dspace-release-manifest/dspace-release-manifest.json
+          EOF

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -324,12 +324,14 @@ jobs:
         id: tags
         run: |
           branch="${{ github.event.inputs.branch || github.ref_name }}"
-          short_sha="$(git rev-parse --short HEAD)"
+          full_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=7 HEAD)"
           tag_prefix="${branch//\//-}"
           sha_tag="ghcr.io/democratizedspace/dspace:${tag_prefix}-${short_sha}"
           latest_tag="ghcr.io/democratizedspace/dspace:${tag_prefix}-latest"
           echo "sha_tag=${sha_tag}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "full_sha=${full_sha}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set image build version
@@ -342,7 +344,7 @@ jobs:
         id: metadata
         env:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ steps.tags.outputs.full_sha }}
         run: |
           created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "created=${created}" >> "$GITHUB_OUTPUT"
@@ -379,8 +381,8 @@ jobs:
             ${{ steps.tags.outputs.latest_tag }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ github.sha }}
-            VITE_GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
@@ -404,8 +406,8 @@ jobs:
             ${{ steps.tags.outputs.latest_tag }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ github.sha }}
-            VITE_GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
@@ -427,16 +429,18 @@ jobs:
           tags: dspace-verify:latest
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ github.sha }}
-            VITE_GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
           cache-from: type=gha
 
       - name: Assert build SHA is baked into frontend bundle
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
         run: |
           docker run --rm \
-            -e EXPECTED_SHA="${GITHUB_SHA}" \
+            -e EXPECTED_SHA \
             -v "$PWD/scripts:/scripts:ro" \
             dspace-verify:latest \
             node /scripts/verify-build-sha.mjs /app/dist
@@ -508,6 +512,11 @@ jobs:
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "source_branch=$source_branch" >> "$GITHUB_OUTPUT"
           echo "chart_tag=$chart_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
 
       - name: Validate all local release coordinates
         id: coordinates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,8 +351,9 @@ frontend versions agree), verifies the corresponding `<branch>-<short-sha>` arti
 reading its GHCR manifest without republishing or retagging it, and queries GHCR for the
 semantic tag before publishing — failing closed on any non-404 outcome, including auth,
 network, timeout, and malformed-response errors — inside a job-level `concurrency` group
-keyed on the tag so two publication runs can't race. The semantic publication step must
-use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
+keyed on the tag so two publication runs can't race. Semantic publication performs exactly one
+bounded `docker buildx imagetools create` alias from the approved immutable `tag@digest`, performs
+no application rebuild, and immediately verifies exact index-digest equality. See
 `scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
 `tests/ghcrManifestGuard.test.ts`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,15 @@ use exactly one `push: true` attempt and must push only `vX.Y.Z`. See
 `scripts/ghcr-manifest.mjs` and `tests/ciImageWorkflow.test.ts` /
 `tests/ghcrManifestGuard.test.ts`.
 
+Full releases are fail-closed and ordered: first publish and verify the immutable
+`<branch>-<short-sha>` multi-platform image, then publish and verify the immutable chart from the
+same full source SHA, and only then publish the GitHub release. The release event verifies both
+prerequisites, creates `vX.Y.Z` as an exact digest alias (never a rebuild), and uploads
+`dspace-release-manifest.json`. Deployments and downstream promotion records must continue to use
+the immutable branch-SHA image tag or digest. The semantic tag is human-readable evidence whose
+digest equality is enforced, not a deployment coordinate. Run
+`node scripts/check-release-consistency.mjs --verify-local-fixtures` when changing these gates.
+
 ### Smoke Test
 
 The `ci-image.yml` workflow includes a smoke test that:

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -161,6 +161,16 @@ version comes from `Chart.yaml:version` and may differ from the application vers
 and the package files. `docs/apps/dspace.version` pins the chart coordinate. After the publish
 workflow has completed successfully, use this installation procedure:
 
+For a full application release, publish this immutable chart after the immutable branch-SHA image
+and before publishing the GitHub release. All three artifacts must identify one approved full
+source SHA. The final release gate reads the published chart OCI manifest/config, verifies chart
+version, `appVersion`, source-revision annotation, and immutable digest, then includes that digest
+with the immutable image coordinate in
+`dspace-release-manifest/dspace-release-manifest.json`. A missing or mismatched chart safely blocks
+the later semantic image alias; the release workflow can be rerun after the chart prerequisite is
+supplied, provided no semantic coordinate exists. Semantic image tags remain human-readable
+evidence only even though exact digest equality with the immutable image index is enforced.
+
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
   --version 3.1.0 \

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -28,6 +28,22 @@ be the audit record for a production deploy.
 
 ## Artifact publishing summary
 
+The mandatory full-release order is fail-closed:
+
+1. Publish and verify the multi-platform immutable `<branch>-<shortsha>` image. Both required
+   platform configs (`linux/amd64` and `linux/arm64`) must identify the approved full source SHA.
+2. Push `chart-v<chart version>` from that same commit. The chart workflow preserves its two
+   authoritative-absence checks and one push, then verifies the published OCI chart version,
+   `appVersion`, source revision, and digest.
+3. Publish the `v<application version>` GitHub release. Its workflow requires both immutable
+   artifacts, creates the semantic image tag as one exact alias of the immutable image index,
+   verifies digest equality, and emits the combined release manifest.
+
+Publishing the GitHub release before either prerequisite exists fails without creating the semantic
+coordinate. After supplying the missing immutable artifact, rerun the failed release workflow. If a
+semantic tag already exists, the workflow always refuses to overwrite or move it; investigate and
+cut a new approved release coordinate rather than retrying a mutation.
+
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
 2. `.github/workflows/ci-helm.yml` publishes only when an exact `chart-v<chart version>` tag is
@@ -47,6 +63,16 @@ authoritative absence. Existing coordinates cannot be replaced. Chart `3.0.1` is
 tombstoned even if it later appears absent; this does not prohibit a newer chart whose `appVersion`
 is `3.0.1`. A successful run summary is the audit record for the release tag, full source SHA,
 package SHA-256, and OCI manifest digest.
+
+Successful full releases upload the deterministic artifact
+`dspace-release-manifest/dspace-release-manifest.json`. Schema version 1 records
+`applicationVersion`, the complete `sourceRevision`, immutable tag-only `imageTag`, image-index
+`imageDigest`, independently versioned `chartVersion`, immutable `chartDigest`, and the semantic
+evidence tag. It intentionally contains no environment, approver, runtime, promotion, or
+credentials. The workflow summary includes the immutable image and chart references plus the image
+index and both platform digests. The semantic `vX.Y.Z` alias is verified to resolve to the exact
+same index digest, but the manifest and deployments continue to select the immutable branch-SHA
+tag.
 
 ## Deploy staging
 

--- a/scripts/check-release-consistency.mjs
+++ b/scripts/check-release-consistency.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  assertTagAbsent,
+  inspectChart,
+  inspectImage,
+} from './ghcr-manifest.mjs';
+
+const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+const IMAGE_TAG = /^(main|v3)-([0-9a-f]{7})$/;
+const MODES = new Set([
+  '--verify-local',
+  '--verify-chart-local',
+  '--verify-local-fixtures',
+  '--pre-semantic',
+  '--verify-image',
+  '--verify-chart',
+  '--emit-manifest',
+  '--validate-manifest',
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+function strict(value, pattern, label) {
+  if (typeof value !== 'string' || !pattern.test(value))
+    fail(`${label} is missing or malformed`);
+  return value;
+}
+function json(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    fail(`${path} is missing or malformed JSON`);
+  }
+}
+function yamlScalar(text, key) {
+  const matches = [
+    ...text.matchAll(
+      new RegExp(`^${key}:\\s*["']?([^"'\\s#]+)["']?\\s*(?:#.*)?$`, 'gm')
+    ),
+  ];
+  if (matches.length !== 1) fail(`Chart.yaml ${key} is missing or ambiguous`);
+  return matches[0][1];
+}
+function oneLine(path) {
+  const lines = readFileSync(path, 'utf8')
+    .split(/\r?\n/)
+    .filter((line) => line && !line.startsWith('#'));
+  if (lines.length !== 1 || lines[0].trim() !== lines[0])
+    fail(`${path} must contain exactly one bare value`);
+  return lines[0];
+}
+function git(root, ...args) {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+export function readLocalCoordinates(root = process.cwd()) {
+  const path = (name) => resolve(root, name);
+  const rootPackage = json(path('package.json'));
+  const frontendPackage = json(path('frontend/package.json'));
+  const lock = json(path('package-lock.json'));
+  const chartText = readFileSync(path('charts/dspace/Chart.yaml'), 'utf8');
+  const applicationVersion = strict(
+    rootPackage.version,
+    SEMVER,
+    'root package version'
+  );
+  for (const [label, value] of [
+    ['frontend package version', frontendPackage.version],
+    ['lockfile version', lock.version],
+    ['lockfile root version', lock.packages?.['']?.version],
+    ['chart appVersion', yamlScalar(chartText, 'appVersion')],
+  ]) {
+    strict(value, SEMVER, label);
+    if (value !== applicationVersion)
+      fail(`${label} does not equal application version ${applicationVersion}`);
+  }
+  const chartVersion = strict(
+    yamlScalar(chartText, 'version'),
+    SEMVER,
+    'chart version'
+  );
+  const documented = strict(
+    oneLine(path('docs/apps/dspace.version')),
+    SEMVER,
+    'documented chart version'
+  );
+  if (documented !== chartVersion)
+    fail('documented chart version does not equal Chart.yaml version');
+  return { applicationVersion, chartVersion };
+}
+
+export function validateReleaseSource({
+  root = process.cwd(),
+  releaseTag,
+  chartTag,
+  sourceRevision,
+  branch,
+  full = true,
+}) {
+  strict(
+    releaseTag,
+    /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/,
+    'release tag'
+  );
+  strict(sourceRevision, SHA, 'source revision');
+  if (!['main', 'v3'].includes(branch))
+    fail('source branch must be main or v3');
+  const local = readLocalCoordinates(root);
+  if (releaseTag !== `v${local.applicationVersion}`)
+    fail('release tag does not equal application version');
+  if (git(root, 'rev-parse', 'HEAD') !== sourceRevision)
+    fail('checked-out commit does not equal approved source revision');
+  if (git(root, 'rev-parse', `${releaseTag}^{commit}`) !== sourceRevision)
+    fail('release tag does not peel to approved source revision');
+  try {
+    git(
+      root,
+      'merge-base',
+      '--is-ancestor',
+      sourceRevision,
+      `origin/${branch}`
+    );
+  } catch {
+    fail(`approved source is not reachable from origin/${branch}`);
+  }
+  if (full) {
+    if (chartTag !== `chart-v${local.chartVersion}`)
+      fail('chart release tag does not equal approved chart version');
+    if (git(root, 'rev-parse', `${chartTag}^{commit}`) !== sourceRevision)
+      fail('chart release tag does not peel to approved source revision');
+  }
+  return {
+    ...local,
+    sourceRevision,
+    branch,
+    releaseTag,
+    chartTag,
+    imageTag: `${branch}-${sourceRevision.slice(0, 7)}`,
+  };
+}
+
+export function validateImageTag(tag, revision) {
+  const match = strict(tag, IMAGE_TAG, 'immutable deployment image tag');
+  if (match.slice(-7) !== revision.slice(0, 7))
+    fail('immutable deployment image tag does not match source revision');
+  return tag;
+}
+
+export function releaseManifest(input) {
+  const manifest = {
+    schemaVersion: 1,
+    app: 'dspace',
+    applicationVersion: strict(
+      input.applicationVersion,
+      SEMVER,
+      'applicationVersion'
+    ),
+    sourceRevision: strict(input.sourceRevision, SHA, 'sourceRevision'),
+    imageTag: validateImageTag(input.imageTag, input.sourceRevision),
+    imageDigest: strict(input.imageDigest, DIGEST, 'imageDigest'),
+    chartVersion: strict(input.chartVersion, SEMVER, 'chartVersion'),
+    chartDigest: strict(input.chartDigest, DIGEST, 'chartDigest'),
+  };
+  if (input.semanticTag !== `v${manifest.applicationVersion}`)
+    fail('semanticTag does not match applicationVersion');
+  manifest.semanticTag = input.semanticTag;
+  return manifest;
+}
+
+function env(name) {
+  return (
+    process.env[name] || fail(`Missing required environment variable ${name}`)
+  );
+}
+function credentials() {
+  return {
+    username: env('GHCR_GUARD_USERNAME'),
+    password: env('GHCR_GUARD_PASSWORD'),
+  };
+}
+function registryBase() {
+  return { owner: 'democratizedspace', ...credentials() };
+}
+function output(values) {
+  const lines =
+    Object.entries(values)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n') + '\n';
+  if (process.env.GITHUB_OUTPUT)
+    writeFileSync(process.env.GITHUB_OUTPUT, lines, { flag: 'a' });
+  else process.stdout.write(lines);
+}
+
+export async function run(mode) {
+  if (!MODES.has(mode)) fail(`Unknown mode ${mode || '(missing)'}`);
+  if (mode === '--verify-local-fixtures') {
+    const revision = '0123456789abcdef0123456789abcdef01234567';
+    const value = releaseManifest({
+      applicationVersion: '3.1.0',
+      sourceRevision: revision,
+      imageTag: 'main-0123456',
+      imageDigest: `sha256:${'1'.repeat(64)}`,
+      chartVersion: '4.2.0',
+      chartDigest: `sha256:${'2'.repeat(64)}`,
+      semanticTag: 'v3.1.0',
+    });
+    if (JSON.stringify(value) !== JSON.stringify(releaseManifest({ ...value })))
+      fail('fixture manifest is not deterministic');
+    console.log('Release consistency fixtures passed (network-free).');
+    return;
+  }
+  if (mode === '--verify-local') {
+    const result = validateReleaseSource({
+      releaseTag: env('RELEASE_TAG'),
+      chartTag: env('CHART_TAG'),
+      sourceRevision: env('SOURCE_SHA'),
+      branch: env('SOURCE_BRANCH'),
+      full: process.env.FULL_RELEASE !== 'false',
+    });
+    output(result);
+    return;
+  }
+  if (mode === '--verify-chart-local') {
+    const local = readLocalCoordinates();
+    if (env('CHART_TAG') !== `chart-v${local.chartVersion}`)
+      fail('chart release tag does not equal chart version');
+    if (local.chartVersion === '3.0.1')
+      fail('chart version 3.0.1 is permanently tombstoned');
+    output(local);
+    return;
+  }
+  if (mode === '--pre-semantic') {
+    await assertTagAbsent({
+      ...registryBase(),
+      repo: 'dspace',
+      tag: env('SEMANTIC_TAG'),
+    });
+    return;
+  }
+  if (mode === '--verify-image') {
+    const evidence = await inspectImage({
+      ...registryBase(),
+      repo: 'dspace',
+      tag: env('IMAGE_TAG'),
+      revision: env('SOURCE_SHA'),
+    });
+    if (
+      process.env.EXPECTED_IMAGE_DIGEST &&
+      evidence.indexDigest !== process.env.EXPECTED_IMAGE_DIGEST
+    )
+      fail('semantic and immutable image index digests differ');
+    output(evidence);
+    return;
+  }
+  if (mode === '--verify-chart') {
+    const evidence = await inspectChart({
+      ...registryBase(),
+      repo: 'charts/dspace',
+      tag: env('CHART_VERSION'),
+      version: env('CHART_VERSION'),
+      appVersion: env('APPLICATION_VERSION'),
+      revision: env('SOURCE_SHA'),
+    });
+    if (
+      process.env.EXPECTED_CHART_DIGEST &&
+      evidence.digest !== process.env.EXPECTED_CHART_DIGEST
+    )
+      fail('published chart digest does not equal the push result');
+    output({ chartDigest: evidence.digest });
+    return;
+  }
+  if (mode === '--emit-manifest') {
+    const manifest = releaseManifest({
+      applicationVersion: env('APPLICATION_VERSION'),
+      sourceRevision: env('SOURCE_SHA'),
+      imageTag: env('IMAGE_TAG'),
+      imageDigest: env('IMAGE_DIGEST'),
+      chartVersion: env('CHART_VERSION'),
+      chartDigest: env('CHART_DIGEST'),
+      semanticTag: env('SEMANTIC_TAG'),
+    });
+    writeFileSync(
+      env('RELEASE_MANIFEST_PATH'),
+      `${JSON.stringify(manifest, null, 2)}\n`
+    );
+    return;
+  }
+  const path = env('RELEASE_MANIFEST_PATH');
+  const parsed = json(path);
+  if (JSON.stringify(parsed) !== JSON.stringify(releaseManifest(parsed)))
+    fail('release manifest has unknown, missing, or non-canonical fields');
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  if (process.argv.length !== 3) {
+    console.error('Usage: check-release-consistency.mjs <mode>');
+    process.exit(2);
+  }
+  run(process.argv[2]).catch((error) => {
+    console.error(error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/check-release-consistency.mjs
+++ b/scripts/check-release-consistency.mjs
@@ -177,6 +177,10 @@ export function releaseManifest(input) {
   return manifest;
 }
 
+export function assertExpectedDigest(actual, expected, message) {
+  if (expected && actual !== expected) fail(message);
+}
+
 function env(name) {
   return (
     process.env[name] || fail(`Missing required environment variable ${name}`)
@@ -214,8 +218,18 @@ export async function run(mode) {
       chartDigest: `sha256:${'2'.repeat(64)}`,
       semanticTag: 'v3.1.0',
     });
-    if (JSON.stringify(value) !== JSON.stringify(releaseManifest({ ...value })))
+    const expected =
+      '{"schemaVersion":1,"app":"dspace","applicationVersion":"3.1.0",' +
+      '"sourceRevision":"0123456789abcdef0123456789abcdef01234567",' +
+      '"imageTag":"main-0123456","imageDigest":"sha256:' +
+      '1111111111111111111111111111111111111111111111111111111111111111",' +
+      '"chartVersion":"4.2.0","chartDigest":"sha256:' +
+      '2222222222222222222222222222222222222222222222222222222222222222",' +
+      '"semanticTag":"v3.1.0"}';
+    if (JSON.stringify(value) !== expected)
       fail('fixture manifest is not deterministic');
+    if (JSON.stringify(releaseManifest(JSON.parse(expected))) !== expected)
+      fail('fixture manifest emit/validate round trip is not deterministic');
     console.log('Release consistency fixtures passed (network-free).');
     return;
   }
@@ -254,11 +268,11 @@ export async function run(mode) {
       tag: env('IMAGE_TAG'),
       revision: env('SOURCE_SHA'),
     });
-    if (
-      process.env.EXPECTED_IMAGE_DIGEST &&
-      evidence.indexDigest !== process.env.EXPECTED_IMAGE_DIGEST
-    )
-      fail('semantic and immutable image index digests differ');
+    assertExpectedDigest(
+      evidence.indexDigest,
+      process.env.EXPECTED_IMAGE_DIGEST,
+      'semantic and immutable image index digests differ'
+    );
     output(evidence);
     return;
   }
@@ -271,11 +285,11 @@ export async function run(mode) {
       appVersion: env('APPLICATION_VERSION'),
       revision: env('SOURCE_SHA'),
     });
-    if (
-      process.env.EXPECTED_CHART_DIGEST &&
-      evidence.digest !== process.env.EXPECTED_CHART_DIGEST
-    )
-      fail('published chart digest does not equal the push result');
+    assertExpectedDigest(
+      evidence.digest,
+      process.env.EXPECTED_CHART_DIGEST,
+      'published chart digest does not equal the push result'
+    );
     output({ chartDigest: evidence.digest });
     return;
   }

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -38,10 +38,11 @@ async function fetchWithTimeout(fetchImpl, url, init, timeoutMs, describeAction)
                 code: 'timeout',
             });
         }
-        throw new GhcrGuardError(
-            `Network error while ${describeAction}: ${error?.message || error}`,
-            { code: 'network' }
-        );
+        // Fetch errors can contain credential-bearing request details. Classify
+        // the failure without propagating the underlying error message.
+        throw new GhcrGuardError(`Network error while ${describeAction}`, {
+            code: 'network',
+        });
     } finally {
         clearTimeout(timer);
     }
@@ -277,6 +278,11 @@ export async function inspectImage({
       fetchImpl,
       timeoutMs,
     });
+    if (manifest.status !== 'present' || manifest.digest !== candidates[0].digest)
+      throw new GhcrGuardError(
+        `linux/${architecture} manifest digest does not match its index descriptor`,
+        { code: 'digest-mismatch' }
+      );
     const configDigest =
       manifest.status === 'present' && manifest.body?.config?.digest;
     if (!DIGEST.test(configDigest || ''))

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -10,6 +10,7 @@ const MANIFEST_ACCEPT_HEADER = [
     'application/vnd.oci.image.manifest.v1+json',
     'application/vnd.docker.distribution.manifest.v2+json',
 ].join(', ');
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
 
 export class GhcrGuardError extends Error {
     constructor(message, { code = 'unknown' } = {}) {
@@ -172,7 +173,205 @@ export async function getManifest({
               }))
         : [];
 
-    return { status: 'present', digest, manifests };
+    const result = { status: 'present', digest, manifests };
+    Object.defineProperty(result, 'body', { value: body, enumerable: false });
+    return result;
+}
+
+export async function getBlob({
+  owner,
+  repo,
+  digest,
+  token,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  requireField(owner, 'owner');
+  requireField(repo, 'repo');
+  requireField(token, 'token');
+  if (!DIGEST.test(digest)) {
+    throw new GhcrGuardError('Invalid OCI blob digest', { code: 'malformed' });
+  }
+  const url = `${REGISTRY_HOST}/v2/${owner}/${repo}/blobs/${digest}`;
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    url,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+    timeoutMs,
+    'requesting a GHCR blob'
+  );
+  if (response.status === 401 || response.status === 403) {
+    throw new GhcrGuardError(
+      `GHCR blob request was denied with status ${response.status}`,
+      { code: 'auth' }
+    );
+  }
+  if (!response.ok) {
+    throw new GhcrGuardError(
+      `GHCR blob request returned an indeterminate status ${response.status}`,
+      { code: 'indeterminate' }
+    );
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new GhcrGuardError('GHCR blob response body was not valid JSON', {
+      code: 'malformed',
+    });
+  }
+}
+
+export async function inspectImage({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  revision,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const token = await fetchGhcrToken({ // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  });
+  const index = await getManifest({
+    owner,
+    repo,
+    tag,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  if (index.status !== 'present')
+    throw new GhcrGuardError(
+      `Required immutable image ${owner}/${repo}:${tag} is missing`,
+      { code: 'missing' }
+    );
+  if (!DIGEST.test(index.digest))
+    throw new GhcrGuardError('Invalid image index digest', {
+      code: 'malformed',
+    });
+  const platforms = {};
+  for (const architecture of ['amd64', 'arm64']) {
+    const candidates = index.manifests.filter(
+      (item) => item.os === 'linux' && item.architecture === architecture
+    );
+    if (candidates.length !== 1 || !DIGEST.test(candidates[0].digest)) {
+      throw new GhcrGuardError(
+        `Image requires exactly one linux/${architecture} manifest`,
+        { code: 'missing-platform' }
+      );
+    }
+    const manifest = await getManifest({
+      owner,
+      repo,
+      tag: candidates[0].digest,
+      token,
+      fetchImpl,
+      timeoutMs,
+    });
+    const configDigest =
+      manifest.status === 'present' && manifest.body?.config?.digest;
+    if (!DIGEST.test(configDigest || ''))
+      throw new GhcrGuardError(
+        `linux/${architecture} manifest has an invalid config`,
+        { code: 'malformed' }
+      );
+    const config = await getBlob({
+      owner,
+      repo,
+      digest: configDigest,
+      token,
+      fetchImpl,
+      timeoutMs,
+    });
+    if (
+      config?.config?.Labels?.['org.opencontainers.image.revision'] !== revision
+    ) {
+      throw new GhcrGuardError(
+        `linux/${architecture} image revision label does not match approved source`,
+        { code: 'revision-mismatch' }
+      );
+    }
+    platforms[architecture] = candidates[0].digest;
+  }
+  return {
+    indexDigest: index.digest,
+    amd64Digest: platforms.amd64,
+    arm64Digest: platforms.arm64,
+  };
+}
+
+export async function inspectChart({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  version,
+  appVersion,
+  revision,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const token = await fetchGhcrToken({ // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  });
+  const artifact = await getManifest({
+    owner,
+    repo,
+    tag,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  if (artifact.status !== 'present')
+    throw new GhcrGuardError(
+      `Required chart ${owner}/${repo}:${tag} is missing`,
+      { code: 'missing' }
+    );
+  const configDigest = artifact.body?.config?.digest;
+  if (!DIGEST.test(artifact.digest) || !DIGEST.test(configDigest || ''))
+    throw new GhcrGuardError('Chart artifact has an invalid digest or config', {
+      code: 'malformed',
+    });
+  const config = await getBlob({
+    owner,
+    repo,
+    digest: configDigest,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  const annotations = {
+    ...(artifact.body?.annotations || {}),
+    ...(config?.annotations || {}),
+  };
+  if (String(config?.version) !== version)
+    throw new GhcrGuardError('Published chart version mismatch', {
+      code: 'version-mismatch',
+    });
+  if (String(config?.appVersion) !== appVersion)
+    throw new GhcrGuardError('Published chart appVersion mismatch', {
+      code: 'version-mismatch',
+    });
+  if (annotations['org.opencontainers.image.revision'] !== revision)
+    throw new GhcrGuardError('Published chart source revision mismatch', {
+      code: 'revision-mismatch',
+    });
+  return { digest: artifact.digest };
 }
 
 // Fails closed: resolves only when the registry authoritatively reports the tag as absent.

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -78,6 +78,9 @@ describe('chart publication workflow integrity', () => {
     const push = step('Push chart exactly once').run;
     expect(push).not.toMatch(/retry|continue-on-error|\|\| true/);
     expect(push).toContain('^sha256:[0-9a-f]{64}$');
+    expect(step('Verify published chart coordinates').env.EXPECTED_CHART_DIGEST).toBe(
+      '${{ steps.push.outputs.oci_digest }}'
+    );
     const summary = step('Write publication evidence').run;
     for (const field of [
       'Chart version',

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -34,7 +34,7 @@ describe('chart publication workflow integrity', () => {
     );
     expect(checkout.with.ref).toBe('${{ github.sha }}');
     expect(checkout.with['fetch-depth']).toBe(0);
-    const release = step('Validate tag, versions, and source revision');
+    const release = step('Authorize chart release source');
     expect(release.env.CHART_TAG).toBe('${{ github.ref_name }}');
     expect(text.match(/github\.ref_name/g)).toHaveLength(1);
     expect(release.env.EVENT_SHA).toBe('${{ github.sha }}');
@@ -45,9 +45,7 @@ describe('chart publication workflow integrity', () => {
   });
 
   it('routes strict matching versions and the chart tombstone through the reusable gate before registry access', () => {
-    const releaseIndex = steps.indexOf(
-      step('Validate tag, versions, and source revision')
-    );
+    const releaseIndex = steps.indexOf(step('Validate chart release coordinates'));
     const guardIndex = steps.indexOf(
       step('Refuse an existing chart coordinate (pre-package)')
     );
@@ -109,8 +107,14 @@ describe('chart publication workflow integrity', () => {
 
   it('installs Node and YAML dependencies before staging', () => {
     expect(step('Setup Node.js').with['node-version-file']).toBe('.nvmrc');
+    expect(steps.indexOf(step('Authorize chart release source'))).toBeLessThan(
+      steps.indexOf(step('Setup Node.js'))
+    );
     expect(steps.indexOf(step('Setup Node.js'))).toBeLessThan(
-      steps.indexOf(step('Validate tag, versions, and source revision'))
+      steps.indexOf(step('Validate chart release coordinates'))
+    );
+    expect(steps.indexOf(step('Validate chart release coordinates'))).toBeLessThan(
+      steps.indexOf(step('Setup pnpm'))
     );
     expect(step('Setup pnpm').with.version).toBe('9.0.0');
     expect(step('Install dependencies').run).toBe(

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -108,7 +108,10 @@ describe('chart publication workflow integrity', () => {
   });
 
   it('installs Node and YAML dependencies before staging', () => {
-    expect(step('Setup Node.js').with['node-version']).toBe(20);
+    expect(step('Setup Node.js').with['node-version-file']).toBe('.nvmrc');
+    expect(steps.indexOf(step('Setup Node.js'))).toBeLessThan(
+      steps.indexOf(step('Validate tag, versions, and source revision'))
+    );
     expect(step('Setup pnpm').with.version).toBe('9.0.0');
     expect(step('Install dependencies').run).toBe(
       'pnpm install --frozen-lockfile --reporter=append-only'

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -44,7 +44,7 @@ describe('chart publication workflow integrity', () => {
     expect(release.run).toContain('"$source_sha" == "$tag_sha"');
   });
 
-  it('enforces strict matching versions and tombstones chart 3.0.1 before registry access', () => {
+  it('routes strict matching versions and the chart tombstone through the reusable gate before registry access', () => {
     const releaseIndex = steps.indexOf(
       step('Validate tag, versions, and source revision')
     );
@@ -52,10 +52,8 @@ describe('chart publication workflow integrity', () => {
       step('Refuse an existing chart coordinate (pre-package)')
     );
     expect(steps[releaseIndex].run).toContain(
-      '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
+      'check-release-consistency.mjs --verify-chart-local'
     );
-    expect(steps[releaseIndex].run).toContain('chart-v${chart_version}');
-    expect(steps[releaseIndex].run).toContain('chart_version" != "3.0.1');
     expect(releaseIndex).toBeLessThan(guardIndex);
   });
 

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -72,6 +72,8 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
 
   it('still publishes the immutable branch-SHA tag and the mutable branch convenience tag', () => {
     const tagsStep = findSteps(job).find((step) => step.id === 'tags');
+    expect(tagsStep.run).toContain('git rev-parse HEAD');
+    expect(tagsStep.run).toContain('git rev-parse --short=7 HEAD');
     expect(tagsStep.run).toMatch(/sha_tag=/);
     expect(tagsStep.run).toMatch(/latest_tag=/);
 
@@ -81,7 +83,22 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     for (const step of realPushSteps) {
       expect(step.with.tags).toContain('steps.tags.outputs.sha_tag');
       expect(step.with.tags).toContain('steps.tags.outputs.latest_tag');
+      expect(step.with['build-args']).toContain(
+        'GIT_SHA=${{ steps.tags.outputs.full_sha }}'
+      );
+      expect(step.with.labels).toContain(
+        'org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}'
+      );
     }
+  });
+
+  it('uses the checked-out commit rather than the dispatch event SHA', () => {
+    const serialized = JSON.stringify(job);
+    expect(serialized).not.toContain('GIT_SHA=${{ github.sha }}');
+    expect(serialized).not.toContain('VITE_GIT_SHA=${{ github.sha }}');
+    expect(
+      findSteps(job).find((step) => step.id === 'metadata').env.GIT_SHA
+    ).toBe('${{ steps.tags.outputs.full_sha }}');
   });
 
   it('keeps multi-arch publication for both supported architectures', () => {
@@ -140,6 +157,14 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
       steps.indexOf(named('Validate all local release coordinates'))
     );
     expect(JSON.stringify(job)).not.toContain('pnpm install');
+  });
+
+  it('pins Node before invoking the release consistency gate', () => {
+    const setup = findStepsUsing(job, 'actions/setup-node')[0];
+    expect(setup.with['node-version-file']).toBe('.nvmrc');
+    expect(steps.indexOf(setup)).toBeLessThan(
+      steps.indexOf(named('Validate all local release coordinates'))
+    );
   });
 
   it('uses the reusable gate for local, image, chart, and manifest validation', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -71,7 +71,14 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
   });
 
   it('still publishes the immutable branch-SHA tag and the mutable branch convenience tag', () => {
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    expect(checkout.with['persist-credentials']).toBe(false);
     const tagsStep = findSteps(job).find((step) => step.id === 'tags');
+    expect(tagsStep.env.SOURCE_BRANCH).toBe(
+      '${{ github.event.inputs.branch || github.ref_name }}'
+    );
+    expect(tagsStep.run).toContain('branch="$SOURCE_BRANCH"');
+    expect(tagsStep.run).not.toContain('${{ github.event.inputs.branch');
     expect(tagsStep.run).toContain('git rev-parse HEAD');
     expect(tagsStep.run).toContain('git rev-parse --short=7 HEAD');
     expect(tagsStep.run).toMatch(/sha_tag=/);

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -110,296 +110,109 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
   });
 });
 
-describe('ci-image.yml "semantic-release" job (release-only publish path)', () => {
+describe('ci-image.yml "semantic-release" job (release-only alias path)', () => {
   const job = workflow.jobs['semantic-release'];
+  const steps = findSteps(job);
+  const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('exists and is gated on a published release, not an ordinary push', () => {
-    expect(job).toBeTruthy();
+  it('is release-only and serialized by semantic tag', () => {
     expect(job.if).toBe(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
-  });
-
-  it('serializes semantic publication with a concurrency group keyed on the tag', () => {
-    expect(job.concurrency).toBeTruthy();
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
 
-  it('checks out the tagged commit explicitly rather than trusting the default ref', () => {
-    const checkoutStep = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkoutStep.with.ref).toContain('github.event.release.tag_name');
-  });
-
-  it('uses the checked-out git rev-parse HEAD as the source revision, never github.sha', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).toMatch(/git rev-parse HEAD/);
-    expect(serialized).not.toContain('${{ github.sha }}');
-  });
-
-  it('peels the release tag to its commit before comparing to HEAD', () => {
-    // "git rev-parse <tag>" alone resolves an annotated/signed tag's own object SHA, not
-    // the commit it points at, which would reject every legitimate release cut from such a
-    // tag even though checkout correctly left HEAD on the tagged commit. The "^{commit}"
-    // peeling suffix is required so both lightweight and annotated/signed tags compare
-    // correctly against HEAD.
-    const revisionStep = findSteps(job).find((step) => step.id === 'revision');
-    expect(revisionStep.run).toMatch(/\$\{RELEASE_TAG\}\^\{commit\}|\$RELEASE_TAG\^\{commit\}/);
-  });
-
-  it('never interpolates the attacker-influenceable release tag directly into a shell script', () => {
-    // Git tag names can contain shell metacharacters ("`, $(), ;). GitHub substitutes
-    // ${{ }} expressions into a run: script's source text before the shell parses it, so
-    // interpolating the raw tag there would let a crafted release tag execute commands with
-    // this job's packages:write/actions:write token. The tag may only reach a `run:` step by
-    // way of an `env:` var (assigned as data, not concatenated into the script) — never as a
-    // literal ${{ github.event.release.tag_name }} expression inside `run:` text. Using it as
-    // a structured action input (checkout's `ref:`, `concurrency.group`) is fine, since those
-    // aren't shell-interpolation contexts.
-    for (const step of findSteps(job)) {
-      if (typeof step.run !== 'string') {
-        continue;
-      }
-      expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
-      if (step.run.includes('RELEASE_TAG')) {
-        expect(step.env?.RELEASE_TAG).toBe(
-          '${{ github.event.release.tag_name }}'
-        );
-      }
-    }
-  });
-
-  it('validates the release tag against v<root package version> before any push', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    expect(versionStep.run).toMatch(/root_version/);
-    expect(versionStep.run).toMatch(/frontend_version/);
-    expect(versionStep.run).toMatch(/expected_tag="v\$\{root_version\}"/);
-    expect(versionStep.run).toMatch(/refusing to publish/);
-
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
+  it('authorizes the checked-out source before lifecycle execution', () => {
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    expect(checkout.with.ref).toContain('github.event.release.tag_name');
+    expect(checkout.with['persist-credentials']).toBe(false);
+    const authorization = named('Authorize release source');
+    expect(authorization.env.RELEASE_TAG).toContain('release.tag_name');
+    expect(authorization.run).toContain(
+      'git rev-parse "${RELEASE_TAG}^{commit}"'
     );
-    const versionIndex = stepIndex(job, (step) => step.id === 'version');
-    expect(versionIndex).toBeGreaterThanOrEqual(0);
-    expect(versionIndex).toBeLessThan(pushIndex);
+    expect(authorization.run).toContain('refs/remotes/origin/main');
+    expect(authorization.run).not.toContain(
+      '${{ github.event.release.tag_name }}'
+    );
+    expect(steps.indexOf(authorization)).toBeLessThan(
+      steps.indexOf(named('Validate all local release coordinates'))
+    );
+    expect(JSON.stringify(job)).not.toContain('pnpm install');
   });
 
-  it('validates package versions before emitting the version output', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    const validation = '[[ ! "$root_version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]';
-    expect(versionStep.run).toContain(validation);
-    expect(versionStep.run.indexOf(validation)).toBeLessThan(
-      versionStep.run.indexOf(
-        'echo "version=${root_version}" >> "$GITHUB_OUTPUT"'
-      )
-    );
-
-    const supportedVersion = /^[0-9]+\.[0-9]+\.[0-9]+$/;
-    expect(supportedVersion.test('3.1.0')).toBe(true);
-    for (const maliciousVersion of [
-      '3.1.$(touch /tmp/pwned)',
-      '3.1.`id`',
-      '3.1.0\nmalicious=value',
+  it('uses the reusable gate for local, image, chart, and manifest validation', () => {
+    for (const mode of [
+      '--verify-local',
+      '--verify-image',
+      '--verify-chart',
+      '--emit-manifest',
+      '--validate-manifest',
     ]) {
-      expect(supportedVersion.test(maliciousVersion)).toBe(false);
-    }
-  });
-
-  it('passes version-derived shell values through env instead of run expressions', () => {
-    const rawVersionExpression = '${{ steps.version.outputs.version }}';
-    for (const step of findSteps(job)) {
-      if (typeof step.run === 'string') {
-        expect(step.run).not.toContain(rawVersionExpression);
-      }
-    }
-
-    const expectedEnvReferences = [
-      ['tags', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      ['build_version', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      [undefined, 'RELEASE_VERSION', '"v${RELEASE_VERSION}"'],
-    ];
-    for (const [id, envName, shellReference] of expectedEnvReferences) {
-      const matchingSteps = findSteps(job).filter(
-        (step) =>
-          (id === undefined || step.id === id) &&
-          step.env?.[envName] === rawVersionExpression &&
-          step.run?.includes(shellReference)
-      );
-      expect(matchingSteps.length).toBeGreaterThan(0);
-    }
-
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.env.SEMANTIC_TAG).toBe(
-      '${{ steps.tags.outputs.semantic_tag }}'
-    );
-    expect(summaryStep.run).toContain('${RELEASE_VERSION}');
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
-    expect(summaryStep.run).toContain('${SEMANTIC_TAG}');
-
-    const semanticRegistrySteps = findSteps(job).filter((step) =>
-      step.run?.includes('--tag "v${RELEASE_VERSION}"')
-    );
-    expect(semanticRegistrySteps).toHaveLength(2);
-    for (const step of semanticRegistrySteps) {
-      expect(step.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    }
-  });
-
-  it('runs the semantic absence guard before publication, and fails closed', () => {
-    const guardIndex = stepIndex(job, (step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
-    );
-    expect(guardIndex).toBeGreaterThanOrEqual(0);
-    expect(pushIndex).toBeGreaterThan(guardIndex);
-  });
-
-  it('keeps multi-arch publication for both supported architectures', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps.length).toBeGreaterThan(0);
-    for (const step of pushSteps) {
-      expect(step.with.platforms).toBe('linux/amd64,linux/arm64');
-    }
-  });
-
-  it('contains exactly one semantic publication step that pushes only the semantic tag', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps).toHaveLength(1);
-    const [pushStep] = pushSteps;
-    expect(pushStep.name).toBe('Build and push semantic release image');
-    expect(pushStep.id).toBe('build_push');
-    expect(pushStep.with.tags).toBe('${{ steps.tags.outputs.semantic_tag }}');
-    expect(pushStep.with.tags).not.toContain('branch_sha_tag');
-    expect(pushStep.with.tags).not.toMatch(/latest/);
-    expect(pushStep['continue-on-error']).toBeUndefined();
-  });
-
-  it('has no second-attempt or retry path for semantic publication', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).not.toMatch(/attempt 1|attempt 2|retry/i);
-    expect(serialized).not.toContain('build_push_1');
-    expect(serialized).not.toContain('build_push_2');
-    expect(serialized).not.toMatch(/outcome == 'failure'/);
-  });
-
-  it('completes local image verification before the sole semantic publication', () => {
-    const steps = findSteps(job);
-    const pushIndex = steps.findIndex(
-      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
-    );
-    const verificationBuildIndex = steps.findIndex(
-      (step) => step.name === 'Build image for SHA verification'
-    );
-    const shaAssertionIndex = steps.findIndex(
-      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
-    );
-    const chatStampIndex = steps.findIndex(
-      (step) => step.name === 'Verify chat build stamp inside image'
-    );
-
-    expect(verificationBuildIndex).toBeGreaterThanOrEqual(0);
-    expect(shaAssertionIndex).toBeGreaterThan(verificationBuildIndex);
-    expect(chatStampIndex).toBeGreaterThan(shaAssertionIndex);
-    expect(pushIndex).toBeGreaterThan(chatStampIndex);
-
-    for (const index of [verificationBuildIndex, shaAssertionIndex, chatStampIndex]) {
-      expect(steps[index].if).toBeUndefined();
-      expect(steps[index]['continue-on-error']).toBeUndefined();
-    }
-
-    expect(steps[verificationBuildIndex].with['build-args']).toBe(steps[pushIndex].with['build-args']);
-    expect(steps[verificationBuildIndex].with.labels).toBe(steps[pushIndex].with.labels);
-  });
-
-  it('lets publication failure terminate the job without conditional recovery', () => {
-    const pushStep = findStepsUsing(job, 'docker/build-push-action').find(
-      (step) => step.with?.push === true
-    );
-    expect(pushStep).toBeTruthy();
-    expect(pushStep.if).toBeUndefined();
-    expect(pushStep['continue-on-error']).toBeUndefined();
-    const laterSteps = findSteps(job).slice(
-      findSteps(job).indexOf(pushStep) + 1
-    );
-    for (const step of laterSteps) {
-      expect(step.if ?? '').not.toMatch(
-        /failure\(\)|outcome == 'failure'|always\(\)/
+      expect(JSON.stringify(job)).toContain(
+        `check-release-consistency.mjs ${mode}`
       );
     }
+    expect(
+      steps.indexOf(named('Verify immutable image provenance'))
+    ).toBeLessThan(steps.indexOf(named('Verify published chart provenance')));
+    expect(
+      steps.indexOf(named('Verify published chart provenance'))
+    ).toBeLessThan(steps.indexOf(named('Publish semantic alias exactly once')));
   });
 
-  it('verifies and summarizes the branch-SHA coordinate without pushing it', () => {
-    const branchDescribeStep = findSteps(job).find(
-      (step) => step.id === 'branch_sha_evidence'
-    );
-    expect(branchDescribeStep).toBeTruthy();
-    expect(branchDescribeStep.run).toContain('ghcr-manifest.mjs describe');
-    expect(branchDescribeStep.run).toContain('steps.branch.outputs.branch');
-    expect(branchDescribeStep.run).toContain(
-      'steps.revision.outputs.short_sha'
-    );
+  it('checks semantic absence twice and immediately before one bounded alias mutation', () => {
+    const guards = steps.filter((step) => step.run?.includes('--pre-semantic'));
+    expect(guards).toHaveLength(2);
+    const alias = named('Publish semantic alias exactly once');
+    expect(steps.indexOf(guards[1])).toBe(steps.indexOf(alias) - 1);
+    expect(alias.run.match(/docker buildx imagetools create/g)).toHaveLength(1);
+    expect(alias.run).toContain('@${IMAGE_DIGEST}');
+    expect(JSON.stringify(job)).not.toContain('docker/build-push-action');
+    expect(JSON.stringify(job)).not.toContain('docker build ');
+  });
 
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
+  it('verifies semantic digest equality after publication', () => {
+    const verify = named('Verify semantic alias digest equality');
+    expect(verify.env.EXPECTED_IMAGE_DIGEST).toBe(
+      '${{ steps.immutable_image.outputs.indexDigest }}'
     );
-    for (const step of pushSteps) {
-      expect(JSON.stringify(step.with)).not.toContain('branch_sha_tag');
+    expect(steps.indexOf(verify)).toBeGreaterThan(
+      steps.indexOf(named('Publish semantic alias exactly once'))
+    );
+  });
+
+  it('uploads a deterministic validated manifest with a pinned action', () => {
+    const emit = named('Emit and validate release manifest');
+    expect(emit.env.RELEASE_MANIFEST_PATH).toBe('dspace-release-manifest.json');
+    const upload = named('Upload release manifest');
+    expect(upload.uses).toMatch(/^actions\/upload-artifact@[0-9a-f]{40}$/);
+    expect(upload.with.name).toBe('dspace-release-manifest');
+    expect(upload.with.path).toBe('dspace-release-manifest.json');
+    expect(steps.indexOf(upload)).toBeGreaterThan(steps.indexOf(emit));
+  });
+
+  it('summarizes full immutable source, image, platform, chart, and manifest evidence', () => {
+    const summary = named('Write complete release evidence');
+    for (const field of [
+      'Full source SHA',
+      'Immutable image',
+      'linux/amd64 manifest',
+      'linux/arm64 manifest',
+      'Immutable chart',
+      'Release manifest artifact',
+    ]) {
+      expect(summary.run).toContain(field);
     }
-
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
+    expect(summary.run).not.toMatch(/password|GITHUB_TOKEN/i);
   });
 
-  it('records the required evidence in the workflow summary without leaking credentials', () => {
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep).toBeTruthy();
-    const summary = summaryStep.run as string;
-    expect(summary).toMatch(/Semantic version/);
-    expect(summary).toMatch(/Full Git SHA/);
-    expect(summary).toMatch(/Immutable branch-SHA tag/);
-    expect(summary).toMatch(/Semantic tag/);
-    expect(summary).toMatch(/Image index digest/);
-    expect(summary).toMatch(/linux\/amd64 digest/);
-    expect(summary).toMatch(/linux\/arm64 digest/);
-    expect(summary).not.toMatch(/GITHUB_TOKEN/);
-    expect(summary).not.toMatch(/password/i);
-  });
-
-  it('passes registry credentials only through env, never inline in a run script', () => {
-    const guardStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const evidenceStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs describe')
-    );
-    for (const step of [guardStep, evidenceStep]) {
-      expect(step.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
-      expect(step.run).not.toContain('secrets.GITHUB_TOKEN');
+  it('passes event-controlled strings and credentials as environment data', () => {
+    for (const step of steps) {
+      if (!step.run) continue;
+      expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
+      expect(step.run).not.toContain('${{ secrets.GITHUB_TOKEN }}');
     }
   });
 });

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -304,8 +304,12 @@ describe('release artifact provenance inspection', () => {
   function imageFetch(
     options: {
       missingArm?: boolean;
+      duplicateArchitecture?: 'amd64' | 'arm64';
       mismatchedAmdDigest?: boolean;
+      wrongAmdRevision?: boolean;
       wrongArmRevision?: boolean;
+      malformedChild?: 'amd64' | 'arm64';
+      malformedBlob?: 'amd64' | 'arm64';
       absent?: boolean;
     } = {}
   ) {
@@ -329,12 +333,18 @@ describe('release artifact provenance inspection', () => {
                     },
                   ]
                 : []),
+              ...(options.duplicateArchitecture ? [{
+                platform: { os: 'linux', architecture: options.duplicateArchitecture },
+                digest: validDigest('8'),
+              }] : []),
             ],
           },
           { 'docker-content-digest': indexDigest }
         );
       }
-      if (url.endsWith(`/manifests/${encodeURIComponent(amd64Digest)}`))
+      if (url.endsWith(`/manifests/${encodeURIComponent(amd64Digest)}`)) {
+        if (options.malformedChild === 'amd64')
+          return malformedJsonResponse(200, { 'docker-content-digest': amd64Digest });
         return jsonResponse(
           200,
           { config: { digest: amd64Config } },
@@ -344,17 +354,25 @@ describe('release artifact provenance inspection', () => {
               : amd64Digest,
           }
         );
-      if (url.endsWith(`/manifests/${encodeURIComponent(arm64Digest)}`))
+      }
+      if (url.endsWith(`/manifests/${encodeURIComponent(arm64Digest)}`)) {
+        if (options.malformedChild === 'arm64')
+          return malformedJsonResponse(200, { 'docker-content-digest': arm64Digest });
         return jsonResponse(
           200,
           { config: { digest: arm64Config } },
           { 'docker-content-digest': arm64Digest }
         );
-      if (url.endsWith(`/blobs/${amd64Config}`))
+      }
+      if (url.endsWith(`/blobs/${amd64Config}`)) {
+        if (options.malformedBlob === 'amd64') return malformedJsonResponse(200);
         return jsonResponse(200, {
-          config: { Labels: { 'org.opencontainers.image.revision': revision } },
+          config: { Labels: { 'org.opencontainers.image.revision':
+            options.wrongAmdRevision ? 'f'.repeat(40) : revision } },
         });
-      if (url.endsWith(`/blobs/${arm64Config}`))
+      }
+      if (url.endsWith(`/blobs/${arm64Config}`)) {
+        if (options.malformedBlob === 'arm64') return malformedJsonResponse(200);
         return jsonResponse(200, {
           config: {
             Labels: {
@@ -364,6 +382,7 @@ describe('release artifact provenance inspection', () => {
             },
           },
         });
+      }
       throw new Error(`Unexpected fixture URL ${url}`);
     };
   }
@@ -423,6 +442,33 @@ describe('release artifact provenance inspection', () => {
         fetchImpl: imageFetch({ mismatchedAmdDigest: true }),
       })
     ).rejects.toMatchObject({ code: 'digest-mismatch' });
+  });
+
+  it.each(['amd64', 'arm64'] as const)('rejects duplicate linux/%s descriptors', async (architecture) => {
+    await expect(inspectImage({
+      owner: 'o', repo: 'r', tag: 'main-0123456', username: 'u',
+      password: SECRET_PASSWORD, revision, // scan-secrets: ignore
+      fetchImpl: imageFetch({ duplicateArchitecture: architecture }),
+    })).rejects.toMatchObject({ code: 'missing-platform' });
+  });
+
+  it.each(['amd64', 'arm64'] as const)('rejects a wrong revision on linux/%s', async (architecture) => {
+    await expect(inspectImage({
+      owner: 'o', repo: 'r', tag: 'main-0123456', username: 'u',
+      password: SECRET_PASSWORD, revision, // scan-secrets: ignore
+      fetchImpl: imageFetch(architecture === 'amd64'
+        ? { wrongAmdRevision: true } : { wrongArmRevision: true }),
+    })).rejects.toMatchObject({ code: 'revision-mismatch' });
+  });
+
+  it.each([
+    ['child manifest', { malformedChild: 'amd64' as const }],
+    ['config blob', { malformedBlob: 'arm64' as const }],
+  ])('fails closed on a malformed %s response', async (_label, options) => {
+    await expect(inspectImage({
+      owner: 'o', repo: 'r', tag: 'main-0123456', username: 'u',
+      password: SECRET_PASSWORD, revision, fetchImpl: imageFetch(options), // scan-secrets: ignore
+    })).rejects.toMatchObject({ code: 'malformed' });
   });
 
   it('requires chart version, appVersion, revision, and immutable digest', async () => {

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -5,8 +5,12 @@ import {
   describeManifest,
   fetchGhcrToken,
   getManifest,
+  inspectChart,
+  inspectImage,
   parseArgs,
 } from '../scripts/ghcr-manifest.mjs';
+
+const validDigest = (character: string) => `sha256:${character.repeat(64)}`;
 
 const SECRET_PASSWORD = 'super-secret-token-value-do-not-leak'; // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
 
@@ -281,6 +285,170 @@ describe('describeManifest', () => {
     ]],
   ])('fails closed when %s', async (_description, manifests) => {
     await expect(describeWith(manifests)).rejects.toMatchObject({ code: 'missing-platform' });
+  });
+});
+
+describe('release artifact provenance inspection', () => {
+  const revision = '0123456789abcdef0123456789abcdef01234567';
+  const indexDigest = validDigest('1');
+  const amd64Digest = validDigest('2');
+  const arm64Digest = validDigest('3');
+  const amd64Config = validDigest('4');
+  const arm64Config = validDigest('5');
+  const token = jsonResponse(200, { token: 'fixture-token' }); // scan-secrets: ignore
+
+  function imageFetch(
+    options: {
+      missingArm?: boolean;
+      wrongArmRevision?: boolean;
+      absent?: boolean;
+    } = {}
+  ) {
+    return async (url: string) => {
+      if (url.includes('/token')) return token;
+      if (url.endsWith('/manifests/main-0123456')) {
+        if (options.absent) return jsonResponse(404, {});
+        return jsonResponse(
+          200,
+          {
+            manifests: [
+              {
+                platform: { os: 'linux', architecture: 'amd64' },
+                digest: amd64Digest,
+              },
+              ...(!options.missingArm
+                ? [
+                    {
+                      platform: { os: 'linux', architecture: 'arm64' },
+                      digest: arm64Digest,
+                    },
+                  ]
+                : []),
+            ],
+          },
+          { 'docker-content-digest': indexDigest }
+        );
+      }
+      if (url.endsWith(`/manifests/${encodeURIComponent(amd64Digest)}`))
+        return jsonResponse(
+          200,
+          { config: { digest: amd64Config } },
+          { 'docker-content-digest': amd64Digest }
+        );
+      if (url.endsWith(`/manifests/${encodeURIComponent(arm64Digest)}`))
+        return jsonResponse(
+          200,
+          { config: { digest: arm64Config } },
+          { 'docker-content-digest': arm64Digest }
+        );
+      if (url.endsWith(`/blobs/${amd64Config}`))
+        return jsonResponse(200, {
+          config: { Labels: { 'org.opencontainers.image.revision': revision } },
+        });
+      if (url.endsWith(`/blobs/${arm64Config}`))
+        return jsonResponse(200, {
+          config: {
+            Labels: {
+              'org.opencontainers.image.revision': options.wrongArmRevision
+                ? 'f'.repeat(40)
+                : revision,
+            },
+          },
+        });
+      throw new Error(`Unexpected fixture URL ${url}`);
+    };
+  }
+
+  it('requires the immutable image and both correctly labelled platforms', async () => {
+    await expect(
+      inspectImage({
+        owner: 'o',
+        repo: 'r',
+        tag: 'main-0123456',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        revision,
+        fetchImpl: imageFetch(),
+      })
+    ).resolves.toEqual({ indexDigest, amd64Digest, arm64Digest }); // scan-secrets: ignore
+    await expect(
+      inspectImage({
+        owner: 'o',
+        repo: 'r',
+        tag: 'main-0123456',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        revision,
+        fetchImpl: imageFetch({ absent: true }),
+      })
+    ).rejects.toMatchObject({ code: 'missing' }); // scan-secrets: ignore
+    await expect(
+      inspectImage({
+        owner: 'o',
+        repo: 'r',
+        tag: 'main-0123456',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        revision,
+        fetchImpl: imageFetch({ missingArm: true }),
+      })
+    ).rejects.toMatchObject({ code: 'missing-platform' }); // scan-secrets: ignore
+    await expect(
+      inspectImage({
+        owner: 'o',
+        repo: 'r',
+        tag: 'main-0123456',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        revision,
+        fetchImpl: imageFetch({ wrongArmRevision: true }),
+      })
+    ).rejects.toMatchObject({ code: 'revision-mismatch' }); // scan-secrets: ignore
+  });
+
+  it('requires chart version, appVersion, revision, and immutable digest', async () => {
+    const configDigest = validDigest('6');
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/token')) return token;
+      if (url.includes('/manifests/4.2.0'))
+        return jsonResponse(
+          200,
+          {
+            config: { digest: configDigest },
+            annotations: { 'org.opencontainers.image.revision': revision },
+          },
+          { 'docker-content-digest': validDigest('7') }
+        );
+      if (url.endsWith(`/blobs/${configDigest}`))
+        return jsonResponse(200, { version: '4.2.0', appVersion: '3.1.0' });
+      throw new Error(`Unexpected fixture URL ${url}`);
+    };
+    await expect(
+      inspectChart({
+        owner: 'o',
+        repo: 'charts/dspace',
+        tag: '4.2.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        version: '4.2.0',
+        appVersion: '3.1.0',
+        revision,
+        fetchImpl,
+      })
+    ).resolves.toEqual({ digest: validDigest('7') }); // scan-secrets: ignore
+    await expect(
+      inspectChart({
+        owner: 'o',
+        repo: 'charts/dspace',
+        tag: '4.2.0',
+        username: 'u',
+        password: SECRET_PASSWORD, // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
+        version: '4.2.1',
+        appVersion: '3.1.0',
+        revision,
+        fetchImpl,
+      })
+    ).rejects.toMatchObject({ code: 'version-mismatch' }); // scan-secrets: ignore
   });
 });
 

--- a/tests/ghcrManifestGuard.test.ts
+++ b/tests/ghcrManifestGuard.test.ts
@@ -68,12 +68,16 @@ const okToken = jsonResponse(200, { token: 'fake-bearer-token' }); // scan-secre
 describe('fetchGhcrToken', () => {
   it('throws a network GhcrGuardError when the request fails', async () => {
     const fetchImpl = async () => {
-      throw new Error('getaddrinfo ENOTFOUND ghcr.io');
+      throw new Error(`request failed with password ${SECRET_PASSWORD}`);
     };
 
     await expect(
       fetchGhcrToken({ owner: 'o', repo: 'r', username: 'u', password: SECRET_PASSWORD, fetchImpl }) // scan-secrets: ignore (fixture/env credential plumbing; no real secret literal)
-    ).rejects.toMatchObject({ code: 'network' });
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toMatchObject({ code: 'network' });
+      expect((error as Error).message).not.toContain(SECRET_PASSWORD);
+      return true;
+    });
   });
 
   it('classifies a 401 as an auth failure and never leaks the password', async () => {
@@ -300,6 +304,7 @@ describe('release artifact provenance inspection', () => {
   function imageFetch(
     options: {
       missingArm?: boolean;
+      mismatchedAmdDigest?: boolean;
       wrongArmRevision?: boolean;
       absent?: boolean;
     } = {}
@@ -333,7 +338,11 @@ describe('release artifact provenance inspection', () => {
         return jsonResponse(
           200,
           { config: { digest: amd64Config } },
-          { 'docker-content-digest': amd64Digest }
+          {
+            'docker-content-digest': options.mismatchedAmdDigest
+              ? validDigest('9')
+              : amd64Digest,
+          }
         );
       if (url.endsWith(`/manifests/${encodeURIComponent(arm64Digest)}`))
         return jsonResponse(
@@ -406,6 +415,16 @@ describe('release artifact provenance inspection', () => {
     ).rejects.toMatchObject({ code: 'revision-mismatch' }); // scan-secrets: ignore
   });
 
+  it('rejects a platform manifest whose authoritative digest differs from its descriptor', async () => {
+    await expect(
+      inspectImage({
+        owner: 'o', repo: 'r', tag: 'main-0123456', username: 'u',
+        password: SECRET_PASSWORD, revision, // scan-secrets: ignore
+        fetchImpl: imageFetch({ mismatchedAmdDigest: true }),
+      })
+    ).rejects.toMatchObject({ code: 'digest-mismatch' });
+  });
+
   it('requires chart version, appVersion, revision, and immutable digest', async () => {
     const configDigest = validDigest('6');
     const fetchImpl = async (url: string) => {
@@ -449,6 +468,43 @@ describe('release artifact provenance inspection', () => {
         fetchImpl,
       })
     ).rejects.toMatchObject({ code: 'version-mismatch' }); // scan-secrets: ignore
+  });
+
+  it.each([
+    ['missing chart', 'missing', 'missing'],
+    ['wrong appVersion', 'appVersion', 'version-mismatch'],
+    ['wrong revision', 'revision', 'revision-mismatch'],
+    ['malformed artifact digest', 'digest', 'malformed'],
+    ['malformed config response', 'config', 'malformed'],
+  ])('fails closed for a %s', async (_description, fault, code) => {
+    const configDigest = validDigest('6');
+    const fetchImpl = async (url: string) => {
+      if (url.includes('/token')) return token;
+      if (url.includes('/manifests/4.2.0')) {
+        if (fault === 'missing') return jsonResponse(404, {});
+        return jsonResponse(
+          200,
+          {
+            config: { digest: fault === 'config' ? 'invalid' : configDigest },
+            annotations: {
+              'org.opencontainers.image.revision': fault === 'revision' ? 'f'.repeat(40) : revision,
+            },
+          },
+          { 'docker-content-digest': fault === 'digest' ? 'invalid' : validDigest('7') }
+        );
+      }
+      if (url.endsWith(`/blobs/${configDigest}`))
+        return jsonResponse(200, {
+          version: '4.2.0',
+          appVersion: fault === 'appVersion' ? '3.1.1' : '3.1.0',
+        });
+      throw new Error(`Unexpected fixture URL ${url}`);
+    };
+    await expect(inspectChart({
+      owner: 'o', repo: 'charts/dspace', tag: '4.2.0', username: 'u',
+      password: SECRET_PASSWORD, version: '4.2.0', appVersion: '3.1.0', // scan-secrets: ignore
+      revision, fetchImpl,
+    })).rejects.toMatchObject({ code });
   });
 });
 

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -1,0 +1,152 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  readLocalCoordinates,
+  releaseManifest,
+  validateImageTag,
+  validateReleaseSource,
+} from '../scripts/check-release-consistency.mjs';
+
+const sha = '0123456789abcdef0123456789abcdef01234567';
+const digest = (value: string) => `sha256:${value.repeat(64)}`;
+
+function coordinateTree(run: (root: string) => void) {
+  const root = mkdtempSync(join(tmpdir(), 'release-coordinates-'));
+  mkdirSync(join(root, 'frontend'), { recursive: true });
+  mkdirSync(join(root, 'charts/dspace'), { recursive: true });
+  mkdirSync(join(root, 'docs/apps'), { recursive: true });
+  const json = (path: string, value: unknown) =>
+    writeFileSync(join(root, path), `${JSON.stringify(value)}\n`);
+  json('package.json', { version: '3.1.0' });
+  json('frontend/package.json', { version: '3.1.0' });
+  json('package-lock.json', {
+    version: '3.1.0',
+    packages: { '': { version: '3.1.0' } },
+  });
+  writeFileSync(
+    join(root, 'charts/dspace/Chart.yaml'),
+    'version: 4.2.0\nappVersion: "3.1.0"\n'
+  );
+  writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.0\n');
+  try {
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('release coordinate consistency', () => {
+  it('accepts independently versioned application and chart coordinates', () =>
+    coordinateTree((root) =>
+      expect(readLocalCoordinates(root)).toEqual({
+        applicationVersion: '3.1.0',
+        chartVersion: '4.2.0',
+      })
+    ));
+
+  it.each([
+    ['frontend/package.json', { version: '3.1.1' }, 'frontend package version'],
+    [
+      'package-lock.json',
+      { version: '3.1.1', packages: { '': { version: '3.1.0' } } },
+      'lockfile version',
+    ],
+  ])('rejects metadata mismatch in %s', (path, body, message) =>
+    coordinateTree((root) => {
+      writeFileSync(join(root, path), JSON.stringify(body));
+      expect(() => readLocalCoordinates(root)).toThrow(message);
+    })
+  );
+
+  it('rejects chart appVersion and documented chart drift', () =>
+    coordinateTree((root) => {
+      writeFileSync(
+        join(root, 'charts/dspace/Chart.yaml'),
+        'version: 4.2.0\nappVersion: "3.1.1"\n'
+      );
+      expect(() => readLocalCoordinates(root)).toThrow('chart appVersion');
+    }));
+
+  it('emits stable canonical manifest JSON data', () => {
+    const input = {
+      applicationVersion: '3.1.0',
+      sourceRevision: sha,
+      imageTag: 'main-0123456',
+      imageDigest: digest('1'),
+      chartVersion: '4.2.0',
+      chartDigest: digest('2'),
+      semanticTag: 'v3.1.0',
+    };
+    expect(JSON.stringify(releaseManifest(input))).toBe(
+      JSON.stringify(releaseManifest(input))
+    );
+    expect(releaseManifest(input)).toMatchObject({
+      imageTag: 'main-0123456',
+      chartVersion: '4.2.0',
+    });
+  });
+
+  it.each(['v3.1.0', 'main-latest', 'feature-0123456', 'main-short'])(
+    'rejects mutable or malformed deployment tag %s',
+    (tag) => {
+      expect(() => validateImageTag(tag, sha)).toThrow();
+    }
+  );
+
+  it.each([
+    ['imageDigest', 'sha256:nope'],
+    ['chartDigest', digest('g')],
+    ['semanticTag', 'v3.1.1'],
+  ])('rejects malformed or mismatched manifest field %s', (field, value) => {
+    const input: any = {
+      applicationVersion: '3.1.0',
+      sourceRevision: sha,
+      imageTag: 'main-0123456',
+      imageDigest: digest('1'),
+      chartVersion: '4.2.0',
+      chartDigest: digest('2'),
+      semanticTag: 'v3.1.0',
+    };
+    input[field] = value;
+    expect(() => releaseManifest(input)).toThrow();
+  });
+
+  it('peels annotated tags and rejects a tag/commit mismatch', () =>
+    coordinateTree((root) => {
+      const git = (...args: string[]) =>
+        execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+      git('init', '-q');
+      git('config', 'user.name', 'Test');
+      git('config', 'user.email', 'test@example.invalid');
+      git('add', '.');
+      git('commit', '-qm', 'release');
+      const approved = git('rev-parse', 'HEAD');
+      git('tag', '-a', 'v3.1.0', '-m', 'application release');
+      git('tag', '-a', 'chart-v4.2.0', '-m', 'chart release');
+      git('update-ref', 'refs/remotes/origin/main', approved);
+      expect(
+        validateReleaseSource({
+          root,
+          releaseTag: 'v3.1.0',
+          chartTag: 'chart-v4.2.0',
+          sourceRevision: approved,
+          branch: 'main',
+        }).sourceRevision
+      ).toBe(approved);
+      writeFileSync(join(root, 'new'), 'new');
+      git('add', 'new');
+      git('commit', '-qm', 'later');
+      expect(() =>
+        validateReleaseSource({
+          root,
+          releaseTag: 'v3.1.0',
+          chartTag: 'chart-v4.2.0',
+          sourceRevision: git('rev-parse', 'HEAD'),
+          branch: 'main',
+        })
+      ).toThrow('release tag');
+    }));
+});

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  assertExpectedDigest,
   readLocalCoordinates,
   releaseManifest,
   validateImageTag,
@@ -92,13 +93,26 @@ describe('release coordinate consistency', () => {
       chartDigest: digest('2'),
       semanticTag: 'v3.1.0',
     };
-    expect(JSON.stringify(releaseManifest(input))).toBe(
-      JSON.stringify(releaseManifest(input))
-    );
-    expect(releaseManifest(input)).toMatchObject({
+    expect(releaseManifest(input)).toEqual({
+      schemaVersion: 1,
+      app: 'dspace',
+      applicationVersion: '3.1.0',
+      sourceRevision: sha,
       imageTag: 'main-0123456',
+      imageDigest: digest('1'),
       chartVersion: '4.2.0',
+      chartDigest: digest('2'),
+      semanticTag: 'v3.1.0',
     });
+    expect(releaseManifest(JSON.parse(JSON.stringify(input)))).toEqual(releaseManifest(input));
+  });
+
+  it.each([
+    'semantic and immutable image index digests differ',
+    'published chart digest does not equal the push result',
+  ])('rejects digest evidence mismatches: %s', (message) => {
+    expect(() => assertExpectedDigest(digest('1'), digest('2'), message)).toThrow(message);
+    expect(() => assertExpectedDigest(digest('1'), digest('1'), message)).not.toThrow();
   });
 
   it.each(['v3.1.0', 'main-latest', 'feature-0123456', 'main-short'])(
@@ -151,6 +165,14 @@ describe('release coordinate consistency', () => {
       writeFileSync(join(root, 'new'), 'new');
       git('add', 'new');
       git('commit', '-qm', 'later');
+      const later = git('rev-parse', 'HEAD');
+      git('tag', '-f', 'chart-v4.2.0', later);
+      git('checkout', '-q', approved);
+      expect(() => validateReleaseSource({
+        root, releaseTag: 'v3.1.0', chartTag: 'chart-v4.2.0',
+        sourceRevision: approved, branch: 'main',
+      })).toThrow('chart release tag does not peel');
+      git('checkout', '-q', later);
       expect(() =>
         validateReleaseSource({
           root,

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -48,11 +48,17 @@ describe('release coordinate consistency', () => {
     ));
 
   it.each([
+    ['package.json', { version: 'not-semver' }, 'root package version'],
     ['frontend/package.json', { version: '3.1.1' }, 'frontend package version'],
     [
       'package-lock.json',
       { version: '3.1.1', packages: { '': { version: '3.1.0' } } },
       'lockfile version',
+    ],
+    [
+      'package-lock.json',
+      { version: '3.1.0', packages: { '': { version: '3.1.1' } } },
+      'lockfile root version',
     ],
   ])('rejects metadata mismatch in %s', (path, body, message) =>
     coordinateTree((root) => {
@@ -61,13 +67,19 @@ describe('release coordinate consistency', () => {
     })
   );
 
-  it('rejects chart appVersion and documented chart drift', () =>
+  it('rejects chart appVersion drift', () =>
     coordinateTree((root) => {
       writeFileSync(
         join(root, 'charts/dspace/Chart.yaml'),
         'version: 4.2.0\nappVersion: "3.1.1"\n'
       );
       expect(() => readLocalCoordinates(root)).toThrow('chart appVersion');
+    }));
+
+  it('rejects documented chart-version drift', () =>
+    coordinateTree((root) => {
+      writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.1\n');
+      expect(() => readLocalCoordinates(root)).toThrow('documented chart version');
     }));
 
   it('emits stable canonical manifest JSON data', () => {
@@ -148,5 +160,26 @@ describe('release coordinate consistency', () => {
           branch: 'main',
         })
       ).toThrow('release tag');
+    }));
+
+  it.each([
+    ['release tag', 'v3.1.1', 'chart-v4.2.0'],
+    ['chart release tag', 'v3.1.0', 'chart-v4.2.1'],
+  ])('rejects a %s/version mismatch', (message, releaseTag, chartTag) =>
+    coordinateTree((root) => {
+      const git = (...args: string[]) =>
+        execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+      git('init', '-q');
+      git('config', 'user.name', 'Test');
+      git('config', 'user.email', 'test@example.invalid');
+      git('add', '.');
+      git('commit', '-qm', 'release');
+      const approved = git('rev-parse', 'HEAD');
+      git('tag', releaseTag);
+      git('tag', chartTag);
+      git('update-ref', 'refs/remotes/origin/main', approved);
+      expect(() => validateReleaseSource({
+        root, releaseTag, chartTag, sourceRevision: approved, branch: 'main',
+      })).toThrow(message);
     }));
 });


### PR DESCRIPTION
### Motivation

- Address [#4730](https://github.com/democratizedspace/dspace/issues/4730) by proving that every release coordinate refers to one approved source commit.
- Close the release-integrity gaps identified in the [2026-07-23 production version-drift postmortem](https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md).
- Provide one reusable, fail-closed gate instead of duplicating release policy across workflow YAML.

### Summary

- Add `scripts/check-release-consistency.mjs` with deterministic local-fixture, source-coordinate, registry-evidence, digest-comparison, manifest-emission, and manifest-validation modes.
- Extend `scripts/ghcr-manifest.mjs` to inspect OCI image indexes, required `linux/amd64` and `linux/arm64` manifests, platform configuration labels, and Helm OCI metadata.
- Make ordinary image publication derive immutable seven-character branch-SHA tags and provenance from the checked-out commit, with persisted checkout credentials disabled and event-controlled branch names passed as environment data.
- Replace semantic image rebuilding with one bounded `docker buildx imagetools create` alias from the approved immutable `tag@digest`, followed immediately by exact index-digest verification.
- Preserve the Helm workflow’s two fail-closed coordinate-absence checks and single push, then verify the published chart version, `appVersion`, source revision, and OCI digest.
- Emit and validate `dspace-release-manifest.json`, upload it through an immutable action SHA, and record the full source, image-index, platform, and chart digests in the workflow summary.
- Document the ordered full-release contract and add deterministic source, workflow, registry, provenance, digest, and manifest regression coverage.

### Release invariants

A full release now requires all of the following:

- The release tag `v<applicationVersion>` peels to the approved full source SHA.
- The approved commit is reachable from `main` or `v3`.
- Root, frontend, lockfile, and chart application metadata agree on a strict application SemVer.
- `Chart.yaml:version` independently agrees with `docs/apps/dspace.version`.
- `chart-v<chartVersion>` peels to the same approved source SHA.
- The deployment image coordinate is the immutable `<branch>-<seven-character-sha>` tag.
- The immutable image index contains exactly one required manifest for each supported platform, and both configuration labels identify the approved full SHA.
- The published chart metadata and digest identify the approved application, chart version, and source SHA.
- Existing semantic image and chart coordinates cannot be overwritten.
- The semantic image tag is human-readable evidence only; deployments and release manifests continue to use the immutable branch-SHA coordinate.

The fail-closed publication order is:

1. Publish and verify the immutable branch-SHA image.
2. Publish and verify the immutable chart from the same commit.
3. Publish the GitHub release, create and verify the semantic digest alias, and emit the combined manifest.

Publishing the GitHub release before an immutable prerequisite exists fails without creating the semantic coordinate. The failed workflow can be rerun after supplying the missing prerequisite.

### Release manifest

The deterministic `dspace-release-manifest/dspace-release-manifest.json` artifact records:

- `schemaVersion`
- `app`
- `applicationVersion`
- `sourceRevision`
- `imageTag`
- `imageDigest`
- `chartVersion`
- `chartDigest`
- `semanticTag`

It intentionally excludes deployment environment, approver, runtime, promotion, and credentials.

### Verification

Verified on latest head `14ba940eee5d3e85b79a43bc73dbda0d6a723360`:

- `bash scripts/check-dspace-chart-version.sh` — passed.
- `node scripts/check-release-consistency.mjs --verify-local-fixtures` — passed.
- `npm run test:root -- tests/releaseConsistency.test.ts tests/ghcrManifestGuard.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts tests/helmChartReleaseVersion.test.ts` — passed during remediation.
- `npm run lint` — passed.
- `npm run type-check` — passed.
- `npm run build` — passed.
- `node scripts/link-check.mjs` — passed.
- `git diff --check` — passed.
- All latest-head GitHub workflows completed successfully: `ci-sentinel`, `link-check`, `Build and publish GHCR image`, `tests`, `Build & Publish Container`, and `CI`.
- The local `npm run test:ci` invocation was stopped during its long comprehensive phase; the equivalent latest-head GitHub CI completed successfully.
- `git diff 40b53727a95089937dd795b3b0b339a597693c43...HEAD | python3 scripts/scan-secrets.py` reported the existing annotated `GHCR_GUARD_PASSWORD` workflow environment plumbing; no newly introduced literal credential was identified.
- `actionlint` was unavailable in the remediation environment.

### Scope and operational follow-up

- No application behavior, application/chart version, chart template/default, release tag, GitHub release, GHCR artifact, or deployment state was changed.
- Development and testing did not create, move, overwrite, or publish external release coordinates.
- Keep #4730 open until a genuine ordered release run uploads the manifest and independently confirms that its source SHA and image/chart digests match the published OCI evidence and workflow summaries.

Refs #4730

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6472104ef0832f8224adff20018e1c)