### PR TITLE
Fix DSPACE 3.0.1 recovery chat smoke compatibility

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -221,10 +221,13 @@ The command is non-destructive: it uses a new isolated browser context, clears b
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared
 production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
-submission, classified availability, or secret-safety drift. OpenAI-default verification omits the
-two token.place expectations; the harness still proves that OpenAI is discoverable and missing-key
-gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
-gate.
+submission, classified availability, or secret-safety drift. Modern OpenAI-default verification
+omits the two token.place expectations while still proving that OpenAI is discoverable and
+missing-key gated. The exact legacy 3.0.1 contract instead verifies the immutable UI's inline key
+configuration using only a hard-coded fake sentinel and requires a mocked successful OpenAI reply;
+it does not imply that the immutable application has modern settings or missing-key behavior. Both
+modes deny unmatched or live provider traffic and require no real credential. This is the
+DSPACE-side harness only, not Sugarkube's promotion gate.
 
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,0 +1,8 @@
+export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
+
+export function chatUiContractFor(identityContract: IdentityContract): ChatUiContract {
+    return identityContract === 'legacy-build-meta-v1'
+        ? 'legacy-inline-openai-v1'
+        : 'modern-settings-v1';
+}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
+import { chatUiContractFor, type IdentityContract } from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -11,8 +12,6 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
-type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
-
 function normalizeIdentityContract(value: string | undefined): IdentityContract {
     if (value === undefined) return 'build-info-v1';
 
@@ -25,6 +24,7 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
+const chatUiContract = chatUiContractFor(identityContract);
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -340,8 +340,59 @@ test.describe('release-aware remote chat smoke', () => {
     test('routing/configuration and submission: approved default journey', async ({ page }) => {
         if (expectedProvider === 'openai') {
             let openAICalls = 0;
-            let credentialPresent = false;
+            let sentinelCredentialPresent = false;
             await installProviderDenyRules(page);
+            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
+
+            if (chatUiContract === 'legacy-inline-openai-v1') {
+                const panel = await openExpectedPanel(page, 'openai');
+                await expect(
+                    page.getByTestId('token-place-disabled-banner'),
+                    'routing/configuration: token.place opt-in state is not visible'
+                ).toBeVisible();
+                await expect(
+                    page.locator('[data-testid="chat-panel"][data-provider="token-place"]'),
+                    'routing/configuration: token.place unexpectedly became active'
+                ).toHaveCount(0);
+                await page.locator('.api-container input[type="text"]').fill(fakeKey);
+                await page.locator('.api-container button[type="submit"]').click();
+                await page.route('https://api.openai.com/v1/responses', async (route) => {
+                    openAICalls += 1;
+                    sentinelCredentialPresent =
+                        route.request().headers().authorization === `Bearer ${fakeKey}`;
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({
+                            id: 'resp_smoke',
+                            object: 'response',
+                            status: 'completed',
+                            output: [
+                                {
+                                    type: 'message',
+                                    role: 'assistant',
+                                    content: [
+                                        { type: 'output_text', text: 'DSPACE OpenAI smoke reply.' },
+                                    ],
+                                },
+                            ],
+                        }),
+                    });
+                });
+                const reloadedPanel = await openExpectedPanel(page, 'openai');
+                await reloadedPanel.getByRole('textbox').fill('Mocked OpenAI smoke');
+                await reloadedPanel.getByRole('button', { name: 'Send' }).click();
+                await expect(
+                    reloadedPanel.getByText('DSPACE OpenAI smoke reply.'),
+                    'submission: no mocked OpenAI reply'
+                ).toBeVisible();
+                expect({ openAICalls, sentinelCredentialPresent }).toEqual({
+                    openAICalls: 1,
+                    sentinelCredentialPresent: true,
+                });
+                return;
+            }
+
             let panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Key gate smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
@@ -350,11 +401,10 @@ test.describe('release-aware remote chat smoke', () => {
                 'routing/configuration: OpenAI key gate'
             ).toHaveAttribute('data-error-type', 'missing-key');
             expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
-            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
             await selectOpenAI(page, fakeKey);
             await page.route('https://api.openai.com/v1/responses', async (route) => {
                 openAICalls += 1;
-                credentialPresent =
+                sentinelCredentialPresent =
                     route.request().headers().authorization?.startsWith('Bearer ') === true;
                 await route.fulfill({
                     status: 200,
@@ -382,9 +432,9 @@ test.describe('release-aware remote chat smoke', () => {
                 panel.getByText('DSPACE OpenAI smoke reply.'),
                 'submission: no mocked OpenAI reply'
             ).toBeVisible();
-            expect({ openAICalls, credentialPresent }).toEqual({
+            expect({ openAICalls, sentinelCredentialPresent }).toEqual({
                 openAICalls: 1,
-                credentialPresent: true,
+                sentinelCredentialPresent: true,
             });
             return;
         }
@@ -466,6 +516,10 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
+        test.skip(
+            chatUiContract === 'legacy-inline-openai-v1',
+            'Legacy recovery uses inline fake-key verification'
+        );
         let providerCalls = 0;
         await installProviderDenyRules(page);
         page.on('request', (request) => {

--- a/frontend/tests/remoteChatSmokeContract.test.ts
+++ b/frontend/tests/remoteChatSmokeContract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { chatUiContractFor } from '../e2e/remote-chat-smoke-contract';
+
+describe('remote chat smoke UI contract selection', () => {
+    it('uses modern settings for modern build identity', () => {
+        expect(chatUiContractFor('build-info-v1')).toBe('modern-settings-v1');
+    });
+
+    it('uses inline OpenAI configuration for the immutable recovery identity', () => {
+        expect(chatUiContractFor('legacy-build-meta-v1')).toBe('legacy-inline-openai-v1');
+    });
+});


### PR DESCRIPTION
### Motivation
- The release-aware remote `/chat` smoke harness failed when run against the immutable 3.0.1 recovery artifact because the harness attempted modern `/settings`-based OpenAI discoverability and missing-key gating instead of the immutable build's inline key flow, causing the OpenAI deny route and a discoverability timeout. The goal is to make the harness correctly verify the exact 3.0.1 legacy contract without weakening modern checks or using any real credential.

### Description
- Add a tiny UI-contract selector in `frontend/e2e/remote-chat-smoke-contract.ts` and a unit test `frontend/tests/remoteChatSmokeContract.test.ts` to choose between `modern-settings-v1` and `legacy-inline-openai-v1` based on the identity contract.
- Update `frontend/e2e/remote-chat-smoke.spec.ts` to branch on the UI contract: for `legacy-inline-openai-v1` the test now verifies one hydrated OpenAI panel, visible token.place-disabled banner, no active token.place panel, fills the immutable inline `/chat` API-key form with a hard-coded sentinel, registers deny routes before the exact mocked `https://api.openai.com/v1/responses` mock, requires exactly one intercepted OpenAI request using the sentinel, and requires the mocked reply to be visible; for modern `build-info-v1` paths the existing settings-based missing-key gating and mocked OpenAI success remain unchanged.
- Update `docs/ops/sugarkube-release.md` to document that modern verification remains missing-key gated and that the exact legacy 3.0.1 contract uses the inline sentinel+mocked-response verification, and that both modes deny unmatched/live provider traffic and require no real credential.
- Preserve the scope lock: no runtime application code, credentials, or deployment artifacts were changed, and provider traffic is fully intercepted by tests.

### Testing
- Ran the focused unit and harness input tests: `pnpm exec vitest run frontend/tests/remoteChatSmokeContract.test.ts scripts/tests/run-remote-chat-smoke.test.ts --testTimeout=20000` — all tests passed (25 tests).
- Static checks and helpers: `node --check scripts/run-remote-chat-smoke.mjs` succeeded, `pnpm exec prettier --check` for affected files succeeded, `npm run type-check` succeeded, and `npm run check` succeeded.
- Secrets scan: `git diff | ./scripts/scan-secrets.py` reported no committed secrets.
- Note: a full `SKIP_E2E=1 npm test` run was started but was manually stopped while the broad root suite continued; focused tests and required static checks listed above passed.
- Operational follow-up required: rerun the live staging verification after merge using the exact `legacy-build-meta-v1` coordinates (`DSPACE_EXPECTED_VERSION=3.0.1`, `DSPACE_EXPECTED_REVISION=1a31a569aff2dbeb238e8c2688b9e85140d2077d`, `DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1`, `DSPACE_EXPECTED_PROVIDER=openai`) because CI alone does not prove recovery deployment success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70058b9298832fa5c5396a1cf0b40f)