### PR TITLE
Expose canonical runtime build identity (build-info.json, validation, Docker/workflow propagation)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -68,6 +68,8 @@ jobs:
           pkg_version="$(node -p "require('./package.json').version")"
           short_sha="$(git rev-parse --short HEAD)"
           echo "value=v${pkg_version}+${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/democratizedspace/dspace:ci-${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies (creates host node_modules)
         run: pnpm install --frozen-lockfile --reporter=append-only
@@ -89,11 +91,16 @@ jobs:
           push: false
           platforms: linux/amd64
           provenance: false
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
 
       - name: Build image with local node_modules present
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -108,11 +115,16 @@ jobs:
           cache-to: type=gha,mode=max,ignore-error=true,scope=ci-image-local
           load: true
           tags: dspace-test:latest
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
 
       - name: Build image for smoke test (no cache for forks)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
@@ -125,11 +137,16 @@ jobs:
           provenance: false
           load: true
           tags: dspace-test:latest
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
           build-args: |
             DSPACE_VERSION=${{ steps.build_version.outputs.value }}
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
 
       - name: Inspect frontend bundle location in built image
         run: |
@@ -259,6 +276,13 @@ jobs:
           fi
           echo "/docs/dCarbon responded with expected content"
 
+          runtime_sha="$(curl -fsS "$BASE_URL/build-info.json" | node -pe 'JSON.parse(fs.readFileSync(0)).revision')"
+          html_sha="$(curl -fsS "$BASE_URL/" | grep -o 'name="dspace-build-revision" content="[0-9a-f]\{40\}"' | grep -o '[0-9a-f]\{40\}')"
+          oci_sha="$(docker image inspect dspace-test:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$runtime_sha" = "$GITHUB_SHA"
+          test "$html_sha" = "$GITHUB_SHA"
+          test "$oci_sha" = "$GITHUB_SHA"
+
           # Cleanup
           docker stop dspace-smoke-test
           docker rm dspace-smoke-test
@@ -387,6 +411,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -412,6 +438,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -435,6 +463,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            DSPACE_BUILD_CREATED=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           cache-from: type=gha
 
       - name: Assert build SHA is baked into frontend bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV PYTHON="/usr/bin/python3"
 ENV DSPACE_VERSION="${DSPACE_VERSION}"
+ENV DSPACE_REVISION="${GIT_SHA}"
+ENV DSPACE_BUILD_CREATED="${DSPACE_BUILD_CREATED}"
+ENV DSPACE_IMAGE="${DSPACE_IMAGE}"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -52,6 +55,8 @@ ARG DSPACE_VERSION
 ARG GIT_SHA=unknown
 ARG VITE_GIT_SHA=${GIT_SHA}
 ARG ENFORCE_VITE_GIT_SHA=0
+ARG DSPACE_BUILD_CREATED
+ARG DSPACE_IMAGE
 # GIT_SHA should be provided via build args; git is not available in the image to compute it.
 RUN if [ "$ENFORCE_VITE_GIT_SHA" = "1" ]; then \
         if [ -z "$VITE_GIT_SHA" ] || [ "$VITE_GIT_SHA" = "unknown" ] || [ "$VITE_GIT_SHA" = "dev-local" ]; then \
@@ -60,6 +65,8 @@ RUN if [ "$ENFORCE_VITE_GIT_SHA" = "1" ]; then \
         fi; \
     fi
 ENV VITE_GIT_SHA="${VITE_GIT_SHA}"
+ENV DSPACE_BUILD_CREATED="${DSPACE_BUILD_CREATED}"
+ENV DSPACE_IMAGE="${DSPACE_IMAGE}"
 # Copy source separately to avoid overlaying host node_modules (pnpm symlinks make this fail when
 # node_modules exists on the host). Build artifacts are excluded via .dockerignore for compatibility
 # with builders that do not support COPY --exclude flags.
@@ -85,7 +92,13 @@ RUN --mount=type=cache,target=/root/.pnpm-store pnpm install --filter ./frontend
 
 FROM base AS runtime
 ARG DSPACE_VERSION=dev
+ARG GIT_SHA=unknown
+ARG DSPACE_BUILD_CREATED
+ARG DSPACE_IMAGE
 ENV DSPACE_VERSION="${DSPACE_VERSION}"
