### PR TITLE
Expose canonical runtime build identity (/build-info.json, HTML marker, verification, CI wiring)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           docker run --rm \
             -e EXPECTED_SHA="${GITHUB_SHA}" \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
             -v "$PWD/scripts:/scripts:ro" \
             dspace-test:latest \
             node /scripts/verify-build-sha.mjs /app/dist
@@ -387,6 +388,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -412,6 +415,8 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
@@ -435,6 +440,12 @@ jobs:
             GIT_SHA=${{ steps.tags.outputs.full_sha }}
             VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
             ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
 
       - name: Assert build SHA is baked into frontend bundle
@@ -444,6 +455,7 @@ jobs:
         run: |
           docker run --rm \
             -e EXPECTED_SHA \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
             -v "$PWD/scripts:/scripts:ro" \
             dspace-verify:latest \
             node /scripts/verify-build-sha.mjs /app/dist
@@ -458,6 +470,19 @@ jobs:
             -w /app \
             dspace-verify:latest \
             node /scripts/verify-chat-build-stamp.mjs
+
+      - name: Compare runtime identity with OCI revision
+        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$label_revision" = "$EXPECTED_SHA"
+          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
+          trap 'docker rm -f "$container"' EXIT
+          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
+          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
 
       - name: Summarize published image tags
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,14 +52,19 @@ ARG DSPACE_VERSION
 ARG GIT_SHA=unknown
 ARG VITE_GIT_SHA=${GIT_SHA}
 ARG ENFORCE_VITE_GIT_SHA=0
+ARG BUILD_TIMESTAMP
+ARG DSPACE_IMAGE
 # GIT_SHA should be provided via build args; git is not available in the image to compute it.
 RUN if [ "$ENFORCE_VITE_GIT_SHA" = "1" ]; then \
-        if [ -z "$VITE_GIT_SHA" ] || [ "$VITE_GIT_SHA" = "unknown" ] || [ "$VITE_GIT_SHA" = "dev-local" ]; then \
+        if ! printf '%s' "$VITE_GIT_SHA" | grep -Eq '^[0-9a-fA-F]{40}$'; then \
             echo "Missing VITE_GIT_SHA build arg; refusing to build frontend assets." >&2; \
             exit 1; \
         fi; \
     fi
 ENV VITE_GIT_SHA="${VITE_GIT_SHA}"
+ENV BUILD_TIMESTAMP="${BUILD_TIMESTAMP}"
+ENV DSPACE_IMAGE="${DSPACE_IMAGE}"
+ENV DSPACE_PRODUCTION_BUILD="${ENFORCE_VITE_GIT_SHA}"
 # Copy source separately to avoid overlaying host node_modules (pnpm symlinks make this fail when
 # node_modules exists on the host). Build artifacts are excluded via .dockerignore for compatibility
 # with builders that do not support COPY --exclude flags.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ ARG BUILD_TIMESTAMP
 ARG DSPACE_IMAGE
 # GIT_SHA should be provided via build args; git is not available in the image to compute it.
 RUN if [ "$ENFORCE_VITE_GIT_SHA" = "1" ]; then \
-        if ! printf '%s' "$VITE_GIT_SHA" | grep -Eq '^[0-9a-fA-F]{40}$'; then \
-            echo "Missing VITE_GIT_SHA build arg; refusing to build frontend assets." >&2; \
+        if ! printf '%s' "$GIT_SHA" | grep -Eq '^[0-9a-fA-F]{40}$' || \
+           ! printf '%s' "$VITE_GIT_SHA" | grep -Eq '^[0-9a-fA-F]{40}$' || \
+           [ "$(printf '%s' "$GIT_SHA" | tr 'A-F' 'a-f')" != "$(printf '%s' "$VITE_GIT_SHA" | tr 'A-F' 'a-f')" ]; then \
+            echo "GIT_SHA and VITE_GIT_SHA must be equal full 40-character hexadecimal SHAs." >&2; \
             exit 1; \
         fi; \
     fi

--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -148,6 +148,10 @@ This section is the citeable route catalog and anchors the canonical routes unde
 - /dchat - dChat interface (AI assistant)
 - /debug - Debug tools
 
+### Runtime metadata and probes
+
+- /build-info.json - Canonical, uncached runtime build identity for artifact verification
+
 ## Dynamic routes
 
 ### Documentation

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -140,6 +140,30 @@ curl -fsS https://democratized.space/livez | jq .
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 
+## Runtime source verification contract
+
+Given the approved full 40-character revision and immutable branch-SHA image, Sugarkube automation
+may use this bounded, read-only contract (substitute the deployment URL and image coordinate):
+
+```bash
+EXPECTED_SHA=REPLACE_WITH_40_CHARACTER_SHA
+BASE_URL=https://staging.democratized.space
+IMAGE=ghcr.io/democratizedspace/dspace:main-REPLACE_SHORTSHA
+
+test "$(curl -fsS "$BASE_URL/build-info.json" | jq -r .revision)" = "$EXPECTED_SHA"
+curl -fsS "$BASE_URL/" |
+  grep -F "name=\"dspace-build-revision\" content=\"$EXPECTED_SHA\""
+test "$(docker image inspect "$IMAGE" \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$EXPECTED_SHA"
+```
+
+`/build-info.json` is uncached and returns the application version, full and seven-character
+revisions, artifact-fixed build timestamp, and (for published images) the immutable image
+coordinate. An unavailable or invalid identity returns HTTP 503. `/build-meta.json` remains the
+compatibility surface. Build identity is additive on `/healthz` and `/livez`; probe availability
+must not be interpreted as source-identity proof. This contract deliberately does not perform the
+remote chat smoke or implement a promotion gate.
+
 ## Rollback
 
 Rollback by redeploying the prior known-good immutable image tag from Sugarkube. Do not rebuild a

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -26,6 +26,38 @@ Use immutable branch-SHA tags or image digests for staging, production approvals
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
 be the audit record for a production deploy.
 
+## Runtime source verification contract
+
+Before approving an already deployed runtime, set its expected full revision, public URL, and
+published immutable image coordinate. The revision must be exactly 40 hexadecimal characters, and
+the image tag must end in the matching seven-character short revision.
+
+```bash
+export EXPECTED_SHA=REPLACE_WITH_40_HEX_REVISION
+export BASE_URL=https://staging.democratized.space
+export EXPECTED_IMAGE=ghcr.io/democratizedspace/dspace:main-${EXPECTED_SHA:0:7}
+
+[[ "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "invalid EXPECTED_SHA" >&2; exit 1; }
+BUILD_INFO="$(curl -fsS "$BASE_URL/build-info.json")"
+test "$(jq -r '.revision' <<<"$BUILD_INFO")" = "${EXPECTED_SHA,,}"
+test "$(jq -r '.image' <<<"$BUILD_INFO")" = "$EXPECTED_IMAGE"
+
+HTML_REVISION="$(curl -fsS "$BASE_URL/" |
+  sed -n 's/.*<meta name="dspace-build-revision" content="\([0-9a-fA-F]\{40\}\)".*/\1/p' |
+  head -n 1)"
+test "${HTML_REVISION,,}" = "${EXPECTED_SHA,,}"
+
+docker pull "$EXPECTED_IMAGE"
+OCI_REVISION="$(docker image inspect "$EXPECTED_IMAGE" \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+test "${OCI_REVISION,,}" = "${EXPECTED_SHA,,}"
+```
+
+These checks compare the approved full SHA with `/build-info.json`, its published immutable image
+coordinate, the `dspace-build-revision` HTML marker, and the pulled image's
+`org.opencontainers.image.revision` label. They are a source-verification contract only; they do
+not implement a remote `/chat` smoke test or a promotion gate.
+
 ## Artifact publishing summary
 
 The mandatory full-release order is fail-closed:

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -140,30 +140,6 @@ curl -fsS https://democratized.space/livez | jq .
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 
-## Runtime source verification contract
-
-Given the approved full 40-character revision and immutable branch-SHA image, Sugarkube automation
-may use this bounded, read-only contract (substitute the deployment URL and image coordinate):
-
-```bash
-EXPECTED_SHA=REPLACE_WITH_40_CHARACTER_SHA
-BASE_URL=https://staging.democratized.space
-IMAGE=ghcr.io/democratizedspace/dspace:main-REPLACE_SHORTSHA
-
-test "$(curl -fsS "$BASE_URL/build-info.json" | jq -r .revision)" = "$EXPECTED_SHA"
-curl -fsS "$BASE_URL/" |
-  grep -F "name=\"dspace-build-revision\" content=\"$EXPECTED_SHA\""
-test "$(docker image inspect "$IMAGE" \
-  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$EXPECTED_SHA"
-```
-
-`/build-info.json` is uncached and returns the application version, full and seven-character
-revisions, artifact-fixed build timestamp, and (for published images) the immutable image
-coordinate. An unavailable or invalid identity returns HTTP 503. `/build-meta.json` remains the
-compatibility surface. Build identity is additive on `/healthz` and `/livez`; probe availability
-must not be interpreted as source-identity proof. This contract deliberately does not perform the
-remote chat smoke or implement a promotion gate.
-
 ## Rollback
 
 Rollback by redeploying the prior known-good immutable image tag from Sugarkube. Do not rebuild a

--- a/frontend/__tests__/buildInfo.test.js
+++ b/frontend/__tests__/buildInfo.test.js
@@ -139,6 +139,18 @@ describe('buildInfo', () => {
         expect(getPromptVersionSha()).toBe('abc123d');
     });
 
