### PR TITLE
Expose canonical runtime build identity and verification surfaces

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -66,8 +66,10 @@ jobs:
         id: build_version
         run: |
           pkg_version="$(node -p "require('./package.json').version")"
-          short_sha="$(git rev-parse --short HEAD)"
+          short_sha="$(git rev-parse --short=7 HEAD)"
           echo "value=v${pkg_version}+${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/democratizedspace/dspace:ci-${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies (creates host node_modules)
         run: pnpm install --frozen-lockfile --reporter=append-only
@@ -94,6 +96,11 @@ jobs:
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
 
       - name: Build image with local node_modules present
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
@@ -113,6 +120,11 @@ jobs:
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
 
       - name: Build image for smoke test (no cache for forks)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
@@ -130,6 +142,11 @@ jobs:
             GIT_SHA=${{ github.sha }}
             VITE_GIT_SHA=${{ github.sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.build_version.outputs.created }}
+            DSPACE_IMAGE=${{ steps.build_version.outputs.image }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.build_version.outputs.created }}
 
       - name: Inspect frontend bundle location in built image
         run: |
@@ -237,6 +254,14 @@ jobs:
           else
             echo "Root page is responding with HTTP 200!"
           fi
+
+          OCI_REVISION=$(docker image inspect dspace-test:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+          RUNTIME_REVISION=$(curl -fsS "$BASE_URL/build-info.json" | node -e \
+            "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>process.stdout.write(JSON.parse(s).revision||''))")
+          HTML_REVISION=$(curl -fsS "$BASE_URL/" | sed -n 's/.*name="dspace-build-revision" content="\([0-9a-f]\{40\}\)".*/\1/p' | head -n1)
+          test "$OCI_REVISION" = "$GITHUB_SHA"
+          test "$RUNTIME_REVISION" = "$OCI_REVISION"
+          test "$HTML_REVISION" = "$OCI_REVISION"
 
           echo "Testing docs SSR page..."
           DOCS_RESPONSE=$(curl -s -w '\n%{http_code}' --max-time 10 "$BASE_URL/docs/dCarbon" 2>/dev/null || echo -e "\n000")
@@ -387,6 +412,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -412,6 +439,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -435,6 +464,11 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_CREATED_AT=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
 
       - name: Assert build SHA is baked into frontend bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 ARG DSPACE_VERSION=dev
 ARG GIT_SHA=unknown
 ARG VITE_GIT_SHA=${GIT_SHA}
+ARG BUILD_CREATED_AT
+ARG DSPACE_IMAGE
 
 FROM node:20-bookworm-slim AS base
 ARG DSPACE_VERSION
@@ -52,14 +54,19 @@ ARG DSPACE_VERSION
 ARG GIT_SHA=unknown
 ARG VITE_GIT_SHA=${GIT_SHA}
 ARG ENFORCE_VITE_GIT_SHA=0
+ARG BUILD_CREATED_AT
+ARG DSPACE_IMAGE
 # GIT_SHA should be provided via build args; git is not available in the image to compute it.
 RUN if [ "$ENFORCE_VITE_GIT_SHA" = "1" ]; then \
-        if [ -z "$VITE_GIT_SHA" ] || [ "$VITE_GIT_SHA" = "unknown" ] || [ "$VITE_GIT_SHA" = "dev-local" ]; then \
-            echo "Missing VITE_GIT_SHA build arg; refusing to build frontend assets." >&2; \
+        if ! printf '%s' "$GIT_SHA" | grep -Eq '^[0-9a-fA-F]{40}$' || [ "$VITE_GIT_SHA" != "$GIT_SHA" ]; then \
+            echo "GIT_SHA must be a full revision and agree with VITE_GIT_SHA." >&2; \
             exit 1; \
         fi; \
     fi
 ENV VITE_GIT_SHA="${VITE_GIT_SHA}"
+ENV GIT_SHA="${GIT_SHA}"
+ENV BUILD_CREATED_AT="${BUILD_CREATED_AT}"
+ENV DSPACE_IMAGE="${DSPACE_IMAGE}"
 # Copy source separately to avoid overlaying host node_modules (pnpm symlinks make this fail when
 # node_modules exists on the host). Build artifacts are excluded via .dockerignore for compatibility
 # with builders that do not support COPY --exclude flags.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -137,6 +137,27 @@ curl -fsS https://democratized.space/healthz | jq .
 curl -fsS https://democratized.space/livez | jq .
 ```
 
+### Verify one approved build identity
+
+Use the immutable, full source revision from the reviewed release record. The runtime identity,
+shared-layout SSR marker, immutable image tag, and OCI revision must all agree before promotion:
+
+```bash
+EXPECTED_SHA='<40-character-approved-git-sha>'
+BASE_URL='https://staging.democratized.space'
+IMAGE="ghcr.io/democratizedspace/dspace:main-${EXPECTED_SHA:0:7}"
+
+test "$(curl -fsS "$BASE_URL/build-info.json" | jq -r .revision)" = "$EXPECTED_SHA"
+test "$(curl -fsS "$BASE_URL/" | sed -n 's/.*name="dspace-build-revision" content="\([0-9a-f]\{40\}\)".*/\1/p' | head -n1)" = "$EXPECTED_SHA"
+test "${IMAGE##*-}" = "${EXPECTED_SHA:0:7}"
+test "$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Image}}' | jq -r '.config.Labels["org.opencontainers.image.revision"]')" = "$EXPECTED_SHA"
+```
+
+`GET /build-info.json` is uncached and returns the semantic application version, full and short
+revision, artifact-fixed build timestamp, and (for image builds) the immutable branch-SHA image
+coordinate. A `503` means identity cannot be proved; it does not redefine `/healthz` readiness or
+`/livez` liveness. Do not substitute a semantic or `*-latest` tag for the immutable image above.
+
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 

--- a/frontend/e2e/build-identity.spec.ts
+++ b/frontend/e2e/build-identity.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test('SSR HTML and runtime endpoint expose the same full build revision', async ({
+    page,
+    request,
+}) => {
+    await page.goto('/');
+    const marker = page.locator('meta[name="dspace-build-revision"]');
+    const revision = await marker.getAttribute('content');
+    expect(revision).toMatch(/^[0-9a-f]{40}$/);
+
+    const response = await request.get('/build-info.json');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['cache-control']).toContain('no-store');
+    const identity = await response.json();
+    expect(identity.revision).toBe(revision);
+    expect(identity.shortRevision).toBe(revision?.slice(0, 7));
+    expect(identity.applicationVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(new Date(identity.builtAt).toISOString()).toBe(identity.builtAt);
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -73,6 +73,7 @@ const TEST_GROUPS = [
         name: 'Structure Tests',
         files: [
             'page-structure.spec.ts',
+            'build-identity.spec.ts',
             'nav-route-smoke.spec.ts',
             'error-pages.spec.ts',
             'svelte-component-hydration.spec.ts',

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { SEO } from 'astro-seo';
 import { OFFLINE_TOAST_PUBLIC_PATH } from '../utils/offlineToastPath';
 import { getCheatsAvailabilityFlag } from '../utils/cheatsAvailability';
+import { getCanonicalBuildIdentity } from '../utils/buildInfo.js';
 
 export interface Props {
 	title: string;
@@ -12,6 +13,7 @@ const { title } = Astro.props as Props;
 const sitewideTitle = `DSPACE (democratized.space)`;
 const offlineWorkerRegistrationUrl = '/scripts/offlineWorkerRegistration.js';
 const cheatsAvailable = getCheatsAvailabilityFlag();
+const buildIdentity = getCanonicalBuildIdentity();
 ---
 
 <!DOCTYPE html>
@@ -21,6 +23,7 @@ const cheatsAvailable = getCheatsAvailabilityFlag();
         data-cheats-available={cheatsAvailable ? 'true' : 'false'}
 >
         <head>
+                <meta name="dspace-build-revision" content={buildIdentity.revision} />
                 <SEO
                         title={sitewideTitle}
                         description="A space exploration idle game where you gradually build up your skillset and eventually proliferate throughout the solar system."

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -89,10 +89,10 @@ export const onRequest = async (context: MiddlewareContext, next: () => Promise<
             break;
         case '/healthz':
         case '/health':
-            fallbackResponse = buildHealthResponse();
+            fallbackResponse = await buildHealthResponse();
             break;
         case '/livez':
-            fallbackResponse = buildLivezResponse();
+            fallbackResponse = await buildLivezResponse();
             break;
         default:
             fallbackResponse = response;

--- a/frontend/src/pages/build-info.json.ts
+++ b/frontend/src/pages/build-info.json.ts
@@ -1,0 +1,7 @@
+import { buildRuntimeBuildMetaResponse } from '../utils/buildMetaServer';
+
+export const prerender = false;
+
+export async function GET() {
+    return buildRuntimeBuildMetaResponse({ compatibility: false, route: '/build-info.json' });
+}

--- a/frontend/src/utils/buildIdentity.js
+++ b/frontend/src/utils/buildIdentity.js
@@ -1,0 +1,44 @@
+const FULL_REVISION = /^[0-9a-f]{40}$/;
+const VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const PLACEHOLDERS = new Set(['unknown', 'missing', 'missing-sha', 'dev-local']);
+const IMMUTABLE_IMAGE =
+    /^ghcr\.io\/democratizedspace\/dspace:([a-z0-9][a-z0-9._-]*)-([0-9a-f]{7})$/;
+
+const bounded = (value, maximum = 160) => {
+    const normalized = String(value ?? '').trim();
+    return normalized.length <= maximum ? normalized : '';
+};
+
+export const isPlaceholderRevision = (value) =>
+    PLACEHOLDERS.has(bounded(value).toLowerCase()) || !bounded(value);
+
+/** Normalize the only public build identity. Throws rather than returning partial production data. */
+export function normalizeBuildIdentity(meta) {
+    if (!meta || typeof meta !== 'object') throw new Error('build metadata is invalid');
+    const applicationVersion = bounded(meta.applicationVersion ?? meta.version, 64);
+    const revision = bounded(meta.revision ?? meta.gitSha, 40).toLowerCase();
+    const builtAt = bounded(meta.builtAt ?? meta.generatedAt, 40);
+    const image = bounded(meta.image ?? meta.imageCoordinate, 200);
+
+    if (!VERSION.test(applicationVersion)) throw new Error('application version is invalid');
+    if (!FULL_REVISION.test(revision) || isPlaceholderRevision(revision)) {
+        throw new Error('revision must be a full 40-character Git SHA');
+    }
+    const timestamp = new Date(builtAt);
+    if (!builtAt || Number.isNaN(timestamp.valueOf()) || timestamp.toISOString() !== builtAt) {
+        throw new Error('build timestamp must be an ISO timestamp');
+    }
+    if (image) {
+        const match = image.match(IMMUTABLE_IMAGE);
+        if (!match || match[2] !== revision.slice(0, 7) || match[1].endsWith('-latest')) {
+            throw new Error('image must be the matching immutable branch-SHA coordinate');
+        }
+    }
+    return {
+        applicationVersion,
+        revision,
+        shortRevision: revision.slice(0, 7),
+        builtAt,
+        ...(image ? { image } : {}),
+    };
+}

--- a/frontend/src/utils/buildInfo.js
+++ b/frontend/src/utils/buildInfo.js
@@ -1,4 +1,5 @@
 import buildMeta from '../generated/build_meta.json';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 const readViteGitSha = () => {
     if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_GIT_SHA) {
@@ -73,6 +74,8 @@ const shortenSha = (value) => {
 };
 
 export const getAppGitSha = () => resolveGitSha();
+
+export const getCanonicalBuildIdentity = () => normalizeBuildIdentity(buildMeta);
 
 export const getAppGitShaWithFallback = (fallbackSha) => {
     const appSha = normalizeSha(readViteGitSha());

--- a/frontend/src/utils/buildMetaServer.js
+++ b/frontend/src/utils/buildMetaServer.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { logServerError } from './serverLogger';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 const RUNTIME_BUILD_META_PATH = '/app/build_meta.json';
 const REPO_BUILD_META_PATH = path.join(
@@ -11,7 +12,6 @@ const REPO_BUILD_META_PATH = path.join(
     'build_meta.json'
 );
 const FRONTEND_BUILD_META_PATH = path.join(process.cwd(), 'src', 'generated', 'build_meta.json');
-const ENV_SOURCES = ['GITHUB_SHA', 'VITE_GIT_SHA', 'GIT_SHA', 'DSPACE_GIT_SHA'];
 
 const normalizeSha = (value) => String(value || '').trim();
 
@@ -37,10 +37,15 @@ const readBuildMetaFile = async (filePath) => {
         if (isPlaceholderSha(gitSha)) {
             return null;
         }
-        const generatedAt = normalizeSha(parsed?.generatedAt) || new Date().toISOString();
+        const generatedAt = normalizeSha(parsed?.generatedAt);
         const source = normalizeSha(parsed?.source) || 'build-meta';
 
         return {
+            applicationVersion: normalizeSha(parsed?.applicationVersion),
+            revision: normalizeSha(parsed?.revision),
+            shortRevision: normalizeSha(parsed?.shortRevision),
+            builtAt: normalizeSha(parsed?.builtAt),
+            ...(normalizeSha(parsed?.image) ? { image: normalizeSha(parsed.image) } : {}),
             gitSha,
             generatedAt,
             source,
@@ -49,21 +54,6 @@ const readBuildMetaFile = async (filePath) => {
     } catch (error) {
         return null;
     }
-};
-
-const resolveBuildMetaFromEnv = () => {
-    for (const key of ENV_SOURCES) {
-        const gitSha = normalizeSha(process.env[key]);
-        if (!isPlaceholderSha(gitSha)) {
-            return {
-                gitSha,
-                generatedAt: new Date().toISOString(),
-                source: `env:${key}`,
-                resolvedFrom: 'env',
-            };
-        }
-    }
-    return null;
 };
 
 export const resolveRuntimeBuildMeta = async () => {
@@ -79,10 +69,6 @@ export const resolveRuntimeBuildMeta = async () => {
     if (frontendMeta) {
         return frontendMeta;
     }
-    const envMeta = resolveBuildMetaFromEnv();
-    if (envMeta) {
-        return envMeta;
-    }
     return {
         gitSha: 'missing',
         generatedAt: '',
@@ -90,6 +76,9 @@ export const resolveRuntimeBuildMeta = async () => {
         resolvedFrom: 'missing',
     };
 };
+
+export const resolveRuntimeBuildIdentity = async () =>
+    normalizeBuildIdentity(await resolveRuntimeBuildMeta());
 
 const toPublicMeta = (meta) => {
     if (!meta || typeof meta !== 'object') {
@@ -104,24 +93,35 @@ const buildHeaders = () => ({
     'Cache-Control': 'no-store',
 });
 
-export async function buildRuntimeBuildMetaResponse() {
+export async function buildRuntimeBuildMetaResponse({
+    compatibility = true,
+    resolver = resolveRuntimeBuildMeta,
+    route = compatibility ? '/build-meta.json' : '/build-info.json',
+} = {}) {
     try {
-        const meta = await resolveRuntimeBuildMeta();
-        if (isPlaceholderSha(meta.gitSha)) {
+        const meta = await resolver();
+        let identity;
+        try {
+            identity = normalizeBuildIdentity(meta);
+        } catch {
             const message = 'Runtime build metadata is missing or invalid';
             logServerError({
-                route: '/build-meta.json',
+                route,
                 method: 'GET',
                 error: message,
                 context: { meta },
             });
-            return new Response(JSON.stringify(toPublicMeta(meta)), {
+            const body = compatibility
+                ? toPublicMeta(meta)
+                : { error: 'build_identity_unavailable' };
+            return new Response(JSON.stringify(body), {
                 status: 503,
                 headers: buildHeaders(),
             });
         }
 
-        return new Response(JSON.stringify(toPublicMeta(meta)), {
+        const body = compatibility ? { ...toPublicMeta(meta), ...identity } : identity;
+        return new Response(JSON.stringify(body), {
             status: 200,
             headers: buildHeaders(),
         });
@@ -130,13 +130,16 @@ export async function buildRuntimeBuildMetaResponse() {
         const errorToLog =
             error instanceof Error ? new Error(`${message}: ${error.message}`) : new Error(message);
         logServerError({
-            route: '/build-meta.json',
+            route,
             method: 'GET',
             error: errorToLog,
             context: { error },
         });
 
-        return new Response(JSON.stringify({ gitSha: 'missing', source: 'missing' }), {
+        const body = compatibility
+            ? { gitSha: 'missing', source: 'missing' }
+            : { error: 'build_identity_unavailable' };
+        return new Response(JSON.stringify(body), {
             status: 503,
             headers: buildHeaders(),
         });

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,5 +1,5 @@
 import { isBrowser } from './ssr.js';
-import { getAppGitSha } from './buildInfo.js';
+import { getCanonicalBuildIdentity } from './buildInfo.js';
 
 const isBrowserRuntime = isBrowser && (typeof process === 'undefined' || !process.versions?.node);
 const defaultLoader = () => import(/* @vite-ignore */ 'prom-client');
@@ -105,6 +105,8 @@ export const normalizeRoute = (urlOrPath) => {
             '/healthz',
             '/livez',
             '/config.json',
+            '/build-info.json',
+            '/build-meta.json',
             '/cache-version.js',
             '/service-worker.js',
         ].includes(pathname)
@@ -130,15 +132,10 @@ const getOrCreateMetric = (constructors, registerInstance, type, config) => {
     return new Ctor({ ...config, registers: [registerInstance] });
 };
 
-const loadBuildInfo = () => ({
-    version: process.env.DSPACE_VERSION || process.env.npm_package_version || 'unknown',
-    revision:
-        process.env.DSPACE_REVISION ||
-        process.env.GITHUB_SHA ||
-        process.env.SOURCE_VERSION ||
-        getAppGitSha() ||
-        'unknown',
-});
+const loadBuildInfo = () => {
+    const identity = getCanonicalBuildIdentity();
+    return { version: identity.applicationVersion, revision: identity.revision };
+};
 
 async function initMetrics(loader = defaultLoader) {
     if (isBrowserRuntime) {
@@ -207,13 +204,9 @@ async function initMetrics(loader = defaultLoader) {
             }),
         };
         const build = loadBuildInfo();
-        if (typeof metricHandles.buildInfo.remove === 'function') {
-            try {
-                metricHandles.buildInfo.remove();
-            } catch {
-                // Duplicate-import safety: older prom-client versions may not support remove().
-            }
-        }
+        // A reused global registry may contain a previous hot-reload series. Reset guarantees
+        // exactly one bounded series for the artifact currently serving requests.
+        if (typeof metricHandles.buildInfo.reset === 'function') metricHandles.buildInfo.reset();
         metricHandles.buildInfo.set(build, 1);
         metricHandles.instrumentationUp.set(1);
         metricsAvailable = true;

--- a/frontend/src/utils/runtimeEndpoints.ts
+++ b/frontend/src/utils/runtimeEndpoints.ts
@@ -3,6 +3,8 @@ import { parseFeatureFlags, readBooleanOverride } from '@dspace/feature-flags';
 import { resolveTokenPlaceBaseUrl, getTokenPlaceChatModel } from './tokenPlace.js';
 import { logServerError } from './serverLogger';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import buildMeta from '../generated/build_meta.json';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 function parseOfflineWorkerEnabled(flags: FeatureFlagParseResult): boolean {
     const envOverride = readBooleanOverride(process.env.DSPACE_OFFLINE_WORKER_ENABLED);
@@ -188,6 +190,12 @@ function buildHealthBody(status: 'ready' | 'alive') {
     const version = process.env.DSPACE_VERSION || process.env.npm_package_version || 'unknown';
     const environment = process.env.DSPACE_ENV || 'unknown';
 
+    let buildIdentity = null;
+    try {
+        buildIdentity = normalizeBuildIdentity(buildMeta);
+    } catch {
+        // Probe availability is intentionally independent of build-identity validity.
+    }
     return {
         status,
         uptimeSeconds: process.uptime(),
@@ -196,6 +204,7 @@ function buildHealthBody(status: 'ready' | 'alive') {
         version,
         env: environment,
         features: flags.tokens,
+        buildIdentity,
     };
 }
 

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -1,86 +1,88 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { assertBuildMetaComplete, readBuildMeta } from './write-build-meta.mjs';
 
-const args = process.argv.slice(2);
-const expectedSha = String(process.env.EXPECTED_SHA || process.env.GIT_SHA || '').trim();
-
-if (!expectedSha) {
-    console.error('Expected SHA is required. Set EXPECTED_SHA or GIT_SHA.');
-    process.exit(1);
+const expectedSha = String(process.env.EXPECTED_SHA || '')
+  .trim()
+  .toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(expectedSha)) {
+  console.error(
+    'EXPECTED_SHA must be the exact expected 40-character hexadecimal revision.'
+  );
+  process.exit(1);
 }
-
-const shortSha = expectedSha.length > 7 ? expectedSha.slice(0, 7) : expectedSha;
-const targets = [expectedSha, shortSha, `v3:${shortSha}`].filter(Boolean);
-const forbidden = ['v3:missing', 'v3:dev-local', 'v3:unknown', 'v3:missing-sha'];
-const allowedExtensions = new Set(['.js', '.mjs', '.cjs', '.css', '.html']);
-
-const candidateDirs =
-    args.length > 0 ? args : ['/app/dist', '/workspace/frontend/dist', 'frontend/dist', 'dist'];
-const existingDirs = candidateDirs.filter((dir) => fs.existsSync(dir));
-
-if (existingDirs.length === 0) {
-    console.error(`No dist directories found. Checked: ${candidateDirs.join(', ')}`);
-    process.exit(1);
+const roots = (
+  process.argv.slice(2).length ? process.argv.slice(2) : ['frontend/dist']
+).filter((p) => fs.existsSync(p));
+if (!roots.length) {
+  console.error('No build output directory found.');
+  process.exit(1);
 }
-
-const stack = [...existingDirs];
-let foundTarget = false;
-const forbiddenHits = new Set();
-
-while (stack.length) {
+const extensions = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.css',
+  '.html',
+  '.json',
+  '.map',
+]);
+const files = [];
+for (const root of roots) {
+  const stack = [root];
+  while (stack.length) {
     const current = stack.pop();
-    if (!current) {
-        continue;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(entryPath);
+      else if (entry.isFile() && extensions.has(path.extname(entryPath)))
+        files.push(entryPath);
     }
-    let entries = [];
-    try {
-        entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch (error) {
-        continue;
-    }
-    for (const entry of entries) {
-        const fullPath = path.join(current, entry.name);
-        if (entry.isDirectory()) {
-            stack.push(fullPath);
-            continue;
-        }
-        if (!entry.isFile()) {
-            continue;
-        }
-        if (!allowedExtensions.has(path.extname(fullPath))) {
-            continue;
-        }
-        try {
-            const content = fs.readFileSync(fullPath, 'utf8');
-            if (!foundTarget && targets.some((target) => content.includes(target))) {
-                foundTarget = true;
-            }
-            for (const forbiddenValue of forbidden) {
-                if (content.includes(forbiddenValue)) {
-                    forbiddenHits.add(forbiddenValue);
-                }
-            }
-        } catch (error) {
-            continue;
-        }
-    }
+  }
 }
-
-if (!foundTarget) {
-    console.error(
-        `Expected build SHA not found in frontend bundle. Looked for: ${targets.join(', ')}`
-    );
+let meta;
+try {
+  meta = await readBuildMeta();
+  assertBuildMetaComplete(meta);
+} catch (error) {
+  console.error(`Canonical build metadata is invalid: ${error.message}`);
+  process.exit(1);
+}
+if (
+  String(meta.revision || meta.gitSha).toLowerCase() !== expectedSha ||
+  meta.shortRevision !== expectedSha.slice(0, 7)
+) {
+  console.error('Canonical build metadata does not agree with EXPECTED_SHA.');
+  process.exit(1);
+}
+let serverHit = false;
+let clientHit = false;
+const placeholders = ['unknown', 'missing-sha', 'dev-local'];
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  if (
+    placeholders.some((marker) =>
+      content.includes(`\"revision\":\"${marker}\"`)
+    )
+  ) {
+    console.error(`Placeholder identity found in ${file}.`);
     process.exit(1);
+  }
+  if (!content.includes(expectedSha)) continue;
+  if (
+    file.includes(`${path.sep}_astro${path.sep}`) ||
+    file.includes(`${path.sep}client${path.sep}`)
+  )
+    clientHit = true;
+  else serverHit = true;
 }