+ENV DSPACE_REVISION="${GIT_SHA}"
+ENV DSPACE_BUILD_CREATED="${DSPACE_BUILD_CREATED}"
+ENV DSPACE_IMAGE="${DSPACE_IMAGE}"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         dumb-init \

--- a/docs/ops/build-identity.md
+++ b/docs/ops/build-identity.md
@@ -1,0 +1,26 @@
+# Runtime build identity verification
+
+DSPACE production images expose one artifact-fixed identity at `GET /build-info.json`. The legacy
+`/build-meta.json` endpoint is backed by the same metadata. Responses are uncached; an invalid or
+missing production identity returns HTTP 503. Health probes include the identity additively but
+retain their availability semantics.
+
+Given the approved full commit and immutable image coordinate, Sugarkube automation can use:
+
+```bash
+expected_sha='<40-character-approved-sha>'
+base_url='https://democratized.space'
+image='ghcr.io/democratizedspace/dspace:main-abcdef0'
+
+runtime_sha="$(curl -fsS "$base_url/build-info.json" | jq -r .revision)"
+html_sha="$(curl -fsS "$base_url/" | sed -n 's/.*name="dspace-build-revision" content="\([0-9a-f]\{40\}\)".*/\1/p' | head -1)"
+oci_sha="$(docker image inspect "$image" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+test "$runtime_sha" = "$expected_sha"
+test "$html_sha" = "$expected_sha"
+test "$oci_sha" = "$expected_sha"
+```
+
+Also require `.shortRevision == ($expected_sha | first seven characters)`, and, when present,
+`.image` to equal the approved immutable branch-SHA coordinate. Never accept `latest` or a semantic
+tag as promotion evidence. This contract verifies an already selected deployment; it does not
+implement a remote chat smoke test or a promotion gate.

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { SEO } from 'astro-seo';
 import { OFFLINE_TOAST_PUBLIC_PATH } from '../utils/offlineToastPath';
 import { getCheatsAvailabilityFlag } from '../utils/cheatsAvailability';