+    it('fails closed when full VITE and generated metadata SHAs disagree', async () => {
+        process.env.VITE_GIT_SHA = '0123456789abcdef0123456789abcdef01234567';
+        process.env.NODE_ENV = 'production';
+        const buildMeta = {
+            gitSha: 'fedcba9876543210fedcba9876543210fedcba98',
+            generatedAt: '2026-07-29T12:00:00Z',
+            source: 'ci',
+        };
+        const { getAppGitSha } = await loadBuildInfo(buildMeta);
+        expect(getAppGitSha()).toBe('missing');
+    });
+
     it('derives the prompt SHA from an existing prompt label', async () => {
         const { getPromptVersionSha } = await loadBuildInfo();
         expect(getPromptVersionSha('v3:feedface')).toBe('feedfac');

--- a/frontend/__tests__/healthEndpoint.test.js
+++ b/frontend/__tests__/healthEndpoint.test.js
@@ -30,33 +30,37 @@ describe('health probes', () => {
     it.each([
         ['canonical', () => buildMeta],
         ['malformed', () => ({ ...buildMeta, revision: 'missing' })],
-    ])('keeps both probes available with %s metadata', async (_label, metadata) => {
-        buildMeta = metadata();
-        const { readiness, liveness } = await getProbes();
-        const readinessResponse = await readiness.GET();
-        const livenessResponse = await liveness.GET();
-        const readinessBody = await readinessResponse.json();
-        const livenessBody = await livenessResponse.json();
+    ])(
+        'keeps both probes available with %s metadata',
+        async (_label, metadata) => {
+            buildMeta = metadata();
+            const { readiness, liveness } = await getProbes();
+            const readinessResponse = await readiness.GET();
+            const livenessResponse = await liveness.GET();
+            const readinessBody = await readinessResponse.json();
+            const livenessBody = await livenessResponse.json();
 
-        expect(readinessResponse.status).toBe(200);
-        expect(readinessBody.status).toBe('ready');
-        expect(typeof readinessBody.timestamp).toBe('string');
-        expect(typeof readinessBody.startedAt).toBe('string');
-        expect(typeof readinessBody.version).toBe('string');
-        expect(typeof readinessBody.env).toBe('string');
-        expect(Array.isArray(readinessBody.features)).toBe(true);
-        expect(livenessResponse.status).toBe(200);
-        expect(livenessBody.status).toBe('alive');
-        expect(typeof livenessBody.uptimeSeconds).toBe('number');
-        expect(typeof livenessBody.startedAt).toBe('string');
-        expect(typeof livenessBody.timestamp).toBe('string');
-        expect(typeof livenessBody.version).toBe('string');
-        expect(typeof livenessBody.env).toBe('string');
-        expect(Array.isArray(livenessBody.features)).toBe(true);
-        const expectedIdentity = _label === 'canonical' ? buildMeta : null;
-        expect(readinessBody.buildIdentity).toEqual(expectedIdentity);
-        expect(livenessBody.buildIdentity).toEqual(expectedIdentity);
-        expect(readiness.prerender).toBe(false);
-        expect(liveness.prerender).toBe(false);
-    });
+            expect(readinessResponse.status).toBe(200);
+            expect(readinessBody.status).toBe('ready');
+            expect(typeof readinessBody.timestamp).toBe('string');
+            expect(typeof readinessBody.startedAt).toBe('string');
+            expect(typeof readinessBody.version).toBe('string');
+            expect(typeof readinessBody.env).toBe('string');
+            expect(Array.isArray(readinessBody.features)).toBe(true);
+            expect(livenessResponse.status).toBe(200);
+            expect(livenessBody.status).toBe('alive');
+            expect(typeof livenessBody.uptimeSeconds).toBe('number');
+            expect(typeof livenessBody.startedAt).toBe('string');
+            expect(typeof livenessBody.timestamp).toBe('string');
+            expect(typeof livenessBody.version).toBe('string');
+            expect(typeof livenessBody.env).toBe('string');
+            expect(Array.isArray(livenessBody.features)).toBe(true);
+            const expectedIdentity = _label === 'canonical' ? buildMeta : null;
+            expect(readinessBody.buildIdentity).toEqual(expectedIdentity);
+            expect(livenessBody.buildIdentity).toEqual(expectedIdentity);
+            expect(readiness.prerender).toBe(false);
+            expect(liveness.prerender).toBe(false);
+        },
+        10000
+    );
 });

