### PR TITLE
ci: add fail-closed full release consistency gate (Refs #4730)

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -22,6 +22,19 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate tag, versions, and source revision
+        id: release
+        env:
+          CHART_TAG: ${{ github.ref_name }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          source_sha="$(git rev-parse HEAD)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match triggering event" >&2; exit 1; }
+          node scripts/check-release-consistency.mjs --mode chart-pre --chart-tag "$CHART_TAG" --source-sha "$source_sha"
+          [[ "$(cat docs/apps/dspace.version)" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -35,28 +48,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --reporter=append-only
-
-      - name: Validate tag, versions, and source revision
-        id: release
-        env:
-          CHART_TAG: ${{ github.ref_name }}
-          EVENT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          chart_version=$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          app_version=$(awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)
-          [[ "$chart_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "Chart version must be strict X.Y.Z SemVer" >&2; exit 1; }
-          [[ "$app_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "appVersion must be strict X.Y.Z SemVer" >&2; exit 1; }
-          [[ "$CHART_TAG" == "chart-v${chart_version}" ]] || { echo "Tag must equal chart-v${chart_version}; refusing to publish" >&2; exit 1; }
-          [[ "$chart_version" != "3.0.1" ]] || { echo "Chart version 3.0.1 is permanently tombstoned" >&2; exit 1; }
-          source_sha=$(git rev-parse HEAD)
-          tag_sha=$(git rev-parse "${CHART_TAG}^{commit}")
-          [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$EVENT_SHA" ]] || { echo "Checked-out HEAD does not match the triggering push event" >&2; exit 1; }
-          [[ "$source_sha" == "$tag_sha" ]] || { echo "Chart tag moved after the triggering push event; refusing to publish" >&2; exit 1; }
-          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
-          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "chart_tag=$CHART_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Refuse an existing chart coordinate (pre-package)
         env:
@@ -123,6 +114,15 @@ jobs:
           digest=$(printf '%s\n' "$output" | sed -n 's/^Digest: \(sha256:[0-9a-f]\{64\}\)$/\1/p')
           [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "helm push did not report one valid OCI digest" >&2; exit 1; }
           echo "oci_digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Verify published chart coordinates and provenance
+        id: published
+        env:
+          CHART_TAG: ${{ steps.release.outputs.chart_tag }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
+        run: node scripts/check-release-consistency.mjs --mode chart-post --chart-tag "$CHART_TAG" --source-sha "$SOURCE_SHA"
 
       - name: Write publication evidence
         env:

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -474,290 +474,120 @@ jobs:
         run: exit 1
 
   semantic-release:
-    name: Publish semantic release image tag
+    name: Verify and alias a full release
     runs-on: ubuntu-latest
-    # Single canonical semantic-publication event for DSPACE #4727: a published GitHub
-    # release. Deliberately not also triggered by a `push: tags: v*` event — creating a
-    # release normally creates its tag too, so triggering on both would race and turn
-    # every ordinary release into an expected "tag already exists" failure. See
-    # outages/2026-07-23-dspace-production-version-drift.md and AGENTS.md.
     if: github.event_name == 'release' && github.event.action == 'published'
     concurrency:
       group: dspace-semantic-image-${{ github.event.release.tag_name }}
       cancel-in-progress: false
     steps:
-      - name: Checkout tagged commit
+      - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Resolve checked-out revision
-        id: revision
-        # The release tag is attacker-influenceable (anyone who can publish a release
-        # controls it) and git ref names may contain shell metacharacters such as `"`,
-        # `` ` ``, `$()`, and `;`. Pass it through env and reference it as "$RELEASE_TAG"
-        # data — never interpolate ${{ github.event.release.tag_name }} directly into a
-        # run: script, since GitHub substitutes it into the script's source text before
-        # the shell parses it, which would let a crafted tag execute arbitrary commands.
+      # Authorize event-controlled source data before setup, installation, or any
+      # repository-controlled lifecycle script executes.
+      - name: Authorize release source and local coordinates
+        id: release
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          full_sha="$(git rev-parse HEAD)"
-          # Peel to the commit form: for annotated/signed tags, "git rev-parse <tag>" alone
-          # resolves the tag *object*'s own SHA, not the commit it points at, which would
-          # reject every legitimate release cut from such a tag even though checkout
-          # correctly left HEAD on the tagged commit.
-          tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
-          if [ -z "$full_sha" ]; then
-            echo "git rev-parse HEAD returned nothing; refusing to publish." >&2
-            exit 1
-          fi
-          if [ "$full_sha" != "$tag_sha" ]; then
-            echo "Checked-out HEAD ($full_sha) does not match tag $RELEASE_TAG ($tag_sha); refusing to publish." >&2
-            exit 1
-          fi
-          short_sha="${full_sha:0:7}"
-          echo "full_sha=${full_sha}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve eligible source branch
-        id: branch
-        run: |
-          # Do not trust github.sha for this event (it can reflect the default branch, not
-          # the tagged commit). Everything downstream keys off steps.revision.outputs.full_sha
-          # (git rev-parse HEAD after checkout), not github.sha.
+          set -euo pipefail
+          source_sha="$(git rev-parse HEAD)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
           git fetch origin main v3 --quiet
-          full_sha="${{ steps.revision.outputs.full_sha }}"
-          matched="$(git branch -r --contains "$full_sha" | sed 's/^[* ]*//' | grep -E '^origin/(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          if [ -z "$matched" ]; then
-            echo "Tagged commit $full_sha is not reachable from origin/main or origin/v3; refusing to publish." >&2
-            exit 1
-          fi
-          echo "branch=${matched}" >> "$GITHUB_OUTPUT"
+          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^origin/(main|v3)$' | head -n1 | sed 's#^origin/##')"
+          [[ -n "$source_branch" ]] || { echo "Release source is not on main or v3" >&2; exit 1; }
+          image_tag="${source_branch}-${source_sha:0:7}"
+          chart_version="$(node -e "const s=require('fs').readFileSync('charts/dspace/Chart.yaml','utf8');const m=s.match(/^version: [\"']?([^\"' ]+)/m);if(!m)process.exit(1);process.stdout.write(m[1])")"
+          node scripts/check-release-consistency.mjs --mode local --release-tag "$RELEASE_TAG" --chart-tag "chart-v${chart_version}" --source-sha "$source_sha" --source-branch "$source_branch" --image-tag "$image_tag"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-          run_install: false
-
-      - name: Verify pnpm is on PATH
-        run: |
-          command -v pnpm
-          pnpm --version
-
-      - name: Validate release version coordinates
-        id: version
-        # See the "Resolve checked-out revision" step above: pass the attacker-influenceable
-        # release tag through env, never interpolate it directly into this run: script.
+      - name: Verify immutable image and require semantic absence
+        id: immutable
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          root_version="$(node -p "require('./package.json').version")"
-          frontend_version="$(node -p "require('./frontend/package.json').version")"
-          expected_tag="v${root_version}"
-
-          if [ "$root_version" != "$frontend_version" ]; then
-            echo "Root package version ($root_version) does not match frontend package version ($frontend_version); refusing to publish." >&2
-            exit 1
-          fi
-
-          # DSPACE release coordinates use the same strict X.Y.Z convention enforced by
-          # scripts/check-dspace-chart-version.sh. Validate before exposing package data as
-          # a step output so shell metacharacters and multiline values fail closed.
-          if [[ ! "$root_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version is not a supported semantic version; refusing to publish." >&2
-            exit 1
-          fi
-
-          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
-            echo "Release tag $RELEASE_TAG does not match expected semantic tag $expected_tag; refusing to publish." >&2
-            exit 1
-          fi
-
-          echo "version=${root_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --reporter=append-only
-
-      - name: Build and verify chat build stamp
-        run: |
-          pnpm run build
-          pnpm run verify:chat-build-stamp
-
-      - name: Define image tags
-        id: tags
-        env:
-          SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          branch_sha_tag="ghcr.io/democratizedspace/dspace:${SOURCE_BRANCH}-${SHORT_SHA}"
-          semantic_tag="ghcr.io/democratizedspace/dspace:v${RELEASE_VERSION}"
-          echo "branch_sha_tag=${branch_sha_tag}" >> "$GITHUB_OUTPUT"
-          echo "semantic_tag=${semantic_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image build version
-        id: build_version
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          SHORT_SHA: ${{ steps.revision.outputs.short_sha }}
-        run: |
-          build_version="v${RELEASE_VERSION}+${SHORT_SHA}"
-          echo "value=${build_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set image metadata
-        id: metadata
-        env:
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          created="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          echo "created=${created}" >> "$GITHUB_OUTPUT"
-          echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
-
-      # Fail-closed guard: only an authoritative "not found" result from GHCR permits
-      # publication. Auth, network, timeout, malformed-response, and any other status are
-      # treated as hard failures by scripts/ghcr-manifest.mjs. Running inside this job's
-      # tag-scoped concurrency group means the check happens only after this run has
-      # exclusive access to that group, so it cannot race a second publish attempt.
-      - name: Refuse to overwrite an existing semantic tag
-        env:
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
         run: |
-          node scripts/ghcr-manifest.mjs check-absent \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          node scripts/check-release-consistency.mjs --mode pre-semantic \
+            --release-tag "$RELEASE_TAG" --chart-tag "chart-v${{ steps.release.outputs.chart_version }}" \
+            --source-sha "${{ steps.release.outputs.source_sha }}" --source-branch "${{ steps.release.outputs.source_branch }}" \
+            --image-tag "${{ steps.release.outputs.image_tag }}"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
-        with:
-          platforms: arm64
+          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Verify corresponding branch-SHA image exists
-        id: branch_sha_evidence
+      - name: Final absence check immediately before alias
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
         run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "${{ steps.branch.outputs.branch }}-${{ steps.revision.outputs.short_sha }}"
+          node scripts/check-release-consistency.mjs --mode pre-semantic \
+            --release-tag "$RELEASE_TAG" --chart-tag "chart-v${{ steps.release.outputs.chart_version }}" \
+            --source-sha "${{ steps.release.outputs.source_sha }}" --source-branch "${{ steps.release.outputs.source_branch }}" \
+            --image-tag "${{ steps.release.outputs.image_tag }}"
 
-      - name: Build image for SHA verification
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
+      - name: Create semantic alias exactly once
+        env:
+          IMMUTABLE_TAG: ${{ steps.release.outputs.image_tag }}
+          APPLICATION_VERSION: ${{ steps.release.outputs.application_version }}
+        run: docker buildx imagetools create --tag "ghcr.io/democratizedspace/dspace:v${APPLICATION_VERSION}" "ghcr.io/democratizedspace/dspace:${IMMUTABLE_TAG}"
 
-      - name: Assert build SHA is baked into frontend bundle
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA="${{ steps.revision.outputs.full_sha }}" \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Build and push semantic release image
-        id: build_push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: ${{ steps.tags.outputs.semantic_tag }}
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.revision.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.full_sha }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha,scope=ci-image-semantic-release
-          cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-semantic-release
-
-      # Records index + per-platform digests as evidence. 'present' is the expected outcome
-      # of this second registry call (the tag was just pushed above); scripts/ghcr-manifest.mjs
-      # writes index_digest/amd64_digest/arm64_digest to $GITHUB_OUTPUT without ever logging
-      # the registry credentials used to fetch them.
-      - name: Record semantic release evidence
-        if: steps.build_push.outcome == 'success'
+      - name: Verify full release and emit manifest
         id: evidence
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           GHCR_GUARD_USERNAME: ${{ github.actor }}
-          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (GitHub Actions secret reference, not a literal credential)
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore
         run: |
-          node scripts/ghcr-manifest.mjs describe \
-            --owner democratizedspace \
-            --repo dspace \
-            --tag "v${RELEASE_VERSION}"
+          node scripts/check-release-consistency.mjs --mode final \
+            --release-tag "$RELEASE_TAG" --chart-tag "chart-v${{ steps.release.outputs.chart_version }}" \
+            --source-sha "${{ steps.release.outputs.source_sha }}" --source-branch "${{ steps.release.outputs.source_branch }}" \
+            --image-tag "${{ steps.release.outputs.image_tag }}" --manifest dspace-release-manifest.json
+          node scripts/check-release-consistency.mjs --mode validate-manifest --manifest dspace-release-manifest.json
 
-      - name: Summarize semantic release evidence
-        if: steps.build_push.outcome == 'success'
+      - name: Upload deterministic release manifest
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: dspace-release-manifest
+          path: dspace-release-manifest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize full release evidence
         env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          BRANCH_SHA_TAG: ${{ steps.tags.outputs.branch_sha_tag }}
-          SEMANTIC_TAG: ${{ steps.tags.outputs.semantic_tag }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          IMAGE_TAG: ${{ steps.release.outputs.image_tag }}
+          APP_VERSION: ${{ steps.release.outputs.application_version }}
+          CHART_VERSION: ${{ steps.release.outputs.chart_version }}
+          IMAGE_DIGEST: ${{ steps.evidence.outputs.image_digest }}
+          CHART_DIGEST: ${{ steps.evidence.outputs.chart_digest }}
+          AMD64_DIGEST: ${{ steps.evidence.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ steps.evidence.outputs.arm64_digest }}
         run: |
           {
-            echo "## DSPACE semantic release image"
-            echo
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Semantic version | \`v${RELEASE_VERSION}\` |"
-            echo "| Full Git SHA | \`${{ steps.revision.outputs.full_sha }}\` |"
-            echo "| Immutable branch-SHA tag | \`${BRANCH_SHA_TAG}\` |"
-            echo "| Semantic tag | \`${SEMANTIC_TAG}\` |"
-            echo "| Image index digest | \`${{ steps.evidence.outputs.index_digest }}\` |"
-            echo "| linux/amd64 digest | \`${{ steps.evidence.outputs.amd64_digest }}\` |"
-            echo "| linux/arm64 digest | \`${{ steps.evidence.outputs.arm64_digest }}\` |"
+            echo "## DSPACE full release consistency evidence"
+            echo "- Full source SHA: \`$SOURCE_SHA\`"
+            echo "- Immutable image: \`ghcr.io/democratizedspace/dspace:$IMAGE_TAG@$IMAGE_DIGEST\`"
+            echo "- Semantic evidence alias: \`v$APP_VERSION\` (same index digest)"
+            echo "- linux/amd64 digest: \`$AMD64_DIGEST\`"
+            echo "- linux/arm64 digest: \`$ARM64_DIGEST\`"
+            echo "- Immutable chart: \`oci://ghcr.io/democratizedspace/charts/dspace:$CHART_VERSION@$CHART_DIGEST\`"
+            echo "- Manifest artifact: \`dspace-release-manifest/dspace-release-manifest.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,3 +432,13 @@ Run `npm test` to verify configuration stays in sync.
 - [Codex Prompt Upgrader](https://github.com/democratizedspace/dspace/blob/main/docs/prompts/codex/upgrader.md)
 - [AGENTS.md Spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6)
 - [Agents.md Guide](https://agentsmd.net/)
+
+### Full release consistency gate
+
+The final release consistency gate is `scripts/check-release-consistency.mjs`. A full release must
+use one approved commit for the peeled application and chart tags, both required image platform
+revision labels, and chart provenance. Publish in this fail-closed order: immutable branch-SHA
+image, immutable chart, then the GitHub release/semantic image alias/combined manifest. The
+semantic tag must be absent before its single alias operation and must resolve to the immutable
+image index digest afterward. Deployments and downstream manifests always retain the immutable
+`<branch>-<shortsha>` image tag (or digest), never the semantic evidence alias.

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -158,7 +158,20 @@ republished even if it appears absent (a later chart may still use application `
 The workflow stages provenance annotations without changing the tracked chart and records the full
 source SHA, packaged archive digest, and OCI manifest digest in its successful run summary. The OCI
 version comes from `Chart.yaml:version` and may differ from the application version in `appVersion`
-and the package files. `docs/apps/dspace.version` pins the chart coordinate. After the publish
+and the package files. `docs/apps/dspace.version` pins the chart coordinate.
+
+For a full application release, publish the immutable branch-SHA image first, this immutable chart
+second from the same approved commit, and the GitHub release last. The final workflow verifies the
+published chart OCI config and image platform provenance before creating the semantic image alias.
+It then uploads `dspace-release-manifest/dspace-release-manifest.json`, which records the application
+version, full source revision, immutable image tag and digest, independently versioned chart and
+digest, and platform digests. An out-of-order release fails before semantic publication and is
+rerunnable after the missing immutable prerequisite exists. Existing chart or semantic coordinates
+remain immutable and cannot be used as retry targets. Although the semantic image alias is required
+to have exactly the immutable image-index digest, it is human-readable evidence only; deployments
+and downstream manifests continue to select the branch-SHA tag or digest.
+
+After the publish
 workflow has completed successfully, use this installation procedure:
 
 ```bash

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -28,6 +28,29 @@ be the audit record for a production deploy.
 
 ## Artifact publishing summary
 
+The full-release order is mandatory and fail closed:
+
+1. Publish and verify the multi-platform immutable `<branch>-<shortsha>` image, including the full
+   source revision label on both `linux/amd64` and `linux/arm64` configs.
+2. Push `chart-v<chart version>` from that same approved commit. The chart workflow verifies the
+   published OCI config's chart version, application version, and full source revision.
+3. Publish the `v<application version>` GitHub release. The release workflow requires both
+   immutable prerequisites, proves the release and chart tags peel to the approved commit, creates
+   the semantic image tag as one exact alias of the immutable image index, verifies digest equality,
+   and uploads `dspace-release-manifest/dspace-release-manifest.json`.
+
+If step 3 is attempted early, it stops before creating the semantic coordinate and may be rerun
+after the missing immutable prerequisite is published. A pre-existing semantic image tag or chart
+version is never accepted, moved, or overwritten. Once a semantic coordinate has been created, a
+failed run requires investigation rather than an overwrite retry.
+
+The deterministic manifest has `schemaVersion`, `app`, `applicationVersion`, full
+`sourceRevision`, immutable tag-only `imageTag`, image-index `imageDigest`, independent
+`chartVersion`, chart `chartDigest`, both platform digests, and the human-readable semantic tag.
+It intentionally contains no environment, approver, runtime, or promotion fields. The semantic
+tag is human-readable release evidence whose exact digest equality is enforced; deployment and
+downstream release records continue to use the immutable image tag or digest.
+
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
 2. `.github/workflows/ci-helm.yml` publishes only when an exact `chart-v<chart version>` tag is

--- a/scripts/check-release-consistency.mjs
+++ b/scripts/check-release-consistency.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  inspectArtifact,
+  inspectImage,
+  assertTagAbsent,
+} from './ghcr-manifest.mjs';
+
+const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+const BRANCHES = new Set(['main', 'v3']);
+const allowed = new Set([
+  'mode',
+  'release-tag',
+  'chart-tag',
+  'source-sha',
+  'source-branch',
+  'image-tag',
+  'manifest',
+  'owner',
+  'image-repo',
+  'chart-repo',
+]);
+const fail = (message) => {
+  throw new Error(message);
+};
+const json = (path) => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return fail(`Missing or malformed coordinate file: ${path}`);
+  }
+};
+const scalar = (path, key) => {
+  const matches = readFileSync(path, 'utf8')
+    .split(/\r?\n/)
+    .map((line) =>
+      line.match(new RegExp(`^${key}:\\s*["']?([^"'#\\s]+)["']?\\s*(?:#.*)?$`))
+    )
+    .filter(Boolean);
+  if (matches.length !== 1) fail(`${path} must contain exactly one ${key}`);
+  return matches[0][1];
+};
+const strictVersion = (value, label) => {
+  if (!SEMVER.test(value || ''))
+    fail(`${label} must be strict bare X.Y.Z SemVer`);
+  return value;
+};
+const git = (...args) =>
+  execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+
+export function readCoordinates(root = '.') {
+  const rootPackage = json(`${root}/package.json`),
+    frontend = json(`${root}/frontend/package.json`),
+    lock = json(`${root}/package-lock.json`);
+  const applicationVersion = strictVersion(
+    rootPackage.version,
+    'root package version'
+  );
+  for (const [label, value] of [
+    ['frontend package version', frontend.version],
+    ['package-lock version', lock.version],
+    ['package-lock root version', lock.packages?.['']?.version],
+    [
+      'Chart.yaml appVersion',
+      scalar(`${root}/charts/dspace/Chart.yaml`, 'appVersion'),
+    ],
+  ]) {
+    strictVersion(value, label);
+    if (value !== applicationVersion)
+      fail(`${label} does not equal application version ${applicationVersion}`);
+  }
+  const chartVersion = strictVersion(
+    scalar(`${root}/charts/dspace/Chart.yaml`, 'version'),
+    'chart version'
+  );
+  const documented = readFileSync(`${root}/docs/apps/dspace.version`, 'utf8')
+    .split(/\r?\n/)
+    .filter((line) => line && !line.startsWith('#'));
+  if (
+    documented.length !== 1 ||
+    strictVersion(documented[0], 'documented chart version') !== chartVersion
+  )
+    fail('docs/apps/dspace.version does not equal chart version');
+  return { applicationVersion, chartVersion };
+}
+
+export function validateLocal(options, gitImpl = git) {
+  const coordinates = readCoordinates();
+  const { sourceSha, sourceBranch, releaseTag, chartTag, imageTag } = options;
+  if (!SHA.test(sourceSha || ''))
+    fail('source revision must be a 40-character lowercase SHA');
+  if (!BRANCHES.has(sourceBranch)) fail('source branch must be main or v3');
+  if (releaseTag !== `v${coordinates.applicationVersion}`)
+    fail('release tag does not match application version');
+  if (gitImpl('rev-parse', `${releaseTag}^{commit}`) !== sourceSha)
+    fail('release tag does not peel to approved source revision');
+  gitImpl('merge-base', '--is-ancestor', sourceSha, `origin/${sourceBranch}`);
+  if (chartTag && chartTag !== `chart-v${coordinates.chartVersion}`)
+    fail('chart tag does not match chart version');
+  if (chartTag && gitImpl('rev-parse', `${chartTag}^{commit}`) !== sourceSha)
+    fail('chart tag does not peel to approved source revision');
+  const expectedImageTag = `${sourceBranch}-${sourceSha.slice(0, 7)}`;
+  if (
+    imageTag !== expectedImageTag ||
+    imageTag.endsWith('-latest') ||
+    imageTag.startsWith('v')
+  )
+    fail(`deployment image tag must be ${expectedImageTag}`);
+  return { ...coordinates, sourceRevision: sourceSha, sourceBranch, imageTag };
+}
+
+export function createManifest(local, image, chart) {
+  const manifest = {
+    schemaVersion: 1,
+    app: 'dspace',
+    applicationVersion: local.applicationVersion,
+    sourceRevision: local.sourceRevision,
+    imageTag: local.imageTag,
+    imageDigest: image.indexDigest,
+    chartVersion: local.chartVersion,
+    chartDigest: chart.digest,
+    platformDigests: {
+      'linux/amd64': image.platforms.amd64.digest,
+      'linux/arm64': image.platforms.arm64.digest,
+    },
+    semanticImageTag: `v${local.applicationVersion}`,
+  };
+  validateManifest(manifest);
+  return manifest;
+}
+export function validateManifest(m) {
+  if (
+    m?.schemaVersion !== 1 ||
+    m?.app !== 'dspace' ||
+    !SEMVER.test(m.applicationVersion || '') ||
+    !SHA.test(m.sourceRevision || '') ||
+    !DIGEST.test(m.imageDigest || '') ||
+    !SEMVER.test(m.chartVersion || '') ||
+    !DIGEST.test(m.chartDigest || '') ||
+    m.imageTag !==
+      `${m.sourceBranch || m.imageTag.split('-')[0]}-${m.sourceRevision.slice(0, 7)}` ||
+    m.semanticImageTag !== `v${m.applicationVersion}` ||
+    !DIGEST.test(m.platformDigests?.['linux/amd64'] || '') ||
+    !DIGEST.test(m.platformDigests?.['linux/arm64'] || '')
+  )
+    fail('release manifest is malformed or inconsistent');
+  return m;
+}
+function parse(argv) {
+  if (argv.length === 1 && argv[0] === '--verify-local-fixtures')
+    return { fixtures: true };
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.slice(2),
+      value = argv[i + 1];
+    if (!argv[i]?.startsWith('--') || !allowed.has(key) || !value || out[key])
+      fail(`Invalid argument: ${argv[i] || '<missing>'}`);
+    out[key.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
+  }
+  if (
+    ![
+      'local',
+      'pre-semantic',
+      'final',
+      'validate-manifest',
+      'chart-pre',
+      'chart-post',
+    ].includes(out.mode)
+  )
+    fail(
+      'mode must be local, chart-pre, chart-post, pre-semantic, final, or validate-manifest'
+    );
+  return out;
+}
+const creds = () => {
+  const username = process.env.GHCR_GUARD_USERNAME,
+    password = process.env.GHCR_GUARD_PASSWORD; // scan-secrets: ignore (environment credential, never logged)
+  if (!username || !password)
+    fail('GHCR credentials must be supplied through environment variables');
+  return { username, password };
+};
+export async function main(
+  argv = process.argv.slice(2),
+  adapters = { inspectImage, inspectArtifact, assertTagAbsent }
+) {
+  const o = parse(argv);
+  if (o.fixtures) {
+    const a = 'a'.repeat(40),
+      d = 'sha256:' + 'b'.repeat(64);
+    const m = createManifest(
+      {
+        applicationVersion: '1.2.3',
+        chartVersion: '4.5.6',
+        sourceRevision: a,
+        imageTag: 'main-aaaaaaa',
+      },
+      {
+        indexDigest: d,
+        platforms: { amd64: { digest: d }, arm64: { digest: d } },
+      },
+      { digest: d }
+    );
+    validateManifest(JSON.parse(JSON.stringify(m)));
+    console.log('Local release-consistency fixtures passed.');
+    return;
+  }
+  if (o.mode === 'validate-manifest') {
+    validateManifest(json(o.manifest));
+    console.log('Release manifest is valid.');
+    return;
+  }
+  if (o.mode === 'chart-pre' || o.mode === 'chart-post') {
+    const c = readCoordinates();
+    if (!SHA.test(o.sourceSha || ''))
+      fail('source revision must be a 40-character lowercase SHA');
+    if (
+      o.chartTag !== `chart-v${c.chartVersion}` ||
+      git('rev-parse', `${o.chartTag}^{commit}`) !== o.sourceSha ||
+      git('rev-parse', 'HEAD') !== o.sourceSha
+    )
+      fail('chart tag/source coordinates do not match');
+    emit({ ...c, sourceRevision: o.sourceSha });
+    if (o.mode === 'chart-pre') return c;
+    const auth = creds(),
+      artifact = await adapters.inspectArtifact({
+        owner: o.owner || 'democratizedspace',
+        repo: o.chartRepo || 'charts/dspace',
+        tag: c.chartVersion,
+        ...auth,
+      });
+    if (
+      artifact.config?.version !== c.chartVersion ||
+      String(artifact.config?.appVersion) !== c.applicationVersion ||
+      artifact.config?.annotations?.['org.opencontainers.image.revision'] !==
+        o.sourceSha ||
+      !DIGEST.test(artifact.digest || '')
+    )
+      fail(
+        'published chart coordinates or provenance do not match approved release'
+      );
+    emit({ ...c, sourceRevision: o.sourceSha, chartDigest: artifact.digest });
+    return artifact;
+  }
+  const local = validateLocal(o);
+  if (o.mode === 'local') {
+    emit(local);
+    return local;
+  }
+  const auth = creds(),
+    common = {
+      owner: o.owner || 'democratizedspace',
+      username: auth.username,
+      password: auth.password, // scan-secrets: ignore (environment credential plumbing)
+    };
+  const image = await adapters.inspectImage({
+    ...common,
+    repo: o.imageRepo || 'dspace',
+    tag: local.imageTag,
+  });
+  for (const arch of ['amd64', 'arm64'])
+    if (image.platforms[arch].revision !== local.sourceRevision)
+      fail(
+        `linux/${arch} image revision does not equal approved source revision`
+      );
+  if (o.mode === 'pre-semantic') {
+    const chart = await adapters.inspectArtifact({
+      ...common,
+      repo: o.chartRepo || 'charts/dspace',
+      tag: local.chartVersion,
+    });
+    if (
+      chart.config?.version !== local.chartVersion ||
+      String(chart.config?.appVersion) !== local.applicationVersion ||
+      chart.config?.annotations?.['org.opencontainers.image.revision'] !==
+        local.sourceRevision ||
+      !DIGEST.test(chart.digest || '')
+    )
+      fail(
+        'published chart coordinates or provenance do not match approved release'
+      );
+    await adapters.assertTagAbsent({
+      ...common,
+      repo: o.imageRepo || 'dspace',
+      tag: `v${local.applicationVersion}`,
+    });
+    emit({
+      ...local,
+      imageDigest: image.indexDigest,
+      chartDigest: chart.digest,
+      amd64Digest: image.platforms.amd64.digest,
+      arm64Digest: image.platforms.arm64.digest,
+    });
+    return { local, image, chart };
+  }
+  const semantic = await adapters.inspectImage({
+    ...common,
+    repo: o.imageRepo || 'dspace',
+    tag: `v${local.applicationVersion}`,
+  });
+  if (semantic.indexDigest !== image.indexDigest)
+    fail('semantic and immutable image index digests differ');
+  const chart = await adapters.inspectArtifact({
+    ...common,
+    repo: o.chartRepo || 'charts/dspace',
+    tag: local.chartVersion,
+  });
+  const c = chart.config;
+  if (
+    c.version !== local.chartVersion ||
+    String(c.appVersion) !== local.applicationVersion ||
+    c.annotations?.['org.opencontainers.image.revision'] !==
+      local.sourceRevision ||
+    !DIGEST.test(chart.digest || '')
+  )
+    fail(
+      'published chart coordinates or provenance do not match approved release'
+    );
+  const manifest = createManifest(local, image, chart);
+  writeFileSync(
+    o.manifest || 'dspace-release-manifest.json',
+    `${JSON.stringify(manifest, null, 2)}\n`
+  );
+  emit(manifest);
+  return manifest;
+}
+function emit(values) {
+  const flat = {
+    application_version: values.applicationVersion,
+    chart_version: values.chartVersion,
+    chart_tag: values.chartVersion && `chart-v${values.chartVersion}`,
+    source_sha: values.sourceRevision,
+    source_branch: values.sourceBranch,
+    image_tag: values.imageTag,
+    image_digest: values.imageDigest,
+    chart_digest: values.chartDigest,
+    amd64_digest: values.amd64Digest || values.platformDigests?.['linux/amd64'],
+    arm64_digest: values.arm64Digest || values.platformDigests?.['linux/arm64'],
+  };
+  const entries = Object.entries(flat).filter(([, v]) => v);
+  if (process.env.GITHUB_OUTPUT)
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      entries.map(([k, v]) => `${k}=${v}`).join('\n') + '\n'
+    );
+  else console.log(JSON.stringify(values, null, 2));
+}
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`)
+  main().catch((error) => {
+    console.error(error?.message || 'release consistency check failed');
+    process.exit(1);
+  });

--- a/scripts/ghcr-manifest.mjs
+++ b/scripts/ghcr-manifest.mjs
@@ -10,6 +10,7 @@ const MANIFEST_ACCEPT_HEADER = [
     'application/vnd.oci.image.manifest.v1+json',
     'application/vnd.docker.distribution.manifest.v2+json',
 ].join(', ');
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
 
 export class GhcrGuardError extends Error {
     constructor(message, { code = 'unknown' } = {}) {
@@ -37,10 +38,8 @@ async function fetchWithTimeout(fetchImpl, url, init, timeoutMs, describeAction)
                 code: 'timeout',
             });
         }
-        throw new GhcrGuardError(
-            `Network error while ${describeAction}: ${error?.message || error}`,
-            { code: 'network' }
-        );
+        // Do not echo the underlying client error: clients may include credentials.
+        throw new GhcrGuardError(`Network error while ${describeAction}`, { code: 'network' });
     } finally {
         clearTimeout(timer);
     }
@@ -172,7 +171,174 @@ export async function getManifest({
               }))
         : [];
 
-    return { status: 'present', digest, manifests };
+    return { status: 'present', digest, manifests, body };
+}
+
+export async function getBlob({
+  owner,
+  repo,
+  digest,
+  token,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  requireField(owner, 'owner');
+  requireField(repo, 'repo');
+  requireField(token, 'token');
+  if (!DIGEST.test(digest || '')) {
+    throw new GhcrGuardError('Invalid OCI blob digest', { code: 'malformed' });
+  }
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    `${REGISTRY_HOST}/v2/${owner}/${repo}/blobs/${digest}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+    timeoutMs,
+    'requesting a GHCR blob'
+  );
+  if (response.status === 401 || response.status === 403) {
+    throw new GhcrGuardError(
+      `GHCR blob request was denied with status ${response.status}`,
+      { code: 'auth' }
+    );
+  }
+  if (!response.ok) {
+    throw new GhcrGuardError(
+      `GHCR blob request returned an indeterminate status ${response.status}`,
+      { code: 'indeterminate' }
+    );
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new GhcrGuardError('GHCR blob response body was not valid JSON', {
+      code: 'malformed',
+    });
+  }
+}
+
+export async function inspectImage({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const token = await fetchGhcrToken({ // scan-secrets: ignore (short-lived registry token plumbing)
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  });
+  const index = await getManifest({
+    owner,
+    repo,
+    tag,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  if (index.status !== 'present')
+    throw new GhcrGuardError(
+      `Expected GHCR image ${owner}/${repo}:${tag} to exist`,
+      { code: 'missing' }
+    );
+  if (!DIGEST.test(index.digest))
+    throw new GhcrGuardError('OCI image index has an invalid digest', {
+      code: 'malformed',
+    });
+  const platforms = {};
+  for (const architecture of ['amd64', 'arm64']) {
+    const entries = index.manifests.filter(
+      (entry) => entry.os === 'linux' && entry.architecture === architecture
+    );
+    if (entries.length !== 1 || !DIGEST.test(entries[0].digest))
+      throw new GhcrGuardError(
+        `GHCR image ${owner}/${repo}:${tag} must contain exactly one linux/${architecture} manifest`,
+        { code: 'missing-platform' }
+      );
+    const platform = await getManifest({
+      owner,
+      repo,
+      tag: entries[0].digest,
+      token,
+      fetchImpl,
+      timeoutMs,
+    });
+    const configDigest = platform.body?.config?.digest;
+    if (platform.status !== 'present' || !DIGEST.test(configDigest || ''))
+      throw new GhcrGuardError(
+        `Malformed linux/${architecture} image manifest`,
+        { code: 'malformed' }
+      );
+    const config = await getBlob({
+      owner,
+      repo,
+      digest: configDigest,
+      token,
+      fetchImpl,
+      timeoutMs,
+    });
+    platforms[architecture] = {
+      digest: entries[0].digest,
+      revision: config?.config?.Labels?.['org.opencontainers.image.revision'],
+    };
+  }
+  return { indexDigest: index.digest, platforms };
+}
+
+export async function inspectArtifact({
+  owner,
+  repo,
+  tag,
+  username,
+  password,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const token = await fetchGhcrToken({ // scan-secrets: ignore (short-lived registry token plumbing)
+    owner,
+    repo,
+    username,
+    password,
+    fetchImpl,
+    timeoutMs,
+  });
+  const manifest = await getManifest({
+    owner,
+    repo,
+    tag,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  if (manifest.status !== 'present')
+    throw new GhcrGuardError(
+      `Expected GHCR artifact ${owner}/${repo}:${tag} to exist`,
+      { code: 'missing' }
+    );
+  if (!DIGEST.test(manifest.digest))
+    throw new GhcrGuardError('OCI artifact has an invalid digest', {
+      code: 'malformed',
+    });
+  const configDigest = manifest.body?.config?.digest;
+  if (!DIGEST.test(configDigest || ''))
+    throw new GhcrGuardError(
+      'OCI artifact manifest has an invalid config digest',
+      { code: 'malformed' }
+    );
+  const config = await getBlob({
+    owner,
+    repo,
+    digest: configDigest,
+    token,
+    fetchImpl,
+    timeoutMs,
+  });
+  return { digest: manifest.digest, config };
 }
 
 // Fails closed: resolves only when the registry authoritatively reports the tag as absent.

--- a/tests/ciHelmWorkflow.test.ts
+++ b/tests/ciHelmWorkflow.test.ts
@@ -34,14 +34,24 @@ describe('chart publication workflow integrity', () => {
     );
     expect(checkout.with.ref).toBe('${{ github.sha }}');
     expect(checkout.with['fetch-depth']).toBe(0);
+    expect(checkout.with['persist-credentials']).toBe(false);
     const release = step('Validate tag, versions, and source revision');
     expect(release.env.CHART_TAG).toBe('${{ github.ref_name }}');
     expect(text.match(/github\.ref_name/g)).toHaveLength(1);
     expect(release.env.EVENT_SHA).toBe('${{ github.sha }}');
     expect(release.run).toContain('git rev-parse HEAD');
-    expect(release.run).toContain('git rev-parse "${CHART_TAG}^{commit}"');
+    expect(release.run).toContain(
+      'check-release-consistency.mjs --mode chart-pre'
+    );
     expect(release.run).toContain('"$source_sha" == "$EVENT_SHA"');
-    expect(release.run).toContain('"$source_sha" == "$tag_sha"');
+    expect(steps.indexOf(release)).toBeLessThan(
+      steps.findIndex((candidate) =>
+        candidate.uses?.startsWith('actions/setup-node')
+      )
+    );
+    expect(steps.indexOf(release)).toBeLessThan(
+      steps.findIndex((candidate) => candidate.run?.includes('pnpm install'))
+    );
   });
 
   it('enforces strict matching versions and tombstones chart 3.0.1 before registry access', () => {
@@ -51,11 +61,9 @@ describe('chart publication workflow integrity', () => {
     const guardIndex = steps.indexOf(
       step('Refuse an existing chart coordinate (pre-package)')
     );
-    expect(steps[releaseIndex].run).toContain(
-      '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
-    );
-    expect(steps[releaseIndex].run).toContain('chart-v${chart_version}');
-    expect(steps[releaseIndex].run).toContain('chart_version" != "3.0.1');
+    expect(steps[releaseIndex].run).toContain('--mode chart-pre');
+    expect(steps[releaseIndex].run).toContain('CHART_TAG');
+    expect(steps[releaseIndex].run).toContain('3.0.1');
     expect(releaseIndex).toBeLessThan(guardIndex);
   });
 
@@ -97,6 +105,15 @@ describe('chart publication workflow integrity', () => {
     }
     expect(summary).toContain(
       'SOURCE_SHA is the authoritative immutable provenance'
+    );
+  });
+
+  it('verifies the published chart through the reusable consistency gate', () => {
+    const published = step('Verify published chart coordinates and provenance');
+    expect(published.run).toContain('check-release-consistency.mjs');
+    expect(published.run).toContain('--mode chart-post');
+    expect(steps.indexOf(published)).toBeGreaterThan(
+      steps.indexOf(step('Push chart exactly once'))
     );
   });
 

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -112,294 +112,76 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
 
 describe('ci-image.yml "semantic-release" job (release-only publish path)', () => {
   const job = workflow.jobs['semantic-release'];
+  const steps = findSteps(job);
 
-  it('exists and is gated on a published release, not an ordinary push', () => {
-    expect(job).toBeTruthy();
+  it('is release-only, tag-scoped, and checks out without persisted credentials', () => {
     expect(job.if).toBe(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
-  });
-
-  it('serializes semantic publication with a concurrency group keyed on the tag', () => {
-    expect(job.concurrency).toBeTruthy();
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
-    expect(job.concurrency['cancel-in-progress']).toBe(false);
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    expect(checkout.with.ref).toContain('github.event.release.tag_name');
+    expect(checkout.with['persist-credentials']).toBe(false);
   });
 
-  it('checks out the tagged commit explicitly rather than trusting the default ref', () => {
-    const checkoutStep = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkoutStep.with.ref).toContain('github.event.release.tag_name');
+  it('authorizes source and reusable local coordinates before setup or lifecycle execution', () => {
+    const authorize = stepIndex(job, (step) => step.id === 'release');
+    const setup = stepIndex(job, (step) =>
+      step.uses?.startsWith('actions/setup-node')
+    );
+    expect(authorize).toBeGreaterThanOrEqual(0);
+    expect(authorize).toBeLessThan(setup);
+    expect(steps[authorize].run).toContain(
+      'check-release-consistency.mjs --mode local'
+    );
+    expect(steps[authorize].run).toContain('git rev-parse HEAD');
+    expect(JSON.stringify(job)).not.toContain('pnpm install');
   });
 
-  it('uses the checked-out git rev-parse HEAD as the source revision, never github.sha', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).toMatch(/git rev-parse HEAD/);
-    expect(serialized).not.toContain('${{ github.sha }}');
-  });
-
-  it('peels the release tag to its commit before comparing to HEAD', () => {
-    // "git rev-parse <tag>" alone resolves an annotated/signed tag's own object SHA, not
-    // the commit it points at, which would reject every legitimate release cut from such a
-    // tag even though checkout correctly left HEAD on the tagged commit. The "^{commit}"
-    // peeling suffix is required so both lightweight and annotated/signed tags compare
-    // correctly against HEAD.
-    const revisionStep = findSteps(job).find((step) => step.id === 'revision');
-    expect(revisionStep.run).toMatch(/\$\{RELEASE_TAG\}\^\{commit\}|\$RELEASE_TAG\^\{commit\}/);
-  });
-
-  it('never interpolates the attacker-influenceable release tag directly into a shell script', () => {
-    // Git tag names can contain shell metacharacters ("`, $(), ;). GitHub substitutes
-    // ${{ }} expressions into a run: script's source text before the shell parses it, so
-    // interpolating the raw tag there would let a crafted release tag execute commands with
-    // this job's packages:write/actions:write token. The tag may only reach a `run:` step by
-    // way of an `env:` var (assigned as data, not concatenated into the script) — never as a
-    // literal ${{ github.event.release.tag_name }} expression inside `run:` text. Using it as
-    // a structured action input (checkout's `ref:`, `concurrency.group`) is fine, since those
-    // aren't shell-interpolation contexts.
-    for (const step of findSteps(job)) {
-      if (typeof step.run !== 'string') {
-        continue;
-      }
+  it('treats the release tag as environment data, not shell source', () => {
+    for (const step of steps.filter(
+      (candidate) => typeof candidate.run === 'string'
+    )) {
       expect(step.run).not.toContain('${{ github.event.release.tag_name }}');
-      if (step.run.includes('RELEASE_TAG')) {
-        expect(step.env?.RELEASE_TAG).toBe(
-          '${{ github.event.release.tag_name }}'
-        );
-      }
     }
   });
 
-  it('validates the release tag against v<root package version> before any push', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    expect(versionStep.run).toMatch(/root_version/);
-    expect(versionStep.run).toMatch(/frontend_version/);
-    expect(versionStep.run).toMatch(/expected_tag="v\$\{root_version\}"/);
-    expect(versionStep.run).toMatch(/refusing to publish/);
-
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
+  it('performs two fail-closed absence checks before one exact alias and no rebuild', () => {
+    const checks = steps.filter((step) =>
+      step.run?.includes('--mode pre-semantic')
     );
-    const versionIndex = stepIndex(job, (step) => step.id === 'version');
-    expect(versionIndex).toBeGreaterThanOrEqual(0);
-    expect(versionIndex).toBeLessThan(pushIndex);
-  });
-
-  it('validates package versions before emitting the version output', () => {
-    const versionStep = findSteps(job).find((step) => step.id === 'version');
-    const validation = '[[ ! "$root_version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]';
-    expect(versionStep.run).toContain(validation);
-    expect(versionStep.run.indexOf(validation)).toBeLessThan(
-      versionStep.run.indexOf(
-        'echo "version=${root_version}" >> "$GITHUB_OUTPUT"'
-      )
+    expect(checks).toHaveLength(2);
+    const alias = steps.filter((step) =>
+      step.run?.includes('docker buildx imagetools create')
     );
-
-    const supportedVersion = /^[0-9]+\.[0-9]+\.[0-9]+$/;
-    expect(supportedVersion.test('3.1.0')).toBe(true);
-    for (const maliciousVersion of [
-      '3.1.$(touch /tmp/pwned)',
-      '3.1.`id`',
-      '3.1.0\nmalicious=value',
-    ]) {
-      expect(supportedVersion.test(maliciousVersion)).toBe(false);
-    }
+    expect(alias).toHaveLength(1);
+    expect(stepIndex(job, (step) => step === checks[1])).toBe(
+      stepIndex(job, (step) => step === alias[0]) - 1
+    );
+    expect(findStepsUsing(job, 'docker/build-push-action')).toHaveLength(0);
+    expect(alias[0].run).toContain('IMMUTABLE_TAG');
   });
 
-  it('passes version-derived shell values through env instead of run expressions', () => {
-    const rawVersionExpression = '${{ steps.version.outputs.version }}';
-    for (const step of findSteps(job)) {
-      if (typeof step.run === 'string') {
-        expect(step.run).not.toContain(rawVersionExpression);
-      }
-    }
-
-    const expectedEnvReferences = [
-      ['tags', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      ['build_version', 'RELEASE_VERSION', '${RELEASE_VERSION}'],
-      [undefined, 'RELEASE_VERSION', '"v${RELEASE_VERSION}"'],
-    ];
-    for (const [id, envName, shellReference] of expectedEnvReferences) {
-      const matchingSteps = findSteps(job).filter(
-        (step) =>
-          (id === undefined || step.id === id) &&
-          step.env?.[envName] === rawVersionExpression &&
-          step.run?.includes(shellReference)
-      );
-      expect(matchingSteps.length).toBeGreaterThan(0);
-    }
-
-    const summaryStep = findSteps(job).find((step) =>
+  it('verifies digest equality, validates the manifest, uploads it with a pinned action, and summarizes all evidence', () => {
+    const final = steps.find((step) => step.id === 'evidence');
+    expect(final.run).toContain('--mode final');
+    expect(final.run).toContain('--mode validate-manifest');
+    const upload = findStepsUsing(job, 'actions/upload-artifact')[0];
+    expect(upload.uses).toMatch(/^actions\/upload-artifact@[0-9a-f]{40}$/);
+    expect(upload.with.name).toBe('dspace-release-manifest');
+    expect(upload.with.path).toBe('dspace-release-manifest.json');
+    const summary = steps.find((step) =>
       step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.env.SEMANTIC_TAG).toBe(
-      '${{ steps.tags.outputs.semantic_tag }}'
-    );
-    expect(summaryStep.run).toContain('${RELEASE_VERSION}');
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
-    expect(summaryStep.run).toContain('${SEMANTIC_TAG}');
-
-    const semanticRegistrySteps = findSteps(job).filter((step) =>
-      step.run?.includes('--tag "v${RELEASE_VERSION}"')
-    );
-    expect(semanticRegistrySteps).toHaveLength(2);
-    for (const step of semanticRegistrySteps) {
-      expect(step.env.RELEASE_VERSION).toBe(rawVersionExpression);
-    }
-  });
-
-  it('runs the semantic absence guard before publication, and fails closed', () => {
-    const guardIndex = stepIndex(job, (step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const pushIndex = stepIndex(
-      job,
-      (step) =>
-        step.uses?.startsWith('docker/build-push-action') &&
-        step.with?.push === true
-    );
-    expect(guardIndex).toBeGreaterThanOrEqual(0);
-    expect(pushIndex).toBeGreaterThan(guardIndex);
-  });
-
-  it('keeps multi-arch publication for both supported architectures', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps.length).toBeGreaterThan(0);
-    for (const step of pushSteps) {
-      expect(step.with.platforms).toBe('linux/amd64,linux/arm64');
-    }
-  });
-
-  it('contains exactly one semantic publication step that pushes only the semantic tag', () => {
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    expect(pushSteps).toHaveLength(1);
-    const [pushStep] = pushSteps;
-    expect(pushStep.name).toBe('Build and push semantic release image');
-    expect(pushStep.id).toBe('build_push');
-    expect(pushStep.with.tags).toBe('${{ steps.tags.outputs.semantic_tag }}');
-    expect(pushStep.with.tags).not.toContain('branch_sha_tag');
-    expect(pushStep.with.tags).not.toMatch(/latest/);
-    expect(pushStep['continue-on-error']).toBeUndefined();
-  });
-
-  it('has no second-attempt or retry path for semantic publication', () => {
-    const serialized = JSON.stringify(job);
-    expect(serialized).not.toMatch(/attempt 1|attempt 2|retry/i);
-    expect(serialized).not.toContain('build_push_1');
-    expect(serialized).not.toContain('build_push_2');
-    expect(serialized).not.toMatch(/outcome == 'failure'/);
-  });
-
-  it('completes local image verification before the sole semantic publication', () => {
-    const steps = findSteps(job);
-    const pushIndex = steps.findIndex(
-      (step) => step.uses?.startsWith('docker/build-push-action') && step.with?.push === true
-    );
-    const verificationBuildIndex = steps.findIndex(
-      (step) => step.name === 'Build image for SHA verification'
-    );
-    const shaAssertionIndex = steps.findIndex(
-      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
-    );
-    const chatStampIndex = steps.findIndex(
-      (step) => step.name === 'Verify chat build stamp inside image'
-    );
-
-    expect(verificationBuildIndex).toBeGreaterThanOrEqual(0);
-    expect(shaAssertionIndex).toBeGreaterThan(verificationBuildIndex);
-    expect(chatStampIndex).toBeGreaterThan(shaAssertionIndex);
-    expect(pushIndex).toBeGreaterThan(chatStampIndex);
-
-    for (const index of [verificationBuildIndex, shaAssertionIndex, chatStampIndex]) {
-      expect(steps[index].if).toBeUndefined();
-      expect(steps[index]['continue-on-error']).toBeUndefined();
-    }
-
-    expect(steps[verificationBuildIndex].with['build-args']).toBe(steps[pushIndex].with['build-args']);
-    expect(steps[verificationBuildIndex].with.labels).toBe(steps[pushIndex].with.labels);
-  });
-
-  it('lets publication failure terminate the job without conditional recovery', () => {
-    const pushStep = findStepsUsing(job, 'docker/build-push-action').find(
-      (step) => step.with?.push === true
-    );
-    expect(pushStep).toBeTruthy();
-    expect(pushStep.if).toBeUndefined();
-    expect(pushStep['continue-on-error']).toBeUndefined();
-    const laterSteps = findSteps(job).slice(
-      findSteps(job).indexOf(pushStep) + 1
-    );
-    for (const step of laterSteps) {
-      expect(step.if ?? '').not.toMatch(
-        /failure\(\)|outcome == 'failure'|always\(\)/
-      );
-    }
-  });
-
-  it('verifies and summarizes the branch-SHA coordinate without pushing it', () => {
-    const branchDescribeStep = findSteps(job).find(
-      (step) => step.id === 'branch_sha_evidence'
-    );
-    expect(branchDescribeStep).toBeTruthy();
-    expect(branchDescribeStep.run).toContain('ghcr-manifest.mjs describe');
-    expect(branchDescribeStep.run).toContain('steps.branch.outputs.branch');
-    expect(branchDescribeStep.run).toContain(
-      'steps.revision.outputs.short_sha'
-    );
-
-    const pushSteps = findStepsUsing(job, 'docker/build-push-action').filter(
-      (step) => step.with?.push === true
-    );
-    for (const step of pushSteps) {
-      expect(JSON.stringify(step.with)).not.toContain('branch_sha_tag');
-    }
-
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep.env.BRANCH_SHA_TAG).toBe(
-      '${{ steps.tags.outputs.branch_sha_tag }}'
-    );
-    expect(summaryStep.run).toContain('${BRANCH_SHA_TAG}');
-  });
-
-  it('records the required evidence in the workflow summary without leaking credentials', () => {
-    const summaryStep = findSteps(job).find((step) =>
-      step.run?.includes('GITHUB_STEP_SUMMARY')
-    );
-    expect(summaryStep).toBeTruthy();
-    const summary = summaryStep.run as string;
-    expect(summary).toMatch(/Semantic version/);
-    expect(summary).toMatch(/Full Git SHA/);
-    expect(summary).toMatch(/Immutable branch-SHA tag/);
-    expect(summary).toMatch(/Semantic tag/);
-    expect(summary).toMatch(/Image index digest/);
-    expect(summary).toMatch(/linux\/amd64 digest/);
-    expect(summary).toMatch(/linux\/arm64 digest/);
-    expect(summary).not.toMatch(/GITHUB_TOKEN/);
-    expect(summary).not.toMatch(/password/i);
-  });
-
-  it('passes registry credentials only through env, never inline in a run script', () => {
-    const guardStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs check-absent')
-    );
-    const evidenceStep = findSteps(job).find((step) =>
-      step.run?.includes('ghcr-manifest.mjs describe')
-    );
-    for (const step of [guardStep, evidenceStep]) {
-      expect(step.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
-      expect(step.run).not.toContain('secrets.GITHUB_TOKEN');
-    }
+    ).run;
+    for (const field of [
+      'Full source SHA',
+      'Immutable image',
+      'linux/amd64 digest',
+      'linux/arm64 digest',
+      'Immutable chart',
+      'Manifest artifact',
+    ])
+      expect(summary).toContain(field);
+    expect(summary).not.toMatch(/TOKEN|PASSWORD|secret/i);
   });
 });

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createManifest,
+  validateManifest,
+} from '../scripts/check-release-consistency.mjs';
+
+const sha = 'a'.repeat(40);
+const digest = `sha256:${'b'.repeat(64)}`;
+const otherDigest = `sha256:${'c'.repeat(64)}`;
+const local = {
+  applicationVersion: '3.1.0',
+  chartVersion: '4.2.0',
+  sourceRevision: sha,
+  imageTag: 'main-aaaaaaa',
+};
+const image = {
+  indexDigest: digest,
+  platforms: {
+    amd64: { digest },
+    arm64: { digest: otherDigest },
+  },
+};
+
+describe('release consistency manifest', () => {
+  it('emits a stable complete manifest with independently versioned chart coordinates', () => {
+    const manifest = createManifest(local, image, { digest: otherDigest });
+    expect(JSON.stringify(manifest, null, 2)).toMatchInlineSnapshot(`
+      "{
+        \"schemaVersion\": 1,
+        \"app\": \"dspace\",
+        \"applicationVersion\": \"3.1.0\",
+        \"sourceRevision\": \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",
+        \"imageTag\": \"main-aaaaaaa\",
+        \"imageDigest\": \"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",
+        \"chartVersion\": \"4.2.0\",
+        \"chartDigest\": \"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",
+        \"platformDigests\": {
+          \"linux/amd64\": \"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",
+          \"linux/arm64\": \"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"
+        },
+        \"semanticImageTag\": \"v3.1.0\"
+      }"
+    `);
+  });
+
+  it.each([
+    ['source revision', { sourceRevision: 'short' }],
+    ['mutable image tag', { imageTag: 'main-latest' }],
+    ['semantic tag', { semanticImageTag: 'v9.9.9' }],
+    ['image digest', { imageDigest: 'malformed' }],
+    ['chart digest', { chartDigest: 'malformed' }],
+    ['required platform', { platformDigests: { 'linux/amd64': digest } }],
+  ])('fails closed for a malformed %s', (_label, change) => {
+    const manifest = {
+      ...createManifest(local, image, { digest: otherDigest }),
+      ...change,
+    };
+    expect(() => validateManifest(manifest)).toThrow(
+      /malformed or inconsistent/
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent release-coordinate drift that caused the 2026-07-23 production version-drift incident by introducing a single, reusable, fail-closed gate that proves tag → commit → app metadata → immutable image → semantic alias → chart provenance describe the same approved release.  
- Provide a deterministic, network-free fixture mode and reuse the existing GHCR client so workflow YAML does not duplicate parsing or registry policy.

### Description

- Add `scripts/check-release-consistency.mjs`, a reusable Node command with modes for `local`, `chart-pre`, `chart-post`, `pre-semantic`, `final`, `validate-manifest`, and `--verify-local-fixtures`, which validates peeled tags, branch reachability, package/lock/chart appVersion alignment, immutable `<branch>-<shortsha>` image selection, platform revision labels, chart provenance, and emits a deterministic `dspace-release-manifest.json`.  
- Extend `scripts/ghcr-manifest.mjs` to inspect OCI image indexes, per-platform manifests/configs, and OCI artifact configs (blobs), and to fail-closed on malformed, auth, or network outcomes while avoiding credential leakage.  
- Integrate the gate into workflows: update `.github/workflows/ci-image.yml` to authorize the checked-out release before lifecycle steps, require two pre-publish absence checks and one exact `docker buildx imagetools create` alias for the semantic tag, verify digest equality, validate and upload the deterministic manifest (SHA-pinned upload action), and summarize full release evidence; update `.github/workflows/ci-helm.yml` to run `chart-pre` before package steps and `chart-post` after push while preserving existing double absence checks and single `helm push`.  
- Add tests `tests/releaseConsistency.test.ts` and adapt CI workflow tests to assert the new gate and workflow structure, and update documentation (`AGENTS.md`, `docs/ops/sugarkube-release.md`, `docs/charts.md`) to document the immutable-image → immutable-chart → GitHub-release/semantic-alias/manifest order and invariants.

### Testing

- Ran `bash scripts/check-dspace-chart-version.sh` and it succeeded.  
- Exercised deterministic fixture mode with `node scripts/check-release-consistency.mjs --verify-local-fixtures` and it passed.  
- Ran targeted test suites: `npm run test:root -- tests/releaseConsistency.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts tests/ghcrManifestGuard.test.ts tests/helmChartReleaseVersion.test.ts` and observed all included tests pass (107 tests).  
- Additional focused run `npm run test:root -- tests/releaseConsistency.test.ts tests/ghcrManifestGuard.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts` passed (61 tests).  
- Ran formatting, lint, type-check, build-stamp and link checks: `npm run lint`, `npm run type-check`, `npm run build` (part of CI test flow), and `node scripts/link-check.mjs` — all succeeded locally.  

Notes and environment limits: `npm run test:ci` completed build and build-stamp phases but the full root runner was interrupted in this environment after a long idle period; focused suites required by the change passed. `actionlint` was not available here and was not run. No tags, GitHub releases, GHCR artifacts, chart versions, or deployments were published or mutated while preparing this change.

Refs #4730
Postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6472156a54832f9c8e6a70788492d8)