### PR TITLE
Fix DSPACE 3.0.1 recovery chat smoke compatibility

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -221,10 +221,15 @@ The command is non-destructive: it uses a new isolated browser context, clears b
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared
 production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
-submission, classified availability, or secret-safety drift. OpenAI-default verification omits the
-two token.place expectations; the harness still proves that OpenAI is discoverable and missing-key
-gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
-gate.
+submission, classified availability, or secret-safety drift. Under the modern contract,
+OpenAI-default verification omits the two token.place expectations but still proves that OpenAI is
+discoverable in settings and missing-key gated. The exact legacy 3.0.1 contract instead proves that
+OpenAI is the hydrated default, token.place remains visibly disabled pending opt-in, and the inline
+key editor can submit through a mocked successful OpenAI response using only the harness's fake
+sentinel credential. Neither mode needs a real credential: both deny unmatched provider traffic and
+never contact a live provider. The legacy assertions describe the harness compatibility contract,
+not modern settings or missing-key behavior in the immutable application. This is the DSPACE-side
+harness only, not Sugarkube's promotion gate.
 
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,0 +1,9 @@
+export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+
+export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
+
+export function selectChatUiContract(identityContract: IdentityContract): ChatUiContract {
+    return identityContract === 'legacy-build-meta-v1'
+        ? 'legacy-inline-openai-v1'
+        : 'modern-settings-v1';
+}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
+import { selectChatUiContract, type IdentityContract } from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -11,8 +12,6 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
-type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
-
 function normalizeIdentityContract(value: string | undefined): IdentityContract {
     if (value === undefined) return 'build-info-v1';
 
@@ -25,6 +24,7 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
+const chatUiContract = selectChatUiContract(identityContract);
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -341,21 +341,33 @@ test.describe('release-aware remote chat smoke', () => {
         if (expectedProvider === 'openai') {
             let openAICalls = 0;
             let credentialPresent = false;
+            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
             await installProviderDenyRules(page);
             let panel = await openExpectedPanel(page);
-            await panel.getByRole('textbox').fill('Key gate smoke');
-            await panel.getByRole('button', { name: 'Send' }).click();
-            await expect(
-                panel.locator('.chat-error'),
-                'routing/configuration: OpenAI key gate'
-            ).toHaveAttribute('data-error-type', 'missing-key');
-            expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
-            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
-            await selectOpenAI(page, fakeKey);
+            if (chatUiContract === 'modern-settings-v1') {
+                await panel.getByRole('textbox').fill('Key gate smoke');
+                await panel.getByRole('button', { name: 'Send' }).click();
+                await expect(
+                    panel.locator('.chat-error'),
+                    'routing/configuration: OpenAI key gate'
+                ).toHaveAttribute('data-error-type', 'missing-key');
+                expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(
+                    0
+                );
+                await selectOpenAI(page, fakeKey);
+            } else {
+                await expect(
+                    page.getByTestId('token-place-disabled-banner'),
+                    'routing/configuration: token.place opt-in state is not visible'
+                ).toBeVisible();
+                await expect(
+                    page.locator('[data-testid="chat-panel"][data-provider="token-place"]'),
+                    'routing/configuration: token.place became active'
+                ).toHaveCount(0);
+            }
             await page.route('https://api.openai.com/v1/responses', async (route) => {
                 openAICalls += 1;
-                credentialPresent =
-                    route.request().headers().authorization?.startsWith('Bearer ') === true;
+                credentialPresent = route.request().headers().authorization === `Bearer ${fakeKey}`;
                 await route.fulfill({
                     status: 200,
                     contentType: 'application/json',
@@ -375,6 +387,13 @@ test.describe('release-aware remote chat smoke', () => {
                     }),
                 });
             });
+            if (chatUiContract === 'legacy-inline-openai-v1') {
+                await page.locator('.api-container input[type="text"]').fill(fakeKey);
+                await page
+                    .locator('.api-container')
+                    .getByRole('button', { name: 'Submit', exact: true })
+                    .click();
+            }
             panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
@@ -466,6 +485,10 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
+        test.skip(
+            chatUiContract === 'legacy-inline-openai-v1',
+            'Legacy recovery uses inline fake-key verification in the approved journey'
+        );
         let providerCalls = 0;
         await installProviderDenyRules(page);
         page.on('request', (request) => {

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectChatUiContract } from '../../frontend/e2e/remote-chat-smoke-contract';
+
+describe('remote chat smoke UI contract selection', () => {
+  it('uses modern settings for build-info identity', () => {
+    expect(selectChatUiContract('build-info-v1')).toBe('modern-settings-v1');
+  });
+
+  it('uses the inline OpenAI editor for the exact legacy identity contract', () => {
+    expect(selectChatUiContract('legacy-build-meta-v1')).toBe(
+      'legacy-inline-openai-v1'
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- The release-aware remote `/chat` smoke failed when run against the immutable 3.0.1 recovery artifact because the harness attempted modern-only settings/missing-key locators and an empty-key submission hit the broad provider deny route instead of exercising the immutable build's inline key flow.
- The immutable 3.0.1 contract differs: OpenAI is the unconditional default, `/settings` has no provider selector, the OpenAI key editor is inline on `/chat`, and token.place is opt-in and must remain disabled/visible. The harness must verify that exact legacy contract without weakening modern verification or contacting real providers.
- This PR implements a minimal harness compatibility fix so the smoke harness can verify the fail-closed legacy identity (exact version+SHA) while preserving the modern `build-info-v1` behavior unchanged.

### Description

- Added a tiny UI-contract selector and unit tests to map identity contracts to the expected chat UI contract (`frontend/e2e/remote-chat-smoke-contract.ts` and test moved to `scripts/tests/remote-chat-smoke-contract.test.ts`).
- Updated the Playwright-based smoke spec (`frontend/e2e/remote-chat-smoke.spec.ts`) to branch the OpenAI journey according to the selected contract so the legacy path: verifies exactly one hydrated OpenAI chat panel, asserts token.place remains visibly disabled, uses the inline `/chat` key editor (only the harness's hard-coded fake sentinel), registers broad provider deny routes first and the exact mocked OpenAI Responses route afterward, submits one deterministic message, and requires exactly one intercepted OpenAI request that used the sentinel credential (the credential value is not printed).
- Preserved the modern `build-info-v1` path unchanged, including modern settings discovery, missing-key gating, and the existing mocked OpenAI success flow.
- Clarified the Sugarkube release runbook (`docs/ops/sugarkube-release.md`) to document the distinct modern vs. legacy verification contracts and to state that both modes deny unmatched provider traffic and require no real credential.

Files changed (high level):
- Added: `frontend/e2e/remote-chat-smoke-contract.ts`
- Added: `scripts/tests/remote-chat-smoke-contract.test.ts`
- Modified: `frontend/e2e/remote-chat-smoke.spec.ts`
- Modified: `docs/ops/sugarkube-release.md`

### Testing

- `git diff --check` passed.
- `node --check scripts/run-remote-chat-smoke.mjs` passed.
- Unit tests and small regression suites: `pnpm exec vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts` passed (all tests in those suites passed).
- Prettier checks for the modified frontend E2E files: `cd frontend && pnpm exec prettier --check e2e/remote-chat-smoke.spec.ts e2e/remote-chat-smoke-contract.ts` passed after formatting.
- Type-check and repo checks: `npm run type-check` and `npm run check` passed.
- Repo secret scan: `git diff | ./scripts/scan-secrets.py` passed (no secrets committed by this change).
- Root-suite note: running the full root test suite with `SKIP_E2E=1 npm test` hit unrelated environment issues in this execution environment (missing `helm` binary caused several helm-chart tests to fail with `spawnSync helm ENOENT` and a separate `fatal: not a tree object` diagnostic); these failures are environmental and unrelated to the smoke-harness logic changes in this PR.

Operational follow-up: live staging verification must be rerun after merge using the exact `legacy-build-meta-v1` 3.0.1 coordinates; CI alone does not establish recovery completion. This PR does not access or mutate staging/production and does not introduce any real provider credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a700587eb18832f8e79cdf252aca74f)