### PR TITLE
Add release-aware remote chat smoke harness (qa:remote-chat-smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
           npm run build
           npm test
           node scripts/link-check.mjs
+      - name: Run deterministic release-aware Chat smoke
+        env:
+          DSPACE_SMOKE_BASE_URL: http://127.0.0.1:4173
+          DSPACE_EXPECTED_PROVIDER: token-place
+          DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: https://token.place
+          DSPACE_EXPECTED_TOKEN_PLACE_MODEL: llama-3.1-8b-instruct
+        run: |
+          export DSPACE_EXPECTED_VERSION="$(node -p "require('./package.json').version")"
+          export DSPACE_EXPECTED_REVISION="$GITHUB_SHA"
+          GITHUB_SHA="$GITHUB_SHA" npm run build
+          npm run qa:remote-chat-smoke
 
   frontend-indexeddb-regression-e2e:
     runs-on: ubuntu-latest

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -137,6 +137,40 @@ tag.
    curl -fsS https://staging.democratized.space/livez | jq .
    ```
 
+### Release-aware Chat smoke
+
+From the DSPACE checkout used for release verification, run the dedicated Chat harness with values
+from the approved release record (never values discovered from the target):
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_FULL_40_CHARACTER_SHA \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+Repeat against production after promotion:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_FULL_40_CHARACTER_SHA \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+This is a non-destructive verification command, not a Sugarkube promotion gate. It uses a fresh,
+isolated browser context; clears client-side state; blocks live token.place and OpenAI traffic; and
+fulfills provider transport inside Playwright. It checks the approved version and full revision,
+HTML build marker, default provider, token.place origin and encrypted-request model, successful
+submission, classified provider unavailability, and OpenAI's discoverable key gate. Any identity,
+routing, hydration, submission, provider-classification, or secret-safety drift returns nonzero.
+
 ## Promote production
 
 Promote only after staging has been validated and the image/chart pair is approved.

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,0 +1,230 @@
+import { constants, createDecipheriv, privateDecrypt, publicEncrypt, webcrypto } from 'node:crypto';
+
+import { expect, test, type Page } from '@playwright/test';
+
+import { clearUserData, waitForHydration } from './test-helpers';
+
+const expected = {
+    version: process.env.DSPACE_EXPECTED_VERSION!,
+    revision: process.env.DSPACE_EXPECTED_REVISION!,
+    provider: process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai',
+    origin: process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN!,
+    model: process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL!,
+};
+const encoder = new TextEncoder();
+const b64 = (value: ArrayBuffer | Uint8Array) =>
+    Buffer.from(value as ArrayBuffer).toString('base64');
+const pem = (value: ArrayBuffer, label: string) => {
+    const body = b64(value)
+        .match(/.{1,64}/g)
+        ?.join('\n');
+    return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----`;
+};
+
+async function relayKeys() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const publicPem = pem(await webcrypto.subtle.exportKey('spki', pair.publicKey), 'PUBLIC KEY');
+    const privatePem = pem(
+        await webcrypto.subtle.exportKey('pkcs8', pair.privateKey),
+        'PRIVATE KEY'
+    );
+    return { publicPem, privatePem, encodedPublic: b64(encoder.encode(publicPem)) };
+}
+
+function decryptRequest(body: Record<string, string>, privateKey: string) {
+    const encodedKey = privateDecrypt(
+        { key: privateKey, padding: constants.RSA_PKCS1_PADDING },
+        Buffer.from(body.cipherkey, 'base64')
+    ).toString('utf8');
+    const decipher = createDecipheriv(
+        `aes-${Buffer.from(encodedKey, 'base64').length * 8}-cbc`,
+        Buffer.from(encodedKey, 'base64'),
+        Buffer.from(body.iv, 'base64')
+    );
+    return JSON.parse(
+        Buffer.concat([
+            decipher.update(Buffer.from(body.ciphertext, 'base64')),
+            decipher.final(),
+        ]).toString('utf8')
+    );
+}
+
+async function encryptedResponse(clientKey: string, requestId: string, response: object) {
+    const clientPem = Buffer.from(clientKey, 'base64').toString('utf8');
+    const aes = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const raw = await webcrypto.subtle.exportKey('raw', aes);
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
+    const ciphertext = await webcrypto.subtle.encrypt(
+        { name: 'AES-CBC', iv },
+        aes,
+        encoder.encode(
+            JSON.stringify({
+                protocol: 'tokenplace_api_v1_relay_e2ee',
+                version: 1,
+                request_id: requestId,
+                client_public_key: clientKey,
+                api_v1_response: response,
+            })
+        )
+    );
+    return {
+        ciphertext: b64(ciphertext),
+        chat_history: b64(ciphertext),
+        iv: b64(iv),
+        cipherkey: b64(
+            publicEncrypt(
+                { key: clientPem, padding: constants.RSA_PKCS1_PADDING },
+                Buffer.from(b64(raw), 'utf8')
+            )
+        ),
+    };
+}
+
+async function blockProviders(page: Page) {
+    await page.route(
+        /https:\/\/(?:[^/]*\.)?token\.place\/.*|https:\/\/api\.openai\.com\/.*/,
+        async (route) => {
+            const url = new URL(route.request().url());
+            if (url.hostname.endsWith('token.place')) {
+                expect(url.origin, '[routing/configuration] token.place origin drift').toBe(
+                    expected.origin
+                );
+            }
+            await route.abort('blockedbyclient');
+        }
+    );
+}
+
+test('approved release chat journey is isolated, routed, classified, and key-gated', async ({
+    page,
+    request,
+}) => {
+    test.setTimeout(90_000);
+    const infoResponse = await request.get('/build-info.json');
+    expect(infoResponse.status(), '[identity] /build-info.json status').toBe(200);
+    const info = await infoResponse.json();
+    expect(info.version, '[identity] application version drift').toBe(expected.version);
+    expect(info.revision, '[identity] source revision drift').toBe(expected.revision);
+    expect(info.shortRevision, '[identity] malformed short revision').toBe(
+        expected.revision.slice(0, 7)
+    );
+
+    await blockProviders(page);
+    await clearUserData(page);
+    await page.goto('/chat');
+    expect(
+        await page.locator('meta[name="dspace-build-revision"]').getAttribute('content'),
+        '[identity] HTML revision marker drift'
+    ).toBe(expected.revision);
+    await waitForHydration(page);
+    const panels = page.locator('[data-testid="chat-panel"]');
+    await expect(panels, '[hydration] expected exactly one chat panel').toHaveCount(1);
+    await expect(panels, '[routing/configuration] default provider drift').toHaveAttribute(
+        'data-provider',
+        expected.provider
+    );
+    await expect(panels.getByRole('textbox'), '[hydration] textbox unusable').toBeEnabled();
+    await expect(
+        panels.getByRole('button', { name: 'Send' }),
+        '[hydration] Send unusable'
+    ).toBeEnabled();
+
+    if (expected.provider === 'token-place') {
+        const keys = await relayKeys();
+        let submission: Record<string, string> | undefined;
+        let retrievals = 0;
+        await page.route(`${expected.origin}/api/v1/relay/servers/next**`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    server_public_key: keys.encodedPublic,
+                    context_tier: new URL(route.request().url()).searchParams.get('context_tier'),
+                    selected_profile_id: 'remote-smoke',
+                }),
+            })
+        );
+        await page.route(`${expected.origin}/api/v1/relay/requests`, async (route) => {
+            expect(
+                route.request().headers().authorization,
+                '[secret-safety] authorization leaked'
+            ).toBeUndefined();
+            submission = JSON.parse(route.request().postData() || '{}');
+            const envelope = decryptRequest(submission!, keys.privatePem);
+            expect(
+                envelope.api_v1_request.model,
+                '[routing/configuration] token.place model drift'
+            ).toBe(expected.model);
+            await route.fulfill({ status: 200, json: { accepted: true } });
+        });
+        await page.route(`${expected.origin}/api/v1/relay/responses/retrieve`, async (route) => {
+            retrievals += 1;
+            const body = JSON.parse(route.request().postData() || '{}');
+            const apiResponse =
+                retrievals === 1
+                    ? {
+                          model: expected.model,
+                          choices: [
+                              { message: { role: 'assistant', content: 'remote smoke reply' } },
+                          ],
+                      }
+                    : { status: 503, error: { type: 'server_error', message: 'Unavailable' } };
+            await route.fulfill({
+                status: 200,
+                json: await encryptedResponse(body.client_public_key, body.request_id, apiResponse),
+            });
+        });
+
+        await panels.getByRole('textbox').fill('deterministic remote smoke');
+        await panels.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panels.getByText('remote smoke reply'),
+            '[submission] mocked relay failed'
+        ).toBeVisible();
+        expect(submission, '[submission] API v1 relay request absent').toBeDefined();
+
+        await panels.getByRole('textbox').fill('controlled unavailable check');
+        await panels.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panels.locator('[data-error-type="server"]'),
+            '[provider availability] HTTP 503 was not stably classified'
+        ).toBeVisible();
+        await expect(
+            panels.locator('.spinner-container'),
+            '[provider availability] spinner persisted'
+        ).toBeHidden();
+    }
+
+    await clearUserData(page);
+    let openAIRequests = 0;
+    await page.route('https://api.openai.com/**', async (route) => {
+        openAIRequests += 1;
+        await route.abort('blockedbyclient');
+    });
+    await page.goto('/settings');
+    await waitForHydration(page);
+    const openAI = page.locator('input[name="chat-provider"][value="openai"]');
+    await expect(openAI, '[routing/configuration] OpenAI option missing').toBeVisible();
+    await openAI.check();
+    await page.goto('/chat');
+    await waitForHydration(page);
+    const openAIPanel = page.locator('[data-testid="chat-panel"][data-provider="openai"]');
+    await openAIPanel.getByRole('textbox').fill('must remain key gated');
+    await openAIPanel.getByRole('button', { name: 'Send' }).click();
+    await expect(
+        openAIPanel.locator('[data-error-type="missing-key"]'),
+        '[secret-safety] missing-key state absent'
+    ).toBeVisible();
+    expect(openAIRequests, '[secret-safety] OpenAI request occurred without a key').toBe(0);
+});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:quest-validation": "npm run test:root -- tests/questDialogueValidation.test.ts tests/questCompletableItems.test.ts tests/runTestsQuestRegression.test.ts",
     "spellcheck": "cspell --no-progress --no-summary \"docs/**/*.md\" \"frontend/src/pages/docs/**/*.md\" \"README.md\" \"AGENTS.md\"",
     "qa:remote-smoke": "node scripts/run-remote-smoke.mjs",