-
-if (forbiddenHits.size > 0) {
-    console.error(
-        `Forbidden build SHA markers found in frontend bundle: ${Array.from(forbiddenHits).join(
-            ', '
-        )}`
-    );
-    process.exit(1);
+if (!serverHit || !clientHit) {
+  console.error(
+    `Expected full SHA must occur in server/SSR and client/static output (server=${serverHit}, client=${clientHit}).`
+  );
+  process.exit(1);
 }
-
-console.log(`Build SHA verified in frontend bundle. Matched: ${targets.join(', ')}`);
+console.log(
+  `Verified canonical full build revision in server and client outputs: ${expectedSha}`
+);

--- a/scripts/write-build-meta.mjs
+++ b/scripts/write-build-meta.mjs
@@ -2,21 +2,22 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { normalizeBuildIdentity } from '../frontend/src/utils/buildIdentity.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const resolveRepoRoot = () =>
-    process.env.VERIFY_REPO_ROOT
-        ? path.resolve(process.env.VERIFY_REPO_ROOT)
-        : path.resolve(__dirname, '..');
+  process.env.VERIFY_REPO_ROOT
+    ? path.resolve(process.env.VERIFY_REPO_ROOT)
+    : path.resolve(__dirname, '..');
 const resolveBuildMetaPath = (root) => {
-    const overridePath = process.env.VERIFY_BUILD_META_PATH;
-    if (overridePath) {
-        return path.isAbsolute(overridePath)
-            ? overridePath
-            : path.resolve(root, overridePath);
-    }
-    return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
+  const overridePath = process.env.VERIFY_BUILD_META_PATH;
+  if (overridePath) {
+    return path.isAbsolute(overridePath)
+      ? overridePath
+      : path.resolve(root, overridePath);
+  }
+  return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
 };
 const repoRoot = resolveRepoRoot();
 const buildMetaPath = resolveBuildMetaPath(repoRoot);
@@ -25,89 +26,117 @@ const allowedSources = new Set(['ci', 'env', 'git']);
 const normalizeSha = (value) => String(value || '').trim();
 
 const isPlaceholderSha = (value) => {
-    const normalized = normalizeSha(value).toLowerCase();
-    return (
-        !normalized ||
-        normalized === 'unknown' ||
-        normalized === 'missing' ||
-        normalized === 'missing-sha' ||
-        normalized === 'dev-local'
-    );
+  const normalized = normalizeSha(value).toLowerCase();
+  return (
+    !normalized ||
+    normalized === 'unknown' ||
+    normalized === 'missing' ||
+    normalized === 'missing-sha' ||
+    normalized === 'dev-local'
+  );
 };
 
 export const assertBuildMetaComplete = (payload) => {
-    if (!payload || typeof payload !== 'object') {
-        throw new Error('build_meta.json payload is missing or invalid.');
-    }
-    if (isPlaceholderSha(payload.gitSha)) {
-        throw new Error(`build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`);
-    }
-    if (!normalizeSha(payload.generatedAt)) {
-        throw new Error('build_meta.json generatedAt is missing.');
-    }
-    const source = String(payload.source || '').trim().toLowerCase();
-    if (!source || source === 'static' || !allowedSources.has(source)) {
-        throw new Error(`build_meta.json source is invalid: ${payload.source || 'empty'}`);
-    }
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('build_meta.json payload is missing or invalid.');
+  }
+  if (isPlaceholderSha(payload.gitSha)) {
+    throw new Error(
+      `build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`
+    );
+  }
+  if (!normalizeSha(payload.generatedAt)) {
+    throw new Error('build_meta.json generatedAt is missing.');
+  }
+  normalizeBuildIdentity(payload);
+  const source = String(payload.source || '')
+    .trim()
+    .toLowerCase();
+  if (!source || source === 'static' || !allowedSources.has(source)) {
+    throw new Error(
+      `build_meta.json source is invalid: ${payload.source || 'empty'}`
+    );
+  }
 };
 
 export const getRepoRoot = () => repoRoot;
 export const getBuildMetaPath = () => buildMetaPath;
 
 export const resolveBuildMeta = () => {
-    const envPriority = [
-        { key: 'GITHUB_SHA', source: 'ci' },
-        { key: 'VITE_GIT_SHA', source: 'env' },
-        { key: 'GIT_SHA', source: 'env' },
-        { key: 'DSPACE_GIT_SHA', source: 'env' },
-    ];
+  const envPriority = [
+    { key: 'GITHUB_SHA', source: 'ci' },
+    { key: 'VITE_GIT_SHA', source: 'env' },
+    { key: 'GIT_SHA', source: 'env' },
+    { key: 'DSPACE_GIT_SHA', source: 'env' },
+  ];
 
-    for (const { key, source } of envPriority) {
-        const value = normalizeSha(process.env[key]);
-        if (value && !isPlaceholderSha(value)) {
-            return { gitSha: value, source };
-        }
+  for (const { key, source } of envPriority) {
+    const value = normalizeSha(process.env[key]);
+    if (value && !isPlaceholderSha(value)) {
+      return { gitSha: value, source };
     }
+  }
 
-    try {
-        const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-        if (isPlaceholderSha(gitSha)) {
-            throw new Error('git rev-parse returned an invalid SHA.');
-        }
-        return { gitSha, source: 'git' };
-    } catch (error) {
-        throw new Error(
-            'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
-        );
+  try {
+    const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+    if (isPlaceholderSha(gitSha)) {
+      throw new Error('git rev-parse returned an invalid SHA.');
     }
+    return { gitSha, source: 'git' };
+  } catch (error) {
+    throw new Error(
+      'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
+    );
+  }
+};
+
+const readApplicationVersion = async () => {
+  const pkg = JSON.parse(
+    await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')
+  );
+  return String(process.env.DSPACE_VERSION || pkg.version)
+    .replace(/^v/, '')
+    .split('+')[0];
 };
 
 export const writeBuildMeta = async ({ gitSha, source = 'build-meta' }) => {
-    const payload = {
-        gitSha: normalizeSha(gitSha),
-        generatedAt: new Date().toISOString(),
-        source,
-    };
-    assertBuildMetaComplete(payload);
-    await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
-    await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
-    return payload;
+  const generatedAt = process.env.BUILD_CREATED_AT || new Date().toISOString();
+  const applicationVersion = await readApplicationVersion();
+  const identity = normalizeBuildIdentity({
+    applicationVersion,
+    revision: normalizeSha(gitSha),
+    builtAt: generatedAt,
+    image: process.env.DSPACE_IMAGE || '',
+  });
+  const payload = {
+    ...identity,
+    gitSha: identity.revision,
+    generatedAt: identity.builtAt,
+    source,
+  };
+  assertBuildMetaComplete(payload);
+  await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
+  await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
+  return payload;
 };
 
 export const readBuildMeta = async () => {
-    const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
-    return JSON.parse(rawMeta);
+  const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
+  return JSON.parse(rawMeta);
 };
 
 const run = async () => {
-    const { gitSha, source } = resolveBuildMeta();
-    await writeBuildMeta({ gitSha, source });
-    console.log(`Build metadata written to ${buildMetaPath}`);
+  const { gitSha, source } = resolveBuildMeta();
+  await writeBuildMeta({ gitSha, source });
+  console.log(`Build metadata written to ${buildMetaPath}`);
 };
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    run().catch((error) => {
-        console.error('Failed to write build metadata:', error);
-        process.exit(1);
-    });
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run().catch((error) => {
+    console.error('Failed to write build metadata:', error);
+    process.exit(1);
+  });
 }

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+    isPlaceholderRevision,
+    normalizeBuildIdentity,
+} from '../frontend/src/utils/buildIdentity.js';
+import { buildRuntimeBuildMetaResponse } from '../frontend/src/utils/buildMetaServer.js';
+import { GET as getBuildInfo } from '../frontend/src/pages/build-info.json.ts';
+import { GET as getBuildMeta } from '../frontend/src/pages/build-meta.json.ts';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const meta = {
+    applicationVersion: '3.1.0',
+    gitSha: revision,
+    generatedAt: '2026-07-29T12:34:56.000Z',
+    source: 'ci',
+};
+
+describe('canonical build identity', () => {
+    it('normalizes legacy metadata and derives the short revision', () => {
+        expect(normalizeBuildIdentity(meta)).toEqual({
+            applicationVersion: '3.1.0',
+            revision,
+            shortRevision: '0123456',
+            builtAt: '2026-07-29T12:34:56.000Z',
+        });
+    });
+
+    it.each(['', 'unknown', 'missing', 'missing-sha', 'dev-local', '0123456', 'g'.repeat(40)])(
+        'rejects missing, placeholder, short, or malformed revision %s',
+        (gitSha) => expect(() => normalizeBuildIdentity({ ...meta, gitSha })).toThrow(/revision/)
+    );
+
+    it('accepts only a matching immutable branch-SHA image coordinate', () => {
+        expect(
+            normalizeBuildIdentity({
+                ...meta,
+                image: 'ghcr.io/democratizedspace/dspace:main-0123456',
+            }).image
+        ).toBe('ghcr.io/democratizedspace/dspace:main-0123456');
+        for (const image of [
+            'ghcr.io/democratizedspace/dspace:main-latest',
+            'ghcr.io/democratizedspace/dspace:v3.1.0',
+            'ghcr.io/democratizedspace/dspace:main-fffffff',
+            'registry.example/dspace:main-0123456',
+        ]) {
+            expect(() => normalizeBuildIdentity({ ...meta, image })).toThrow(/immutable/);
+        }
+    });
+
+    it('recognizes all reserved local/missing placeholders', () => {
+        expect(
+            ['unknown', 'missing', 'missing-sha', 'dev-local'].every(isPlaceholderRevision)
+        ).toBe(true);
+    });
+});
+
+describe('build identity endpoints', () => {
+    it('serves generated canonical metadata through both route handlers', async () => {
+        const info = await getBuildInfo();
+        const compatible = await getBuildMeta();
+        expect(info.status).toBe(200);
+        expect(compatible.status).toBe(200);
+        const identity = await info.json();
+        expect(identity.revision).toMatch(/^[0-9a-f]{40}$/);
+        expect(await compatible.json()).toMatchObject({
+            gitSha: identity.revision,
+            revision: identity.revision,
+        });
+    });
+
+    it('returns the canonical uncached identity and a compatible build-meta superset', async () => {
+        const resolver = async () => meta;
+        const identity = await buildRuntimeBuildMetaResponse({
+            compatibility: false,
+            resolver,
+        });
+        expect(identity.status).toBe(200);
+        expect(identity.headers.get('cache-control')).toBe('no-store');
+        expect(await identity.json()).toMatchObject({
+            revision,
+            shortRevision: '0123456',
+        });
+
+        const compatible = await buildRuntimeBuildMetaResponse({ resolver });
+        expect(await compatible.json()).toMatchObject({
+            gitSha: revision,
+            source: 'ci',
+            revision,
+        });
+    });
+
+    it('fails closed without exposing resolver details', async () => {
+        const response = await buildRuntimeBuildMetaResponse({
+            compatibility: false,
+            resolver: async () => ({
+                ...meta,
+                gitSha: 'missing',
+                resolvedFrom: '/secret/path',
+            }),
+        });
+        expect(response.status).toBe(503);
+        expect(await response.json()).toEqual({
+            error: 'build_identity_unavailable',
+        });
+    });
+});

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -96,6 +96,12 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
       expect(step.with.labels).toContain(
         'org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}'
       );
