### PR TITLE
Support the immutable 3.0.1 recovery identity contract

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -204,6 +204,30 @@ two token.place expectations; the harness still proves that OpenAI is discoverab
 gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
 gate.
 
+By default, the harness uses the strict `build-info-v1` identity contract: it requires
+same-origin `/build-info.json` identity fields and the matching HTML build-revision marker. The
+contract can also be selected explicitly with
+`DSPACE_EXPECTED_IDENTITY_CONTRACT=build-info-v1` (or `--identity-contract=build-info-v1`).
+
+The immutable 3.0.1 recovery artifact predates those identity surfaces. Verify that artifact only
+with its explicit legacy contract and exact approved coordinates:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.0.1 \
+DSPACE_EXPECTED_REVISION=1a31a569aff2dbeb238e8c2688b9e85140d2077d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+This mode verifies the recovery artifact through same-origin `/build-meta.json` and is accepted
+only for version `3.0.1` at revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`. It exists solely
+to verify that immutable artifact; it must not become an automatic or general fallback when modern
+identity verification fails.
+
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -11,6 +11,9 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
+const identityContract = process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT as
+    | 'build-info-v1'
+    | 'legacy-build-meta-v1';
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -273,6 +276,33 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('identity: approved build identity matches JSON and HTML', async ({ page, request }) => {
+        if (identityContract === 'legacy-build-meta-v1') {
+            const response = await request.get('/build-meta.json');
+            expect(
+                new URL(response.url()).origin,
+                'routing/configuration: /build-meta.json origin drift'
+            ).toBe(requestedOrigin);
+            expect(response.status(), 'identity: /build-meta.json did not return 200').toBe(200);
+            const identity: unknown = await response.json();
+            expect(
+                typeof identity === 'object' && identity !== null && !Array.isArray(identity),
+                'identity: /build-meta.json did not return an object'
+            ).toBe(true);
+            const legacyIdentity = identity as Record<string, unknown>;
+            expect(legacyIdentity.gitSha, 'identity: source-revision drift').toBe(expectedRevision);
+            expect(
+                typeof legacyIdentity.generatedAt === 'string' &&
+                    legacyIdentity.generatedAt.trim().length > 0 &&
+                    Number.isFinite(Date.parse(legacyIdentity.generatedAt)),
+                'identity: generatedAt is not a non-empty valid timestamp'
+            ).toBe(true);
+            expect(
+                typeof legacyIdentity.source === 'string' &&
+                    legacyIdentity.source.trim().length > 0,
+                'identity: source is not a non-empty string'
+            ).toBe(true);
+            return;
+        }
         const response = await request.get('/build-info.json');
         expect(
             new URL(response.url()).origin,

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -11,6 +11,7 @@ const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
   expectedVersion: ['expected-version', 'DSPACE_EXPECTED_VERSION'],
   expectedRevision: ['expected-revision', 'DSPACE_EXPECTED_REVISION'],
+  identityContract: ['identity-contract', 'DSPACE_EXPECTED_IDENTITY_CONTRACT'],
   expectedProvider: ['expected-provider', 'DSPACE_EXPECTED_PROVIDER'],
   expectedTokenPlaceOrigin: [
     'expected-token-place-origin',
@@ -48,6 +49,17 @@ export function parseAndValidateArgs(argv, env = process.env) {
     // Explicit flags deterministically take precedence over the environment.
     result[key] = flags.get(flag) ?? env[environment]?.trim();
   }
+  if (
+    (flags.has('identity-contract') ||
+      Object.prototype.hasOwnProperty.call(
+        env,
+        'DSPACE_EXPECTED_IDENTITY_CONTRACT'
+      )) &&
+    !result.identityContract
+  ) {
+    throw new Error('validation: identity contract requires a value');
+  }
+  result.identityContract ||= 'build-info-v1';
   const missing = Object.entries(definitions)
     .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
     .map(([, [, environment]]) => environment);
@@ -100,6 +112,20 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (!/^[0-9a-f]{40}$/.test(result.expectedRevision)) {
     throw new Error(
       'validation: expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (
+    !['build-info-v1', 'legacy-build-meta-v1'].includes(result.identityContract)
+  ) {
+    throw new Error('validation: unknown identity contract');
+  }
+  if (
+    result.identityContract === 'legacy-build-meta-v1' &&
+    (result.expectedVersion !== '3.0.1' ||
+      result.expectedRevision !== '1a31a569aff2dbeb238e8c2688b9e85140d2077d')
+  ) {
+    throw new Error(
+      'validation: legacy identity contract is restricted to approved recovery coordinates'
     );
   }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
@@ -166,6 +192,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
     DSPACE_EXPECTED_VERSION: options.expectedVersion,
     DSPACE_EXPECTED_REVISION: options.expectedRevision,
+    DSPACE_EXPECTED_IDENTITY_CONTRACT: options.identityContract,
     DSPACE_EXPECTED_PROVIDER: options.expectedProvider,
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
+const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -18,9 +19,77 @@ describe('remote chat smoke input validation', () => {
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');
+    expect(options.identityContract).toBe('build-info-v1');
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'build-info-v1'
+    );
     expect(buildSmokeEnv(options, {}).REMOTE_CHAT_SMOKE_USE_WEBSERVER).toBe(
       '0'
     );
+  });
+
+  it('accepts an explicit modern identity contract', () => {
+    expect(
+      parseAndValidateArgs(['--identity-contract=build-info-v1'], completeEnv)
+        .identityContract
+    ).toBe('build-info-v1');
+  });
+
+  it('accepts the legacy identity contract only for the recovery build', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.0.1',
+      DSPACE_EXPECTED_REVISION: recoveryRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+    });
+    expect(options.identityContract).toBe('legacy-build-meta-v1');
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'legacy-build-meta-v1'
+    );
+  });
+
+  it.each([
+    ['3.0.2', recoveryRevision],
+    ['3.0.1', revision],
+  ])(
+    'rejects the legacy identity contract for version %s and revision %s',
+    (expectedVersion, expectedRevision) => {
+      expect(() =>
+        parseAndValidateArgs([], {
+          ...completeEnv,
+          DSPACE_EXPECTED_VERSION: expectedVersion,
+          DSPACE_EXPECTED_REVISION: expectedRevision,
+          DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+        })
+      ).toThrow('restricted to approved recovery coordinates');
+    }
+  );
+
+  it('rejects unknown, empty, and contradictory identity contract inputs', () => {
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: 'future-contract',
+      })
+    ).toThrow('unknown identity contract');
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: '   ',
+      })
+    ).toThrow('identity contract requires a value');
+    expect(() =>
+      parseAndValidateArgs(['--identity-contract=   '], completeEnv)
+    ).toThrow('identity contract requires a value');
+    expect(() =>
+      parseAndValidateArgs(
+        [
+          '--identity-contract=build-info-v1',
+          '--identity-contract=legacy-build-meta-v1',
+        ],
+        completeEnv
+      )
+    ).toThrow('contradictory');
   });
 
   it.each([
@@ -99,7 +168,11 @@ describe('remote chat smoke input validation', () => {
 
   it('keeps malformed-input diagnostics bounded and free of supplied values', () => {
     const sentinel = 'operator-private-query-sentinel';
-    for (const argv of [[sentinel], [`--unknown=${sentinel}`]]) {
+    for (const argv of [
+      [sentinel],
+      [`--unknown=${sentinel}`],
+      [`--identity-contract=${sentinel}`],
+    ]) {
       let message = '';
       try {
         parseAndValidateArgs(argv, completeEnv);


### PR DESCRIPTION
### Motivation

- The remote non-mutating chat smoke harness must be able to verify a one-off immutable recovery artifact that predates the modern `/build-info.json` + HTML build marker without weakening modern checks.
- The legacy verification surface must be explicit, fail-closed, and allowlisted to a single approved coordinate pair so it cannot be used as a general fallback.

### Description

- Add an `--identity-contract` CLI flag and `DSPACE_EXPECTED_IDENTITY_CONTRACT` environment variable with the default `build-info-v1` and an additional allowed value `legacy-build-meta-v1` in `scripts/run-remote-chat-smoke.mjs`.
- Validate inputs strictly and fail early for unknown, empty, or contradictory contract values, and permit `legacy-build-meta-v1` only when `expectedVersion === "3.0.1"` and `expectedRevision === "1a31a569aff2dbeb238e8c2688b9e85140d2077d"`, propagating the selected contract into Playwright via `buildSmokeEnv`.
- Extend the Playwright E2E `frontend/e2e/remote-chat-smoke.spec.ts` to, when explicitly requested, validate same-origin `/build-meta.json` with `gitSha` equaling the full expected revision, a non-empty valid `generatedAt` timestamp, and a non-empty `source` string while preserving the strict modern `build-info-v1` JSON + HTML marker checks.
- Add focused unit tests in `scripts/tests/run-remote-chat-smoke.test.ts` to cover omission/default selection, explicit modern contract, allowlisted legacy acceptance, legacy rejection for other coordinates, unknown/empty/contradictory inputs, and propagation via `buildSmokeEnv`, and update operational docs `docs/ops/sugarkube-release.md` with the new default and the exact legacy invocation instructions.

### Testing

- Ran the focused unit tests with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts` and observed `22 tests passed` (all tests in that file passed).
- Checked formatting with `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts frontend/e2e/remote-chat-smoke.spec.ts docs/ops/sugarkube-release.md` and fixed with `prettier --write`, after which `--check` reported success.
- Ran repository checks `pnpm lint` and `pnpm type-check` and they completed successfully in this environment.
- Performed `git diff --check` to ensure no trailing issues remain and verified the changed files are limited to the smoke runner, its tests/spec, and the related docs as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2ae60a90832f893612efc830ca9d)