### PR TITLE
Add release-aware remote chat smoke harness (qa:remote-chat-smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,34 @@ jobs:
           npm run build
           DSPACE_EXPECTED_VERSION="$(node -p "require('./package.json').version")" \
             npm run qa:remote-chat-smoke
+          expected_version="$(node -p "require('./package.json').version")"
+          run_negative() {
+            stage="$1"
+            shift
+            output_file="$(mktemp)"
+            if env DSPACE_EXPECTED_VERSION="$expected_version" "$@" \
+              npm run qa:remote-chat-smoke >"$output_file" 2>&1; then
+              echo "negative smoke unexpectedly passed: $stage"
+              rm -f "$output_file"
+              exit 1
+            fi
+            if grep -Fq 'sk-dspace-ci-sentinel' "$output_file"; then
+              echo "negative smoke emitted forbidden sentinel: $stage"
+              rm -f "$output_file"
+              exit 1
+            fi
+            if ! grep -Fqi "$stage" "$output_file"; then
+              echo "negative smoke missed sanitized stage: $stage"
+              rm -f "$output_file"
+              exit 1
+            fi
+            rm -f "$output_file"
+            echo "negative smoke failed closed at stage=$stage"
+          }
+          run_negative identity env DSPACE_EXPECTED_VERSION=0.0.0
+          run_negative identity env DSPACE_EXPECTED_REVISION=0000000000000000000000000000000000000000
+          run_negative routing/configuration env DSPACE_EXPECTED_PROVIDER=openai DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN= DSPACE_EXPECTED_TOKEN_PLACE_MODEL=
+          run_negative routing/configuration env DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://invalid.example.test
+          run_negative routing/configuration env DSPACE_EXPECTED_TOKEN_PLACE_MODEL=wrong-model
+          run_negative hydration env DSPACE_REMOTE_CHAT_SMOKE_FAULT=hydration
+          run_negative submission env DSPACE_REMOTE_CHAT_SMOKE_FAULT=submission

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,15 @@ jobs:
       - name: Run IndexedDB regression Playwright spec
         working-directory: frontend
         run: npx playwright test e2e/indexeddb-availability.spec.ts --project=chromium --reporter=dot
+      - name: Run release-aware local chat smoke harness
+        env:
+          DSPACE_SMOKE_BASE_URL: http://127.0.0.1:4173
+          DSPACE_EXPECTED_REVISION: ${{ github.sha }}
+          DSPACE_EXPECTED_PROVIDER: token-place
+          DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: https://token.place
+          DSPACE_EXPECTED_TOKEN_PLACE_MODEL: llama-3.1-8b-instruct
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          npm run build
+          DSPACE_EXPECTED_VERSION="$(node -p "require('./package.json').version")" \
+            npm run qa:remote-chat-smoke

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -169,6 +169,41 @@ curl -fsS https://democratized.space/healthz | jq .
 curl -fsS https://democratized.space/livez | jq .
 ```
 
+### Release-aware `/chat` smoke
+
+From a DSPACE checkout with dependencies and the Playwright Chromium browser installed, verify the
+remotely served frontend against release expectations taken from the approved artifact (never from
+the runtime under test). Replace the revision with the approved full 40-character source SHA:
+
+```bash
+# Staging
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+
+# Production (run only after the staging result and promotion are approved)
+DSPACE_SMOKE_BASE_URL=https://democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
+blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
+Playwright. It sends no live chat request or user secret and does not mutate server or shared
+production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
+submission, classified availability, or secret-safety drift. OpenAI-default verification omits the
+two token.place expectations; the harness still proves that OpenAI is discoverable and missing-key
+gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
+gate.
+
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -70,11 +70,15 @@ async function encryptedResponse(body: Record<string, string>) {
 }
 
 async function blockUnexpectedProviders(page: Page, allowedOrigin?: string) {
+    const providerOrigins = ['https://api.openai.com', allowedOrigin].filter(Boolean) as string[];
+    for (const origin of providerOrigins) {
+        await page.route(`${origin}/**`, async (route) => {
+            await route.abort('blockedbyclient');
+            throw new Error('secret-safety: blocked unexpected live chat-provider traffic');
+        });
+    }
     await page.route(/https?:\/\/[^/]+\/(?:api\/v1\/relay|v1\/responses).*/, async (route) => {
-        if (allowedOrigin && new URL(route.request().url()).origin === allowedOrigin) {
-            await route.fallback();
-            return;
-        }
+        await route.abort('blockedbyclient');
         throw new Error('secret-safety: blocked unexpected live chat-provider traffic');
     });
 }
@@ -82,6 +86,9 @@ async function blockUnexpectedProviders(page: Page, allowedOrigin?: string) {
 async function installSuccessfulRelay(page: Page) {
     const key = await relayPublicKey();
     const calls: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
+    // Register the deny rule first: Playwright evaluates newer routes first, so only the
+    // explicit mocks below can supersede it. Every other path on the provider origin is blocked.
+    await blockUnexpectedProviders(page, expectedOrigin);
     await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, async (route) => {
         calls.push({ url: route.request().url(), headers: route.request().headers(), body: '' });
         const requestUrl = new URL(route.request().url());
@@ -125,7 +132,6 @@ async function installSuccessfulRelay(page: Page) {
             body: JSON.stringify(await encryptedResponse(body)),
         });
     });
-    await blockUnexpectedProviders(page, expectedOrigin);
     return calls;
 }
 
