### PR TITLE
Fix 3.0.1 recovery chat smoke compatibility

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -221,10 +221,13 @@ The command is non-destructive: it uses a new isolated browser context, clears b
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared
 production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
-submission, classified availability, or secret-safety drift. OpenAI-default verification omits the
-two token.place expectations; the harness still proves that OpenAI is discoverable and missing-key
-gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
-gate.
+submission, classified availability, or secret-safety drift. Modern OpenAI-default verification
+omits the two token.place expectations and proves that OpenAI is discoverable and missing-key gated.
+The exact legacy 3.0.1 recovery contract instead verifies the immutable UI's inline `/chat` key
+configuration with a hard-coded fake sentinel and requires a successful mocked OpenAI response; it
+does not assume that the immutable application has modern settings or missing-key behavior. Both
+modes deny unmatched or live provider traffic and require no real credential. This is the
+DSPACE-side harness only, not Sugarkube's promotion gate.
 
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,0 +1,8 @@
+export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-key-v1';
+
+export function chatUiContractForIdentity(identityContract: IdentityContract): ChatUiContract {
+    return identityContract === 'legacy-build-meta-v1'
+        ? 'legacy-inline-key-v1'
+        : 'modern-settings-v1';
+}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
+import { chatUiContractForIdentity, type IdentityContract } from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -11,8 +12,6 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
-type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
-
 function normalizeIdentityContract(value: string | undefined): IdentityContract {
     if (value === undefined) return 'build-info-v1';
 
@@ -25,6 +24,7 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
+const chatUiContract = chatUiContractForIdentity(identityContract);
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -341,21 +341,11 @@ test.describe('release-aware remote chat smoke', () => {
         if (expectedProvider === 'openai') {
             let openAICalls = 0;
             let credentialPresent = false;
-            await installProviderDenyRules(page);
-            let panel = await openExpectedPanel(page);
-            await panel.getByRole('textbox').fill('Key gate smoke');
-            await panel.getByRole('button', { name: 'Send' }).click();
-            await expect(
-                panel.locator('.chat-error'),
-                'routing/configuration: OpenAI key gate'
-            ).toHaveAttribute('data-error-type', 'missing-key');
-            expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
             const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
-            await selectOpenAI(page, fakeKey);
+            await installProviderDenyRules(page);
             await page.route('https://api.openai.com/v1/responses', async (route) => {
                 openAICalls += 1;
-                credentialPresent =
-                    route.request().headers().authorization?.startsWith('Bearer ') === true;
+                credentialPresent = route.request().headers().authorization === `Bearer ${fakeKey}`;
                 await route.fulfill({
                     status: 200,
                     contentType: 'application/json',
@@ -375,6 +365,40 @@ test.describe('release-aware remote chat smoke', () => {
                     }),
                 });
             });
+            let panel = await openExpectedPanel(page);
+            if (chatUiContract === 'legacy-inline-key-v1') {
+                await expect(
+                    page.getByTestId('token-place-disabled-banner'),
+                    'routing/configuration: token.place opt-in state is not visible'
+                ).toBeVisible();
+                await expect(
+                    page.locator('[data-testid="chat-panel"][data-provider="token-place"]'),
+                    'routing/configuration: token.place must not be active'
+                ).toHaveCount(0);
+                const inlineKeyForm = page.locator('.api-container form');
+                await inlineKeyForm.locator('input[type="text"]').fill(fakeKey);
+                await inlineKeyForm.getByRole('button', { name: 'Submit', exact: true }).click();
+                panel = await openExpectedPanel(page, 'openai');
+                await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
+                await panel.getByRole('button', { name: 'Send' }).click();
+                await expect(
+                    panel.getByText('DSPACE OpenAI smoke reply.'),
+                    'submission: no mocked OpenAI reply'
+                ).toBeVisible();
+                expect({ openAICalls, credentialPresent }).toEqual({
+                    openAICalls: 1,
+                    credentialPresent: true,
+                });
+                return;
+            }
+            await panel.getByRole('textbox').fill('Key gate smoke');
+            await panel.getByRole('button', { name: 'Send' }).click();
+            await expect(
+                panel.locator('.chat-error'),
+                'routing/configuration: OpenAI key gate'
+            ).toHaveAttribute('data-error-type', 'missing-key');
+            expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
+            await selectOpenAI(page, fakeKey);
             panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
@@ -466,6 +490,10 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
+        test.skip(
+            chatUiContract === 'legacy-inline-key-v1',
+            'Legacy recovery uses inline key configuration and has no modern provider selector'
+        );
         let providerCalls = 0;
         await installProviderDenyRules(page);
         page.on('request', (request) => {

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -3,6 +3,7 @@ import {
   buildSmokeEnv,
   parseAndValidateArgs,
 } from '../run-remote-chat-smoke.mjs';
+import { chatUiContractForIdentity } from '../../frontend/e2e/remote-chat-smoke-contract';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
 const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
@@ -16,6 +17,15 @@ const completeEnv = {
 };
 
 describe('remote chat smoke input validation', () => {
+  it('selects the chat UI contract from the validated identity contract', () => {
+    expect(chatUiContractForIdentity('build-info-v1')).toBe(
+      'modern-settings-v1'
+    );
+    expect(chatUiContractForIdentity('legacy-build-meta-v1')).toBe(
+      'legacy-inline-key-v1'
+    );
+  });
+
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');


### PR DESCRIPTION
### Motivation

- The release-aware remote `/chat` smoke harness failed against the immutable 3.0.1 recovery artifact because the test attempted to use modern `/settings`-based OpenAI discovery and a missing-key assertion while the immutable UI instead exposes an inline `/chat` API-key form, which caused an empty-key request to hit the broad `https://api.openai.com/**` deny route and the modern selector discovery to time out.
- The harness must verify the exact legacy 3.0.1 contract (version `3.0.1`, revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`) without weakening modern verification or contacting live providers or accepting real credentials.

### Description

- Added a tiny pure mapping helper `frontend/e2e/remote-chat-smoke-contract.ts` that selects the chat UI contract (`modern-settings-v1` vs `legacy-inline-key-v1`) from the validated identity contract.
- Modified `frontend/e2e/remote-chat-smoke.spec.ts` to preserve the modern settings/missing-key flow while adding a legacy path that: registers broad provider deny rules first and the exact mocked `https://api.openai.com/v1/responses` route afterward; verifies the token.place disabled/opt-in banner is visible and no token.place panel is active; fills the immutable build's inline API-key form with the existing hard-coded fake sentinel (never a real credential); submits a deterministic message and requires the mocked OpenAI reply; and asserts exactly one OpenAI request used the sentinel without printing it.
- Added focused regression coverage in `scripts/tests/run-remote-chat-smoke.test.ts` to assert that `build-info-v1` selects the modern UI contract and `legacy-build-meta-v1` selects the legacy inline-key contract.
- Updated `docs/ops/sugarkube-release.md` to clearly document the difference: modern verification remains missing-key gated via `/settings`, while the exact immutable 3.0.1 recovery contract verifies an inline `/chat` key flow using a mocked sentinel and mocked OpenAI response; both modes continue to deny unmatched/live provider traffic and require no real credential.
- No application runtime code was changed; the patch touches only the smoke harness tests, a tiny helper, and documentation, and keeps all deny/mocking behavior strict.

### Testing

- Ran the focused unit/regression tests with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts` and observed all tests pass (`24 tests passed`).
- Performed static/check steps: `git diff --check`, `node --check scripts/run-remote-chat-smoke.mjs`, `npm run type-check`, and `npm run check`, all of which completed without error in the available run.
- Ensured formatting with `cd frontend && pnpm exec prettier --check e2e/remote-chat-smoke.spec.ts e2e/remote-chat-smoke-contract.ts` (fixed one stylistic warning with `prettier --write`), and re-ran the check to confirm compliance.
- Ran repository secret scans via `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no secrets reported; the sentinel key is an explicit test sentinel and is not a real credential (and is not printed in logs/assertions).
- Notes and limitations: `SKIP_E2E=1 npm test` (full precommit PR suite) was started but did not complete within the available execution window so the comprehensive single-worker root suite did not finish here; focused tests and repository checks listed above succeeded.

Operational follow-up: live staging verification must be rerun after merge using the exact `legacy-build-meta-v1` 3.0.1 coordinates to confirm recovery end-to-end; CI and these local checks do not by themselves establish that recovery is complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70057aea68832fbf0b958dfa7362c4)