### PR TITLE
Make remote chat smoke runner deterministic

### DIFF
--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -185,6 +185,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     hostname.endsWith('.local');
   return {
     ...baseEnv,
+    PW_WORKERS: '1',
     BASE_URL: options.baseURL,
     REMOTE_CHAT_SMOKE: '1',
     REMOTE_CHAT_SMOKE_USE_WEBSERVER: local ? '1' : '0',

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -16,6 +16,24 @@ const completeEnv = {
 };
 
 describe('remote chat smoke input validation', () => {
+  it('runs Playwright serially by default while preserving the caller environment', () => {
+    const options = parseAndValidateArgs([], completeEnv);
+    const smokeEnv = buildSmokeEnv(options, { PROPAGATED_VALUE: 'preserved' });
+
+    expect(smokeEnv.PW_WORKERS).toBe('1');
+    expect(smokeEnv.PROPAGATED_VALUE).toBe('preserved');
+  });
+
+  it.each(['2', '8'])(
+    'overrides ambient PW_WORKERS=%s with serial execution',
+    (ambientWorkers) => {
+      const options = parseAndValidateArgs([], completeEnv);
+      expect(
+        buildSmokeEnv(options, { PW_WORKERS: ambientWorkers }).PW_WORKERS
+      ).toBe('1');
+    }
+  );
+
   it('accepts the documented environment and configures remote mode', () => {
     const options = parseAndValidateArgs([], completeEnv);
     expect(options.expectedProvider).toBe('token-place');


### PR DESCRIPTION
### Motivation
- Prevent intermittent `/chat` navigation aborts observed when the canonical remote chat smoke ran Playwright with multiple workers by enforcing serial execution inside the runner itself.

### Description
- Force `PW_WORKERS: '1'` in `buildSmokeEnv()` so the runner always launches Playwright with a single worker regardless of ambient `PW_WORKERS` values.
- Add regression tests in `scripts/tests/run-remote-chat-smoke.test.ts` that assert the runner selects serial execution by default, preserves unrelated caller environment variables, and overrides ambient `PW_WORKERS` values such as `2` or `8`.
- Limit changes to the smoke runner and its test; global Playwright configuration and other smoke contracts are not modified.

### Testing
- Ran `node --check scripts/run-remote-chat-smoke.mjs` which completed without errors.
- Ran `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and observed all tests pass (2 files, 29 tests passed).
- Ran `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts` to verify formatting; the final check passed after formatting fixes.
- The changed files are `scripts/run-remote-chat-smoke.mjs` and `scripts/tests/run-remote-chat-smoke.test.ts`, and the new tests would fail if the runner no longer enforced serial Playwright execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70efb5f2c4832fa71ab4d7e43b2810)