@@ -179,10 +185,7 @@ test.describe('release-aware remote chat smoke', () => {
 
     test('routing/configuration and submission: approved default journey', async ({ page }) => {
         const calls = expectedProvider === 'token-place' ? await installSuccessfulRelay(page) : [];
-        await blockUnexpectedProviders(
-            page,
-            expectedProvider === 'token-place' ? expectedOrigin : undefined
-        );
+        if (expectedProvider === 'openai') await blockUnexpectedProviders(page);
         const panel = await openExpectedPanel(page);
         if (expectedProvider === 'openai') {
             await panel.getByRole('textbox').fill('Key gate smoke');
@@ -221,6 +224,7 @@ test.describe('release-aware remote chat smoke', () => {
             expectedProvider !== 'token-place',
             'Only applies to token.place-default releases'
         );
+        await blockUnexpectedProviders(page, expectedOrigin);
         await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, (route) =>
             route.fulfill({
                 status: 503,
@@ -228,7 +232,6 @@ test.describe('release-aware remote chat smoke', () => {
                 body: '{"error":"unavailable"}',
             })
         );
-        await blockUnexpectedProviders(page, expectedOrigin);
         const panel = await openExpectedPanel(page);
         await panel.getByRole('textbox').fill('Controlled unavailable smoke');
         await panel.getByRole('button', { name: 'Send' }).click();

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,0 +1,275 @@
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
+
+import { expect, test, type Page } from '@playwright/test';
+
+import { clearUserData, waitForHydration } from './test-helpers';
+
+const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
+const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
+const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
+const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+const encoder = new TextEncoder();
+
+const bytesToBase64 = (value: ArrayBuffer | Uint8Array) =>
+    Buffer.from(value instanceof Uint8Array ? value : new Uint8Array(value)).toString('base64');
+const base64ToPem = (value: string) =>
+    `-----BEGIN PUBLIC KEY-----\n${value.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
+
+async function relayPublicKey() {
+    const pair = await webcrypto.subtle.generateKey(
+        {
+            name: 'RSA-OAEP',
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt']
+    );
+    const spki = await webcrypto.subtle.exportKey('spki', pair.publicKey);
+    const pem = base64ToPem(bytesToBase64(spki));
+    return bytesToBase64(encoder.encode(pem));
+}
+
+async function encryptedResponse(body: Record<string, string>) {
+    const response = {
+        protocol: 'tokenplace_api_v1_relay_e2ee',
+        version: 1,
+        request_id: body.request_id,
+        client_public_key: body.client_public_key,
+        api_v1_response: {
+            id: 'chatcmpl-dspace-smoke',
+            object: 'chat.completion',
+            created: 1780000000,
+            model: expectedModel,
+            choices: [{ message: { role: 'assistant', content: 'DSPACE smoke reply.' } }],
+        },
+    };
+    const key = await webcrypto.subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, [
+        'encrypt',
+    ]);
+    const rawKey = await webcrypto.subtle.exportKey('raw', key);
+    const iv = webcrypto.getRandomValues(new Uint8Array(16));
+    const ciphertext = await webcrypto.subtle.encrypt(
+        { name: 'AES-CBC', iv },
+        key,
+        encoder.encode(JSON.stringify(response))
+    );
+    const clientPem = Buffer.from(body.client_public_key, 'base64').toString('utf8');
+    const cipherkey = publicEncrypt(
+        { key: clientPem, padding: constants.RSA_PKCS1_PADDING },
+        Buffer.from(bytesToBase64(rawKey), 'utf8')
+    ).toString('base64');
+    return {
+        chat_history: bytesToBase64(ciphertext),
+        ciphertext: bytesToBase64(ciphertext),
+        cipherkey,
+        iv: bytesToBase64(iv),
+    };
+}
+
+async function blockUnexpectedProviders(page: Page, allowedOrigin?: string) {
+    await page.route(/https?:\/\/[^/]+\/(?:api\/v1\/relay|v1\/responses).*/, async (route) => {
+        if (allowedOrigin && new URL(route.request().url()).origin === allowedOrigin) {
+            await route.fallback();
+            return;
+        }
+        throw new Error('secret-safety: blocked unexpected live chat-provider traffic');
+    });
+}
+
+async function installSuccessfulRelay(page: Page) {
+    const key = await relayPublicKey();
+    const calls: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
+    await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, async (route) => {
+        calls.push({ url: route.request().url(), headers: route.request().headers(), body: '' });
+        const requestUrl = new URL(route.request().url());
+        expect(requestUrl.origin, 'routing/configuration: token.place origin drift').toBe(
+            expectedOrigin
+        );
+        expect(
+            requestUrl.searchParams.get('model'),
+            'routing/configuration: token.place model drift'
+        ).toBe(expectedModel);
+        const tier = requestUrl.searchParams.get('context_tier');
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                server_public_key: key,
+                context_tier: tier,
+                selected_profile_id: `smoke-${tier}`,
+                selected_model_support: [expectedModel],
+            }),
+        });
+    });
+    await page.route(`${expectedOrigin}/api/v1/relay/requests`, async (route) => {
+        calls.push({
+            url: route.request().url(),
+            headers: route.request().headers(),
+            body: route.request().postData() || '',
+        });
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: '{"accepted":true}',
+        });
+    });
+    await page.route(`${expectedOrigin}/api/v1/relay/responses/retrieve`, async (route) => {
+        const body = JSON.parse(route.request().postData() || '{}');
+        calls.push({ url: route.request().url(), headers: route.request().headers(), body: '' });
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(await encryptedResponse(body)),
+        });
+    });
+    await blockUnexpectedProviders(page, expectedOrigin);
+    return calls;
+}
+
+async function openExpectedPanel(page: Page) {
+    await page.goto('/chat');
+    await waitForHydration(page);
+    const panels = page.locator('[data-testid="chat-panel"]');
+    await expect(panels, 'hydration: exactly one chat panel must be active').toHaveCount(1);
+    await expect(panels, 'routing/configuration: default provider drift').toHaveAttribute(
+        'data-provider',
+        expectedProvider
+    );
+    await expect(panels, 'hydration: chat panel did not hydrate').toHaveAttribute(
+        'data-hydrated',
+        'true'
+    );
+    await expect(panels.getByRole('textbox'), 'hydration: textbox is unusable').toBeEnabled();
+    await expect(
+        panels.getByRole('button', { name: 'Send' }),
+        'hydration: Send is unusable'
+    ).toBeEnabled();
+    return panels;
+}
+
+test.describe('release-aware remote chat smoke', () => {
+    test.skip(
+        process.env.REMOTE_CHAT_SMOKE !== '1',
+        'Run through npm run qa:remote-chat-smoke with explicit release expectations.'
+    );
+    test.use({ serviceWorkers: 'block', storageState: { cookies: [], origins: [] } });
+    test.beforeEach(async ({ context, page }) => {
+        await context.clearCookies();
+        await clearUserData(page);
+    });
+
+    test('identity: approved build identity matches JSON and HTML', async ({ page, request }) => {
+        const response = await request.get('/build-info.json');
+        expect(response.status(), 'identity: /build-info.json did not return 200').toBe(200);
+        const identity = await response.json();
+        expect(identity.version, 'identity: application-version drift').toBe(expectedVersion);
+        expect(identity.revision, 'identity: source-revision drift').toBe(expectedRevision);
+        expect(identity.shortRevision, 'identity: invalid derived short revision').toBe(
+            expectedRevision.slice(0, 7)
+        );
+        await page.goto('/chat');
+        await expect(
+            page.locator('meta[name="dspace-build-revision"]'),
+            'identity: HTML build marker drift'
+        ).toHaveAttribute('content', expectedRevision);
+    });
+
+    test('routing/configuration and submission: approved default journey', async ({ page }) => {
+        const calls = expectedProvider === 'token-place' ? await installSuccessfulRelay(page) : [];
+        await blockUnexpectedProviders(
+            page,
+            expectedProvider === 'token-place' ? expectedOrigin : undefined
+        );
+        const panel = await openExpectedPanel(page);
+        if (expectedProvider === 'openai') {
+            await panel.getByRole('textbox').fill('Key gate smoke');
+            await panel.getByRole('button', { name: 'Send' }).click();
+            await expect(
+                panel.locator('.chat-error'),
+                'routing/configuration: OpenAI key gate'
+            ).toHaveAttribute('data-error-type', 'missing-key');
+            return;
+        }
+        await panel.getByRole('textbox').fill('Deterministic remote chat smoke');
+        await panel.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panel.getByText('DSPACE smoke reply.'),
+            'submission: no mocked relay reply'
+        ).toBeVisible();
+        expect(
+            calls.map(({ url }) => new URL(url).origin).every((origin) => origin === expectedOrigin)
+        ).toBe(true);
+        expect(calls).toHaveLength(3);
+        for (const call of calls) {
+            expect(
+                JSON.stringify(call.headers),
+                'secret-safety: authorization header was sent'
+            ).not.toMatch(/authorization|api.?key|bearer|sk-/i);
+            expect(call.body, 'secret-safety: OpenAI credential material was sent').not.toMatch(
+                /api.?key|bearer|sk-/i
+            );
+        }
+    });
+
+    test('provider availability: controlled token.place failure is classified and bounded', async ({
+        page,
+    }) => {
+        test.skip(
+            expectedProvider !== 'token-place',
+            'Only applies to token.place-default releases'
+        );
+        await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, (route) =>
+            route.fulfill({
+                status: 503,
+                contentType: 'application/json',
+                body: '{"error":"unavailable"}',
+            })
+        );
+        await blockUnexpectedProviders(page, expectedOrigin);
+        const panel = await openExpectedPanel(page);
+        await panel.getByRole('textbox').fill('Controlled unavailable smoke');
+        await panel.getByRole('button', { name: 'Send' }).click();
+        await expect(
+            panel.locator('.chat-error'),
+            'provider availability: failure was unclassified'
+        ).toHaveAttribute('data-error-type', 'server');
+        await expect(
+            panel.locator('.spinner-container'),
+            'provider availability: loading did not terminate'
+        ).not.toBeVisible();
+    });
+
+    test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
+        let providerCalls = 0;
+        await page.route(/https:\/\/(?:api\.openai\.com|token\.place)\/.*/, async (route) => {
+            providerCalls += 1;
+            await route.abort('blockedbyclient');
+        });
+        await page.goto('/settings');
+        await waitForHydration(page);
+        const option = page.locator('input[name="chat-provider"][value="openai"]');
+        await expect(option, 'routing/configuration: OpenAI option is absent').toBeVisible();
+        if (!(await option.isChecked())) await option.check();
+        await expect(page.getByLabel('OpenAI API key', { exact: true })).toBeVisible();
+        const panel = await openExpectedPanelForOpenAI(page);
+        await panel.getByRole('textbox').fill('OpenAI missing-key smoke');
+        await panel.getByRole('button', { name: 'Send' }).click();
+        await expect(panel.locator('.chat-error')).toHaveAttribute(
+            'data-error-type',
+            'missing-key'
+        );
+        expect(providerCalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
+    });
+});
+
+async function openExpectedPanelForOpenAI(page: Page) {
+    await page.goto('/chat');
+    await waitForHydration(page);
+    const panel = page.locator('[data-testid="chat-panel"]');
+    await expect(panel).toHaveCount(1);
+    await expect(panel).toHaveAttribute('data-provider', 'openai');
+    return panel;
+}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { constants, publicEncrypt, webcrypto } from 'node:crypto';
+import { constants, privateDecrypt, publicEncrypt, webcrypto } from 'node:crypto';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -9,14 +9,24 @@ const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+const requestedOrigin = new URL(process.env.BASE_URL!).origin;
+const fault = process.env.DSPACE_REMOTE_CHAT_SMOKE_FAULT;
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
 const bytesToBase64 = (value: ArrayBuffer | Uint8Array) =>
     Buffer.from(value instanceof Uint8Array ? value : new Uint8Array(value)).toString('base64');
 const base64ToPem = (value: string) =>
     `-----BEGIN PUBLIC KEY-----\n${value.match(/.{1,64}/g)?.join('\n') || ''}\n-----END PUBLIC KEY-----`;
 
-async function relayPublicKey() {
+type RelayEvidence = {
+    paths: string[];
+    originsMatch: boolean;
+    credentialsPresent: boolean;
+    dispatchModelMatches: boolean;
+};
+
+async function relayKeypair() {
     const pair = await webcrypto.subtle.generateKey(
         {
             name: 'RSA-OAEP',
@@ -28,8 +38,32 @@ async function relayPublicKey() {
         ['encrypt', 'decrypt']
     );
     const spki = await webcrypto.subtle.exportKey('spki', pair.publicKey);
-    const pem = base64ToPem(bytesToBase64(spki));
-    return bytesToBase64(encoder.encode(pem));
+    const pkcs8 = await webcrypto.subtle.exportKey('pkcs8', pair.privateKey);
+    return {
+        publicKey: bytesToBase64(encoder.encode(base64ToPem(bytesToBase64(spki)))),
+        privateKey: `-----BEGIN PRIVATE KEY-----\n${bytesToBase64(pkcs8)
+            .match(/.{1,64}/g)
+            ?.join('\n')}\n-----END PRIVATE KEY-----`,
+    };
+}
+
+async function decryptDispatch(body: Record<string, string>, privateKey: string) {
+    const rawKey = privateDecrypt(
+        { key: privateKey, padding: constants.RSA_PKCS1_PADDING },
+        Buffer.from(body.cipherkey, 'base64')
+    );
+    // JSEncrypt wraps the base64 representation of the AES key.
+    const aesBytes = Buffer.from(decoder.decode(rawKey), 'base64');
+    const aesKey = await webcrypto.subtle.importKey('raw', aesBytes, { name: 'AES-CBC' }, false, [
+        'decrypt',
+    ]);
+    const plaintext = await webcrypto.subtle.decrypt(
+        { name: 'AES-CBC', iv: Buffer.from(body.iv, 'base64') },
+        aesKey,
+        Buffer.from(body.ciphertext, 'base64')
+    );
+    const envelope = JSON.parse(decoder.decode(plaintext));
+    return envelope?.api_v1_request?.model === expectedModel;
 }
 
 async function encryptedResponse(body: Record<string, string>) {
@@ -69,75 +103,121 @@ async function encryptedResponse(body: Record<string, string>) {
     };
 }
 
-async function blockUnexpectedProviders(page: Page, allowedOrigin?: string) {
-    const providerOrigins = ['https://api.openai.com', allowedOrigin].filter(Boolean) as string[];
-    for (const origin of providerOrigins) {
-        await page.route(`${origin}/**`, async (route) => {
-            await route.abort('blockedbyclient');
-            throw new Error('secret-safety: blocked unexpected live chat-provider traffic');
-        });
-    }
-    await page.route(/https?:\/\/[^/]+\/(?:api\/v1\/relay|v1\/responses).*/, async (route) => {
+async function installProviderDenyRules(page: Page) {
+    const abortDrift = async (route: Parameters<Parameters<Page['route']>[1]>[0]) => {
         await route.abort('blockedbyclient');
-        throw new Error('secret-safety: blocked unexpected live chat-provider traffic');
-    });
+        throw new Error('routing/configuration: blocked unmatched provider transport');
+    };
+    // These are registered before exact mocks because Playwright gives the newest route priority.
+    await page.route('https://api.openai.com/**', abortDrift);
+    if (expectedOrigin) await page.route(`${expectedOrigin}/**`, abortDrift);
+    await page.route(/https?:\/\/[^/]+\/api\/v1\/(?:relay|chat\/completions).*/, abortDrift);
+    await page.route(`${requestedOrigin}/api/chat`, abortDrift);
 }
 
 async function installSuccessfulRelay(page: Page) {
-    const key = await relayPublicKey();
-    const calls: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
-    // Register the deny rule first: Playwright evaluates newer routes first, so only the
-    // explicit mocks below can supersede it. Every other path on the provider origin is blocked.
-    await blockUnexpectedProviders(page, expectedOrigin);
-    await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, async (route) => {
-        calls.push({ url: route.request().url(), headers: route.request().headers(), body: '' });
-        const requestUrl = new URL(route.request().url());
-        expect(requestUrl.origin, 'routing/configuration: token.place origin drift').toBe(
-            expectedOrigin
+    const key = await relayKeypair();
+    const evidence: RelayEvidence = {
+        paths: [],
+        originsMatch: true,
+        credentialsPresent: false,
+        dispatchModelMatches: false,
+    };
+    await installProviderDenyRules(page);
+
+    const handle = async (
+        route: Parameters<Parameters<Page['route']>[1]>[0],
+        operation: string,
+        payload: Record<string, string>
+    ) => {
+        const request = route.request();
+        evidence.paths.push(operation);
+        evidence.originsMatch &&=
+            new URL(request.url()).origin ===
+            (request.url().includes('/api/chat') ? requestedOrigin : expectedOrigin);
+        const headerNames = Object.keys(request.headers()).map((name) => name.toLowerCase());
+        evidence.credentialsPresent ||= headerNames.some(
+            (name) => name === 'authorization' || name.includes('api-key')
         );
-        expect(
-            requestUrl.searchParams.get('model'),
-            'routing/configuration: token.place model drift'
-        ).toBe(expectedModel);
-        const tier = requestUrl.searchParams.get('context_tier');
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({
-                server_public_key: key,
-                context_tier: tier,
-                selected_profile_id: `smoke-${tier}`,
-                selected_model_support: [expectedModel],
-            }),
+        if (operation === 'select') {
+            const model = payload.model || new URL(request.url()).searchParams.get('model');
+            if (model !== expectedModel)
+                throw new Error('routing/configuration: token.place model drift');
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    server_public_key: key.publicKey,
+                    context_tier:
+                        payload.contextTier ||
+                        new URL(request.url()).searchParams.get('context_tier'),
+                    selected_profile_id: 'dspace-smoke',
+                    selected_model_support: [expectedModel],
+                }),
+            });
+        } else if (operation === 'dispatch') {
+            evidence.dispatchModelMatches = await decryptDispatch(payload, key.privateKey);
+            await route.fulfill({
+                status: 200,
+                headers: {
+                    'content-type': 'application/json',
+                    'x-dspace-correlation-token': 'bounded-smoke-correlation',
+                },
+                body: '{"accepted":true}',
+            });
+        } else if (operation === 'retrieve') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(await encryptedResponse(payload)),
+            });
+        } else if (operation === 'complete') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: '{"ok":true}',
+            });
+        } else {
+            await route.abort('blockedbyclient');
+            throw new Error('routing/configuration: unexpected token.place proxy operation');
+        }
+    };
+
+    await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, (route) => {
+        const url = new URL(route.request().url());
+        return handle(route, 'select', {
+            model: url.searchParams.get('model') || '',
+            contextTier: url.searchParams.get('context_tier') || '',
         });
     });
