### PR TITLE
Run remote chat smoke tests with one Playwright worker

### DIFF
--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -185,6 +185,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     hostname.endsWith('.local');
   return {
     ...baseEnv,
+    PW_WORKERS: '1',
     BASE_URL: options.baseURL,
     REMOTE_CHAT_SMOKE: '1',
     REMOTE_CHAT_SMOKE_USE_WEBSERVER: local ? '1' : '0',

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -16,6 +16,28 @@ const completeEnv = {
 };
 
 describe('remote chat smoke input validation', () => {
+  it('always configures serial Playwright execution while preserving the environment', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+
+    expect(
+      buildSmokeEnv(options, { CUSTOM_SMOKE_VALUE: 'preserved' })
+    ).toMatchObject({
+      CUSTOM_SMOKE_VALUE: 'preserved',
+      PW_WORKERS: '1',
+    });
+  });
+
+  it.each(['2', '8'])(
+    'overrides ambient PW_WORKERS=%s with serial execution',
+    (workers) => {
+      const options = parseAndValidateArgs([], completeEnv);
+
+      expect(buildSmokeEnv(options, { PW_WORKERS: workers }).PW_WORKERS).toBe(
+        '1'
+      );
+    }
+  );
+
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');


### PR DESCRIPTION
### Motivation

- Ensure the canonical release-aware remote chat smoke runner executes Playwright serially to avoid navigation races (e.g. `net::ERR_ABORTED`) observed when the smoke ran tests in parallel, so operators and Sugarkube do not need to set `PW_WORKERS=1` externally.

### Description

- Force `PW_WORKERS: '1'` when constructing the smoke environment in `scripts/run-remote-chat-smoke.mjs` (after spreading the caller environment) and add focused regression tests in `scripts/tests/run-remote-chat-smoke.test.ts` that assert serial execution is selected by default, ambient `PW_WORKERS` values cannot override it, and unrelated environment variables are preserved, while preserving existing identity/validation/transport behavior.

### Testing

- Executed `node --check scripts/run-remote-chat-smoke.mjs` (ok), `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` (29 tests passed), `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts` (ok), and `git diff --check` (clean).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70efb1704c832fa02b46129f217892)