### PR TITLE
Fix the DSPACE 3.0.1 recovery chat smoke contract

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -221,10 +221,13 @@ The command is non-destructive: it uses a new isolated browser context, clears b
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside
 Playwright. It sends no live chat request or user secret and does not mutate server or shared
 production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
-submission, classified availability, or secret-safety drift. OpenAI-default verification omits the
-two token.place expectations; the harness still proves that OpenAI is discoverable and missing-key
-gated without requiring a real key. This is the DSPACE-side harness only, not Sugarkube's promotion
-gate.
+submission, classified availability, or secret-safety drift. Modern OpenAI verification proves
+that OpenAI is discoverable through settings and missing-key gated. The exact legacy 3.0.1 contract
+instead proves that OpenAI is the default, configures only a hard-coded fake sentinel through the
+inline `/chat` key form, and requires one mocked successful OpenAI response; it does not imply that
+the immutable application has modern settings or missing-key behavior. Both modes deny unmatched
+or live provider traffic and require no real credential. This is the DSPACE-side harness only, not
+Sugarkube's promotion gate.
 
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,0 +1,8 @@
+export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
+
+export function chatUiContractFor(identityContract: IdentityContract): ChatUiContract {
+    return identityContract === 'legacy-build-meta-v1'
+        ? 'legacy-inline-openai-v1'
+        : 'modern-settings-v1';
+}

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
+import { chatUiContractFor, type IdentityContract } from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -11,8 +12,6 @@ const JSEncrypt = createRequire(import.meta.url)(
 
 const expectedVersion = process.env.DSPACE_EXPECTED_VERSION!;
 const expectedRevision = process.env.DSPACE_EXPECTED_REVISION!;
-type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
-
 function normalizeIdentityContract(value: string | undefined): IdentityContract {
     if (value === undefined) return 'build-info-v1';
 
@@ -25,6 +24,7 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
+const chatUiContract = chatUiContractFor(identityContract);
 const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
@@ -342,6 +342,56 @@ test.describe('release-aware remote chat smoke', () => {
             let openAICalls = 0;
             let credentialPresent = false;
             await installProviderDenyRules(page);
+            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
+
+            if (chatUiContract === 'legacy-inline-openai-v1') {
+                await page.route('https://api.openai.com/v1/responses', async (route) => {
+                    openAICalls += 1;
+                    credentialPresent =
+                        route.request().headers().authorization === `Bearer ${fakeKey}`;
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({
+                            id: 'resp_smoke',
+                            object: 'response',
+                            status: 'completed',
+                            output: [
+                                {
+                                    type: 'message',
+                                    role: 'assistant',
+                                    content: [
+                                        { type: 'output_text', text: 'DSPACE OpenAI smoke reply.' },
+                                    ],
+                                },
+                            ],
+                        }),
+                    });
+                });
+                let panel = await openExpectedPanel(page, 'openai');
+                await expect(page.getByTestId('token-place-disabled-banner')).toBeVisible();
+                await expect(
+                    page.locator('[data-testid="chat-panel"][data-provider="token-place"]')
+                ).toHaveCount(0);
+                await page.locator('.api-container form input[type="text"]').fill(fakeKey);
+                await page
+                    .locator('.api-container form')
+                    .getByRole('button', { name: 'Submit' })
+                    .click();
+                panel = await openExpectedPanel(page, 'openai');
+                await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
+                await panel.getByRole('button', { name: 'Send' }).click();
+                await expect(
+                    panel.getByText('DSPACE OpenAI smoke reply.'),
+                    'submission: no mocked OpenAI reply'
+                ).toBeVisible();
+                expect({ openAICalls, credentialPresent }).toEqual({
+                    openAICalls: 1,
+                    credentialPresent: true,
+                });
+                return;
+            }
+
             let panel = await openExpectedPanel(page);
             await panel.getByRole('textbox').fill('Key gate smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
@@ -350,7 +400,6 @@ test.describe('release-aware remote chat smoke', () => {
                 'routing/configuration: OpenAI key gate'
             ).toHaveAttribute('data-error-type', 'missing-key');
             expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
-            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
             await selectOpenAI(page, fakeKey);
             await page.route('https://api.openai.com/v1/responses', async (route) => {
                 openAICalls += 1;
@@ -466,6 +515,10 @@ test.describe('release-aware remote chat smoke', () => {
     });
 
     test('routing/configuration: OpenAI remains discoverable and key-gated', async ({ page }) => {
+        test.skip(
+            chatUiContract === 'legacy-inline-openai-v1',
+            'Legacy recovery UI configures OpenAI inline and is not missing-key gated.'
+        );
         let providerCalls = 0;
         await installProviderDenyRules(page);
         page.on('request', (request) => {

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -122,7 +122,8 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (
     result.identityContract === 'legacy-build-meta-v1' &&
     (result.expectedVersion !== legacyIdentityCoordinates.version ||
-      result.expectedRevision !== legacyIdentityCoordinates.revision)
+      result.expectedRevision !== legacyIdentityCoordinates.revision ||
+      result.expectedProvider !== 'openai')
   ) {
     throw new Error('validation: legacy identity contract is restricted');
   }

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract';
+
+describe('remote chat smoke UI contract selection', () => {
+  it.each([
+    ['build-info-v1', 'modern-settings-v1'],
+    ['legacy-build-meta-v1', 'legacy-inline-openai-v1'],
+  ] as const)('maps %s to %s', (identityContract, expected) => {
+    expect(chatUiContractFor(identityContract)).toBe(expected);
+  });
+});

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -35,11 +35,17 @@ describe('remote chat smoke input validation', () => {
   });
 
   it('accepts the legacy identity contract only for the recovery coordinates', () => {
-    const options = parseAndValidateArgs([], {
+    const legacyEnv = {
       ...completeEnv,
       DSPACE_EXPECTED_VERSION: '3.0.1',
       DSPACE_EXPECTED_REVISION: recoveryRevision,
       DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: 'openai',
+    };
+    delete legacyEnv.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+    delete legacyEnv.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+    const options = parseAndValidateArgs([], {
+      ...legacyEnv,
     });
     expect(options.identityContract).toBe('legacy-build-meta-v1');
     expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
@@ -63,6 +69,17 @@ describe('remote chat smoke input validation', () => {
       ).toThrow('legacy identity contract is restricted');
     }
   );
+
+  it('rejects token.place for the legacy OpenAI-only UI contract', () => {
+    expect(() =>
+      parseAndValidateArgs([], {
+        ...completeEnv,
+        DSPACE_EXPECTED_VERSION: '3.0.1',
+        DSPACE_EXPECTED_REVISION: recoveryRevision,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      })
+    ).toThrow('legacy identity contract is restricted');
+  });
 
   it('rejects unknown, empty, and contradictory identity contracts', () => {
     expect(() =>


### PR DESCRIPTION
### Motivation

- A release-aware remote `/chat` smoke run against `https://staging.democratized.space` for application version `3.0.1` (SHA `1a31a569aff2dbeb238e8c2688b9e85140d2077d`) showed the legacy identity passed and token.place availability was correctly skipped, but the harness exercised modern-only flows: an empty-key submit hit the broad `https://api.openai.com/**` deny route instead of using the immutable build's inline key flow, and discovery timed out looking for a `/settings` provider selector that does not exist in the immutable 3.0.1 UI; this is a harness compatibility defect, not a change to the immutable artifact. 

### Description

- Add a tiny UI-contract mapping (`frontend/e2e/remote-chat-smoke-contract.ts`) and use it in the smoke spec so the harness selects a `legacy-inline-openai-v1` contract for the exact legacy identity and `modern-settings-v1` otherwise. 
- Update the smoke spec (`frontend/e2e/remote-chat-smoke.spec.ts`) to implement the legacy contract: register broad provider deny routes first, then register the exact mocked `https://api.openai.com/v1/responses` handler, fill the immutable inline `/chat` API-key form with a hard-coded sentinel, assert the OpenAI chat panel is the single hydrated panel and token.place remains disabled, submit one deterministic message, and require exactly one intercepted OpenAI request that used the sentinel (without printing the sentinel). 
- Restrict legacy identity validation in the runner (`scripts/run-remote-chat-smoke.mjs`) to the exact recovery coordinates and OpenAI provider only, add focused unit tests (`scripts/tests/remote-chat-smoke-contract.test.ts`) for contract selection and input validation, and clarify the release doc (`docs/ops/sugarkube-release.md`) to distinguish modern missing-key gating from the legacy inline fake-key + mocked-response contract.

### Testing

- Ran `git diff --check` and `node --check scripts/run-remote-chat-smoke.mjs` with no errors. 
- Ran focused tests with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and `pnpm exec vitest run scripts/tests/remote-chat-smoke-contract.test.ts`; all focused tests passed (26 tests total). 
- Ran formatting and static checks: `cd frontend && pnpm exec prettier --check e2e/remote-chat-smoke.spec.ts e2e/remote-chat-smoke-contract.ts`, `npm run type-check`, `npm run check`, and `git diff | ./scripts/scan-secrets.py`, all of which passed. 

Note: `SKIP_E2E=1 npm test` (the broader root suite) was started but did not complete within the task execution window; the narrow, relevant tests and checks above passed. Live staging verification must be rerun after merge using the approved legacy coordinates (the separately approved revision-26 `legacy-build-meta-v1` invocation); this PR does not claim recovery completion from CI alone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70058cbe48832f8b1402a13a6527dd)