-    await page.route(`${expectedOrigin}/api/v1/relay/requests`, async (route) => {
-        calls.push({
-            url: route.request().url(),
-            headers: route.request().headers(),
-            body: route.request().postData() || '',
-        });
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: '{"accepted":true}',
-        });
-    });
-    await page.route(`${expectedOrigin}/api/v1/relay/responses/retrieve`, async (route) => {
+    await page.route(`${expectedOrigin}/api/v1/relay/requests`, (route) =>
+        handle(route, 'dispatch', JSON.parse(route.request().postData() || '{}'))
+    );
+    await page.route(`${expectedOrigin}/api/v1/relay/responses/retrieve`, (route) =>
+        handle(route, 'retrieve', JSON.parse(route.request().postData() || '{}'))
+    );
+    await page.route(`${requestedOrigin}/api/chat`, async (route) => {
         const body = JSON.parse(route.request().postData() || '{}');
-        calls.push({ url: route.request().url(), headers: route.request().headers(), body: '' });
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(await encryptedResponse(body)),
-        });
+        if (
+            body.provider !== 'tokenplace' ||
+            !['select', 'dispatch', 'retrieve', 'complete'].includes(body.operation)
+        ) {
+            await route.abort('blockedbyclient');
+            throw new Error('routing/configuration: unexpected chat proxy request');
+        }
+        await handle(route, body.operation, body.payload || {});
     });
