### PR TITLE
Support immutable 3.0.1 recovery identity smoke contract

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -195,6 +195,29 @@ DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
 npm run qa:remote-chat-smoke
 ```
 
+By default, the harness uses the strict `build-info-v1` identity contract: it verifies
+same-origin `/build-info.json` version, full and derived short revisions, and the exact HTML build
+revision marker. The contract may also be selected explicitly with
+`DSPACE_EXPECTED_IDENTITY_CONTRACT=build-info-v1` (or `--identity-contract=build-info-v1`).
+
+The immutable 3.0.1 recovery artifact predates those identity surfaces. It may be verified only
+with the explicitly selected legacy contract and its exact approved coordinates:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://democratized.space \
+DSPACE_EXPECTED_VERSION=3.0.1 \
+DSPACE_EXPECTED_REVISION=1a31a569aff2dbeb238e8c2688b9e85140d2077d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+This mode checks same-origin `/build-meta.json` and exists solely to verify that immutable recovery
+artifact. The runner rejects it for every other version/revision pair; it must not become an
+automatic or general fallback when modern identity verification fails.
+
 The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -11,6 +11,9 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
+const expectedIdentityContract = process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT as
+    | 'build-info-v1'
+    | 'legacy-build-meta-v1';
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -272,7 +275,38 @@ test.describe('release-aware remote chat smoke', () => {
         await clearUserData(page);
     });
 
-    test('identity: approved build identity matches JSON and HTML', async ({ page, request }) => {
+    test('identity: approved build identity matches selected contract', async ({
+        page,
+        request,
+    }) => {
+        if (expectedIdentityContract === 'legacy-build-meta-v1') {
+            const response = await request.get('/build-meta.json');
+            expect(
+                new URL(response.url()).origin,
+                'routing/configuration: /build-meta.json origin drift'
+            ).toBe(requestedOrigin);
+            expect(response.status(), 'identity: /build-meta.json did not return 200').toBe(200);
+            const identity: unknown = await response.json();
+            expect(
+                typeof identity === 'object' && identity !== null && !Array.isArray(identity),
+                'identity: /build-meta.json did not return an object'
+            ).toBe(true);
+            const legacyIdentity = identity as Record<string, unknown>;
+            expect(legacyIdentity.gitSha, 'identity: source-revision drift').toBe(expectedRevision);
+            expect(
+                typeof legacyIdentity.generatedAt === 'string' &&
+                    legacyIdentity.generatedAt.trim().length > 0 &&
+                    Number.isFinite(Date.parse(legacyIdentity.generatedAt)),
+                'identity: generatedAt must be a non-empty valid timestamp'
+            ).toBe(true);
+            expect(
+                typeof legacyIdentity.source === 'string' &&
+                    legacyIdentity.source.trim().length > 0,
+                'identity: source must be a non-empty string'
+            ).toBe(true);
+            return;
+        }
+
         const response = await request.get('/build-info.json');
         expect(
             new URL(response.url()).origin,

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -6,11 +6,17 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
+const defaultIdentityContract = 'build-info-v1';
+const legacyRecoveryCoordinates = {
+  version: '3.0.1',
+  revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
+};
 
 const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
   expectedVersion: ['expected-version', 'DSPACE_EXPECTED_VERSION'],
   expectedRevision: ['expected-revision', 'DSPACE_EXPECTED_REVISION'],
+  identityContract: ['identity-contract', 'DSPACE_EXPECTED_IDENTITY_CONTRACT'],
   expectedProvider: ['expected-provider', 'DSPACE_EXPECTED_PROVIDER'],
   expectedTokenPlaceOrigin: [
     'expected-token-place-origin',
@@ -48,8 +54,16 @@ export function parseAndValidateArgs(argv, env = process.env) {
     // Explicit flags deterministically take precedence over the environment.
     result[key] = flags.get(flag) ?? env[environment]?.trim();
   }
+  if (result.identityContract === undefined) {
+    result.identityContract = defaultIdentityContract;
+  }
   const missing = Object.entries(definitions)
-    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .filter(
+      ([key]) =>
+        !result[key] &&
+        key !== 'identityContract' &&
+        !key.startsWith('expectedTokenPlace')
+    )
     .map(([, [, environment]]) => environment);
   if (missing.length)
     throw new Error(
@@ -100,6 +114,22 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (!/^[0-9a-f]{40}$/.test(result.expectedRevision)) {
     throw new Error(
       'validation: expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (
+    !['build-info-v1', 'legacy-build-meta-v1'].includes(result.identityContract)
+  ) {
+    throw new Error(
+      'validation: identity contract must be build-info-v1 or legacy-build-meta-v1'
+    );
+  }
+  if (
+    result.identityContract === 'legacy-build-meta-v1' &&
+    (result.expectedVersion !== legacyRecoveryCoordinates.version ||
+      result.expectedRevision !== legacyRecoveryCoordinates.revision)
+  ) {
+    throw new Error(
+      'validation: legacy identity contract is restricted to the approved recovery build'
     );
   }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
@@ -166,6 +196,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
     DSPACE_EXPECTED_VERSION: options.expectedVersion,
     DSPACE_EXPECTED_REVISION: options.expectedRevision,
+    DSPACE_EXPECTED_IDENTITY_CONTRACT: options.identityContract,
     DSPACE_EXPECTED_PROVIDER: options.expectedProvider,
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
+const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -18,8 +19,67 @@ describe('remote chat smoke input validation', () => {
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');
+    expect(options.identityContract).toBe('build-info-v1');
     expect(buildSmokeEnv(options, {}).REMOTE_CHAT_SMOKE_USE_WEBSERVER).toBe(
       '0'
+    );
+  });
+
+  it('accepts an explicit modern identity contract', () => {
+    expect(
+      parseAndValidateArgs(['--identity-contract=build-info-v1'], completeEnv)
+        .identityContract
+    ).toBe('build-info-v1');
+  });
+
+  it('accepts the legacy identity contract only for the recovery build', () => {
+    const recoveryEnv = {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.0.1',
+      DSPACE_EXPECTED_REVISION: recoveryRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+    };
+    const options = parseAndValidateArgs([], recoveryEnv);
+    expect(options.identityContract).toBe('legacy-build-meta-v1');
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'legacy-build-meta-v1'
+    );
+
+    for (const env of [
+      { ...recoveryEnv, DSPACE_EXPECTED_VERSION: '3.0.2' },
+      { ...recoveryEnv, DSPACE_EXPECTED_REVISION: revision },
+    ]) {
+      expect(() => parseAndValidateArgs([], env)).toThrow(
+        'restricted to the approved recovery build'
+      );
+    }
+  });
+
+  it('rejects unknown, empty, and contradictory identity contracts', () => {
+    expect(() =>
+      parseAndValidateArgs(['--identity-contract=unknown'], completeEnv)
+    ).toThrow('identity contract must be');
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: ' ',
+      })
+    ).toThrow('identity contract must be');
+    expect(() =>
+      parseAndValidateArgs(
+        [
+          '--identity-contract=build-info-v1',
+          '--identity-contract=legacy-build-meta-v1',
+        ],
+        completeEnv
+      )
+    ).toThrow('contradictory');
+  });
+
+  it('propagates the default identity contract to Playwright', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'build-info-v1'
     );
   });
 
@@ -99,7 +159,11 @@ describe('remote chat smoke input validation', () => {
 
   it('keeps malformed-input diagnostics bounded and free of supplied values', () => {
     const sentinel = 'operator-private-query-sentinel';
-    for (const argv of [[sentinel], [`--unknown=${sentinel}`]]) {
+    for (const argv of [
+      [sentinel],
+      [`--unknown=${sentinel}`],
+      [`--identity-contract=${sentinel}`],
+    ]) {
       let message = '';
       try {
         parseAndValidateArgs(argv, completeEnv);


### PR DESCRIPTION
### Motivation
- The remote chat smoke harness must be able to verify an immutable DSPACE 3.0.1 recovery artifact that exposes legacy identity metadata (`/build-meta.json`) without rebuilding or weakening the modern `/build-info.json` checks.
- The legacy identity surface is older and incomplete, so selection of a weaker legacy contract must be explicit, tightly allowlisted, and fail-closed to avoid becoming a general fallback.

### Description
- Add `--identity-contract` CLI flag and `DSPACE_EXPECTED_IDENTITY_CONTRACT` environment variable accepting `build-info-v1` (default) or `legacy-build-meta-v1`, with bounded validation and contradiction detection in `scripts/run-remote-chat-smoke.mjs`.
- Restrict `legacy-build-meta-v1` to the exact approved recovery coordinates (version `3.0.1` and revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`) and propagate the selected contract into Playwright via the environment.
- Extend Playwright spec `frontend/e2e/remote-chat-smoke.spec.ts` to validate the selected contract: keep the strict modern `build-info-v1` checks unchanged and add the explicit legacy `/build-meta.json` checks (HTTP 200, object shape, `gitSha` equals expected revision, non-empty valid `generatedAt`, and non-empty `source`).
- Add focused unit tests in `scripts/tests/run-remote-chat-smoke.test.ts` covering default selection, explicit modern selection, acceptance of the legacy contract only for the recovery build, rejection of other version/revision pairs, unknown/empty/contradictory inputs, and propagation to Playwright; and update operational docs `docs/ops/sugarkube-release.md` to document default and legacy invocation rules.

### Testing
- `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts` — all tests passed (21/21).
- `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts docs/ops/sugarkube-release.md` and `pnpm exec prettier --config frontend/.prettierrc --check frontend/e2e/remote-chat-smoke.spec.ts` — formatting checked and fixed where necessary, final checks passed.
- `pnpm lint` — frontend lint run completed without new failures.
- `pnpm type-check` — TypeScript checks ran (`build:meta` and `build:docs-rag` executed) and completed successfully.
- `git diff --check` and repository checks were run locally to ensure no style or whitespace errors remain.

All automated checks listed above completed successfully in the authoring environment; Playwright end-to-end execution against live targets was not performed here and remains subject to available browsers/remote endpoints during CI or manual runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2af23354832fb375445786fdc10c)