### PR TITLE
Add release-aware remote chat smoke harness (`qa:remote-chat-smoke`)

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -1,5 +1,41 @@
 # DSPACE Sugarkube release runbook
 
+## Release-aware `/chat` smoke gate
+
+After deploying an approved immutable revision, run the dedicated DSPACE harness from a DSPACE
+checkout. It serves no mutations: it uses a new isolated browser context, clears browser state,
+mocks token.place/OpenAI transport inside Playwright, and never needs a real provider credential.
+It exits nonzero when release identity, provider routing/configuration, hydration, submission,
+provider error classification, or secret-safety drifts. Expectations must come from the approved
+release record, never from the deployment under test.
+
+```bash
+# Staging
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=<approved-full-40-character-staging-revision> \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+
+# Production (use the independently approved production manifest values)
+DSPACE_SMOKE_BASE_URL=https://democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=<approved-full-40-character-production-revision> \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+CLI equivalents are `--base-url`, `--expected-version`, `--expected-revision`,
+`--expected-provider`, `--expected-token-place-origin`, and `--expected-token-place-model`; an
+explicit flag overrides its environment variable. For an approved OpenAI-default release, set
+`DSPACE_EXPECTED_PROVIDER=openai` and omit both token.place expectations. This harness supplies
+only the DSPACE-side evidence needed by a future promotion gate; it does not implement Sugarkube
+issue #2328.
+
 DSPACE is the mature Sugarkube baseline. Its staging and production path already works, so this
 runbook documents the known-good flow instead of replacing it. Use this page as the steady-state
 release source of truth for Sugarkube operators; keep lower-level Kubernetes, chart, and Cloudflare

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,0 +1,202 @@
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
+import { expect, test, type Page } from '@playwright/test';
+import { clearUserData, waitForHydration } from './test-helpers';
+
+const version = process.env.DSPACE_EXPECTED_VERSION!;
+const revision = process.env.DSPACE_EXPECTED_REVISION!;
+const provider = process.env.DSPACE_EXPECTED_PROVIDER!;
+const tokenOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN!;
+const tokenModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL!;
+const encoder = new TextEncoder();
+const b64 = (value: ArrayBuffer | Uint8Array) =>
+    Buffer.from(value instanceof Uint8Array ? value : new Uint8Array(value)).toString('base64');
+
+async function relayKey() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = b64(await webcrypto.subtle.exportKey('spki', pair.publicKey));
+    const pem = `-----BEGIN PUBLIC KEY-----\n${spki.match(/.{1,64}/g)!.join('\n')}\n-----END PUBLIC KEY-----`;
+    return { pem, wire: b64(encoder.encode(pem)) };
+}
+
+async function encryptedResponse(clientKey: string, requestId: string, failure = false) {
+    const key = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const raw = await webcrypto.subtle.exportKey('raw', key);
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
+    const payload = {
+        protocol: 'tokenplace_api_v1_relay_e2ee',
+        version: 1,
+        request_id: requestId,
+        client_public_key: clientKey,
+        api_v1_response: failure
+            ? { status: 503, error: { message: 'Unavailable', type: 'server_error' } }
+            : {
+                  model: tokenModel,
+                  choices: [{ message: { role: 'assistant', content: 'remote smoke reply' } }],
+              },
+    };
+    const ciphertext = b64(
+        await webcrypto.subtle.encrypt(
+            { name: 'AES-CBC', iv },
+            key,
+            encoder.encode(JSON.stringify(payload))
+        )
+    );
+    const pem = Buffer.from(clientKey, 'base64').toString('utf8');
+    const cipherkey = b64(
+        publicEncrypt(
+            { key: pem, padding: constants.RSA_PKCS1_PADDING },
+            Buffer.from(b64(raw), 'utf8')
+        )
+    );
+    return { chat_history: ciphertext, ciphertext, cipherkey, iv: b64(iv) };
+}
+
+async function mockTokenPlace(page: Page, failure = false) {
+    const key = await relayKey();
+    const seen: string[] = [];
+    await page.route(`${tokenOrigin}/api/v1/relay/servers/next**`, async (route) => {
+        const url = new URL(route.request().url());
+        seen.push(url.href);
+        expect(url.origin, '[routing/configuration] token.place origin drift').toBe(tokenOrigin);
+        expect(
+            url.searchParams.get('model'),
+            '[routing/configuration] token.place model drift'
+        ).toBe(tokenModel);
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                server_public_key: key.wire,
+                context_tier: url.searchParams.get('context_tier'),
+                selected_profile_id: 'remote-smoke',
+                model_support: [tokenModel],
+            }),
+        });
+    });
+    await page.route(`${tokenOrigin}/api/v1/relay/requests`, async (route) => {
+        seen.push(route.request().url());
+        expect(
+            route.request().headers().authorization,
+            '[secret-safety] unexpected authorization'
+        ).toBeUndefined();
+        expect(route.request().postData() || '').not.toMatch(/api.?key|sk-/i);
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: '{"accepted":true}',
+        });
+    });
+    await page.route(`${tokenOrigin}/api/v1/relay/responses/retrieve`, async (route) => {
+        seen.push(route.request().url());
+        const body = JSON.parse(route.request().postData() || '{}');
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(
+                await encryptedResponse(body.client_public_key, body.request_id, failure)
+            ),
+        });
+    });
+    return seen;
+}
+
+test.skip(
+    process.env.REMOTE_CHAT_SMOKE !== '1',
+    'Run through npm run qa:remote-chat-smoke with explicit release expectations.'
+);
+
+test('approved non-mutating remote chat journey', async ({ page, request }) => {
+    await test.step('identity', async () => {
+        const response = await request.get('/build-info.json');
+        expect(response.status(), '[identity] build-info request failed').toBe(200);
+        const info = await response.json();
+        expect(info.version, '[identity] application version drift').toBe(version);
+        expect(info.revision, '[identity] source revision drift').toBe(revision);
+        expect(info.shortRevision, '[identity] malformed short revision').toBe(
+            revision.slice(0, 7)
+        );
+        const html = await request.get('/chat');
+        expect(await html.text(), '[identity] HTML revision marker drift').toContain(
+            `<meta name="dspace-build-revision" content="${revision}"`
+        );
+    });
+
+    await clearUserData(page);
+    await page.route(
+        /https:\/\/(?:token\.place|staging\.token\.place|api\.openai\.com)\/.*/,
+        (route) => route.abort('blockedbyclient')
+    );
+    const seen = provider === 'token-place' ? await mockTokenPlace(page) : [];
+    await page.goto('/chat');
+    await waitForHydration(page);
+    const panels = page.locator('[data-testid="chat-panel"]');
+    await expect(panels, '[hydration] exactly one panel must hydrate').toHaveCount(1);
+    await expect(panels, '[routing/configuration] default provider drift').toHaveAttribute(
+        'data-provider',
+        provider
+    );
+    await expect(panels.getByRole('textbox'), '[hydration] textbox unusable').toBeEnabled();
+    await expect(
+        panels.getByRole('button', { name: 'Send' }),
+        '[hydration] Send unusable'
+    ).toBeEnabled();
+    if (provider === 'token-place') {
+        await panels.getByRole('textbox').fill('deterministic remote smoke');
+        await panels.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panels.getByText('remote smoke reply'),
+            '[submission] token.place relay submission failed'
+        ).toBeVisible();
+        expect(seen, '[submission] API v1 relay path was not exercised').toHaveLength(3);
+
+        await clearUserData(page);
+        const unavailable = await mockTokenPlace(page, true);
+        await page.goto('/chat');
+        await waitForHydration(page);
+        const panel = page.locator('[data-testid="chat-panel"]');
+        await panel.getByRole('textbox').fill('controlled unavailable smoke');
+        await panel.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panel.locator('.chat-error'),
+            '[provider availability] failure was not classified'
+        ).toHaveAttribute('data-error-type', 'server');
+        await expect(
+            panel.locator('.spinner-container'),
+            '[provider availability] spinner did not terminate'
+        ).not.toBeVisible();
+        expect(unavailable.length).toBeGreaterThan(0);
+    }
+
+    await clearUserData(page);
+    let openAIRequests = 0;
+    await page.route('https://api.openai.com/**', async (route) => {
+        openAIRequests += 1;
+        await route.abort('blockedbyclient');
+    });
+    await page.goto('/settings');
+    await waitForHydration(page);
+    const option = page.locator('input[name="chat-provider"][value="openai"]');
+    await expect(option, '[routing/configuration] OpenAI opt-in is not discoverable').toBeVisible();
+    await option.check();
+    await page.goto('/chat');
+    await waitForHydration(page);
+    const openPanel = page.locator('[data-testid="chat-panel"][data-provider="openai"]');
+    await openPanel.getByRole('textbox').fill('missing key smoke');
+    await openPanel.getByRole('button', { name: 'Send' }).click();
+    await expect(
+        openPanel.locator('.chat-error'),
+        '[secret-safety] missing-key state absent'
+    ).toHaveAttribute('data-error-type', 'missing-key');
+    expect(openAIRequests, '[secret-safety] OpenAI contacted without a key').toBe(0);
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,6 +28,8 @@ declare const process: {
         PLAYWRIGHT_SKIP_INSTALL_DEPS?: string;
         REMOTE_SMOKE?: string;
         REMOTE_SMOKE_USE_WEBSERVER?: string;
+        REMOTE_CHAT_SMOKE?: string;
+        REMOTE_CHAT_SMOKE_USE_WEBSERVER?: string;
         REMOTE_MIGRATION?: string;
         REMOTE_MIGRATION_USE_WEBSERVER?: string;
         REMOTE_COMPLETIONIST_AWARD_III?: string;

--- a/frontend/scripts/utils/playwright-remote-mode.js
+++ b/frontend/scripts/utils/playwright-remote-mode.js
@@ -4,6 +4,11 @@ const hasQuestsPerfBaseUrl = () => Boolean(process.env.QUESTS_PERF_BASE_URL?.tri
 
 export const REMOTE_PLAYWRIGHT_MODE_CONFIGS = Object.freeze([
     {
+        name: 'remoteChatSmoke',
+        isEnabled: () => isEnabled(process.env.REMOTE_CHAT_SMOKE),
+        useWebServerEnv: 'REMOTE_CHAT_SMOKE_USE_WEBSERVER',
+    },
+    {
         name: 'remoteSmoke',
         isEnabled: ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
             isEnabled(process.env.REMOTE_SMOKE) ||

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:quest-validation": "npm run test:root -- tests/questDialogueValidation.test.ts tests/questCompletableItems.test.ts tests/runTestsQuestRegression.test.ts",
     "spellcheck": "cspell --no-progress --no-summary \"docs/**/*.md\" \"frontend/src/pages/docs/**/*.md\" \"README.md\" \"AGENTS.md\"",
     "qa:remote-smoke": "node scripts/run-remote-smoke.mjs",
+    "qa:remote-chat-smoke": "node scripts/run-remote-chat-smoke.mjs",
     "qa:remote-migration": "npx -y node@20 scripts/run-remote-migration.mjs",
     "qa:remote-completionist-award-iii": "npx -y node@20 scripts/run-remote-completionist-award-iii.mjs",
     "generate-quest": "cd frontend && npm run generate-quest",

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frontendDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'frontend'
+);
+const fields = {
+  baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
+  version: ['expected-version', 'DSPACE_EXPECTED_VERSION'],
+  revision: ['expected-revision', 'DSPACE_EXPECTED_REVISION'],
+  provider: ['expected-provider', 'DSPACE_EXPECTED_PROVIDER'],
+  tokenPlaceOrigin: [
+    'expected-token-place-origin',
+    'DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN',
+  ],
+  tokenPlaceModel: [
+    'expected-token-place-model',
+    'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
+  ],
+};
+
+export function parseArgs(argv, env = process.env) {
+  const result = Object.fromEntries(
+    Object.entries(fields).map(([key, [, envName]]) => [
+      key,
+      env[envName]?.trim() || undefined,
+    ])
+  );
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const match = Object.entries(fields).find(
+      ([, [flag]]) =>
+        argument === `--${flag}` || argument.startsWith(`--${flag}=`)
+    );
+    if (!match) throw new Error(`unknown argument: ${argument}`);
+    const [key, [flag]] = match;
+    const value = argument.includes('=')
+      ? argument.slice(argument.indexOf('=') + 1)
+      : argv[++index];
+    if (!value?.trim()) throw new Error(`--${flag} requires a value`);
+    result[key] = value.trim(); // Flags deterministically override environment values.
+  }
+  return result;
+}
+
+export function validateOptions(options) {
+  for (const key of ['baseURL', 'version', 'revision', 'provider']) {
+    if (!options[key]) throw new Error(`missing required ${fields[key][1]}`);
+  }
+  let url;
+  try {
+    url = new URL(options.baseURL);
+  } catch {
+    throw new Error('base URL must be an absolute HTTP(S) URL');
+  }
+  if (!['http:', 'https:'].includes(url.protocol))
+    throw new Error('base URL must be an absolute HTTP(S) URL');
+  if (!/^[0-9a-f]{40}$/.test(options.revision))
+    throw new Error(
+      'expected revision must be a full lowercase 40-character Git SHA'
+    );
+  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(options.version))
+    throw new Error('expected version must be an exact semantic version');
+  if (!['token-place', 'openai'].includes(options.provider))
+    throw new Error('expected provider must be token-place or openai');
+  if (options.provider === 'token-place') {
+    if (!options.tokenPlaceOrigin || !options.tokenPlaceModel)
+      throw new Error(
+        'token-place provider requires expected origin and model'
+      );
+    const origin = new URL(options.tokenPlaceOrigin);
+    if (
+      origin.origin !== options.tokenPlaceOrigin ||
+      !['http:', 'https:'].includes(origin.protocol)
+    )
+      throw new Error('token.place origin must contain only scheme and host');
+  } else if (options.tokenPlaceOrigin || options.tokenPlaceModel) {
+    throw new Error(
+      'token.place expectations are inapplicable when expected provider is openai'
+    );
+  }
+  return options;
+}
+
+export function buildEnv(options, env = process.env) {
+  const host = new URL(options.baseURL).hostname;
+  return {
+    ...env,
+    BASE_URL: options.baseURL,
+    REMOTE_CHAT_SMOKE: '1',
+    REMOTE_CHAT_SMOKE_USE_WEBSERVER: ['localhost', '127.0.0.1', '::1'].includes(
+      host
+    )
+      ? '1'
+      : '0',
+    PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
+    DSPACE_EXPECTED_VERSION: options.version,
+    DSPACE_EXPECTED_REVISION: options.revision,
+    DSPACE_EXPECTED_PROVIDER: options.provider,
+    DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.tokenPlaceOrigin || '',
+    DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.tokenPlaceModel || '',
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = validateOptions(parseArgs(argv));
+  } catch (error) {
+    console.error(`[qa:remote-chat-smoke] validation: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+  console.log(
+    `[qa:remote-chat-smoke] target=${new URL(options.baseURL).origin} provider=${options.provider}`
+  );
+  const child = spawn(
+    'node',
+    [
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ],
+    { cwd: frontendDir, stdio: 'inherit', env: buildEnv(options) }
+  );
+  child.on('error', (error) => {
+    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.on('exit', (code) => {
+    process.exitCode = code ?? 1;
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildEnv,
+  parseArgs,
+  validateOptions,
+} from '../run-remote-chat-smoke.mjs';
+
+const valid = {
+  baseURL: 'https://staging.example.test',
+  version: '3.1.0',
+  revision: '0123456789abcdef0123456789abcdef01234567',
+  provider: 'token-place',
+  tokenPlaceOrigin: 'https://token.place',
+  tokenPlaceModel: 'llama-3.1-8b-instruct',
+};
+
+describe('remote chat smoke arguments', () => {
+  it('lets flags deterministically override environment values', () => {
+    const parsed = parseArgs(
+      ['--expected-version=3.1.0', '--base-url', valid.baseURL],
+      {
+        DSPACE_EXPECTED_VERSION: '9.9.9',
+        DSPACE_SMOKE_BASE_URL: 'https://wrong.test',
+      }
+    );
+    expect(parsed.version).toBe('3.1.0');
+    expect(parsed.baseURL).toBe(valid.baseURL);
+  });
+
+  it.each([
+    [{ ...valid, revision: '0123456' }, /full lowercase 40-character/],
+    [{ ...valid, provider: 'other' }, /token-place or openai/],
+    [
+      { ...valid, tokenPlaceOrigin: undefined },
+      /requires expected origin and model/,
+    ],
+    [{ ...valid, provider: 'openai' }, /inapplicable/],
+    [{ ...valid, baseURL: 'production' }, /absolute HTTP/],
+  ])(
+    'rejects malformed, contradictory, or incomplete input',
+    (input, message) => {
+      expect(() => validateOptions(input)).toThrow(message);
+    }
+  );
+
+  it('accepts OpenAI only without token.place expectations', () => {
+    expect(
+      validateOptions({
+        ...valid,
+        provider: 'openai',
+        tokenPlaceOrigin: undefined,
+        tokenPlaceModel: undefined,
+      })
+    ).toBeTruthy();
+  });
+
+  it('builds isolated remote-mode environment without secret values', () => {
+    const env = buildEnv(valid, {});
+    expect(env.REMOTE_CHAT_SMOKE).toBe('1');
+    expect(JSON.stringify(env)).not.toMatch(/authorization|api.?key|sk-/i);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent accidental promotion of a deployed frontend whose served identity or default chat journey drifts from the independently approved release identity. 
- Provide a focused, non-mutating smoke gate that verifies exact `build-info.json` identity and the default `/chat` journey (provider routing, token.place origin/model negotiation, hydration/submission, and classified provider failures). 
- Ensure deterministic, auditable checks that never leak secrets or contact live providers during verification by mocking provider transport in Playwright. 

### Description

- Add a dedicated runner `scripts/run-remote-chat-smoke.mjs` that accepts CLI flags or environment variables with deterministic flag-over-env precedence and rejects missing/malformed/inapplicable inputs (supports `DSPACE_SMOKE_BASE_URL`, `DSPACE_EXPECTED_VERSION`, `DSPACE_EXPECTED_REVISION`, `DSPACE_EXPECTED_PROVIDER`, `DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN`, `DSPACE_EXPECTED_TOKEN_PLACE_MODEL`).
- Add a focused Playwright spec `frontend/e2e/remote-chat-smoke.spec.ts` that validates `/build-info.json`, HTML `dspace-build-revision` marker, single-panel hydration, provider routing, token.place API v1 relay origin/model negotiation and encrypted relay flow, provider-unavailable classification, and OpenAI opt-in/missing-key behavior while blocking live provider traffic.
- Add unit/regression tests `scripts/tests/run-remote-chat-smoke.test.ts` for argument/env parsing, validation, and non-secret environment shaping, and wire the new command into `package.json` as `qa:remote-chat-smoke`.
- Extend Playwright remote-mode wiring (`frontend/scripts/utils/playwright-remote-mode.js` and `frontend/playwright.config.ts`) and document copy-pasteable Sugarkube staging/production examples in `docs/ops/sugarkube-release.md` that explain the harness is non-destructive and mocks provider transport.
- Preserve existing `qa:remote-smoke` behavior and reuse the canonical `/build-info.json` and `<meta name="dspace-build-revision">` contract; do not change runtime identity or provider defaults.
- Closes #4733

### Testing

- Ran the focused runner tests with `npm run test:root -- scripts/tests/run-remote-chat-smoke.test.ts`, which passed (8 tests passed). 
- Type-check, formatting, lint, and link checks passed via `npm run type-check`, `npm run format:check`, `npm run lint`, and `npm run link-check` respectively. 
- Built a local release with `GITHUB_SHA=$SHA npm run build` successfully to verify the harness can be exercised against a locally produced build. 
- Attempted to run the full harness via `npm run qa:remote-chat-smoke` which launched Playwright and the focused spec, but the Playwright browser download failed in this network-restricted environment (multiple `ENETUNREACH` failures); this is an environment/tooling limitation rather than a code failure and CI with preinstalled Playwright browsers should run the end-to-end harness successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6984345454832fafb79cc14141792a)