--- a/frontend/__tests__/healthEndpoint.test.js
+++ b/frontend/__tests__/healthEndpoint.test.js
@@ -12,6 +12,7 @@ describe('health probes', () => {
         expect(body.status).toBe('ready');
         expect(typeof body.timestamp).toBe('string');
         expect(Array.isArray(body.features)).toBe(true);
+        expect(body).toHaveProperty('buildIdentity');
     });
 
     it('marks readiness route as dynamic', () => {
@@ -24,6 +25,7 @@ describe('health probes', () => {
         const body = await res.json();
         expect(body.status).toBe('alive');
         expect(typeof body.uptimeSeconds).toBe('number');
+        expect(body).toHaveProperty('buildIdentity');
     });
 
     it('marks liveness route as dynamic', () => {

--- a/frontend/__tests__/healthEndpoint.test.js
+++ b/frontend/__tests__/healthEndpoint.test.js
@@ -1,34 +1,62 @@
 /** @jest-environment node */
-import { GET as readinessGET, prerender as readinessPrerender } from '../src/pages/healthz.ts';
-import { GET as livenessGET, prerender as livenessPrerender } from '../src/pages/livez.ts';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
-import { describe, it, expect } from 'vitest';
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+let buildMeta;
+
+vi.mock('../src/generated/build_meta.json', () => ({
+    get default() {
+        return buildMeta;
+    },
+}));
+
+beforeEach(() => {
+    buildMeta = {
+        version: '3.1.0',
+        revision: SHA,
+        shortRevision: SHA.slice(0, 7),
+        buildTimestamp: '2026-07-29T12:00:00Z',
+    };
+});
+
+const getProbes = async () => {
+    vi.resetModules();
+    const readiness = await import('../src/pages/healthz.ts');
+    const liveness = await import('../src/pages/livez.ts');
+    return { readiness, liveness };
+};
 
 describe('health probes', () => {
-    it('reports readiness', async () => {
-        const res = await readinessGET();
-        expect(res.status).toBe(200);
-        const body = await res.json();
-        expect(body.status).toBe('ready');
-        expect(typeof body.timestamp).toBe('string');
-        expect(Array.isArray(body.features)).toBe(true);
-        expect(body).toHaveProperty('buildIdentity');
-    });
+    it.each([
+        ['canonical', () => buildMeta],
+        ['malformed', () => ({ ...buildMeta, revision: 'missing' })],
+    ])('keeps both probes available with %s metadata', async (_label, metadata) => {
+        buildMeta = metadata();
+        const { readiness, liveness } = await getProbes();
+        const readinessResponse = await readiness.GET();
+        const livenessResponse = await liveness.GET();
+        const readinessBody = await readinessResponse.json();
+        const livenessBody = await livenessResponse.json();
 
-    it('marks readiness route as dynamic', () => {
-        expect(readinessPrerender).toBe(false);
-    });
-
-    it('reports liveness', async () => {
-        const res = await livenessGET();
-        expect(res.status).toBe(200);
-        const body = await res.json();
-        expect(body.status).toBe('alive');
-        expect(typeof body.uptimeSeconds).toBe('number');
-        expect(body).toHaveProperty('buildIdentity');
-    });
-
-    it('marks liveness route as dynamic', () => {
-        expect(livenessPrerender).toBe(false);
+        expect(readinessResponse.status).toBe(200);
+        expect(readinessBody.status).toBe('ready');
+        expect(typeof readinessBody.timestamp).toBe('string');
+        expect(typeof readinessBody.startedAt).toBe('string');
+        expect(typeof readinessBody.version).toBe('string');
+        expect(typeof readinessBody.env).toBe('string');
+        expect(Array.isArray(readinessBody.features)).toBe(true);
+        expect(livenessResponse.status).toBe(200);
+        expect(livenessBody.status).toBe('alive');
+        expect(typeof livenessBody.uptimeSeconds).toBe('number');
+        expect(typeof livenessBody.startedAt).toBe('string');
+        expect(typeof livenessBody.timestamp).toBe('string');
+        expect(typeof livenessBody.version).toBe('string');
+        expect(typeof livenessBody.env).toBe('string');
+        expect(Array.isArray(livenessBody.features)).toBe(true);
+        const expectedIdentity = _label === 'canonical' ? buildMeta : null;
+        expect(readinessBody.buildIdentity).toEqual(expectedIdentity);
+        expect(livenessBody.buildIdentity).toEqual(expectedIdentity);
+        expect(readiness.prerender).toBe(false);
+        expect(liveness.prerender).toBe(false);
     });
 });

--- a/frontend/e2e/build-identity.spec.ts
+++ b/frontend/e2e/build-identity.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test('serves one full revision in JSON and shared-layout HTML', async ({ page, request }) => {
+    const response = await request.get('/build-info.json');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['cache-control']).toContain('no-store');
+    const identity = await response.json();
+    expect(identity.revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(identity.shortRevision).toBe(identity.revision.slice(0, 7));
+
+    await page.goto('/');
+    await expect(page.locator('meta[name="dspace-build-revision"]')).toHaveAttribute(
+        'content',
+        identity.revision
+    );
+});

--- a/frontend/scripts/run-test-groups.mjs
+++ b/frontend/scripts/run-test-groups.mjs
@@ -39,6 +39,12 @@ const TEST_GROUPS = [
         parallel: false,
         workers: 1,
     },
+    {
+        name: 'Build Identity',
+        files: ['build-identity.spec.ts'],
+        parallel: false,
+        workers: 1,
+    },
     ...(includeRemoteSmoke
         ? [
               {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -2,6 +2,8 @@
 import { SEO } from 'astro-seo';
 import { OFFLINE_TOAST_PUBLIC_PATH } from '../utils/offlineToastPath';
 import { getCheatsAvailabilityFlag } from '../utils/cheatsAvailability';
+import buildMeta from '../generated/build_meta.json';
+import { normalizeBuildIdentity } from '../utils/buildIdentity.js';
 
 export interface Props {
 	title: string;
@@ -12,6 +14,12 @@ const { title } = Astro.props as Props;
 const sitewideTitle = `DSPACE (democratized.space)`;
 const offlineWorkerRegistrationUrl = '/scripts/offlineWorkerRegistration.js';
 const cheatsAvailable = getCheatsAvailabilityFlag();
+let buildRevision = '';
+try {
+        buildRevision = normalizeBuildIdentity(buildMeta).revision;
+} catch {
+        // Local development may intentionally have an unverifiable identity.
+}
 ---
 
 <!DOCTYPE html>
@@ -48,6 +56,7 @@ const cheatsAvailable = getCheatsAvailabilityFlag();
                 <meta name="viewport" content="width=device-width" />
                 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
                 <meta name="generator" content={Astro.generator} />
+                {buildRevision && <meta name="dspace-build-revision" content={buildRevision} />}
                 <script is:inline>
                         (function bootstrapTheme() {
                                 const STORAGE_KEY = 'dspace-theme';

--- a/frontend/src/pages/build-info.json.ts
+++ b/frontend/src/pages/build-info.json.ts
@@ -1,0 +1,7 @@
+import { buildRuntimeBuildInfoResponse } from '../utils/buildMetaServer';
+
+export const prerender = false;
+
+export async function GET() {
+    return buildRuntimeBuildInfoResponse();
+}

--- a/frontend/src/utils/buildIdentity.js
+++ b/frontend/src/utils/buildIdentity.js
@@ -31,6 +31,12 @@ export function normalizeBuildIdentity(meta) {
     if (isPlaceholderRevision(revision) || !FULL_GIT_SHA.test(revision)) {
         throw new Error('revision must be exactly 40 hexadecimal characters');
     }
+    if (meta?.revision != null && meta?.gitSha != null) {
+        const gitSha = boundedString(meta.gitSha, 'gitSha', 40).toLowerCase();
+        if (!FULL_GIT_SHA.test(gitSha) || gitSha !== revision) {
+            throw new Error('gitSha does not agree with revision');
+        }
+    }
     const shortRevision = revision.slice(0, 7);
     if (meta?.shortRevision && String(meta.shortRevision).toLowerCase() !== shortRevision) {
         throw new Error('shortRevision does not agree with revision');

--- a/frontend/src/utils/buildIdentity.js
+++ b/frontend/src/utils/buildIdentity.js
@@ -24,7 +24,7 @@ export const isPlaceholderRevision = (value) =>
 
 export function normalizeBuildIdentity(meta) {
     const version = boundedString(meta?.version, 'version', 64);
-    if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
         throw new Error('version is not semantic');
     }
     const revision = boundedString(meta?.revision ?? meta?.gitSha, 'revision', 40).toLowerCase();
@@ -40,9 +40,14 @@ export function normalizeBuildIdentity(meta) {
         'buildTimestamp',
         40
     );
+    const parsedTimestamp = Date.parse(buildTimestamp);
+    const canonicalTimestamp = Number.isNaN(parsedTimestamp)
+        ? ''
+        : new Date(parsedTimestamp).toISOString();
     if (
         !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(buildTimestamp) ||
-        Number.isNaN(Date.parse(buildTimestamp))
+        (buildTimestamp !== canonicalTimestamp &&
+            buildTimestamp.replace(/Z$/, '.000Z') !== canonicalTimestamp)
     ) {
         throw new Error('buildTimestamp must be an ISO UTC timestamp');
     }

--- a/frontend/src/utils/buildIdentity.js
+++ b/frontend/src/utils/buildIdentity.js
@@ -1,0 +1,64 @@
+export const FULL_GIT_SHA = /^[0-9a-f]{40}$/i;
+const IMMUTABLE_IMAGE =
+    /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)?[a-z0-9._/-]+:([a-z0-9._-]+)-([0-9a-f]{7})$/i;
+const PLACEHOLDERS = new Set(['', 'unknown', 'missing', 'missing-sha', 'dev-local']);
+
+const boundedString = (value, name, maxLength = 256) => {
+    const normalized = String(value ?? '').trim();
+    const hasControlCharacter = [...normalized].some((character) => {
+        const code = character.codePointAt(0);
+        return code < 32 || code === 127;
+    });
+    if (!normalized || normalized.length > maxLength || hasControlCharacter) {
+        throw new Error(`${name} is missing or invalid`);
+    }
+    return normalized;
+};
+
+export const isPlaceholderRevision = (value) =>
+    PLACEHOLDERS.has(
+        String(value ?? '')
+            .trim()
+            .toLowerCase()
+    );
+
+export function normalizeBuildIdentity(meta) {
+    const version = boundedString(meta?.version, 'version', 64);
+    if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+        throw new Error('version is not semantic');
+    }
+    const revision = boundedString(meta?.revision ?? meta?.gitSha, 'revision', 40).toLowerCase();
+    if (isPlaceholderRevision(revision) || !FULL_GIT_SHA.test(revision)) {
+        throw new Error('revision must be exactly 40 hexadecimal characters');
+    }
+    const shortRevision = revision.slice(0, 7);
+    if (meta?.shortRevision && String(meta.shortRevision).toLowerCase() !== shortRevision) {
+        throw new Error('shortRevision does not agree with revision');
+    }
+    const buildTimestamp = boundedString(
+        meta?.buildTimestamp ?? meta?.generatedAt,
+        'buildTimestamp',
+        40
+    );
+    if (
+        !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(buildTimestamp) ||
+        Number.isNaN(Date.parse(buildTimestamp))
+    ) {
+        throw new Error('buildTimestamp must be an ISO UTC timestamp');
+    }
+
+    const identity = { version, revision, shortRevision, buildTimestamp };
+    const image = String(meta?.image ?? '').trim();
+    if (image) {
+        const match = boundedString(image, 'image', 256).match(IMMUTABLE_IMAGE);
+        if (
+            !match ||
+            match[2].toLowerCase() !== shortRevision ||
+            /(?:^|[-_.])latest(?:$|[-_.])/i.test(match[1])
+        ) {
+            throw new Error('image must be an immutable branch-SHA coordinate matching revision');
+        }
+        identity.image = image;
+    }
+    return Object.freeze(identity);
+}

--- a/frontend/src/utils/buildInfo.js
+++ b/frontend/src/utils/buildInfo.js
@@ -11,6 +11,7 @@ const readViteGitSha = () => {
 };
 
 const normalizeSha = (value) => String(value || '').trim();
+const isFullSha = (value) => /^[0-9a-f]{40}$/i.test(normalizeSha(value));
 
 const readBuildMetaSha = () => normalizeSha(buildMeta?.gitSha);
 
@@ -56,6 +57,10 @@ const isBuildMetaUsable = () => {
 const resolveGitSha = () => {
     const normalized = normalizeSha(readViteGitSha());
     if (!isPlaceholderSha(normalized)) {
+        const metadataSha = readBuildMetaSha();
+        if (isFullSha(normalized) && isFullSha(metadataSha) && normalized !== metadataSha) {
+            return 'missing';
+        }
         return normalized;
     }
     if (isBuildMetaUsable()) {
@@ -77,6 +82,10 @@ export const getAppGitSha = () => resolveGitSha();
 export const getAppGitShaWithFallback = (fallbackSha) => {
     const appSha = normalizeSha(readViteGitSha());
     if (!isPlaceholderSha(appSha)) {
+        const metadataSha = readBuildMetaSha();
+        if (isFullSha(appSha) && isFullSha(metadataSha) && appSha !== metadataSha) {
+            return { sha: 'missing', source: 'mismatch' };
+        }
         return { sha: appSha, source: 'vite' };
     }
     if (isBuildMetaUsable()) {

--- a/frontend/src/utils/buildMetaServer.js
+++ b/frontend/src/utils/buildMetaServer.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { logServerError } from './serverLogger';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 const RUNTIME_BUILD_META_PATH = '/app/build_meta.json';
 const REPO_BUILD_META_PATH = path.join(
@@ -11,8 +12,6 @@ const REPO_BUILD_META_PATH = path.join(
     'build_meta.json'
 );
 const FRONTEND_BUILD_META_PATH = path.join(process.cwd(), 'src', 'generated', 'build_meta.json');
-const ENV_SOURCES = ['GITHUB_SHA', 'VITE_GIT_SHA', 'GIT_SHA', 'DSPACE_GIT_SHA'];
-
 const normalizeSha = (value) => String(value || '').trim();
 
 const isPlaceholderSha = (value) => {
@@ -37,10 +36,15 @@ const readBuildMetaFile = async (filePath) => {
         if (isPlaceholderSha(gitSha)) {
             return null;
         }
-        const generatedAt = normalizeSha(parsed?.generatedAt) || new Date().toISOString();
+        const generatedAt = normalizeSha(parsed?.generatedAt);
         const source = normalizeSha(parsed?.source) || 'build-meta';
 
         return {
+            version: parsed?.version,
+            revision: parsed?.revision,
+            shortRevision: parsed?.shortRevision,
+            buildTimestamp: parsed?.buildTimestamp,
+            ...(parsed?.image ? { image: parsed.image } : {}),
             gitSha,
             generatedAt,
             source,
@@ -49,21 +53,6 @@ const readBuildMetaFile = async (filePath) => {
     } catch (error) {
         return null;
     }
-};
-
-const resolveBuildMetaFromEnv = () => {
-    for (const key of ENV_SOURCES) {
-        const gitSha = normalizeSha(process.env[key]);
-        if (!isPlaceholderSha(gitSha)) {
-            return {
-                gitSha,
-                generatedAt: new Date().toISOString(),
-                source: `env:${key}`,
-                resolvedFrom: 'env',
-            };
-        }
-    }
-    return null;
 };
 
 export const resolveRuntimeBuildMeta = async () => {
@@ -78,10 +67,6 @@ export const resolveRuntimeBuildMeta = async () => {
     const frontendMeta = await readBuildMetaFile(FRONTEND_BUILD_META_PATH);
     if (frontendMeta) {
         return frontendMeta;
-    }
-    const envMeta = resolveBuildMetaFromEnv();
-    if (envMeta) {
-        return envMeta;
     }
     return {
         gitSha: 'missing',
@@ -98,6 +83,9 @@ const toPublicMeta = (meta) => {
     const { resolvedFrom, ...publicMeta } = meta;
     return publicMeta;
 };
+
+export const resolveRuntimeBuildIdentity = async () =>
+    normalizeBuildIdentity(await resolveRuntimeBuildMeta());
 
 const buildHeaders = () => ({
     'Content-Type': 'application/json; charset=utf-8',
@@ -137,6 +125,23 @@ export async function buildRuntimeBuildMetaResponse() {
         });
 
         return new Response(JSON.stringify({ gitSha: 'missing', source: 'missing' }), {
+            status: 503,
+            headers: buildHeaders(),
+        });
+    }
+}
+
+export async function buildRuntimeBuildInfoResponse() {
+    try {
+        const identity = await resolveRuntimeBuildIdentity();
+        return new Response(JSON.stringify(identity), { status: 200, headers: buildHeaders() });
+    } catch (error) {
+        logServerError({
+            route: '/build-info.json',
+            method: 'GET',
+            error: 'Runtime build identity is unavailable',
+        });
+        return new Response(JSON.stringify({ error: 'build_identity_unavailable' }), {
             status: 503,
             headers: buildHeaders(),
         });

--- a/frontend/src/utils/buildMetaServer.js
+++ b/frontend/src/utils/buildMetaServer.js
@@ -44,7 +44,7 @@ const readBuildMetaFile = async (filePath) => {
             revision: parsed?.revision,
             shortRevision: parsed?.shortRevision,
             buildTimestamp: parsed?.buildTimestamp,
-            ...(parsed?.image ? { image: parsed.image } : {}),
+            ...(parsed?.image !== undefined ? { image: parsed.image } : {}),
             gitSha,
             generatedAt,
             source,

--- a/frontend/src/utils/metrics.js
+++ b/frontend/src/utils/metrics.js
@@ -1,5 +1,6 @@
 import { isBrowser } from './ssr.js';
-import { getAppGitSha } from './buildInfo.js';
+import buildMeta from '../generated/build_meta.json';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 const isBrowserRuntime = isBrowser && (typeof process === 'undefined' || !process.versions?.node);
 const defaultLoader = () => import(/* @vite-ignore */ 'prom-client');
@@ -130,15 +131,14 @@ const getOrCreateMetric = (constructors, registerInstance, type, config) => {
     return new Ctor({ ...config, registers: [registerInstance] });
 };
 
-const loadBuildInfo = () => ({
-    version: process.env.DSPACE_VERSION || process.env.npm_package_version || 'unknown',
-    revision:
-        process.env.DSPACE_REVISION ||
-        process.env.GITHUB_SHA ||
-        process.env.SOURCE_VERSION ||
-        getAppGitSha() ||
-        'unknown',
-});
+const loadBuildInfo = () => {
+    try {
+        const identity = normalizeBuildIdentity(buildMeta);
+        return { version: identity.version, revision: identity.revision };
+    } catch {
+        return { version: 'unknown', revision: 'unknown' };
+    }
+};
 
 async function initMetrics(loader = defaultLoader) {
     if (isBrowserRuntime) {
@@ -207,13 +207,7 @@ async function initMetrics(loader = defaultLoader) {
             }),
         };
         const build = loadBuildInfo();
-        if (typeof metricHandles.buildInfo.remove === 'function') {
-            try {
-                metricHandles.buildInfo.remove();
-            } catch {
-                // Duplicate-import safety: older prom-client versions may not support remove().
-            }
-        }
+        metricHandles.buildInfo.reset();
         metricHandles.buildInfo.set(build, 1);
         metricHandles.instrumentationUp.set(1);
         metricsAvailable = true;

--- a/frontend/src/utils/runtimeEndpoints.ts
+++ b/frontend/src/utils/runtimeEndpoints.ts
@@ -3,6 +3,8 @@ import { parseFeatureFlags, readBooleanOverride } from '@dspace/feature-flags';
 import { resolveTokenPlaceBaseUrl, getTokenPlaceChatModel } from './tokenPlace.js';
 import { logServerError } from './serverLogger';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import buildMeta from '../generated/build_meta.json';
+import { normalizeBuildIdentity } from './buildIdentity.js';
 
 function parseOfflineWorkerEnabled(flags: FeatureFlagParseResult): boolean {
     const envOverride = readBooleanOverride(process.env.DSPACE_OFFLINE_WORKER_ENABLED);
@@ -188,6 +190,12 @@ function buildHealthBody(status: 'ready' | 'alive') {
     const version = process.env.DSPACE_VERSION || process.env.npm_package_version || 'unknown';
     const environment = process.env.DSPACE_ENV || 'unknown';
 
+    let buildIdentity = null;
+    try {
+        buildIdentity = normalizeBuildIdentity(buildMeta);
+    } catch {
+        // Probe availability is intentionally independent from build-identity validation.
+    }
     return {
         status,
         uptimeSeconds: process.uptime(),
@@ -196,6 +204,7 @@ function buildHealthBody(status: 'ready' | 'alive') {
         version,
         env: environment,
         features: flags.tokens,
+        buildIdentity,
     };
 }
 

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -55,8 +55,8 @@ const verify = () => {
   const timestamp = meta?.buildTimestamp ?? meta?.generatedAt;
   if (!canonicalTimestamp(timestamp))
     fail('Canonical build metadata has an invalid buildTimestamp.');
-  if (meta?.image) {
-    const image = String(meta.image).trim();
+  const image = String(meta?.image ?? '').trim();
+  if (image) {
     const hasControlCharacter = [...image].some((character) => {
       const code = character.codePointAt(0);
       return code < 32 || code === 127;

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -5,6 +5,8 @@ import path from 'node:path';
 const FULL_SHA = /^[0-9a-f]{40}$/;
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const IMMUTABLE_IMAGE =
+  /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)?[a-z0-9._/-]+:([a-z0-9._-]+)-([0-9a-f]{7})$/i;
 const fail = (message) => {
   throw new Error(message);
 };
@@ -54,10 +56,19 @@ const verify = () => {
   if (!canonicalTimestamp(timestamp))
     fail('Canonical build metadata has an invalid buildTimestamp.');
   if (meta?.image) {
-    const image = String(meta.image);
+    const image = String(meta.image).trim();
+    const hasControlCharacter = [...image].some((character) => {
+      const code = character.codePointAt(0);
+      return code < 32 || code === 127;
+    });
+    const match = image.match(IMMUTABLE_IMAGE);
     if (
-      !image.endsWith(`-${expected.slice(0, 7)}`) ||
-      /(?:^|[-_.])latest(?:$|[-_.])/i.test(image)
+      !image ||
+      image.length > 256 ||
+      hasControlCharacter ||
+      !match ||
+      match[2].toLowerCase() !== expected.slice(0, 7) ||
+      /(?:^|[-_.])latest(?:$|[-_.])/i.test(match[1])
     )
       fail(
         'Canonical build metadata has a mismatched immutable image coordinate.'

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -2,85 +2,64 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const args = process.argv.slice(2);
-const expectedSha = String(process.env.EXPECTED_SHA || process.env.GIT_SHA || '').trim();
-
-if (!expectedSha) {
-    console.error('Expected SHA is required. Set EXPECTED_SHA or GIT_SHA.');
-    process.exit(1);
+const expected = String(process.env.EXPECTED_SHA || '')
+  .trim()
+  .toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(expected)) {
+  throw new Error('EXPECTED_SHA must be exactly 40 hexadecimal characters.');
+}
+const root = path.resolve(process.argv[2] || 'frontend/dist');
+const metaPath =
+  process.env.VERIFY_BUILD_META_PATH ||
+  path.resolve('frontend/src/generated/build_meta.json');
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+if (!/^[0-9a-f]{40}$/i.test(String(meta.gitSha || ''))) {
+  throw new Error('Canonical build metadata has an invalid full revision.');
+}
+if (
+  meta.gitSha.toLowerCase() !== expected ||
+  meta.revision.toLowerCase() !== expected
+) {
+  throw new Error('Canonical build metadata does not match EXPECTED_SHA.');
 }
 
-const shortSha = expectedSha.length > 7 ? expectedSha.slice(0, 7) : expectedSha;
-const targets = [expectedSha, shortSha, `v3:${shortSha}`].filter(Boolean);
-const forbidden = ['v3:missing', 'v3:dev-local', 'v3:unknown', 'v3:missing-sha'];
-const allowedExtensions = new Set(['.js', '.mjs', '.cjs', '.css', '.html']);
-
-const candidateDirs =
-    args.length > 0 ? args : ['/app/dist', '/workspace/frontend/dist', 'frontend/dist', 'dist'];
-const existingDirs = candidateDirs.filter((dir) => fs.existsSync(dir));
-
-if (existingDirs.length === 0) {
-    console.error(`No dist directories found. Checked: ${candidateDirs.join(', ')}`);
-    process.exit(1);
+const extensions = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.css',
+  '.html',
+  '.map',
+  '.json',
+]);
+const files = [];
+const walk = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(file);
+    else if (entry.isFile() && extensions.has(path.extname(file)))
+      files.push(file);
+  }
+};
+walk(root);
+const server = files.filter((file) =>
+  /(?:^|\/)(?:server|chunks|pages)(?:\/|$)/.test(file)
+);
+const client = files.filter((file) =>
+  /(?:^|\/)(?:client|_astro|assets)(?:\/|$)/.test(file)
+);
+const containsExpected = (file) =>
+  fs.readFileSync(file, 'utf8').includes(expected);
+if (!server.some(containsExpected))
+  throw new Error('Expected full SHA is missing from SSR/server output.');
+if (!client.some(containsExpected))
+  throw new Error('Expected full SHA is missing from client/static output.');
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  if (/v3:(?:missing|unknown|dev-local|missing-sha)/i.test(content)) {
+    throw new Error(`Placeholder build identity found in ${file}`);
+  }
 }
-
-const stack = [...existingDirs];
-let foundTarget = false;
-const forbiddenHits = new Set();
-
-while (stack.length) {
-    const current = stack.pop();
-    if (!current) {
-        continue;
-    }
-    let entries = [];
-    try {
-        entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch (error) {
-        continue;
-    }
-    for (const entry of entries) {
-        const fullPath = path.join(current, entry.name);
-        if (entry.isDirectory()) {
-            stack.push(fullPath);
-            continue;
-        }
-        if (!entry.isFile()) {
-            continue;
-        }
-        if (!allowedExtensions.has(path.extname(fullPath))) {
-            continue;
-        }
-        try {
-            const content = fs.readFileSync(fullPath, 'utf8');
-            if (!foundTarget && targets.some((target) => content.includes(target))) {
-                foundTarget = true;
-            }
-            for (const forbiddenValue of forbidden) {
-                if (content.includes(forbiddenValue)) {
-                    forbiddenHits.add(forbiddenValue);
-                }
-            }
-        } catch (error) {
-            continue;
-        }
-    }
-}
-
-if (!foundTarget) {
-    console.error(
-        `Expected build SHA not found in frontend bundle. Looked for: ${targets.join(', ')}`
-    );
-    process.exit(1);
-}
-
-if (forbiddenHits.size > 0) {
-    console.error(
-        `Forbidden build SHA markers found in frontend bundle: ${Array.from(forbiddenHits).join(
-            ', '
-        )}`
-    );
-    process.exit(1);
-}
-
-console.log(`Build SHA verified in frontend bundle. Matched: ${targets.join(', ')}`);
+console.log(
+  `Verified full build SHA ${expected} in canonical metadata, server, and client output.`
+);

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -13,13 +13,16 @@ const metaPath =
   process.env.VERIFY_BUILD_META_PATH ||
   path.resolve('frontend/src/generated/build_meta.json');
 const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-if (!/^[0-9a-f]{40}$/i.test(String(meta.gitSha || ''))) {
+const gitSha = String(meta?.gitSha ?? '')
+  .trim()
+  .toLowerCase();
+const revision = String(meta?.revision ?? '')
+  .trim()
+  .toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(gitSha) || !/^[0-9a-f]{40}$/.test(revision)) {
   throw new Error('Canonical build metadata has an invalid full revision.');
 }
-if (
-  meta.gitSha.toLowerCase() !== expected ||
-  meta.revision.toLowerCase() !== expected
-) {
+if (gitSha !== expected || revision !== expected) {
   throw new Error('Canonical build metadata does not match EXPECTED_SHA.');
 }
 

--- a/scripts/verify-build-sha.mjs
+++ b/scripts/verify-build-sha.mjs
@@ -2,67 +2,115 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const expected = String(process.env.EXPECTED_SHA || '')
-  .trim()
-  .toLowerCase();
-if (!/^[0-9a-f]{40}$/.test(expected)) {
-  throw new Error('EXPECTED_SHA must be exactly 40 hexadecimal characters.');
-}
-const root = path.resolve(process.argv[2] || 'frontend/dist');
-const metaPath =
-  process.env.VERIFY_BUILD_META_PATH ||
-  path.resolve('frontend/src/generated/build_meta.json');
-const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-const gitSha = String(meta?.gitSha ?? '')
-  .trim()
-  .toLowerCase();
-const revision = String(meta?.revision ?? '')
-  .trim()
-  .toLowerCase();
-if (!/^[0-9a-f]{40}$/.test(gitSha) || !/^[0-9a-f]{40}$/.test(revision)) {
-  throw new Error('Canonical build metadata has an invalid full revision.');
-}
-if (gitSha !== expected || revision !== expected) {
-  throw new Error('Canonical build metadata does not match EXPECTED_SHA.');
-}
-
-const extensions = new Set([
-  '.js',
-  '.mjs',
-  '.cjs',
-  '.css',
-  '.html',
-  '.map',
-  '.json',
-]);
-const files = [];
-const walk = (dir) => {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const file = path.join(dir, entry.name);
-    if (entry.isDirectory()) walk(file);
-    else if (entry.isFile() && extensions.has(path.extname(file)))
-      files.push(file);
-  }
+const FULL_SHA = /^[0-9a-f]{40}$/;
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const fail = (message) => {
+  throw new Error(message);
 };
-walk(root);
-const server = files.filter((file) =>
-  /(?:^|\/)(?:server|chunks|pages)(?:\/|$)/.test(file)
-);
-const client = files.filter((file) =>
-  /(?:^|\/)(?:client|_astro|assets)(?:\/|$)/.test(file)
-);
-const containsExpected = (file) =>
-  fs.readFileSync(file, 'utf8').includes(expected);
-if (!server.some(containsExpected))
-  throw new Error('Expected full SHA is missing from SSR/server output.');
-if (!client.some(containsExpected))
-  throw new Error('Expected full SHA is missing from client/static output.');
-for (const file of files) {
-  const content = fs.readFileSync(file, 'utf8');
-  if (/v3:(?:missing|unknown|dev-local|missing-sha)/i.test(content)) {
-    throw new Error(`Placeholder build identity found in ${file}`);
+const canonicalTimestamp = (value) => {
+  if (typeof value !== 'string' || !TIMESTAMP.test(value)) return false;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return false;
+  const iso = new Date(parsed).toISOString();
+  return value === iso || value.replace(/Z$/, '.000Z') === iso;
+};
+
+const verify = () => {
+  const expected = String(process.env.EXPECTED_SHA || '')
+    .trim()
+    .toLowerCase();
+  if (!FULL_SHA.test(expected))
+    fail('EXPECTED_SHA must be exactly 40 hexadecimal characters.');
+
+  const root = path.resolve(process.argv[2] || 'frontend/dist');
+  const metaPath =
+    process.env.VERIFY_BUILD_META_PATH ||
+    path.resolve('frontend/src/generated/build_meta.json');
+  let meta;
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  } catch {
+    fail('Canonical build metadata is missing or malformed.');
   }
+  const gitSha = String(meta?.gitSha ?? '')
+    .trim()
+    .toLowerCase();
+  const revision = String(meta?.revision ?? '')
+    .trim()
+    .toLowerCase();
+  const shortRevision = String(meta?.shortRevision ?? '')
+    .trim()
+    .toLowerCase();
+  if (!FULL_SHA.test(gitSha) || !FULL_SHA.test(revision))
+    fail('Canonical build metadata has an invalid full revision.');
+  if (gitSha !== expected || revision !== expected)
+    fail('Canonical build metadata does not match EXPECTED_SHA.');
+  if (shortRevision !== expected.slice(0, 7))
+    fail('Canonical build metadata has an invalid shortRevision.');
+  if (!SEMVER.test(String(meta?.version ?? '')))
+    fail('Canonical build metadata has an invalid version.');
+  const timestamp = meta?.buildTimestamp ?? meta?.generatedAt;
+  if (!canonicalTimestamp(timestamp))
+    fail('Canonical build metadata has an invalid buildTimestamp.');
+  if (meta?.image) {
+    const image = String(meta.image);
+    if (
+      !image.endsWith(`-${expected.slice(0, 7)}`) ||
+      /(?:^|[-_.])latest(?:$|[-_.])/i.test(image)
+    )
+      fail(
+        'Canonical build metadata has a mismatched immutable image coordinate.'
+      );
+  }
+
+  const extensions = new Set([
+    '.js',
+    '.mjs',
+    '.cjs',
+    '.css',
+    '.html',
+    '.map',
+    '.json',
+  ]);
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const file = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(file);
+      else if (entry.isFile() && extensions.has(path.extname(file)))
+        files.push(file);
+    }
+  };
+  walk(root);
+  const executable = files.filter((file) => path.extname(file) !== '.map');
+  const server = executable.filter((file) =>
+    /(?:^|\/)(?:server|chunks|pages)(?:\/|$)/.test(file)
+  );
+  const client = executable.filter((file) =>
+    /(?:^|\/)(?:client|_astro|assets)(?:\/|$)/.test(file)
+  );
+  const containsExpected = (file) =>
+    fs.readFileSync(file, 'utf8').includes(expected);
+  if (!server.some(containsExpected))
+    fail('Expected full SHA is missing from SSR/server output.');
+  if (!client.some(containsExpected))
+    fail('Expected full SHA is missing from client/static output.');
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    if (/v3:(?:missing|unknown|dev-local|missing-sha)/i.test(content))
+      fail(`Placeholder build identity found in ${file}`);
+  }
+  console.log(
+    `Verified full build SHA ${expected} in canonical metadata, server, and client output.`
+  );
+};
+
+try {
+  verify();
+} catch (error) {
+  console.error(
+    `Build SHA verification failed: ${error instanceof Error ? error.message : 'unknown error'}`
+  );
+  process.exitCode = 1;
 }
-console.log(
-  `Verified full build SHA ${expected} in canonical metadata, server, and client output.`
-);

--- a/scripts/write-build-meta.mjs
+++ b/scripts/write-build-meta.mjs
@@ -2,21 +2,26 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import packageJson from '../package.json' with { type: 'json' };
+import {
+  FULL_GIT_SHA,
+  normalizeBuildIdentity,
+} from '../frontend/src/utils/buildIdentity.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const resolveRepoRoot = () =>
-    process.env.VERIFY_REPO_ROOT
-        ? path.resolve(process.env.VERIFY_REPO_ROOT)
-        : path.resolve(__dirname, '..');
+  process.env.VERIFY_REPO_ROOT
+    ? path.resolve(process.env.VERIFY_REPO_ROOT)
+    : path.resolve(__dirname, '..');
 const resolveBuildMetaPath = (root) => {
-    const overridePath = process.env.VERIFY_BUILD_META_PATH;
-    if (overridePath) {
-        return path.isAbsolute(overridePath)
-            ? overridePath
-            : path.resolve(root, overridePath);
-    }
-    return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
+  const overridePath = process.env.VERIFY_BUILD_META_PATH;
+  if (overridePath) {
+    return path.isAbsolute(overridePath)
+      ? overridePath
+      : path.resolve(root, overridePath);
+  }
+  return path.join(root, 'frontend', 'src', 'generated', 'build_meta.json');
 };
 const repoRoot = resolveRepoRoot();
 const buildMetaPath = resolveBuildMetaPath(repoRoot);
@@ -25,89 +30,116 @@ const allowedSources = new Set(['ci', 'env', 'git']);
 const normalizeSha = (value) => String(value || '').trim();
 
 const isPlaceholderSha = (value) => {
-    const normalized = normalizeSha(value).toLowerCase();
-    return (
-        !normalized ||
-        normalized === 'unknown' ||
-        normalized === 'missing' ||
-        normalized === 'missing-sha' ||
-        normalized === 'dev-local'
-    );
+  const normalized = normalizeSha(value).toLowerCase();
+  return (
+    !normalized ||
+    normalized === 'unknown' ||
+    normalized === 'missing' ||
+    normalized === 'missing-sha' ||
+    normalized === 'dev-local'
+  );
 };
 
-export const assertBuildMetaComplete = (payload) => {
-    if (!payload || typeof payload !== 'object') {
-        throw new Error('build_meta.json payload is missing or invalid.');
-    }
-    if (isPlaceholderSha(payload.gitSha)) {
-        throw new Error(`build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`);
-    }
-    if (!normalizeSha(payload.generatedAt)) {
-        throw new Error('build_meta.json generatedAt is missing.');
-    }
-    const source = String(payload.source || '').trim().toLowerCase();
-    if (!source || source === 'static' || !allowedSources.has(source)) {
-        throw new Error(`build_meta.json source is invalid: ${payload.source || 'empty'}`);
-    }
+export const assertBuildMetaComplete = (
+  payload,
+  { production = false } = {}
+) => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('build_meta.json payload is missing or invalid.');
+  }
+  if (isPlaceholderSha(payload.gitSha)) {
+    throw new Error(
+      `build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`
+    );
+  }
+  if (!normalizeSha(payload.generatedAt)) {
+    throw new Error('build_meta.json generatedAt is missing.');
+  }
+  const source = String(payload.source || '')
+    .trim()
+    .toLowerCase();
+  if (!source || source === 'static' || !allowedSources.has(source)) {
+    throw new Error(
+      `build_meta.json source is invalid: ${payload.source || 'empty'}`
+    );
+  }
+  if (production || FULL_GIT_SHA.test(normalizeSha(payload.gitSha))) {
+    normalizeBuildIdentity(payload);
+  }
 };
 
 export const getRepoRoot = () => repoRoot;
 export const getBuildMetaPath = () => buildMetaPath;
 
 export const resolveBuildMeta = () => {
-    const envPriority = [
-        { key: 'GITHUB_SHA', source: 'ci' },
-        { key: 'VITE_GIT_SHA', source: 'env' },
-        { key: 'GIT_SHA', source: 'env' },
-        { key: 'DSPACE_GIT_SHA', source: 'env' },
-    ];
+  const envPriority = [
+    { key: 'GITHUB_SHA', source: 'ci' },
+    { key: 'VITE_GIT_SHA', source: 'env' },
+    { key: 'GIT_SHA', source: 'env' },
+    { key: 'DSPACE_GIT_SHA', source: 'env' },
+  ];
 
-    for (const { key, source } of envPriority) {
-        const value = normalizeSha(process.env[key]);
-        if (value && !isPlaceholderSha(value)) {
-            return { gitSha: value, source };
-        }
+  for (const { key, source } of envPriority) {
+    const value = normalizeSha(process.env[key]);
+    if (value && !isPlaceholderSha(value)) {
+      return { gitSha: value, source };
     }
+  }
 
-    try {
-        const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-        if (isPlaceholderSha(gitSha)) {
-            throw new Error('git rev-parse returned an invalid SHA.');
-        }
-        return { gitSha, source: 'git' };
-    } catch (error) {
-        throw new Error(
-            'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
-        );
+  try {
+    const gitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+    if (isPlaceholderSha(gitSha)) {
+      throw new Error('git rev-parse returned an invalid SHA.');
     }
+    return { gitSha, source: 'git' };
+  } catch (error) {
+    throw new Error(
+      'Unable to resolve git SHA from environment or git. Provide GITHUB_SHA, VITE_GIT_SHA, GIT_SHA, or DSPACE_GIT_SHA.'
+    );
+  }
 };
 
-export const writeBuildMeta = async ({ gitSha, source = 'build-meta' }) => {
-    const payload = {
-        gitSha: normalizeSha(gitSha),
-        generatedAt: new Date().toISOString(),
-        source,
-    };
-    assertBuildMetaComplete(payload);
-    await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
-    await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
-    return payload;
+export const writeBuildMeta = async ({
+  gitSha,
+  source = 'build-meta',
+  generatedAt = process.env.BUILD_TIMESTAMP || new Date().toISOString(),
+  image = process.env.DSPACE_IMAGE || undefined,
+  production = process.env.DSPACE_PRODUCTION_BUILD === '1',
+}) => {
+  const normalizedRevision = normalizeSha(gitSha).toLowerCase();
+  const payload = {
+    version: packageJson.version,
+    revision: normalizedRevision,
+    shortRevision: normalizedRevision.slice(0, 7),
+    buildTimestamp: generatedAt,
+    ...(image ? { image } : {}),
+    gitSha: normalizedRevision,
+    generatedAt,
+    source,
+  };
+  assertBuildMetaComplete(payload, { production });
+  await fs.mkdir(path.dirname(buildMetaPath), { recursive: true });
+  await fs.writeFile(buildMetaPath, `${JSON.stringify(payload, null, 4)}\n`);
+  return payload;
 };
 
 export const readBuildMeta = async () => {
-    const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
-    return JSON.parse(rawMeta);
+  const rawMeta = await fs.readFile(buildMetaPath, 'utf8');
+  return JSON.parse(rawMeta);
 };
 
 const run = async () => {
-    const { gitSha, source } = resolveBuildMeta();
-    await writeBuildMeta({ gitSha, source });
-    console.log(`Build metadata written to ${buildMetaPath}`);
+  const { gitSha, source } = resolveBuildMeta();
+  await writeBuildMeta({ gitSha, source });
+  console.log(`Build metadata written to ${buildMetaPath}`);
 };
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    run().catch((error) => {
-        console.error('Failed to write build metadata:', error);
-        process.exit(1);
-    });
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run().catch((error) => {
+    console.error('Failed to write build metadata:', error);
+    process.exit(1);
+  });
 }

--- a/scripts/write-build-meta.mjs
+++ b/scripts/write-build-meta.mjs
@@ -25,7 +25,7 @@ const resolveBuildMetaPath = (root) => {
 };
 const repoRoot = resolveRepoRoot();
 const buildMetaPath = resolveBuildMetaPath(repoRoot);
-const allowedSources = new Set(['ci', 'env', 'git']);
+const allowedSources = new Set(['ci', 'env', 'git', 'local']);
 
 const normalizeSha = (value) => String(value || '').trim();
 
@@ -47,6 +47,9 @@ export const assertBuildMetaComplete = (
   if (!payload || typeof payload !== 'object') {
     throw new Error('build_meta.json payload is missing or invalid.');
   }
+  const localMode =
+    payload.gitSha === 'dev-local' && payload.source === 'local';
+  if (localMode && !production) return;
   if (isPlaceholderSha(payload.gitSha)) {
     throw new Error(
       `build_meta.json gitSha is not set: ${payload.gitSha || 'empty'}`
@@ -101,7 +104,7 @@ export const resolveBuildMeta = () => {
 
 export const writeBuildMeta = async ({
   gitSha,
-  source = 'build-meta',
+  source = 'local',
   generatedAt = process.env.BUILD_TIMESTAMP || new Date().toISOString(),
   image = process.env.DSPACE_IMAGE || undefined,
   production = process.env.DSPACE_PRODUCTION_BUILD === '1',

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBuildIdentity } from '../frontend/src/utils/buildIdentity.js';
+
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+const valid = {
+  version: '3.1.0',
+  revision: SHA,
+  shortRevision: SHA.slice(0, 7),
+  buildTimestamp: '2026-07-29T12:00:00Z',
+};
+
+describe('canonical public build identity', () => {
+  it('normalizes the full identity and derives the short revision', () => {
+    expect(
+      normalizeBuildIdentity({ ...valid, shortRevision: undefined })
+    ).toEqual(valid);
+  });
+
+  it.each([
+    '',
+    'unknown',
+    'missing',
+    'missing-sha',
+    'dev-local',
+    'abc1234',
+    `${SHA}0`,
+  ])('rejects invalid revision %j', (revision) =>
+    expect(() => normalizeBuildIdentity({ ...valid, revision })).toThrow()
+  );
+
+  it('rejects mismatched short revisions and request-like timestamps', () => {
+    expect(() =>
+      normalizeBuildIdentity({ ...valid, shortRevision: 'fffffff' })
+    ).toThrow();
+    expect(() =>
+      normalizeBuildIdentity({ ...valid, buildTimestamp: '' })
+    ).toThrow();
+  });
+
+  it('accepts only an agreeing immutable branch-SHA image coordinate', () => {
+    const image = `ghcr.io/democratizedspace/dspace:main-${SHA.slice(0, 7)}`;
+    expect(normalizeBuildIdentity({ ...valid, image }).image).toBe(image);
+    for (const movable of [
+      'ghcr.io/democratizedspace/dspace:latest',
+      'ghcr.io/democratizedspace/dspace:main-latest',
+      'ghcr.io/democratizedspace/dspace:v3.1.0',
+      'ghcr.io/democratizedspace/dspace:main-fffffff',
+    ]) {
+      expect(() =>
+        normalizeBuildIdentity({ ...valid, image: movable })
+      ).toThrow();
+    }
+  });
+});

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -16,6 +16,13 @@ describe('canonical public build identity', () => {
     ).toEqual(valid);
   });
 
+  it('accepts semantic versions with both prerelease and build metadata', () => {
+    expect(
+      normalizeBuildIdentity({ ...valid, version: '3.2.0-rc.1+build.7' })
+        .version
+    ).toBe('3.2.0-rc.1+build.7');
+  });
+
   it.each([
     '',
     'unknown',
@@ -35,6 +42,12 @@ describe('canonical public build identity', () => {
     expect(() =>
       normalizeBuildIdentity({ ...valid, buildTimestamp: '' })
     ).toThrow();
+    expect(() =>
+      normalizeBuildIdentity({
+        ...valid,
+        buildTimestamp: '2026-02-31T00:00:00Z',
+      })
+    ).toThrow('buildTimestamp must be an ISO UTC timestamp');
   });
 
   it('accepts only an agreeing immutable branch-SHA image coordinate', () => {

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeBuildIdentity } from '../frontend/src/utils/buildIdentity.js';
+import { assertBuildMetaComplete } from '../scripts/write-build-meta.mjs';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const valid = {
@@ -48,6 +49,25 @@ describe('canonical public build identity', () => {
         buildTimestamp: '2026-02-31T00:00:00Z',
       })
     ).toThrow('buildTimestamp must be an ISO UTC timestamp');
+  });
+
+  it('rejects disagreement between supplied full revisions', () => {
+    expect(() =>
+      normalizeBuildIdentity({ ...valid, gitSha: 'f'.repeat(40) })
+    ).toThrow('gitSha does not agree with revision');
+  });
+
+  it('isolates explicit dev-local metadata from canonical and production identities', () => {
+    const local = {
+      gitSha: 'dev-local',
+      source: 'local',
+      generatedAt: '2026-07-29T12:00:00Z',
+    };
+    expect(() => assertBuildMetaComplete(local)).not.toThrow();
+    expect(() => normalizeBuildIdentity(local)).toThrow();
+    expect(() => assertBuildMetaComplete(local, { production: true })).toThrow(
+      'gitSha is not set'
+    );
   });
 
   it('accepts only an agreeing immutable branch-SHA image coordinate', () => {

--- a/tests/buildInfoEndpoint.test.ts
+++ b/tests/buildInfoEndpoint.test.ts
@@ -60,4 +60,49 @@ describe('runtime build identity endpoints', () => {
     });
     expect(body.resolvedFrom).toBeUndefined();
   });
+
+  it('preserves legacy-only build-meta success while canonical build-info fails closed', async () => {
+    filePayload = {
+      gitSha: SHA,
+      generatedAt: '2026-07-29T12:00:00Z',
+      source: 'legacy-ci',
+    };
+    const buildMeta = await import('../frontend/src/pages/build-meta.json.ts');
+    const legacyResponse = await buildMeta.GET();
+    expect(legacyResponse.status).toBe(200);
+    expect(await legacyResponse.json()).toEqual(filePayload);
+
+    const buildInfo = await import('../frontend/src/pages/build-info.json.ts');
+    const canonicalResponse = await buildInfo.GET();
+    expect(canonicalResponse.status).toBe(503);
+    expect(await canonicalResponse.json()).toEqual({
+      error: 'build_identity_unavailable',
+    });
+  });
+
+  it.each(['missing', 'dev-local'])(
+    'keeps placeholder %s metadata private and unavailable',
+    async (gitSha) => {
+      filePayload.gitSha = gitSha;
+      filePayload.revision = gitSha;
+      const buildMeta =
+        await import('../frontend/src/pages/build-meta.json.ts');
+      const legacyResponse = await buildMeta.GET();
+      const legacyBody = await legacyResponse.json();
+      expect(legacyResponse.status).toBe(503);
+      expect(legacyBody).toMatchObject({
+        gitSha: 'missing',
+        source: 'missing',
+      });
+      expect(legacyBody.resolvedFrom).toBeUndefined();
+
+      const buildInfo =
+        await import('../frontend/src/pages/build-info.json.ts');
+      const canonicalResponse = await buildInfo.GET();
+      expect(canonicalResponse.status).toBe(503);
+      expect(await canonicalResponse.json()).toEqual({
+        error: 'build_identity_unavailable',
+      });
+    }
+  );
 });

--- a/tests/buildInfoEndpoint.test.ts
+++ b/tests/buildInfoEndpoint.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+let filePayload;
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: vi.fn(async () => JSON.stringify(filePayload)),
+  },
+}));
+vi.mock('../frontend/src/utils/serverLogger', () => ({
+  logServerError: vi.fn(),
+}));
+
+describe('runtime build identity endpoints', () => {
+  beforeEach(() => {
+    filePayload = {
+      version: '3.1.0',
+      revision: SHA,
+      shortRevision: SHA.slice(0, 7),
+      buildTimestamp: '2026-07-29T12:00:00Z',
+      gitSha: SHA,
+      generatedAt: '2026-07-29T12:00:00Z',
+      source: 'ci',
+    };
+  });
+
+  it('returns the canonical identity without caching or internal paths', async () => {
+    const { GET } = await import('../frontend/src/pages/build-info.json.ts');
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(await response.json()).toEqual({
+      version: '3.1.0',
+      revision: SHA,
+      shortRevision: SHA.slice(0, 7),
+      buildTimestamp: '2026-07-29T12:00:00Z',
+    });
+  });
+
+  it('fails closed with a bounded error for invalid production identity', async () => {
+    filePayload.revision = filePayload.gitSha = 'missing';
+    const { GET } = await import('../frontend/src/pages/build-info.json.ts');
+    const response = await GET();
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: 'build_identity_unavailable',
+    });
+  });
+
+  it('preserves the legacy build-meta fields and status behavior', async () => {
+    const { GET } = await import('../frontend/src/pages/build-meta.json.ts');
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      gitSha: SHA,
+      generatedAt: filePayload.generatedAt,
+      source: 'ci',
+    });
+    expect(body.resolvedFrom).toBeUndefined();
+  });
+});

--- a/tests/buildInfoEndpoint.test.ts
+++ b/tests/buildInfoEndpoint.test.ts
@@ -19,6 +19,7 @@ describe('runtime build identity endpoints', () => {
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',
+      image: `ghcr.io/democratizedspace/dspace:main-${SHA.slice(0, 7)}`,
       gitSha: SHA,
       generatedAt: '2026-07-29T12:00:00Z',
       source: 'ci',
@@ -35,8 +36,22 @@ describe('runtime build identity endpoints', () => {
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',
+      image: `ghcr.io/democratizedspace/dspace:main-${SHA.slice(0, 7)}`,
     });
   });
+
+  it.each([false, 0])(
+    'fails closed with a bounded error for supplied falsey image %j',
+    async (image) => {
+      filePayload.image = image;
+      const { GET } = await import('../frontend/src/pages/build-info.json.ts');
+      const response = await GET();
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({
+        error: 'build_identity_unavailable',
+      });
+    }
+  );
 
   it('fails closed with a bounded error for invalid production identity', async () => {
     filePayload.revision = filePayload.gitSha = 'missing';

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -94,6 +94,9 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
         'GIT_SHA=${{ steps.tags.outputs.full_sha }}'
       );
       expect(step.with['build-args']).toContain(
+        'VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}'
+      );
+      expect(step.with['build-args']).toContain(
         'BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}'
       );
       expect(step.with['build-args']).toContain(
@@ -113,6 +116,8 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(step.run).toContain('org.opencontainers.image.revision');
     expect(step.run).toContain('/build-info.json');
     expect(step.run).toContain('dspace-build-revision');
+    expect(step.env.EXPECTED_SHA).toBe('${{ steps.tags.outputs.full_sha }}');
+    expect(step.run).toContain('test "$label_revision" = "$EXPECTED_SHA"');
   });
 
   it('uses the checked-out commit rather than the dispatch event SHA', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -93,10 +93,26 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
       expect(step.with['build-args']).toContain(
         'GIT_SHA=${{ steps.tags.outputs.full_sha }}'
       );
+      expect(step.with['build-args']).toContain(
+        'BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}'
+      );
+      expect(step.with['build-args']).toContain(
+        'DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}'
+      );
       expect(step.with.labels).toContain(
         'org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}'
       );
     }
+  });
+
+  it('compares runtime JSON and HTML identity with the OCI revision', () => {
+    const step = findSteps(job).find(
+      (candidate) =>
+        candidate.name === 'Compare runtime identity with OCI revision'
+    );
+    expect(step.run).toContain('org.opencontainers.image.revision');
+    expect(step.run).toContain('/build-info.json');
+    expect(step.run).toContain('dspace-build-revision');
   });
 
   it('uses the checked-out commit rather than the dispatch event SHA', () => {

--- a/tests/metricsFallback.test.ts
+++ b/tests/metricsFallback.test.ts
@@ -1440,10 +1440,10 @@ describe('DSPACE application metrics', () => {
         const metrics = await importMetrics();
         const text = await metrics.register.metrics();
         const buildInfo = getMetricLines(text, 'dspace_build_info');
-        expect(buildInfo.length).toBeGreaterThanOrEqual(1);
-        expect(
-            buildInfo.every((line) => line.includes('version=') && line.includes('revision='))
-        ).toBe(true);
+        expect(buildInfo).toHaveLength(1);
+        expect(buildInfo[0]).toMatch(
+            /^dspace_build_info\{version="[^"]+",revision="[0-9a-f]{40}"\} 1$/
+        );
         expect(buildInfo.join('\n')).not.toMatch(/user|session|request|prompt|model|token/i);
         expect(text).toContain('dspace_instrumentation_up 1');
     });

--- a/tests/verifyBuildSha.test.ts
+++ b/tests/verifyBuildSha.test.ts
@@ -1,43 +1,104 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
+const OTHER_SHA = 'fedcba9876543210fedcba9876543210fedcba98';
 const temporaryDirectories: string[] = [];
+const validMeta = {
+  version: '3.2.0-rc.1+build.7',
+  gitSha: SHA,
+  revision: SHA,
+  shortRevision: SHA.slice(0, 7),
+  buildTimestamp: '2026-07-29T12:00:00Z',
+};
 
 afterEach(() => {
-  for (const directory of temporaryDirectories.splice(0)) {
+  for (const directory of temporaryDirectories.splice(0))
     rmSync(directory, { recursive: true, force: true });
-  }
 });
 
-describe('verify-build-sha metadata validation', () => {
-  it('reports a bounded validation error when revision is missing', () => {
-    const directory = mkdtempSync(join(tmpdir(), 'dspace-build-sha-'));
-    temporaryDirectories.push(directory);
-    const metadataPath = join(directory, 'build_meta.json');
-    writeFileSync(metadataPath, JSON.stringify({ gitSha: SHA }));
+const runVerifier = (
+  meta: Record<string, unknown> | string,
+  { server = SHA, client = SHA, sourceMapsOnly = false } = {}
+) => {
+  const directory = mkdtempSync(join(tmpdir(), 'dspace-build-sha-'));
+  temporaryDirectories.push(directory);
+  const dist = join(directory, 'dist');
+  mkdirSync(join(dist, 'server'), { recursive: true });
+  mkdirSync(join(dist, '_astro'), { recursive: true });
+  writeFileSync(
+    join(dist, 'server', sourceMapsOnly ? 'entry.js.map' : 'entry.js'),
+    server
+  );
+  writeFileSync(
+    join(dist, '_astro', sourceMapsOnly ? 'app.js.map' : 'app.js'),
+    client
+  );
+  const metadataPath = join(directory, 'build_meta.json');
+  writeFileSync(
+    metadataPath,
+    typeof meta === 'string' ? meta : JSON.stringify(meta)
+  );
+  return spawnSync(
+    process.execPath,
+    [resolve('scripts/verify-build-sha.mjs'), dist],
+    {
+      cwd: resolve('.'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        EXPECTED_SHA: SHA,
+        VERIFY_BUILD_META_PATH: metadataPath,
+      },
+    }
+  );
+};
 
-    const result = spawnSync(
-      process.execPath,
-      [resolve('scripts/verify-build-sha.mjs'), directory],
-      {
-        cwd: resolve('.'),
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          EXPECTED_SHA: SHA,
-          VERIFY_BUILD_META_PATH: metadataPath,
-        },
-      }
-    );
+describe('verify-build-sha metadata and artifact validation', () => {
+  it('accepts complete canonical metadata embedded in executable artifacts', () => {
+    expect(runVerifier(validMeta).status).toBe(0);
+  });
 
+  it.each([
+    [{ ...validMeta, revision: undefined }, 'invalid full revision'],
+    [{ ...validMeta, gitSha: OTHER_SHA }, 'does not match EXPECTED_SHA'],
+    [{ ...validMeta, revision: SHA.slice(0, 7) }, 'invalid full revision'],
+    [{ ...validMeta, shortRevision: 'fffffff' }, 'invalid shortRevision'],
+    [{ ...validMeta, version: 'release' }, 'invalid version'],
+    [
+      { ...validMeta, buildTimestamp: '2026-02-31T00:00:00Z' },
+      'invalid buildTimestamp',
+    ],
+    [
+      { ...validMeta, image: 'ghcr.io/example/dspace:main-fffffff' },
+      'mismatched immutable',
+    ],
+  ])('rejects invalid metadata with a controlled error', (meta, message) => {
+    const result = runVerifier(meta);
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain(
-      'Canonical build metadata has an invalid full revision.'
-    );
-    expect(result.stderr).not.toContain('TypeError');
+    expect(result.stderr).toContain(message);
+    expect(result.stderr).not.toContain('    at ');
+  });
+
+  it('rejects malformed metadata without a stack trace', () => {
+    const result = runVerifier('{');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('metadata is missing or malformed');
+    expect(result.stderr).not.toContain('SyntaxError');
+  });
+
+  it('does not count source maps as executable identity evidence', () => {
+    const result = runVerifier(validMeta, { sourceMapsOnly: true });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('missing from SSR/server output');
+  });
+
+  it('rejects placeholders in scanned artifacts', () => {
+    const result = runVerifier(validMeta, { server: `${SHA} v3:dev-local` });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Placeholder build identity');
   });
 });

--- a/tests/verifyBuildSha.test.ts
+++ b/tests/verifyBuildSha.test.ts
@@ -59,7 +59,12 @@ const runVerifier = (
 
 describe('verify-build-sha metadata and artifact validation', () => {
   it('accepts complete canonical metadata embedded in executable artifacts', () => {
-    expect(runVerifier(validMeta).status).toBe(0);
+    expect(
+      runVerifier({
+        ...validMeta,
+        image: `ghcr.io/democratizedspace/dspace:main-${SHA.slice(0, 7)}`,
+      }).status
+    ).toBe(0);
   });
 
   it.each([
@@ -74,6 +79,32 @@ describe('verify-build-sha metadata and artifact validation', () => {
     ],
     [
       { ...validMeta, image: 'ghcr.io/example/dspace:main-fffffff' },
+      'mismatched immutable',
+    ],
+    [
+      { ...validMeta, image: `:not-a-coordinate-${SHA.slice(0, 7)}` },
+      'mismatched immutable',
+    ],
+    [
+      { ...validMeta, image: 'ghcr.io/example/dspace:latest' },
+      'mismatched immutable',
+    ],
+    [
+      { ...validMeta, image: 'ghcr.io/example/dspace:v3.1.0' },
+      'mismatched immutable',
+    ],
+    [
+      {
+        ...validMeta,
+        image: `ghcr.io/example/${'a'.repeat(250)}:main-${SHA.slice(0, 7)}`,
+      },
+      'mismatched immutable',
+    ],
+    [
+      {
+        ...validMeta,
+        image: `ghcr.io/example/dspace:\nmain-${SHA.slice(0, 7)}`,
+      },
       'mismatched immutable',
     ],
   ])('rejects invalid metadata with a controlled error', (meta, message) => {

--- a/tests/verifyBuildSha.test.ts
+++ b/tests/verifyBuildSha.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('verify-build-sha metadata validation', () => {
+  it('reports a bounded validation error when revision is missing', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dspace-build-sha-'));
+    temporaryDirectories.push(directory);
+    const metadataPath = join(directory, 'build_meta.json');
+    writeFileSync(metadataPath, JSON.stringify({ gitSha: SHA }));
+
+    const result = spawnSync(
+      process.execPath,
+      [resolve('scripts/verify-build-sha.mjs'), directory],
+      {
+        cwd: resolve('.'),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          EXPECTED_SHA: SHA,
+          VERIFY_BUILD_META_PATH: metadataPath,
+        },
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'Canonical build metadata has an invalid full revision.'
+    );
+    expect(result.stderr).not.toContain('TypeError');
+  });
+});

--- a/tests/verifyBuildSha.test.ts
+++ b/tests/verifyBuildSha.test.ts
@@ -73,6 +73,8 @@ describe('verify-build-sha metadata and artifact validation', () => {
     [{ ...validMeta, revision: SHA.slice(0, 7) }, 'invalid full revision'],
     [{ ...validMeta, shortRevision: 'fffffff' }, 'invalid shortRevision'],
     [{ ...validMeta, version: 'release' }, 'invalid version'],
+    [{ ...validMeta, image: false }, 'mismatched immutable'],
+    [{ ...validMeta, image: 0 }, 'mismatched immutable'],
     [
       { ...validMeta, buildTimestamp: '2026-02-31T00:00:00Z' },
       'invalid buildTimestamp',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -108,6 +108,8 @@ export default defineConfig({
       'backend/**/*.test.ts',
       'frontend/src/components/__tests__/**/*.spec.ts',
       'frontend/src/pages/**/__tests__/**/*.spec.ts',
+      'frontend/__tests__/buildInfo.test.js',
+      'frontend/__tests__/healthEndpoint.test.js',
       'frontend/__tests__/Quests.test.js',
       'frontend/__tests__/gameState/common.test.js',
       'frontend/__tests__/ShoppingForm.test.js',


### PR DESCRIPTION
### Motivation

Prevent production version drift by exposing one bounded, machine-verifiable build identity so operators and Sugarkube automation can prove the backend response, frontend assets, served HTML, and OCI image came from the same approved commit.

### Implementation

- Added canonical build-identity normalization for the semantic application version, full 40-character revision, derived seven-character revision, artifact-fixed ISO timestamp, and optional immutable branch-SHA image coordinate.
- Kept `frontend/src/generated/build_meta.json` and the existing build pipeline as the source of truth, with strict production validation and an explicit non-production `dev-local` path.
- Added uncached `GET /build-info.json`, returning HTTP 503 with a bounded error when canonical identity is missing or invalid.
- Preserved `/build-meta.json` compatibility, including legacy-only success behavior and existing public fields and statuses.
- Added the canonical identity to `/healthz` and `/livez` without changing their availability, status, or HTTP semantics.
- Added the shared-layout `<meta name="dspace-build-revision">` marker and verified the full revision survives SSR/server and client/static asset generation.
- Kept `dspace_build_info` bounded to canonical `version` and full `revision` labels and reset stale build-info series during initialization.
- Hardened `scripts/verify-build-sha.mjs` to require the exact expected full SHA, validate canonical metadata and immutable image coordinates, reject placeholders and malformed values, and require full-SHA evidence in both server and client outputs.
- Wired the same full SHA, build timestamp, and immutable image coordinate through the Docker build, `VITE_GIT_SHA`, and OCI revision label.
- Extended image CI to compare `/build-info.json` and the HTML marker with the image’s `org.opencontainers.image.revision` label.
- Added focused normalization, endpoint, probe, metrics, verifier, workflow, and Playwright coverage, including fail-closed handling for malformed or falsey image metadata.
- Added the route catalog entry and a copy-pasteable Sugarkube verification contract in `docs/ops/sugarkube-release.md`.

### Compatibility and scope

- Existing `/build-meta.json`, `/healthz`, `/livez`, and metrics consumers remain compatible.
- Readiness and liveness remain independent of build-identity validation.
- No application or chart versions, pins, release coordinates, deployment configuration, or chat behavior were changed.
- This PR does not implement the remote `/chat` smoke test or Sugarkube promotion gate.

### Verification

Focused implementation checks completed successfully:

- `GITHUB_SHA="$(git rev-parse HEAD)" npm run build`
- `npm run verify:chat-build-stamp`
- `EXPECTED_SHA="$(git rev-parse HEAD)" node scripts/verify-build-sha.mjs frontend/dist`
- `npm run test:root -- tests/buildInfoEndpoint.test.ts tests/buildIdentity.test.ts tests/verifyBuildSha.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `git diff --check`
- `git diff main...HEAD | python3 scripts/scan-secrets.py`

All relevant latest-head GitHub checks completed successfully, including build, unit/coverage, root tests, both E2E shards, IndexedDB regression E2E, lint, documentation and link checks, workflow integrity, Docker host-`node_modules` validation, Codecov patch coverage, and both multi-architecture image builds. Release-only publication jobs were appropriately skipped for the pull request.

`actionlint` was unavailable locally. The changed workflow was parsed by the repository workflow-integrity checks, covered by deterministic workflow tests, and exercised successfully by both latest-head multi-architecture image jobs.

Closes #4732

Postmortem: https://github.com/democratizedspace/dspace/blob/main/outages/2026-07-23-dspace-production-version-drift.md

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69432540cc832f92c1660869c01102)