### PR TITLE
Make remote chat smoke runner deterministic and serial

### DIFF
--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -185,6 +185,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     hostname.endsWith('.local');
   return {
     ...baseEnv,
+    PW_WORKERS: '1',
     BASE_URL: options.baseURL,
     REMOTE_CHAT_SMOKE: '1',
     REMOTE_CHAT_SMOKE_USE_WEBSERVER: local ? '1' : '0',

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -16,6 +16,23 @@ const completeEnv = {
 };
 
 describe('remote chat smoke input validation', () => {
+  it('selects serial Playwright execution by default', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    expect(buildSmokeEnv(options, {}).PW_WORKERS).toBe('1');
+  });
+
+  it('overrides ambient Playwright worker settings while preserving the environment', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    const smokeEnv = buildSmokeEnv(options, {
+      PW_WORKERS: '8',
+      OPERATOR_CONTEXT: 'preserved',
+    });
+    expect(smokeEnv).toMatchObject({
+      PW_WORKERS: '1',
+      OPERATOR_CONTEXT: 'preserved',
+    });
+  });
+
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');


### PR DESCRIPTION
### Motivation
- The canonical release-aware remote chat smoke occasionally races when Playwright runs the smoke cases in parallel, causing intermittent `net::ERR_ABORTED` `/chat` navigations despite healthy servers, so the runner must enforce serial Playwright execution itself.

### Description
- Force `PW_WORKERS: '1'` in the runner environment returned by `buildSmokeEnv()` in `scripts/run-remote-chat-smoke.mjs` so the spawned Playwright child always runs with a single worker regardless of ambient `PW_WORKERS`.
- Add regression tests in `scripts/tests/run-remote-chat-smoke.test.ts` asserting the runner: selects serial execution by default and overrides conflicting ambient `PW_WORKERS` while preserving unrelated environment entries.
- Kept the change narrowly scoped to the smoke runner and tests and did not modify `frontend/playwright.config.ts` or any global Playwright or CI configuration.

### Testing
- Ran `node --check scripts/run-remote-chat-smoke.mjs` which completed successfully.
- Ran `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and both test files passed (28 tests total passed).
- Ran `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts` which reported files are formatted.
- Ran `npm run lint` and `git diff --check` with no issues.

Commands used for verification:
- `node --check scripts/run-remote-chat-smoke.mjs`
- `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts`
- `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts`
- `npm run lint`

All automated checks listed above passed. The change meets the acceptance criteria that the smoke runner uses one Playwright worker by default, overrides ambient `PW_WORKERS`, and preserves existing environment propagation and validation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70efa990b4832fa57f0225eac06d2f)