+      expect(step.with['build-args']).toContain(
+        'BUILD_CREATED_AT=${{ steps.metadata.outputs.created }}'
+      );
+      expect(step.with['build-args']).toContain(
+        'DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}'
+      );
     }
   });
 
@@ -131,6 +137,16 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
 
   it('does not run redundantly for release events', () => {
     expect(job.if).toBe("github.event_name != 'release'");
+  });
+
+  it('compares runtime and HTML revisions to the OCI revision label', () => {
+    const serialized = JSON.stringify(job);
+    expect(serialized).toContain('/build-info.json');
+    expect(serialized).toContain('dspace-build-revision');
+    expect(serialized).toContain('org.opencontainers.image.revision');
+    expect(serialized).toContain('RUNTIME_REVISION');
+    expect(serialized).toContain('HTML_REVISION');
+    expect(serialized).toContain('OCI_REVISION');
   });
 });
 


### PR DESCRIPTION
### Motivation

- Provide one bounded, machine-readable build identity (version, 40-char SHA, 7-char short SHA, artifact-fixed ISO timestamp, optional immutable image coordinate) so operators and Sugarkube automation can prove server, client, HTML, and image all come from the same approved commit. Closes #4732 and links the postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md.
- Harden existing build-meta pipeline and verification so placeholders, short/malformed SHAs, or movable tags are rejected for production/CI image builds.
- Expose an uncached runtime endpoint and an SSR HTML marker to make the canonical identity directly and consistently observable at runtime.