-    return calls;
+    return evidence;
 }
 
 async function openExpectedPanel(page: Page) {
-    await page.goto('/chat');
+    const navigation = await page.goto('/chat');
+    expect(
+        new URL(navigation?.url() || page.url()).origin,
+        'routing/configuration: /chat origin drift'
+    ).toBe(requestedOrigin);
     await waitForHydration(page);
+    if (fault === 'hydration') throw new Error('hydration: injected bounded CI fault');
     const panels = page.locator('[data-testid="chat-panel"]');
     await expect(panels, 'hydration: exactly one chat panel must be active').toHaveCount(1);
     await expect(panels, 'routing/configuration: default provider drift').toHaveAttribute(
@@ -148,20 +228,29 @@ async function openExpectedPanel(page: Page) {
         'data-hydrated',
         'true'
     );
-    await expect(panels.getByRole('textbox'), 'hydration: textbox is unusable').toBeEnabled();
-    await expect(
-        panels.getByRole('button', { name: 'Send' }),
-        'hydration: Send is unusable'
-    ).toBeEnabled();
     return panels;
 }
 
+async function selectOpenAI(page: Page, key?: string) {
+    await page.goto('/settings');
+    await waitForHydration(page);
+    const option = page.locator('input[name="chat-provider"][value="openai"]');
+    if (!(await option.isChecked())) await option.check();
+    if (key) {
+        await page.getByLabel('OpenAI API key', { exact: true }).fill(key);
+        await page.getByRole('button', { name: 'Save OpenAI API key' }).click();
+    }
+}
+
 test.describe('release-aware remote chat smoke', () => {
-    test.skip(
-        process.env.REMOTE_CHAT_SMOKE !== '1',
-        'Run through npm run qa:remote-chat-smoke with explicit release expectations.'
-    );
-    test.use({ serviceWorkers: 'block', storageState: { cookies: [], origins: [] } });
+    test.skip(process.env.REMOTE_CHAT_SMOKE !== '1', 'Requires explicit release expectations.');
+    test.use({
+        serviceWorkers: 'block',
+        storageState: { cookies: [], origins: [] },
+        trace: 'off',
+        video: 'off',
+        screenshot: 'off',
+    });
     test.beforeEach(async ({ context, page }) => {
         await context.clearCookies();
         await clearUserData(page);
@@ -169,6 +258,10 @@ test.describe('release-aware remote chat smoke', () => {
 
     test('identity: approved build identity matches JSON and HTML', async ({ page, request }) => {
         const response = await request.get('/build-info.json');
+        expect(
+            new URL(response.url()).origin,
+            'routing/configuration: /build-info.json origin drift'
+        ).toBe(requestedOrigin);
         expect(response.status(), 'identity: /build-info.json did not return 200').toBe(200);
         const identity = await response.json();
         expect(identity.version, 'identity: application-version drift').toBe(expectedVersion);
@@ -176,7 +269,11 @@ test.describe('release-aware remote chat smoke', () => {
         expect(identity.shortRevision, 'identity: invalid derived short revision').toBe(
             expectedRevision.slice(0, 7)
         );
-        await page.goto('/chat');
+        const navigation = await page.goto('/chat');
+        expect(
+            new URL(navigation?.url() || page.url()).origin,
+            'routing/configuration: /chat origin drift'
+        ).toBe(requestedOrigin);
         await expect(
             page.locator('meta[name="dspace-build-revision"]'),
             'identity: HTML build marker drift'
@@ -184,47 +281,86 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('routing/configuration and submission: approved default journey', async ({ page }) => {
-        const calls = expectedProvider === 'token-place' ? await installSuccessfulRelay(page) : [];
-        if (expectedProvider === 'openai') await blockUnexpectedProviders(page);
-        const panel = await openExpectedPanel(page);
         if (expectedProvider === 'openai') {
+            let openAICalls = 0;
+            let credentialPresent = false;
+            await installProviderDenyRules(page);
+            await selectOpenAI(page);
+            let panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Key gate smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
             await expect(
                 panel.locator('.chat-error'),
                 'routing/configuration: OpenAI key gate'
             ).toHaveAttribute('data-error-type', 'missing-key');
+            expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
+            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
+            await selectOpenAI(page, fakeKey);
+            await page.route('https://api.openai.com/v1/responses', async (route) => {
+                openAICalls += 1;
+                credentialPresent =
+                    route.request().headers().authorization?.startsWith('Bearer ') === true;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        id: 'resp_smoke',
+                        object: 'response',
+                        status: 'completed',
+                        output: [
+                            {
+                                type: 'message',
+                                role: 'assistant',
+                                content: [
+                                    { type: 'output_text', text: 'DSPACE OpenAI smoke reply.' },
+                                ],
+                            },
+                        ],
+                    }),
+                });
+            });
+            panel = await openExpectedPanel(page);
+            await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
+            await panel.getByRole('button', { name: 'Send' }).click();
+            await expect(
+                panel.getByText('DSPACE OpenAI smoke reply.'),
+                'submission: no mocked OpenAI reply'
+            ).toBeVisible();
+            expect({ openAICalls, credentialPresent }).toEqual({
+                openAICalls: 1,
+                credentialPresent: true,
+            });
             return;
         }
+        const evidence = await installSuccessfulRelay(page);
+        const panel = await openExpectedPanel(page);
         await panel.getByRole('textbox').fill('Deterministic remote chat smoke');
         await panel.getByRole('button', { name: 'Send' }).click();
+        if (fault === 'submission') throw new Error('submission: injected bounded CI fault');
         await expect(
             panel.getByText('DSPACE smoke reply.'),
             'submission: no mocked relay reply'
         ).toBeVisible();
+        expect(evidence.originsMatch, 'routing/configuration: token.place origin drift').toBe(true);
+        expect(evidence.credentialsPresent, 'secret-safety: provider credential was sent').toBe(
+            false
+        );
         expect(
-            calls.map(({ url }) => new URL(url).origin).every((origin) => origin === expectedOrigin)
+            evidence.dispatchModelMatches,
+            'routing/configuration: encrypted dispatch model drift'
         ).toBe(true);
-        expect(calls).toHaveLength(3);
-        for (const call of calls) {
-            expect(
-                JSON.stringify(call.headers),
-                'secret-safety: authorization header was sent'
-            ).not.toMatch(/authorization|api.?key|bearer|sk-/i);
-            expect(call.body, 'secret-safety: OpenAI credential material was sent').not.toMatch(
-                /api.?key|bearer|sk-/i
-            );
-        }
+        expect(evidence.paths.filter((path) => path !== 'complete')).toEqual([
+            'select',
+            'dispatch',
+            'retrieve',
+        ]);
     });
 
     test('provider availability: controlled token.place failure is classified and bounded', async ({
         page,
     }) => {
-        test.skip(
-            expectedProvider !== 'token-place',
-            'Only applies to token.place-default releases'
-        );
-        await blockUnexpectedProviders(page, expectedOrigin);
+        test.skip(expectedProvider !== 'token-place', 'Only applies to token.place releases');
+        await installProviderDenyRules(page);
         await page.route(`${expectedOrigin}/api/v1/relay/servers/next**`, (route) =>
             route.fulfill({
                 status: 503,
@@ -232,6 +368,16 @@ test.describe('release-aware remote chat smoke', () => {
                 body: '{"error":"unavailable"}',
             })
         );
+        await page.route(`${requestedOrigin}/api/chat`, async (route) => {
+            const body = JSON.parse(route.request().postData() || '{}');
+            if (body.provider === 'tokenplace' && body.operation === 'select')
+                await route.fulfill({
+                    status: 503,
+                    contentType: 'application/json',
+                    body: '{"error":"unavailable"}',
+                });
+            else await route.abort('blockedbyclient');
+        });
         const panel = await openExpectedPanel(page);
         await panel.getByRole('textbox').fill('Controlled unavailable smoke');
         await panel.getByRole('button', { name: 'Send' }).click();
@@ -247,17 +393,13 @@ test.describe('release-aware remote chat smoke', () => {
 
     test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
         let providerCalls = 0;
-        await page.route(/https:\/\/(?:api\.openai\.com|token\.place)\/.*/, async (route) => {
-            providerCalls += 1;
-            await route.abort('blockedbyclient');
+        await installProviderDenyRules(page);
+        page.on('request', (request) => {
+            if (['https://api.openai.com', expectedOrigin].includes(new URL(request.url()).origin))
+                providerCalls += 1;
         });
-        await page.goto('/settings');
-        await waitForHydration(page);
-        const option = page.locator('input[name="chat-provider"][value="openai"]');
-        await expect(option, 'routing/configuration: OpenAI option is absent').toBeVisible();
-        if (!(await option.isChecked())) await option.check();
-        await expect(page.getByLabel('OpenAI API key', { exact: true })).toBeVisible();
-        const panel = await openExpectedPanelForOpenAI(page);
+        await selectOpenAI(page);
+        const panel = await openExpectedPanel(page);
         await panel.getByRole('textbox').fill('OpenAI missing-key smoke');
         await panel.getByRole('button', { name: 'Send' }).click();
         await expect(panel.locator('.chat-error')).toHaveAttribute(
@@ -267,12 +409,3 @@ test.describe('release-aware remote chat smoke', () => {
         expect(providerCalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
     });
 });
-
-async function openExpectedPanelForOpenAI(page: Page) {
-    await page.goto('/chat');
-    await waitForHydration(page);
-    const panel = page.locator('[data-testid="chat-panel"]');
-    await expect(panel).toHaveCount(1);
-    await expect(panel).toHaveAttribute('data-provider', 'openai');
-    return panel;
-}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -9,10 +9,19 @@ const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
-const requestedOrigin = new URL(process.env.BASE_URL!).origin;
+const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';
+const requestedOrigin = remoteChatSmokeEnabled ? new URL(process.env.BASE_URL!).origin : undefined;
 const fault = process.env.DSPACE_REMOTE_CHAT_SMOKE_FAULT;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+test.use({
+    serviceWorkers: 'block',
+    storageState: { cookies: [], origins: [] },
+    trace: 'off',
+    video: 'off',
+    screenshot: 'off',
+});
 
 const bytesToBase64 = (value: ArrayBuffer | Uint8Array) =>
     Buffer.from(value instanceof Uint8Array ? value : new Uint8Array(value)).toString('base64');
@@ -210,7 +219,7 @@ async function installSuccessfulRelay(page: Page) {
     return evidence;
 }
 
-async function openExpectedPanel(page: Page) {
+async function openExpectedPanel(page: Page, provider = expectedProvider) {
     const navigation = await page.goto('/chat');
     expect(
         new URL(navigation?.url() || page.url()).origin,
@@ -222,7 +231,7 @@ async function openExpectedPanel(page: Page) {
     await expect(panels, 'hydration: exactly one chat panel must be active').toHaveCount(1);
     await expect(panels, 'routing/configuration: default provider drift').toHaveAttribute(
         'data-provider',
-        expectedProvider
+        provider
     );
     await expect(panels, 'hydration: chat panel did not hydrate').toHaveAttribute(
         'data-hydrated',
@@ -243,14 +252,7 @@ async function selectOpenAI(page: Page, key?: string) {
 }
 
 test.describe('release-aware remote chat smoke', () => {
-    test.skip(process.env.REMOTE_CHAT_SMOKE !== '1', 'Requires explicit release expectations.');
-    test.use({
-        serviceWorkers: 'block',
-        storageState: { cookies: [], origins: [] },
-        trace: 'off',
-        video: 'off',
-        screenshot: 'off',
-    });
+    test.skip(!remoteChatSmokeEnabled, 'Requires explicit release expectations.');
     test.beforeEach(async ({ context, page }) => {
         await context.clearCookies();
         await clearUserData(page);
@@ -285,7 +287,6 @@ test.describe('release-aware remote chat smoke', () => {
             let openAICalls = 0;
             let credentialPresent = false;
             await installProviderDenyRules(page);
-            await selectOpenAI(page);
             let panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Key gate smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
@@ -332,6 +333,24 @@ test.describe('release-aware remote chat smoke', () => {
             });
             return;
         }
+        const configResponse = await page.request.get('/config.json');
+        expect(
+            new URL(configResponse.url()).origin,
+            'routing/configuration: /config.json origin drift'
+        ).toBe(requestedOrigin);
+        expect(
+            configResponse.status(),
+            'routing/configuration: /config.json did not return 200'
+        ).toBe(200);
+        const config = await configResponse.json();
+        expect(
+            new URL(config.tokenPlace.url).origin,
+            'routing/configuration: token.place configured origin drift'
+        ).toBe(expectedOrigin);
+        expect(
+            config.tokenPlace.model,
+            'routing/configuration: token.place configured model drift'
+        ).toBe(expectedModel);
         const evidence = await installSuccessfulRelay(page);
         const panel = await openExpectedPanel(page);
         await panel.getByRole('textbox').fill('Deterministic remote chat smoke');
@@ -399,7 +418,7 @@ test.describe('release-aware remote chat smoke', () => {
                 providerCalls += 1;
         });
         await selectOpenAI(page);
-        const panel = await openExpectedPanel(page);
+        const panel = await openExpectedPanel(page, 'openai');
         await panel.getByRole('textbox').fill('OpenAI missing-key smoke');
         await panel.getByRole('button', { name: 'Send' }).click();
         await expect(panel.locator('.chat-error')).toHaveAttribute(

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,8 +1,11 @@
-import { constants, privateDecrypt, publicEncrypt, webcrypto } from 'node:crypto';
+import { constants, publicEncrypt, webcrypto } from 'node:crypto';
+import { createRequire } from 'node:module';
 
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
+
+const { JSEncrypt } = createRequire(import.meta.url)('jsencrypt') as typeof import('jsencrypt');
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
@@ -57,22 +60,31 @@ async function relayKeypair() {
 }
 
 async function decryptDispatch(body: Record<string, string>, privateKey: string) {
-    const rawKey = privateDecrypt(
-        { key: privateKey, padding: constants.RSA_PKCS1_PADDING },
-        Buffer.from(body.cipherkey, 'base64')
-    );
-    // JSEncrypt wraps the base64 representation of the AES key.
-    const aesBytes = Buffer.from(decoder.decode(rawKey), 'base64');
-    const aesKey = await webcrypto.subtle.importKey('raw', aesBytes, { name: 'AES-CBC' }, false, [
-        'decrypt',
-    ]);
-    const plaintext = await webcrypto.subtle.decrypt(
-        { name: 'AES-CBC', iv: Buffer.from(body.iv, 'base64') },
-        aesKey,
-        Buffer.from(body.ciphertext, 'base64')
-    );
-    const envelope = JSON.parse(decoder.decode(plaintext));
-    return envelope?.api_v1_request?.model === expectedModel;
+    try {
+        const rsa = new JSEncrypt();
+        rsa.setPrivateKey(privateKey);
+        // JSEncrypt wraps the base64 representation of the AES key.
+        const decryptedKey = rsa.decrypt(body.cipherkey);
+        if (!decryptedKey) throw new Error('empty decrypted key');
+        const aesBytes = Buffer.from(decryptedKey, 'base64');
+        if (aesBytes.length === 0) throw new Error('empty AES key');
+        const aesKey = await webcrypto.subtle.importKey(
+            'raw',
+            aesBytes,
+            { name: 'AES-CBC' },
+            false,
+            ['decrypt']
+        );
+        const plaintext = await webcrypto.subtle.decrypt(
+            { name: 'AES-CBC', iv: Buffer.from(body.iv, 'base64') },
+            aesKey,
+            Buffer.from(body.ciphertext, 'base64')
+        );
+        const envelope = JSON.parse(decoder.decode(plaintext));
+        return envelope?.api_v1_request?.model === expectedModel;
+    } catch {
+        throw new Error('routing/configuration: encrypted dispatch could not be verified');
+    }
 }
 
 async function encryptedResponse(body: Record<string, string>) {

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -5,7 +5,9 @@ import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
 
-const { JSEncrypt } = createRequire(import.meta.url)('jsencrypt') as typeof import('jsencrypt');
+const JSEncrypt = createRequire(import.meta.url)(
+    'jsencrypt'
+) as typeof import('jsencrypt').JSEncrypt;
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,6 +28,8 @@ declare const process: {
         PLAYWRIGHT_SKIP_INSTALL_DEPS?: string;
         REMOTE_SMOKE?: string;
         REMOTE_SMOKE_USE_WEBSERVER?: string;
+        REMOTE_CHAT_SMOKE?: string;
+        REMOTE_CHAT_SMOKE_USE_WEBSERVER?: string;
         REMOTE_MIGRATION?: string;
         REMOTE_MIGRATION_USE_WEBSERVER?: string;
         REMOTE_COMPLETIONIST_AWARD_III?: string;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,8 +28,6 @@ declare const process: {
         PLAYWRIGHT_SKIP_INSTALL_DEPS?: string;
         REMOTE_SMOKE?: string;
         REMOTE_SMOKE_USE_WEBSERVER?: string;
-        REMOTE_CHAT_SMOKE?: string;
-        REMOTE_CHAT_SMOKE_USE_WEBSERVER?: string;
         REMOTE_MIGRATION?: string;
         REMOTE_MIGRATION_USE_WEBSERVER?: string;
         REMOTE_COMPLETIONIST_AWARD_III?: string;

--- a/frontend/scripts/utils/playwright-remote-mode.js
+++ b/frontend/scripts/utils/playwright-remote-mode.js
@@ -4,6 +4,11 @@ const hasQuestsPerfBaseUrl = () => Boolean(process.env.QUESTS_PERF_BASE_URL?.tri
 
 export const REMOTE_PLAYWRIGHT_MODE_CONFIGS = Object.freeze([
     {
+        name: 'remoteChatSmoke',
+        isEnabled: () => isEnabled(process.env.REMOTE_CHAT_SMOKE),
+        useWebServerEnv: 'REMOTE_CHAT_SMOKE_USE_WEBSERVER',
+    },
+    {
         name: 'remoteSmoke',
         isEnabled: ({ includeQuestsPerfBaseUrlSignal = false } = {}) =>
             isEnabled(process.env.REMOTE_SMOKE) ||

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:quest-validation": "npm run test:root -- tests/questDialogueValidation.test.ts tests/questCompletableItems.test.ts tests/runTestsQuestRegression.test.ts",
     "spellcheck": "cspell --no-progress --no-summary \"docs/**/*.md\" \"frontend/src/pages/docs/**/*.md\" \"README.md\" \"AGENTS.md\"",
     "qa:remote-smoke": "node scripts/run-remote-smoke.mjs",
+    "qa:remote-chat-smoke": "node scripts/run-remote-chat-smoke.mjs",
     "qa:remote-migration": "npx -y node@20 scripts/run-remote-migration.mjs",
     "qa:remote-completionist-award-iii": "npx -y node@20 scripts/run-remote-completionist-award-iii.mjs",
     "generate-quest": "cd frontend && npm run generate-quest",

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -27,13 +27,13 @@ export function parseAndValidateArgs(argv, env = process.env) {
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (!argument.startsWith('--'))
-      throw new Error(`validation: unexpected argument "${argument}"`);
+      throw new Error('validation: unexpected positional argument');
     const equals = argument.indexOf('=');
     const name = argument.slice(2, equals === -1 ? undefined : equals);
     const definition = Object.values(definitions).find(
       ([flag]) => flag === name
     );
-    if (!definition) throw new Error(`validation: unknown flag "--${name}"`);
+    if (!definition) throw new Error('validation: unknown flag');
     const value = equals === -1 ? argv[++index] : argument.slice(equals + 1);
     if (!value || value.startsWith('--'))
       throw new Error(`validation: --${name} requires a value`);
@@ -65,13 +65,33 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (
     !['http:', 'https:'].includes(base.protocol) ||
     base.username ||
-    base.password
+    base.password ||
+    base.pathname !== '/' ||
+    base.search ||
+    base.hash
   ) {
     throw new Error(
       'validation: base URL must be an absolute credential-free http(s) URL'
     );
   }
-  result.baseURL = base.href.replace(/\/$/, '');
+  result.baseURL = base.origin;
+  const fault = env.DSPACE_REMOTE_CHAT_SMOKE_FAULT?.trim();
+  const normalizedHostname = base.hostname.replace(/^\[|\]$/g, '');
+  const localTarget =
+    ['127.0.0.1', 'localhost', '0.0.0.0', '::1'].includes(normalizedHostname) ||
+    normalizedHostname.endsWith('.local');
+  if (fault) {
+    if (
+      !['hydration', 'submission'].includes(fault) ||
+      env.CI !== 'true' ||
+      !localTarget
+    ) {
+      throw new Error(
+        'validation: smoke fault is restricted to bounded local CI cases'
+      );
+    }
+    result.fault = fault;
+  }
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(result.expectedVersion)) {
     throw new Error(
       'validation: expected version must be an exact semantic version'
@@ -135,7 +155,9 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
   // Node exposes bracketed IPv6 URL hostnames as "[::1]"; normalize them before
   // deciding whether Playwright should manage the local preview server.
   const hostname = new URL(options.baseURL).hostname.replace(/^\[|\]$/g, '');
-  const local = ['127.0.0.1', 'localhost', '0.0.0.0', '::1'].includes(hostname);
+  const local =
+    ['127.0.0.1', 'localhost', '0.0.0.0', '::1'].includes(hostname) ||
+    hostname.endsWith('.local');
   return {
     ...baseEnv,
     BASE_URL: options.baseURL,
@@ -147,6 +169,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     DSPACE_EXPECTED_PROVIDER: options.expectedProvider,
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',
+    DSPACE_REMOTE_CHAT_SMOKE_FAULT: options.fault || '',
   };
 }
 

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -132,7 +132,9 @@ export function parseAndValidateArgs(argv, env = process.env) {
 }
 
 export function buildSmokeEnv(options, baseEnv = process.env) {
-  const hostname = new URL(options.baseURL).hostname;
+  // Node exposes bracketed IPv6 URL hostnames as "[::1]"; normalize them before
+  // deciding whether Playwright should manage the local preview server.
+  const hostname = new URL(options.baseURL).hostname.replace(/^\[|\]$/g, '');
   const local = ['127.0.0.1', 'localhost', '0.0.0.0', '::1'].includes(hostname);
   return {
     ...baseEnv,

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendDir = join(scriptDir, '..', 'frontend');
+
+const definitions = {
+  baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
+  expectedVersion: ['expected-version', 'DSPACE_EXPECTED_VERSION'],
+  expectedRevision: ['expected-revision', 'DSPACE_EXPECTED_REVISION'],
+  expectedProvider: ['expected-provider', 'DSPACE_EXPECTED_PROVIDER'],
+  expectedTokenPlaceOrigin: [
+    'expected-token-place-origin',
+    'DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN',
+  ],
+  expectedTokenPlaceModel: [
+    'expected-token-place-model',
+    'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
+  ],
+};
+
+export function parseAndValidateArgs(argv, env = process.env) {
+  const flags = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (!argument.startsWith('--'))
+      throw new Error(`validation: unexpected argument "${argument}"`);
+    const equals = argument.indexOf('=');
+    const name = argument.slice(2, equals === -1 ? undefined : equals);
+    const definition = Object.values(definitions).find(
+      ([flag]) => flag === name
+    );
+    if (!definition) throw new Error(`validation: unknown flag "--${name}"`);
+    const value = equals === -1 ? argv[++index] : argument.slice(equals + 1);
+    if (!value || value.startsWith('--'))
+      throw new Error(`validation: --${name} requires a value`);
+    if (flags.has(name) && flags.get(name) !== value) {
+      throw new Error(`validation: contradictory values for --${name}`);
+    }
+    flags.set(name, value.trim());
+  }
+
+  const result = {};
+  for (const [key, [flag, environment]] of Object.entries(definitions)) {
+    // Explicit flags deterministically take precedence over the environment.
+    result[key] = flags.get(flag) ?? env[environment]?.trim();
+  }
+  const missing = Object.entries(definitions)
+    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .map(([, [, environment]]) => environment);
+  if (missing.length)
+    throw new Error(
+      `validation: missing required input(s): ${missing.join(', ')}`
+    );
+
+  let base;
+  try {
+    base = new URL(result.baseURL);
+  } catch {
+    throw new Error('validation: base URL must be an absolute http(s) URL');
+  }
+  if (
+    !['http:', 'https:'].includes(base.protocol) ||
+    base.username ||
+    base.password
+  ) {
+    throw new Error(
+      'validation: base URL must be an absolute credential-free http(s) URL'
+    );
+  }
+  result.baseURL = base.href.replace(/\/$/, '');
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(result.expectedVersion)) {
+    throw new Error(
+      'validation: expected version must be an exact semantic version'
+    );
+  }
+  if (!/^[0-9a-f]{40}$/.test(result.expectedRevision)) {
+    throw new Error(
+      'validation: expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (!['token-place', 'openai'].includes(result.expectedProvider)) {
+    throw new Error(
+      'validation: expected provider must be token-place or openai'
+    );
+  }
+
+  if (result.expectedProvider === 'token-place') {
+    if (!result.expectedTokenPlaceOrigin || !result.expectedTokenPlaceModel) {
+      throw new Error(
+        'validation: token-place requires DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN and DSPACE_EXPECTED_TOKEN_PLACE_MODEL'
+      );
+    }
+    let origin;
+    try {
+      origin = new URL(result.expectedTokenPlaceOrigin);
+    } catch {
+      throw new Error(
+        'validation: token.place origin must be an absolute http(s) origin'
+      );
+    }
+    if (
+      !['http:', 'https:'].includes(origin.protocol) ||
+      origin.origin !== result.expectedTokenPlaceOrigin.replace(/\/$/, '') ||
+      origin.username ||
+      origin.password
+    ) {
+      throw new Error(
+        'validation: token.place origin must contain only scheme, host, and port'
+      );
+    }
+    result.expectedTokenPlaceOrigin = origin.origin;
+    if (
+      !/^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/.test(
+        result.expectedTokenPlaceModel
+      )
+    ) {
+      throw new Error('validation: token.place model is malformed');
+    }
+  } else if (
+    result.expectedTokenPlaceOrigin ||
+    result.expectedTokenPlaceModel
+  ) {
+    throw new Error(
+      'validation: token.place origin/model are inapplicable when provider is openai'
+    );
+  }
+  return result;
+}
+
+export function buildSmokeEnv(options, baseEnv = process.env) {
+  const hostname = new URL(options.baseURL).hostname;
+  const local = ['127.0.0.1', 'localhost', '0.0.0.0', '::1'].includes(hostname);
+  return {
+    ...baseEnv,
+    BASE_URL: options.baseURL,
+    REMOTE_CHAT_SMOKE: '1',
+    REMOTE_CHAT_SMOKE_USE_WEBSERVER: local ? '1' : '0',
+    PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
+    DSPACE_EXPECTED_VERSION: options.expectedVersion,
+    DSPACE_EXPECTED_REVISION: options.expectedRevision,
+    DSPACE_EXPECTED_PROVIDER: options.expectedProvider,
+    DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
+    DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = parseAndValidateArgs(argv);
+  } catch (error) {
+    console.error(`[qa:remote-chat-smoke] ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+  console.log(`[qa:remote-chat-smoke] target=${options.baseURL}`);
+  console.log(
+    `[qa:remote-chat-smoke] expectedVersion=${options.expectedVersion}`
+  );
+  console.log(
+    `[qa:remote-chat-smoke] expectedRevision=${options.expectedRevision}`
+  );
+  console.log(
+    `[qa:remote-chat-smoke] expectedProvider=${options.expectedProvider}`
+  );
+  console.log(
+    '[qa:remote-chat-smoke] transport=intercepted; profile=isolated; mutation=disabled'
+  );
+  const child = spawn(
+    'node',
+    [
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ],
+    { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+  );
+  child.on('error', (error) => {
+    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    else process.exitCode = code ?? 1;
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSmokeEnv,
+  parseAndValidateArgs,
+} from '../run-remote-chat-smoke.mjs';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const completeEnv = {
+  DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
+  DSPACE_EXPECTED_VERSION: '3.1.0',
+  DSPACE_EXPECTED_REVISION: revision,
+  DSPACE_EXPECTED_PROVIDER: 'token-place',
+  DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+  DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+};
+
+describe('remote chat smoke input validation', () => {
+  it('accepts the documented environment and configures remote mode', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    expect(options.expectedProvider).toBe('token-place');
+    expect(buildSmokeEnv(options, {}).REMOTE_CHAT_SMOKE_USE_WEBSERVER).toBe(
+      '0'
+    );
+  });
+
+  it('gives flags deterministic precedence over environment values', () => {
+    const options = parseAndValidateArgs(
+      ['--expected-version=3.2.0'],
+      completeEnv
+    );
+    expect(options.expectedVersion).toBe('3.2.0');
+  });
+
+  it.each([
+    [
+      { ...completeEnv, DSPACE_EXPECTED_REVISION: revision.slice(0, 7) },
+      'full 40-character',
+    ],
+    [
+      { ...completeEnv, DSPACE_EXPECTED_PROVIDER: 'other' },
+      'token-place or openai',
+    ],
+    [
+      {
+        ...completeEnv,
+        DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place/path',
+      },
+      'only scheme',
+    ],
+    [
+      { ...completeEnv, DSPACE_EXPECTED_TOKEN_PLACE_MODEL: '' },
+      'token-place requires',
+    ],
+    [
+      { ...completeEnv, DSPACE_SMOKE_BASE_URL: 'token.place' },
+      'absolute http(s)',
+    ],
+  ])('rejects malformed input without launching Playwright', (env, message) => {
+    expect(() => parseAndValidateArgs([], env)).toThrow(message);
+  });
+
+  it('rejects provider-inapplicable and contradictory inputs', () => {
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_PROVIDER: 'openai',
+      })
+    ).toThrow('inapplicable');
+    expect(() =>
+      parseAndValidateArgs(
+        ['--expected-version=3.1.0', '--expected-version=3.2.0'],
+        completeEnv
+      )
+    ).toThrow('contradictory');
+  });
+
+  it('accepts OpenAI only when token.place expectations are absent', () => {
+    const env = { ...completeEnv, DSPACE_EXPECTED_PROVIDER: 'openai' };
+    delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+    delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+    expect(parseAndValidateArgs([], env).expectedProvider).toBe('openai');
+  });
+});

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -26,7 +26,9 @@ describe('remote chat smoke input validation', () => {
   it.each([
     'http://127.0.0.1:4173',
     'http://localhost:4173',
+    'http://0.0.0.0:4173',
     'http://[::1]:4173',
+    'http://dspace.local:4173',
   ])('enables the managed web server for loopback URL %s', (baseURL) => {
     const options = parseAndValidateArgs([], {
       ...completeEnv,
@@ -69,6 +71,13 @@ describe('remote chat smoke input validation', () => {
       { ...completeEnv, DSPACE_SMOKE_BASE_URL: 'token.place' },
       'absolute http(s)',
     ],
+    [
+      {
+        ...completeEnv,
+        DSPACE_SMOKE_BASE_URL: 'https://example.test/path?opaque=value',
+      },
+      'credential-free http(s)',
+    ],
   ])('rejects malformed input without launching Playwright', (env, message) => {
     expect(() => parseAndValidateArgs([], env)).toThrow(message);
   });
@@ -86,6 +95,39 @@ describe('remote chat smoke input validation', () => {
         completeEnv
       )
     ).toThrow('contradictory');
+  });
+
+  it('keeps malformed-input diagnostics bounded and free of supplied values', () => {
+    const sentinel = 'operator-private-query-sentinel';
+    for (const argv of [[sentinel], [`--unknown=${sentinel}`]]) {
+      let message = '';
+      try {
+        parseAndValidateArgs(argv, completeEnv);
+      } catch (error) {
+        message = String(error.message);
+      }
+      expect(message).toContain('validation:');
+      expect(message).not.toContain(sentinel);
+      expect(message.length).toBeLessThan(100);
+    }
+  });
+
+  it('restricts bounded fault injection to local CI runs', () => {
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_REMOTE_CHAT_SMOKE_FAULT: 'hydration',
+      })
+    ).toThrow('bounded local CI');
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      CI: 'true',
+      DSPACE_SMOKE_BASE_URL: 'http://127.0.0.1:4173',
+      DSPACE_REMOTE_CHAT_SMOKE_FAULT: 'submission',
+    });
+    expect(buildSmokeEnv(options, {}).DSPACE_REMOTE_CHAT_SMOKE_FAULT).toBe(
+      'submission'
+    );
   });
 
   it('accepts OpenAI only when token.place expectations are absent', () => {

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -23,6 +23,20 @@ describe('remote chat smoke input validation', () => {
     );
   });
 
+  it.each([
+    'http://127.0.0.1:4173',
+    'http://localhost:4173',
+    'http://[::1]:4173',
+  ])('enables the managed web server for loopback URL %s', (baseURL) => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_SMOKE_BASE_URL: baseURL,
+    });
+    expect(buildSmokeEnv(options, {}).REMOTE_CHAT_SMOKE_USE_WEBSERVER).toBe(
+      '1'
+    );
+  });
+
   it('gives flags deterministic precedence over environment values', () => {
     const options = parseAndValidateArgs(
       ['--expected-version=3.2.0'],

--- a/tests/run-test-groups.test.ts
+++ b/tests/run-test-groups.test.ts
@@ -131,6 +131,7 @@ describe('run-test-groups', () => {
       'remote-release-smoke.spec.ts',
       'remote-legacy-migration.spec.ts',
       'remote-completionist-award-iii.spec.ts',
+      'remote-chat-smoke.spec.ts',
     ]);
     const missingFiles = specFiles.filter(
       (file) => !groupedFiles.has(file) && !optionalRemoteSpecs.has(file)


### PR DESCRIPTION
### Motivation

Add a deterministic, non-destructive smoke harness for verifying the approved `/chat` journey and release identity against local builds, staging, or production. The harness fails closed on build, provider, origin, model, hydration, submission, availability-classification, and secret-safety drift.

### Description

- Add `npm run qa:remote-chat-smoke` backed by `scripts/run-remote-chat-smoke.mjs`.
  - Accept equivalent CLI flags and `DSPACE_*` environment variables.
  - Give flags deterministic precedence over environment values.
  - Reject missing, malformed, contradictory, provider-inapplicable, or short-SHA inputs before Playwright starts.
  - Preserve the existing `qa:remote-smoke` behavior.
- Add `frontend/e2e/remote-chat-smoke.spec.ts`.
  - Verify `/build-info.json`, the full revision, derived short revision, and the `dspace-build-revision` HTML marker.
  - Reject redirects away from the requested base origin.
  - Require one hydrated chat panel with the exact expected default provider and usable submission controls.
  - Verify configured token.place origin/model and decrypt the test-owned relay envelope to inspect the authoritative dispatched model.
  - Mock direct token.place relay and same-origin `/api/chat` proxy operations without contacting a live provider.
  - Verify deterministic token.place submission and classified HTTP 503 behavior with a terminated loading state.
  - Verify OpenAI remains discoverable and missing-key gated without making a provider request.
  - When OpenAI is the expected default, exercise an exact mocked successful submission using an isolated fake key.
  - Block unmatched token.place and OpenAI traffic and disable secret-bearing Playwright artifacts.
- Extend the existing Playwright remote-mode helper and classify the new spec as optional remote-only for ordinary grouped E2E runs.
- Add focused runner validation tests and CI coverage for the actual locally served harness.
- Add fail-closed CI cases for wrong version, revision, provider, token.place origin/model, hydration failure, and submission failure while checking sanitized output.
- Document copy-paste staging and production commands in `docs/ops/sugarkube-release.md`.

### Safety and compatibility

- Uses a fresh browser context and clears cookies, local/session storage, IndexedDB, caches, and service-worker effects.
- Does not use a persistent profile, contact token.place or OpenAI, send real credentials, or mutate server/shared production state.
- Reuses the canonical `/build-info.json` and `dspace-build-revision` contracts without changing runtime identity compatibility.
- Does not change the default provider, product routing, application/chart versions, release coordinates, deployment pins, or publication behavior.
- Implements only the DSPACE harness; it does not implement Sugarkube’s promotion gate.

### Verification

- `npm run test:root -- scripts/tests/run-remote-chat-smoke.test.ts tests/run-test-groups.test.ts` — 24 tests passed.
- Latest-head release-aware harness:
  - Four Playwright contracts passed: release identity, approved token.place journey, classified provider unavailability, and OpenAI opt-in/missing-key behavior.
  - Seven negative command cases failed closed at the expected sanitized stages.
- Latest-head GitHub Actions completed successfully:
  - `CI`
  - `tests`
  - `link-check`
  - `ci-sentinel`
  - `Build & Publish Container`
  - `Build and publish GHCR image`
- Formatting, lint, type checking, build, diff checks, workflow integrity, and secret scanning passed.

Closes #4733

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69843dcc58832fab62858c5fe47dbd)