+import buildMeta from '../generated/build_meta.json';
 
 export interface Props {
 	title: string;
@@ -48,6 +49,7 @@ const cheatsAvailable = getCheatsAvailabilityFlag();
                 <meta name="viewport" content="width=device-width" />
                 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
                 <meta name="generator" content={Astro.generator} />
+                <meta name="dspace-build-revision" content={buildMeta.gitSha} />
                 <script is:inline>
                         (function bootstrapTheme() {
                                 const STORAGE_KEY = 'dspace-theme';

--- a/frontend/src/pages/build-info.json.ts
+++ b/frontend/src/pages/build-info.json.ts
@@ -1,0 +1,7 @@
+import { buildRuntimeBuildMetaResponse } from '../utils/buildMetaServer';
+
+export const prerender = false;
+
+export async function GET() {
+    return buildRuntimeBuildMetaResponse('/build-info.json');
+}

--- a/frontend/src/utils/buildInfo.js
+++ b/frontend/src/utils/buildInfo.js
@@ -11,6 +11,41 @@ const readViteGitSha = () => {
 };
 
 const normalizeSha = (value) => String(value || '').trim();
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+
+export const normalizeBuildIdentity = (value) => {
+    if (!value || typeof value !== 'object') throw new Error('Build identity is missing.');
+    const revision = normalizeSha(value.revision || value.gitSha);
+    if (isPlaceholderSha(revision) || !FULL_SHA.test(revision)) {
+        throw new Error('Build revision must be a full 40-character hexadecimal SHA.');
+    }
+    const version = String(value.version || '').trim();
+    if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+        throw new Error('Build version is invalid.');
+    }
+    const generatedAt = String(value.generatedAt || '').trim();
+    if (!generatedAt || Number.isNaN(Date.parse(generatedAt))) {
+        throw new Error('Build timestamp is invalid.');
+    }
+    const shortRevision = revision.slice(0, 7);
+    if (value.shortRevision && value.shortRevision !== shortRevision) {
+        throw new Error('Short revision does not match full revision.');
+    }
+    const identity = { version, revision, shortRevision, generatedAt };
+    if (value.image) {
+        const image = String(value.image).trim();
+        const escaped = shortRevision.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        if (
+            !new RegExp(`^[a-z0-9.-]+(?:/[a-z0-9._-]+)+:[a-z0-9._-]+-${escaped}$`, 'i').test(image)
+        ) {
+            throw new Error('Image coordinate is not an immutable matching branch-SHA tag.');
+        }
+        identity.image = image;
+    }
+    return identity;
+};
+
+export const getCanonicalBuildIdentity = () => normalizeBuildIdentity(buildMeta);
 
 const readBuildMetaSha = () => normalizeSha(buildMeta?.gitSha);
 

--- a/frontend/src/utils/buildMetaServer.js
+++ b/frontend/src/utils/buildMetaServer.js
@@ -11,7 +11,7 @@ const REPO_BUILD_META_PATH = path.join(
     'build_meta.json'
 );
 const FRONTEND_BUILD_META_PATH = path.join(process.cwd(), 'src', 'generated', 'build_meta.json');
-const ENV_SOURCES = ['GITHUB_SHA', 'VITE_GIT_SHA', 'GIT_SHA', 'DSPACE_GIT_SHA'];
+const FULL_SHA = /^[0-9a-f]{40}$/i;
 
 const normalizeSha = (value) => String(value || '').trim();
 
@@ -34,36 +34,41 @@ const readBuildMetaFile = async (filePath) => {
         const raw = await fs.readFile(filePath, 'utf8');
         const parsed = JSON.parse(raw);
         const gitSha = normalizeSha(parsed?.gitSha);
-        if (isPlaceholderSha(gitSha)) {
+        if (isPlaceholderSha(gitSha) || !FULL_SHA.test(gitSha)) {
             return null;
         }
-        const generatedAt = normalizeSha(parsed?.generatedAt) || new Date().toISOString();
+        const generatedAt = normalizeSha(parsed?.generatedAt);
         const source = normalizeSha(parsed?.source) || 'build-meta';
+        const version = normalizeSha(parsed?.version);
+        const shortRevision = gitSha.slice(0, 7);
+        if (!version || !generatedAt || Number.isNaN(Date.parse(generatedAt))) return null;
+        if (parsed.shortRevision && parsed.shortRevision !== shortRevision) return null;
+        const image = normalizeSha(parsed?.image);
+        if (image) {
+            const escaped = shortRevision.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            if (
+                !new RegExp(
+                    `^[a-z0-9.-]+(?:/[a-z0-9._-]+)+:[a-z0-9._-]+-${escaped}$`,
+                    'i'
+                ).test(image)
+            ) {
+                return null;
+            }
+        }
 
         return {
             gitSha,
+            version,
+            revision: gitSha,
+            shortRevision,
             generatedAt,
+            ...(image ? { image } : {}),
             source,
             resolvedFrom: filePath,
         };
     } catch (error) {
         return null;
     }
-};
-
-const resolveBuildMetaFromEnv = () => {
-    for (const key of ENV_SOURCES) {
-        const gitSha = normalizeSha(process.env[key]);
-        if (!isPlaceholderSha(gitSha)) {
-            return {
-                gitSha,
-                generatedAt: new Date().toISOString(),
-                source: `env:${key}`,
-                resolvedFrom: 'env',
-            };
-        }
-    }
-    return null;
 };
 
 export const resolveRuntimeBuildMeta = async () => {
@@ -78,10 +83,6 @@ export const resolveRuntimeBuildMeta = async () => {
     const frontendMeta = await readBuildMetaFile(FRONTEND_BUILD_META_PATH);
     if (frontendMeta) {
         return frontendMeta;
-    }
-    const envMeta = resolveBuildMetaFromEnv();
-    if (envMeta) {
-        return envMeta;
     }
     return {
         gitSha: 'missing',
@@ -104,13 +105,13 @@ const buildHeaders = () => ({
     'Cache-Control': 'no-store',
 });
 
-export async function buildRuntimeBuildMetaResponse() {
+export async function buildRuntimeBuildMetaResponse(route = '/build-meta.json') {
     try {
         const meta = await resolveRuntimeBuildMeta();
         if (isPlaceholderSha(meta.gitSha)) {
             const message = 'Runtime build metadata is missing or invalid';
             logServerError({
-                route: '/build-meta.json',
+                route,
                 method: 'GET',
                 error: message,
                 context: { meta },
@@ -130,7 +131,7 @@ export async function buildRuntimeBuildMetaResponse() {
         const errorToLog =
             error instanceof Error ? new Error(`${message}: ${error.message}`) : new Error(message);
         logServerError({
-            route: '/build-meta.json',
+            route,
             method: 'GET',
             error: errorToLog,
             context: { error },

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,5 +1,5 @@
 import { isBrowser } from './ssr.js';
-import { getAppGitSha } from './buildInfo.js';
+import buildMeta from '../generated/build_meta.json';
 
 const isBrowserRuntime = isBrowser && (typeof process === 'undefined' || !process.versions?.node);
 const defaultLoader = () => import(/* @vite-ignore */ 'prom-client');
@@ -131,13 +131,8 @@ const getOrCreateMetric = (constructors, registerInstance, type, config) => {
 };
 
 const loadBuildInfo = () => ({
-    version: process.env.DSPACE_VERSION || process.env.npm_package_version || 'unknown',
-    revision:
-        process.env.DSPACE_REVISION ||
-        process.env.GITHUB_SHA ||
-        process.env.SOURCE_VERSION ||
-        getAppGitSha() ||
-        'unknown',
+    version: buildMeta.version,
+    revision: buildMeta.gitSha,
 });
 
 async function initMetrics(loader = defaultLoader) {
@@ -209,7 +204,7 @@ async function initMetrics(loader = defaultLoader) {
         const build = loadBuildInfo();
         if (typeof metricHandles.buildInfo.remove === 'function') {
             try {
-                metricHandles.buildInfo.remove();
+                metricHandles.buildInfo.reset();
             } catch {
                 // Duplicate-import safety: older prom-client versions may not support remove().
             }

--- a/frontend/src/utils/runtimeEndpoints.ts
+++ b/frontend/src/utils/runtimeEndpoints.ts
@@ -3,6 +3,7 @@ import { parseFeatureFlags, readBooleanOverride } from '@dspace/feature-flags';
 import { resolveTokenPlaceBaseUrl, getTokenPlaceChatModel } from './tokenPlace.js';
 import { logServerError } from './serverLogger';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import buildMeta from '../generated/build_meta.json';
 
 function parseOfflineWorkerEnabled(flags: FeatureFlagParseResult): boolean {
     const envOverride = readBooleanOverride(process.env.DSPACE_OFFLINE_WORKER_ENABLED);
@@ -196,6 +197,13 @@ function buildHealthBody(status: 'ready' | 'alive') {
         version,
         env: environment,
         features: flags.tokens,
+        build: {
+            version: buildMeta.version,
+            revision: buildMeta.gitSha,
+            shortRevision: buildMeta.shortRevision,
+            generatedAt: buildMeta.generatedAt,
+            ...('image' in buildMeta ? { image: buildMeta.image } : {}),
+        },
     };
 }
 

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -2,85 +2,51 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const args = process.argv.slice(2);
-const expectedSha = String(process.env.EXPECTED_SHA || process.env.GIT_SHA || '').trim();
-
-if (!expectedSha) {
-    console.error('Expected SHA is required. Set EXPECTED_SHA or GIT_SHA.');
-    process.exit(1);
+const expected = String(
+  process.env.EXPECTED_SHA || process.env.GIT_SHA || ''
+).trim();
+if (!/^[0-9a-f]{40}$/i.test(expected)) {
+  console.error('EXPECTED_SHA must be exactly 40 hexadecimal characters.');
+  process.exit(1);
 }
-
-const shortSha = expectedSha.length > 7 ? expectedSha.slice(0, 7) : expectedSha;
-const targets = [expectedSha, shortSha, `v3:${shortSha}`].filter(Boolean);
-const forbidden = ['v3:missing', 'v3:dev-local', 'v3:unknown', 'v3:missing-sha'];
-const allowedExtensions = new Set(['.js', '.mjs', '.cjs', '.css', '.html']);
-
-const candidateDirs =
-    args.length > 0 ? args : ['/app/dist', '/workspace/frontend/dist', 'frontend/dist', 'dist'];
-const existingDirs = candidateDirs.filter((dir) => fs.existsSync(dir));
-
-if (existingDirs.length === 0) {
-    console.error(`No dist directories found. Checked: ${candidateDirs.join(', ')}`);
-    process.exit(1);
+const roots = process.argv.slice(2).filter((entry) => fs.existsSync(entry));
+if (!roots.length) {
+  console.error('No build output directory found.');
+  process.exit(1);
 }
-
-const stack = [...existingDirs];
-let foundTarget = false;
-const forbiddenHits = new Set();
-
+const placeholders = ['unknown', 'missing-sha', 'dev-local'];
+let server = false;
+let client = false;
+let canonical = false;
+const stack = [...roots];
 while (stack.length) {
-    const current = stack.pop();
-    if (!current) {
-        continue;
-    }
-    let entries = [];
-    try {
-        entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch (error) {
-        continue;
-    }
-    for (const entry of entries) {
-        const fullPath = path.join(current, entry.name);
-        if (entry.isDirectory()) {
-            stack.push(fullPath);
-            continue;
-        }
-        if (!entry.isFile()) {
-            continue;
-        }
-        if (!allowedExtensions.has(path.extname(fullPath))) {
-            continue;
-        }
-        try {
-            const content = fs.readFileSync(fullPath, 'utf8');
-            if (!foundTarget && targets.some((target) => content.includes(target))) {
-                foundTarget = true;
-            }
-            for (const forbiddenValue of forbidden) {
-                if (content.includes(forbiddenValue)) {
-                    forbiddenHits.add(forbiddenValue);
-                }
-            }
-        } catch (error) {
-            continue;
-        }
-    }
-}
-
-if (!foundTarget) {
-    console.error(
-        `Expected build SHA not found in frontend bundle. Looked for: ${targets.join(', ')}`
-    );
+  const current = stack.pop();
+  const stat = fs.statSync(current);
+  if (stat.isDirectory()) {
+    for (const name of fs.readdirSync(current))
+      stack.push(path.join(current, name));
+    continue;
+  }
+  if (!/\.(?:js|mjs|cjs|html|json|css)$/.test(current)) continue;
+  const text = fs.readFileSync(current, 'utf8');
+  if (placeholders.some((value) => text.includes(`v3:${value}`))) {
+    console.error(`Placeholder build identity found in ${current}`);
     process.exit(1);
+  }
+  if (!text.includes(expected)) continue;
+  const relative = path.relative(roots[0], current).replaceAll(path.sep, '/');
+  if (relative.includes('_astro/') || relative.includes('client/'))
+    client = true;
+  else server = true;
+  if (text.includes('shortRevision') && text.includes(expected.slice(0, 7)))
+    canonical = true;
 }
-
-if (forbiddenHits.size > 0) {
-    console.error(
-        `Forbidden build SHA markers found in frontend bundle: ${Array.from(forbiddenHits).join(
-            ', '
-        )}`
-    );
-    process.exit(1);
+if (!server || !client || !canonical) {
+  console.error(
+    `Build identity verification failed (server=${server}, client=${client}, canonical=${canonical}).`
+  );
+  process.exit(1);
 }
-
-console.log(`Build SHA verified in frontend bundle. Matched: ${targets.join(', ')}`);
+console.log(
+  `Verified full build SHA ${expected} in canonical metadata, server output, and client assets.`
+);

--- a/scripts/write-build-meta.mjs
+++ b/scripts/write-build-meta.mjs
@@ -6,108 +6,169 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const resolveRepoRoot = () =>
-    process.env.VERIFY_REPO_ROOT
-        ? path.resolve(process.env.VERIFY_REPO_ROOT)
-        : path.resolve(__dirname, '..');
+  process.env.VERIFY_REPO_ROOT
+    ? path.resolve(process.env.VERIFY_REPO_ROOT)
+    : path.resolve(__dirname, '..');
 const resolveBuildMetaPath = (root) => {
-    const overridePath = process.env.VERIFY_BUILD_META_PATH;
-    if (overridePath) {
-        return path.isAbsolute(overridePath)
-            ? overridePath
-            : path.resolve(root, overridePath);
-    }
-    return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
+  const overridePath = process.env.VERIFY_BUILD_META_PATH;
+  if (overridePath) {
+    return path.isAbsolute(overridePath)
+      ? overridePath
+      : path.resolve(root, overridePath);
+  }
+  return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
 };
 const repoRoot = resolveRepoRoot();
 const buildMetaPath = resolveBuildMetaPath(repoRoot);
 const allowedSources = new Set(['ci', 'env', 'git']);
+const FULL_SHA = /^[0-9a-f]{40}$/i;
 
 const normalizeSha = (value) => String(value || '').trim();
 
 const isPlaceholderSha = (value) => {
-    const normalized = normalizeSha(value).toLowerCase();
-    return (
-        !normalized ||
-        normalized === 'unknown' ||
-        normalized === 'missing' ||
-        normalized === 'missing-sha' ||
-        normalized === 'dev-local'
-    );
+  const normalized = normalizeSha(value).toLowerCase();
+  return (
+    !normalized ||
+    normalized === 'unknown' ||
+    normalized === 'missing' ||
+    normalized === 'missing-sha' ||
+    normalized === 'dev-local'
+  );
 };
 
 export const assertBuildMetaComplete = (payload) => {
-    if (!payload || typeof payload !== 'object') {
-        throw new Error('build_meta.json payload is missing or invalid.');
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('build_meta.json payload is missing or invalid.');
+  }
+  if (isPlaceholderSha(payload.gitSha)) {
+    throw new Error(
+      `build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`
+    );
+  }
+  if (!FULL_SHA.test(normalizeSha(payload.gitSha))) {
+    throw new Error(
+      'build_meta.json gitSha must be exactly 40 hexadecimal characters.'
+    );
+  }
+  if (!normalizeSha(payload.generatedAt)) {
+    throw new Error('build_meta.json generatedAt is missing.');
+  }
+  if (new Date(payload.generatedAt).toISOString() !== payload.generatedAt) {
+    throw new Error(
+      'build_meta.json generatedAt must be a normalized ISO timestamp.'
+    );
+  }
+  if (
+    !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(
+      String(payload.version || '')
+    )
+  ) {
+    throw new Error('build_meta.json version is invalid.');
+  }
+  if (payload.shortRevision !== normalizeSha(payload.gitSha).slice(0, 7)) {
+    throw new Error(
+      'build_meta.json shortRevision does not agree with gitSha.'
+    );
+  }
+  if (payload.image) {
+    const escaped = payload.shortRevision.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&'
+    );
+    if (
+      !new RegExp(
+        `^[a-z0-9.-]+(?:/[a-z0-9._-]+)+:[a-z0-9._-]+-${escaped}$`,
+        'i'
+      ).test(payload.image)
+    ) {
+      throw new Error(
+        'build_meta.json image must be an immutable branch-SHA coordinate matching gitSha.'
+      );
     }
-    if (isPlaceholderSha(payload.gitSha)) {
-        throw new Error(`build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`);
-    }
-    if (!normalizeSha(payload.generatedAt)) {
-        throw new Error('build_meta.json generatedAt is missing.');
-    }
-    const source = String(payload.source || '').trim().toLowerCase();
-    if (!source || source === 'static' || !allowedSources.has(source)) {
-        throw new Error(`build_meta.json source is invalid: ${payload.source || 'empty'}`);
-    }
+  }
+  const source = String(payload.source || '')
+    .trim()
+    .toLowerCase();
+  if (!source || source === 'static' || !allowedSources.has(source)) {
+    throw new Error(
+      `build_meta.json source is invalid: ${payload.source || 'empty'}`
+    );
+  }
 };
 
 export const getRepoRoot = () => repoRoot;
 export const getBuildMetaPath = () => buildMetaPath;
 
 export const resolveBuildMeta = () => {
-    const envPriority = [
-        { key: 'GITHUB_SHA', source: 'ci' },
-        { key: 'VITE_GIT_SHA', source: 'env' },
-        { key: 'GIT_SHA', source: 'env' },
-        { key: 'DSPACE_GIT_SHA', source: 'env' },
-    ];
+  const envPriority = [
+    { key: 'GITHUB_SHA', source: 'ci' },
+    { key: 'VITE_GIT_SHA', source: 'env' },
+    { key: 'GIT_SHA', source: 'env' },
+    { key: 'DSPACE_GIT_SHA', source: 'env' },
+  ];
 
-    for (const { key, source } of envPriority) {
-        const value = normalizeSha(process.env[key]);
-        if (value && !isPlaceholderSha(value)) {
-            return { gitSha: value, source };
-        }
+  for (const { key, source } of envPriority) {
+    const value = normalizeSha(process.env[key]);
+    if (value && !isPlaceholderSha(value)) {
+      return { gitSha: value, source };
     }
+  }
 
-    try {
-        const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-        if (isPlaceholderSha(gitSha)) {
-            throw new Error('git rev-parse returned an invalid SHA.');
-        }
-        return { gitSha, source: 'git' };
-    } catch (error) {
-        throw new Error(
-            'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
-        );
+  try {
+    const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+    if (isPlaceholderSha(gitSha)) {
+      throw new Error('git rev-parse returned an invalid SHA.');
     }
+    return { gitSha, source: 'git' };
+  } catch (error) {
+    throw new Error(
+      'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
+    );
+  }
 };
 
 export const writeBuildMeta = async ({ gitSha, source = 'build-meta' }) => {
-    const payload = {
-        gitSha: normalizeSha(gitSha),
-        generatedAt: new Date().toISOString(),
-        source,
-    };
-    assertBuildMetaComplete(payload);
-    await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
-    await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
-    return payload;
+  const packageJson = JSON.parse(
+    await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')
+  );
+  const suppliedAt = normalizeSha(process.env.DSPACE_BUILD_CREATED);
+  const generatedAt = suppliedAt
+    ? new Date(suppliedAt).toISOString()
+    : new Date().toISOString();
+  const payload = {
+    version: packageJson.version,
+    gitSha: normalizeSha(gitSha),
+    revision: normalizeSha(gitSha),
+    shortRevision: normalizeSha(gitSha).slice(0, 7),
+    generatedAt,
+    ...(normalizeSha(process.env.DSPACE_IMAGE)
+      ? { image: normalizeSha(process.env.DSPACE_IMAGE) }
+      : {}),
+    source,
+  };
+  assertBuildMetaComplete(payload);
+  await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
+  await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
+  return payload;
 };
 
 export const readBuildMeta = async () => {
-    const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
-    return JSON.parse(rawMeta);
+  const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
+  return JSON.parse(rawMeta);
 };
 
 const run = async () => {
-    const { gitSha, source } = resolveBuildMeta();
-    await writeBuildMeta({ gitSha, source });
-    console.log(`Build metadata written to ${buildMetaPath}`);
+  const { gitSha, source } = resolveBuildMeta();
+  await writeBuildMeta({ gitSha, source });
+  console.log(`Build metadata written to ${buildMetaPath}`);
 };
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    run().catch((error) => {
-        console.error('Failed to write build metadata:', error);
-        process.exit(1);
-    });
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run().catch((error) => {
+    console.error('Failed to write build metadata:', error);
+    process.exit(1);
+  });
 }

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBuildIdentity } from '../frontend/src/utils/buildInfo.js';
+import { GET as getBuildInfo } from '../frontend/src/pages/build-info.json';
+import { GET as getBuildMeta } from '../frontend/src/pages/build-meta.json';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const base = {
+  version: '3.1.0',
+  gitSha: revision,
+  shortRevision: '0123456',
+  generatedAt: '2026-07-23T12:00:00.000Z',
+};
+
+describe('canonical runtime build identity', () => {
+  it('normalizes the full and short revision and matching immutable image', () => {
+    expect(
+      normalizeBuildIdentity({
+        ...base,
+        image: 'ghcr.io/democratizedspace/dspace:main-0123456',
+      })
+    ).toEqual({
+      version: '3.1.0',
+      revision,
+      shortRevision: '0123456',
+      generatedAt: base.generatedAt,
+      image: 'ghcr.io/democratizedspace/dspace:main-0123456',
+    });
+  });
+
+  it.each([
+    '',
+    'unknown',
+    'missing',
+    'missing-sha',
+    'dev-local',
+    '0123456',
+    `${revision}00`,
+  ])(
+    'rejects missing, placeholder, short, or malformed revision %s',
+    (gitSha) =>
+      expect(() => normalizeBuildIdentity({ ...base, gitSha })).toThrow(
+        /revision/i
+      )
+  );
+
+  it('rejects mismatched short revisions and movable or mismatched image tags', () => {
+    expect(() =>
+      normalizeBuildIdentity({ ...base, shortRevision: 'abcdef0' })
+    ).toThrow(/Short/);
+    for (const image of [
+      'ghcr.io/democratizedspace/dspace:latest',
+      'ghcr.io/democratizedspace/dspace:v3.1.0',
+      'ghcr.io/democratizedspace/dspace:main-abcdef0',
+    ])
+      expect(() => normalizeBuildIdentity({ ...base, image })).toThrow(
+        /immutable/
+      );
+  });
+
+  it('serves the new endpoint and legacy compatible endpoint from one metadata resolver', async () => {
+    const [info, legacy] = await Promise.all([getBuildInfo(), getBuildMeta()]);
+    expect(info.status).toBe(200);
+    expect(info.headers.get('cache-control')).toBe('no-store');
+    const infoBody = await info.json();
+    const legacyBody = await legacy.json();
+    expect(infoBody).toEqual(legacyBody);
+    expect(infoBody.revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(infoBody.shortRevision).toBe(infoBody.revision.slice(0, 7));
+    expect(infoBody.gitSha).toBe(infoBody.revision);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide one bounded, verifiable build identity so operators and Sugarkube can prove server responses, SSR HTML, client assets, and OCI image metadata all originate from the same approved commit.  
- Harden existing partial support and fail closed on missing/malformed production identity to prevent version-drift issues described in the postmortem.  

### Description

- Add strict canonical build identity generation, normalization and validation in the existing build-meta pipeline (`scripts/write-build-meta.mjs`) including semantic `version`, 40-char full `revision` (gitSha), 7-char `shortRevision`, artifact-fixed ISO `generatedAt`, and optional immutable `image` coordinate; placeholders and malformed values are rejected.  
- Expose an uncached machine-readable `GET /build-info.json` backed by the same runtime resolver used by `/build-meta.json` so both endpoints share one source of truth (`frontend/src/utils/buildMetaServer.js`, `frontend/src/pages/build-info.json.ts`).  
- Surface the canonical identity additively in `/healthz` and `/livez` payloads without changing readiness/liveness semantics (same HTTP behavior, added `build` field).  
- Add deterministic SSR marker meta tag `<meta name="dspace-build-revision" content="<full-sha>" />` to the shared layout so the full SHA is present in HTML and survives client asset generation.  
- Harden verification tooling: `scripts/verify-build-sha.mjs` requires an exact 40-char SHA and ensures the full SHA appears in canonical metadata, server SSR output, and client/static assets; `verify-chat-build-stamp` is preserved and reused.  
- Wire workflow and Docker build args/labels so the same values propagate through: `GIT_SHA`/`VITE_GIT_SHA`, `DSPACE_BUILD_CREATED` (timestamp), `DSPACE_IMAGE` (immutable tag) and OCI label `org.opencontainers.image.revision` are set and validated in the smoke checks.  
- Preserve bounded Prometheus `dspace_build_info{version,revision}` labels and reset previous series before initializing the current build-info gauge.  
- Add focused tests for identity normalization, placeholder/rejection cases, immutable image validation, endpoint compatibility, and canonical presence in server/client outputs, plus a short ops doc with a Sugarkube copy-paste verification snippet.  

### Testing

- Ran package install and builds: `pnpm install --frozen-lockfile --reporter=append-only` (passed) and `GITHUB_SHA="$(git rev-parse HEAD)" npm run build` (passed).  
- Verification runs: `npm run verify:chat-build-stamp` (passed) and `EXPECTED_SHA="$(git rev-parse HEAD)" node scripts/verify-build-sha.mjs frontend/dist` (passed).  
- Unit/integration tests: `npm run test:root -- tests/buildIdentity.test.ts tests/ciImageWorkflow.test.ts tests/middlewareRuntimeEndpoints.test.ts` passed (3 files, 39 tests total passed).  
- Lint/typing/link checks: `npm run lint`, `npm run type-check`, and `npm run link-check` passed.  
- End-to-end CI check: `npm run test:ci` was started in the environment (build and build-stamp verification succeeded) but the full CI run was interrupted in this environment after the root suite ran for several minutes; focused suites listed above passed locally in this run.  
- Workflow & CI hygiene: `git diff --check` and repository secret scans were run against the diff and passed; `actionlint` was not available in this environment (warning).  

Closes #4732
Postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69432330fc832f881bbd47fa9b804d)