### Description

- Add a canonical normalizer and validator at `frontend/src/utils/buildIdentity.js` that enforces semantic `applicationVersion`, a full 40-char `revision`, derived `shortRevision`, ISO `builtAt`, and optional immutable GHCR image coordinate matching the short SHA. (Rejects placeholders, malformed, and movable tags.)
- Wire build-meta pipeline to produce a normalized canonical payload via `scripts/write-build-meta.mjs`, and validate it at runtime in `frontend/src/utils/buildMetaServer.js`; add a new uncached `GET /build-info.json` (minimal, non-compatibility view) backed by the same resolver and retain `/build-meta.json` compatibility as a superset.
- Add SSR marker `<meta name="dspace-build-revision" content="<full-sha>" />` to `frontend/src/layouts/Layout.astro` and expose the same identity in readiness/liveness payloads (added bounded `buildIdentity` field) while preserving existing probe availability semantics.
- Harden verification and image/workflow plumbing: updated `scripts/verify-build-sha.mjs` to require the exact expected 40-char SHA and confirm presence in both server/SSR and client/static outputs; Dockerfile and `.github/workflows/ci-image.yml` were extended to pass `BUILD_CREATED_AT`, `DSPACE_IMAGE`, and OCI labels (`org.opencontainers.image.revision`/`created`) and to compare OCI, runtime and HTML revisions in the smoke test.
- Ensure Prometheus `dspace_build_info` uses the canonical identity and reset behavior to keep a single bounded series during initialization (`frontend/src/utils/metrics.js`).
- Add focused tests and docs: unit tests `tests/buildIdentity.test.ts`, Playwright E2E spec `frontend/e2e/build-identity.spec.ts`, CI/workflow assertions in `tests/ciImageWorkflow.test.ts`, and a Sugarkube verification snippet added to `docs/ops/sugarkube-release.md`.

