### PR TITLE
Add explicit legacy recovery identity contract to remote chat smoke

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -195,6 +195,28 @@ DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
 npm run qa:remote-chat-smoke
 ```
 
+When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-info-v1`
+contract, which strictly checks same-origin `/build-info.json` version, full and short revisions,
+and the HTML build-revision marker. The immutable 3.0.1 recovery artifact predates those surfaces;
+verify that artifact explicitly with its legacy public metadata contract:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://democratized.space \
+DSPACE_EXPECTED_VERSION=3.0.1 \
+DSPACE_EXPECTED_REVISION=1a31a569aff2dbeb238e8c2688b9e85140d2077d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+The legacy mode verifies same-origin `/build-meta.json`, including the exact full `gitSha`, a valid
+non-empty `generatedAt` timestamp, and a non-empty `source`. It is allowlisted only for application
+version `3.0.1` at revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`, solely to verify that
+immutable recovery artifact. It must not become a general fallback: the harness never selects it
+automatically after a missing or malformed modern identity response.
+
 The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -11,6 +11,9 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
+const identityContract = process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT as
+    | 'build-info-v1'
+    | 'legacy-build-meta-v1';
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -273,6 +276,40 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('identity: approved build identity matches JSON and HTML', async ({ page, request }) => {
+        if (identityContract === 'legacy-build-meta-v1') {
+            const response = await request.get('/build-meta.json');
+            expect(
+                new URL(response.url()).origin,
+                'routing/configuration: /build-meta.json origin drift'
+            ).toBe(requestedOrigin);
+            expect(response.status(), 'identity: /build-meta.json did not return 200').toBe(200);
+            const identity = await response.json();
+            expect(typeof identity, 'identity: legacy build metadata must be an object').toBe(
+                'object'
+            );
+            expect(identity, 'identity: legacy build metadata must not be null').not.toBeNull();
+            expect(
+                Array.isArray(identity),
+                'identity: legacy build metadata must not be an array'
+            ).toBe(false);
+            expect(identity.gitSha, 'identity: source-revision drift').toBe(expectedRevision);
+            expect(
+                identity.generatedAt,
+                'identity: generatedAt must be a non-empty timestamp'
+            ).toEqual(expect.any(String));
+            expect(identity.generatedAt.trim(), 'identity: generatedAt must be non-empty').not.toBe(
+                ''
+            );
+            expect(
+                Number.isNaN(Date.parse(identity.generatedAt)),
+                'identity: generatedAt must be a valid timestamp'
+            ).toBe(false);
+            expect(identity.source, 'identity: source must be a non-empty string').toEqual(
+                expect.any(String)
+            );
+            expect(identity.source.trim(), 'identity: source must be non-empty').not.toBe('');
+            return;
+        }
         const response = await request.get('/build-info.json');
         expect(
             new URL(response.url()).origin,

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -6,11 +6,17 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
+const defaultIdentityContract = 'build-info-v1';
+const legacyRecoveryIdentity = {
+  version: '3.0.1',
+  revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
+};
 
 const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
   expectedVersion: ['expected-version', 'DSPACE_EXPECTED_VERSION'],
   expectedRevision: ['expected-revision', 'DSPACE_EXPECTED_REVISION'],
+  identityContract: ['identity-contract', 'DSPACE_EXPECTED_IDENTITY_CONTRACT'],
   expectedProvider: ['expected-provider', 'DSPACE_EXPECTED_PROVIDER'],
   expectedTokenPlaceOrigin: [
     'expected-token-place-origin',
@@ -40,13 +46,24 @@ export function parseAndValidateArgs(argv, env = process.env) {
     if (flags.has(name) && flags.get(name) !== value) {
       throw new Error(`validation: contradictory values for --${name}`);
     }
-    flags.set(name, value.trim());
+    const trimmedValue = value.trim();
+    if (!trimmedValue)
+      throw new Error(`validation: --${name} requires a value`);
+    flags.set(name, trimmedValue);
   }
 
   const result = {};
   for (const [key, [flag, environment]] of Object.entries(definitions)) {
     // Explicit flags deterministically take precedence over the environment.
-    result[key] = flags.get(flag) ?? env[environment]?.trim();
+    const environmentValue = env[environment];
+    if (flags.has(flag)) result[key] = flags.get(flag);
+    else if (environmentValue !== undefined) {
+      result[key] = environmentValue.trim();
+      if (key === 'identityContract' && !result[key])
+        throw new Error(`validation: ${environment} requires a value`);
+    } else if (key === 'identityContract') {
+      result[key] = defaultIdentityContract;
+    }
   }
   const missing = Object.entries(definitions)
     .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
@@ -100,6 +117,20 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (!/^[0-9a-f]{40}$/.test(result.expectedRevision)) {
     throw new Error(
       'validation: expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (
+    !['build-info-v1', 'legacy-build-meta-v1'].includes(result.identityContract)
+  ) {
+    throw new Error('validation: unknown identity contract');
+  }
+  if (
+    result.identityContract === 'legacy-build-meta-v1' &&
+    (result.expectedVersion !== legacyRecoveryIdentity.version ||
+      result.expectedRevision !== legacyRecoveryIdentity.revision)
+  ) {
+    throw new Error(
+      'validation: legacy identity contract is restricted to the approved recovery build'
     );
   }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
@@ -166,6 +197,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     PLAYWRIGHT_SKIP_INSTALL_DEPS: '1',
     DSPACE_EXPECTED_VERSION: options.expectedVersion,
     DSPACE_EXPECTED_REVISION: options.expectedRevision,
+    DSPACE_EXPECTED_IDENTITY_CONTRACT: options.identityContract,
     DSPACE_EXPECTED_PROVIDER: options.expectedProvider,
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',
@@ -188,6 +220,9 @@ export function main(argv = process.argv.slice(2)) {
   );
   console.log(
     `[qa:remote-chat-smoke] expectedRevision=${options.expectedRevision}`
+  );
+  console.log(
+    `[qa:remote-chat-smoke] identityContract=${options.identityContract}`
   );
   console.log(
     `[qa:remote-chat-smoke] expectedProvider=${options.expectedProvider}`

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
+const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -18,8 +19,74 @@ describe('remote chat smoke input validation', () => {
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');
+    expect(options.identityContract).toBe('build-info-v1');
     expect(buildSmokeEnv(options, {}).REMOTE_CHAT_SMOKE_USE_WEBSERVER).toBe(
       '0'
+    );
+  });
+
+  it('accepts the explicit modern identity contract', () => {
+    expect(
+      parseAndValidateArgs(['--identity-contract=build-info-v1'], completeEnv)
+        .identityContract
+    ).toBe('build-info-v1');
+  });
+
+  it('accepts the legacy contract only for the immutable recovery build', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.0.1',
+      DSPACE_EXPECTED_REVISION: recoveryRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+    });
+    expect(options.identityContract).toBe('legacy-build-meta-v1');
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'legacy-build-meta-v1'
+    );
+  });
+
+  it.each([
+    ['3.0.2', recoveryRevision],
+    ['3.0.1', revision],
+  ])(
+    'rejects legacy identity for version %s and revision %s',
+    (version, sha) => {
+      expect(() =>
+        parseAndValidateArgs([], {
+          ...completeEnv,
+          DSPACE_EXPECTED_VERSION: version,
+          DSPACE_EXPECTED_REVISION: sha,
+          DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+        })
+      ).toThrow('restricted to the approved recovery build');
+    }
+  );
+
+  it('rejects unknown, empty, and contradictory identity contracts', () => {
+    expect(() =>
+      parseAndValidateArgs(['--identity-contract=unknown'], completeEnv)
+    ).toThrow('unknown identity contract');
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: ' ',
+      })
+    ).toThrow('requires a value');
+    expect(() =>
+      parseAndValidateArgs(
+        [
+          '--identity-contract=build-info-v1',
+          '--identity-contract=legacy-build-meta-v1',
+        ],
+        completeEnv
+      )
+    ).toThrow('contradictory');
+  });
+
+  it('propagates the default modern identity contract', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
+      'build-info-v1'
     );
   });
 
@@ -99,7 +166,11 @@ describe('remote chat smoke input validation', () => {
 
   it('keeps malformed-input diagnostics bounded and free of supplied values', () => {
     const sentinel = 'operator-private-query-sentinel';
-    for (const argv of [[sentinel], [`--unknown=${sentinel}`]]) {
+    for (const argv of [
+      [sentinel],
+      [`--unknown=${sentinel}`],
+      [`--identity-contract=${sentinel}`],
+    ]) {
       let message = '';
       try {
         parseAndValidateArgs(argv, completeEnv);


### PR DESCRIPTION
### Motivation
- The immutable DSPACE 3.0.1 recovery artifact predates `/build-info.json` and the HTML build-revision marker and must be verifiable with a separate, allowlisted legacy identity contract. 
- The remote chat smoke harness must support an explicit, fail-closed selection of that legacy contract without weakening existing modern identity checks or enabling automatic fallback.

### Description
- Add `--identity-contract` CLI flag and `DSPACE_EXPECTED_IDENTITY_CONTRACT` environment variable with allowed values `build-info-v1` and `legacy-build-meta-v1`, defaulting to `build-info-v1` when omitted. 
- Restrict `legacy-build-meta-v1` to the exact allowlist (application `3.0.1` and revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`), validate and reject unknown/empty/contradictory inputs, and propagate the selected contract into Playwright via `DSPACE_EXPECTED_IDENTITY_CONTRACT`.
- Extend the Playwright smoke spec so that when the legacy contract is explicitly selected it requests same-origin `/build-meta.json` and requires HTTP 200 plus shape- and content-level checks for `gitSha` (exact full revision), `generatedAt` (non-empty valid timestamp), and `source` (non-empty string), while preserving all modern `build-info.json` and HTML-marker checks unchanged.
- Add unit tests covering default behavior, explicit modern contract, legacy acceptance for the exact recovery coordinates, legacy rejection for other coordinates, unknown/empty/contradictory inputs, env propagation, and bounded/redacted diagnostics; and update operational docs (`docs/ops/sugarkube-release.md`) to document the default and the one-off legacy invocation and its restriction.

### Testing
- `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts` — ran the focused unit tests; result: all tests passed (23/23).
- `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts frontend/e2e/remote-chat-smoke.spec.ts docs/ops/sugarkube-release.md` — formatting check passed after formatting run (no style violations remained).
- `pnpm lint` — frontend lint run completed with no blocking failures.
- `pnpm type-check` — TypeScript/type-check step completed successfully (built meta/docs rag as part of the check).

All automated checks listed above passed in the authoring environment; no Playwright browser E2E run against a remote runtime was executed here as part of these unit/CI-style checks. The change preserves strict modern identity verification and only enables the legacy contract when the exact immutable 3.0.1 coordinates are selected explicitly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2af526f0832f9b1a20fff4151278)