+    "qa:remote-chat-smoke": "node scripts/run-remote-chat-smoke.mjs",
     "qa:remote-migration": "npx -y node@20 scripts/run-remote-migration.mjs",
     "qa:remote-completionist-award-iii": "npx -y node@20 scripts/run-remote-completionist-award-iii.mjs",
     "generate-quest": "cd frontend && npm run generate-quest",

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const frontendDir = join(repoRoot, 'frontend');
+
+const fields = {
+  'base-url': ['baseURL', 'DSPACE_SMOKE_BASE_URL'],
+  'expected-version': ['version', 'DSPACE_EXPECTED_VERSION'],
+  'expected-revision': ['revision', 'DSPACE_EXPECTED_REVISION'],
+  'expected-provider': ['provider', 'DSPACE_EXPECTED_PROVIDER'],
+  'expected-token-place-origin': [
+    'tokenPlaceOrigin',
+    'DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN',
+  ],
+  'expected-token-place-model': [
+    'tokenPlaceModel',
+    'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
+  ],
+};
+
+export function parseArgs(argv, env = process.env) {
+  const options = Object.fromEntries(
+    Object.values(fields).map(([key, envName]) => [
+      key,
+      env[envName]?.trim() || undefined,
+    ])
+  );
+  const seen = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const match = /^--([^=]+)(?:=(.*))?$/.exec(argument);
+    if (!match || !fields[match[1]])
+      throw new Error(`unknown argument: ${argument}`);
+    const value = match[2] ?? argv[++index];
+    if (!value || value.startsWith('--'))
+      throw new Error(`missing value for --${match[1]}`);
+    if (seen.has(match[1]) && seen.get(match[1]) !== value) {
+      throw new Error(`contradictory values for --${match[1]}`);
+    }
+    seen.set(match[1], value);
+    options[fields[match[1]][0]] = value.trim(); // flags intentionally override environment
+  }
+  return options;
+}
+
+export function validateOptions(options) {
+  for (const [key, label] of [
+    ['baseURL', 'base URL'],
+    ['version', 'expected version'],
+    ['revision', 'expected revision'],
+    ['provider', 'expected provider'],
+  ]) {
+    if (!options[key]) throw new Error(`missing ${label}`);
+  }
+  let url;
+  try {
+    url = new URL(options.baseURL);
+  } catch {
+    throw new Error('base URL must be an absolute HTTP(S) URL');
+  }
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error('base URL must be a credential-free HTTP(S) URL');
+  }
+  if (
+    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      options.version
+    )
+  ) {
+    throw new Error('expected version must be an exact semantic version');
+  }
+  if (!/^[0-9a-f]{40}$/.test(options.revision)) {
+    throw new Error(
+      'expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (!['token-place', 'openai'].includes(options.provider)) {
+    throw new Error('expected provider must be token-place or openai');
+  }
+  if (options.provider === 'token-place') {
+    if (!options.tokenPlaceOrigin || !options.tokenPlaceModel) {
+      throw new Error(
+        'token.place origin and model are required for token-place'
+      );
+    }
+    const origin = new URL(options.tokenPlaceOrigin);
+    if (
+      origin.origin !== options.tokenPlaceOrigin ||
+      origin.protocol !== 'https:'
+    ) {
+      throw new Error(
+        'token.place origin must be an HTTPS origin without a path'
+      );
+    }
+  } else if (options.tokenPlaceOrigin || options.tokenPlaceModel) {
+    throw new Error(
+      'token.place expectations are inapplicable when provider is openai'
+    );
+  }
+  return options;
+}
+
+export function buildEnv(options, env = process.env) {
+  const hostname = new URL(options.baseURL).hostname;
+  const local = ['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(hostname);
+  return {
+    ...env,
+    BASE_URL: options.baseURL,
+    REMOTE_SMOKE: '1',
+    REMOTE_SMOKE_USE_WEBSERVER: local ? '1' : '0',
+    PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
+    DSPACE_EXPECTED_VERSION: options.version,
+    DSPACE_EXPECTED_REVISION: options.revision,
+    DSPACE_EXPECTED_PROVIDER: options.provider,
+    DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.tokenPlaceOrigin || '',
+    DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.tokenPlaceModel || '',
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = validateOptions(parseArgs(argv));
+  } catch (error) {
+    console.error(`[qa:remote-chat-smoke] validation: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+  console.log(
+    `[qa:remote-chat-smoke] target=${new URL(options.baseURL).origin}`
+  );
+  console.log(
+    `[qa:remote-chat-smoke] approved=${options.version} revision=${options.revision}`
+  );
+  console.log(
+    `[qa:remote-chat-smoke] provider=${options.provider}; transport=mocked; profile=isolated`
+  );
+  const child = spawn(
+    'node',
+    [
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ],
+    { cwd: frontendDir, env: buildEnv(options), stdio: 'inherit' }
+  );
+  child.on('error', (error) => {
+    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    else process.exitCode = code ?? 1;
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildEnv,
+  parseArgs,
+  validateOptions,
+} from '../run-remote-chat-smoke.mjs';
+
+const valid = {
+  DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
+  DSPACE_EXPECTED_VERSION: '3.1.0',
+  DSPACE_EXPECTED_REVISION: 'a'.repeat(40),
+  DSPACE_EXPECTED_PROVIDER: 'token-place',
+  DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+  DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+};
+
+describe('remote chat smoke argument validation', () => {
+  it('uses flags in preference to environment', () => {
+    expect(parseArgs(['--expected-version=3.2.0'], valid).version).toBe(
+      '3.2.0'
+    );
+  });
+
+  it('accepts a complete token.place contract and creates non-live remote mode', () => {
+    const options = validateOptions(parseArgs([], valid));
+    expect(buildEnv(options, {}).REMOTE_SMOKE_USE_WEBSERVER).toBe('0');
+    expect(
+      buildEnv({ ...options, baseURL: 'http://127.0.0.1:4173' }, {})
+        .REMOTE_SMOKE_USE_WEBSERVER
+    ).toBe('1');
+  });
+
+  it.each([
+    [{ ...valid, DSPACE_EXPECTED_REVISION: 'abc1234' }, /full 40-character/],
+    [{ ...valid, DSPACE_EXPECTED_PROVIDER: 'other' }, /token-place or openai/],
+    [
+      {
+        ...valid,
+        DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place/api',
+      },
+      /without a path/,
+    ],
+    [{ ...valid, DSPACE_EXPECTED_TOKEN_PLACE_MODEL: '' }, /origin and model/],
+    [
+      { ...valid, DSPACE_SMOKE_BASE_URL: 'https://user:secret@example.test' },
+      /credential-free/,
+    ],
+  ])('rejects malformed input without launching Playwright', (env, message) => {
+    expect(() => validateOptions(parseArgs([], env))).toThrow(message);
+  });
+
+  it('rejects provider-inapplicable and contradictory values', () => {
+    expect(() =>
+      validateOptions(
+        parseArgs([], {
+          ...valid,
+          DSPACE_EXPECTED_PROVIDER: 'openai',
+        })
+      )
+    ).toThrow(/inapplicable/);
+    expect(() =>
+      parseArgs(['--expected-version=1.0.0', '--expected-version=2.0.0'], valid)
+    ).toThrow(/contradictory/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent accidental promotions by verifying that a served DSPACE build and its default `/chat` journey match an independently-approved release identity and provider contract.
- Provide a deterministic, non-destructive smoke harness that fails closed on identity, provider, token.place origin/model, hydration, submission, provider-availability, and secret-safety drift.

### Description
- Add a strict runner `scripts/run-remote-chat-smoke.mjs` that accepts CLI flags and `DSPACE_*` environment variables with deterministic flag-over-environment precedence and fail-closed validation for `base-url`, exact semantic `expected-version`, full 40-character `expected-revision`, `expected-provider`, and token.place-specific `origin`/`model` expectations. The runner launches Playwright with an isolated profile and bounded diagnostics. (`scripts/run-remote-chat-smoke.mjs`, `package.json` script)
- Implement a focused Playwright spec `frontend/e2e/remote-chat-smoke.spec.ts` that: verifies `/build-info.json` and the HTML `dspace-build-revision` marker; clears client-side state; ensures exactly one hydrated chat panel and matching `data-provider`; blocks live token.place/OpenAI traffic; mocks token.place API v1 relay with test-owned key material; decrypts and inspects the authoritative relay request to assert the actual selected model and absence of OpenAI auth; asserts deterministic submission success and a controlled HTTP 503 classification scenario; and verifies OpenAI remains discoverable and key-gated. (`frontend/e2e/remote-chat-smoke.spec.ts`)
- Add unit tests for the runner argument/validation semantics `scripts/tests/run-remote-chat-smoke.test.ts` to exercise flag-vs-env precedence, malformed inputs, short SHAs, and provider-inapplicable values.
- Wire the harness into CI for local-built verification (non-live provider traffic) and add a documented Sugarkube invocation in `docs/ops/sugarkube-release.md` illustrating staging and production verification using the harness; do not change runtime identity contract or provider defaults. (`.github/workflows/ci.yml`, `docs/ops/sugarkube-release.md`)

### Testing
- Ran the new runner unit tests: `npm run test:root -- scripts/tests/run-remote-chat-smoke.test.ts` — passed (validation and precedence cases).
- Ran combined root tests including CI/imagery checks: `npm run test:root -- scripts/tests/run-remote-chat-smoke.test.ts tests/ciWorkflow.test.ts tests/ciImageWorkflow.test.ts` — completed; total observed tests passed (27 tests in that run).
- Formatting, linting and type checks: `npm run format:check`, `npm run lint`, `npm run type-check` — all succeeded in this environment.
- Performed local build and exercised the harness invocation sequence: `GITHUB_SHA=$SHA npm run build` then `DSPACE_... npm run qa:remote-chat-smoke`; Astro server/client build steps completed in this environment, and CI is configured to run the full Playwright harness where provider mocking and Playwright browser setup will complete the end-to-end verification.

Closes #4733

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69844489a4832fb2959734ed54d6b0)