### Testing

- Wrote build metadata and ran a local production build: `GITHUB_SHA="$(git rev-parse HEAD)" npm run build` which completed successfully.
- Verified chat build stamp: `npm run verify:chat-build-stamp` succeeded and `EXPECTED_SHA="$(git rev-parse HEAD)" node scripts/verify-build-sha.mjs frontend/dist` passed (verified canonical full SHA in server and client outputs).
- Ran focused root/unit and workflow tests: `npm run test:root -- tests/buildIdentity.test.ts frontend/__tests__/buildInfo.test.js frontend/__tests__/healthEndpoint.test.js tests/runtimeConfig.test.ts tests/ciImageWorkflow.test.ts tests/middlewareRuntimeEndpoints.test.ts` and subsequent targeted runs; these test groups passed in this environment (non-Helm targets passed and the new identity tests passed).
- Lint/type-check/link-check: `npm run lint`, `npm run type-check`, and `npm run link-check` completed successfully in this environment.
- Environment-limited checks: Playwright E2E (`npm --prefix frontend run test:e2e`) could not complete because Playwright browser/system dependency downloads failed due to network restrictions in this environment, and `actionlint` is not installed locally so workflow linting is deferred to GitHub CI; helm-dependent chart tests require `helm` and are validated in CI where `helm` is available.

All non-environment-limited automated checks passed locally; CI will run full e2e/helm/actionlint validations before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69432009b8832fa339d362c6250e98)