### PR TITLE
Prepare provenance-bearing DSPACE Helm chart 3.1.1 (chart-only for app 3.1.0)

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.1.0
+version: 3.1.1
 description: Helm chart for deploying the DSPACE application
 type: application
 appVersion: "3.1.0"

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.1.0
+3.1.1

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -149,7 +149,10 @@ Helm commands below remain useful for local clusters, development environments, 
 inspection.
 
 The chart is published only by pushing the exact tag `chart-v<chart-version>` (for example,
-`chart-v3.1.0`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
+`chart-v3.1.1`). Chart `3.1.1` is a chart-only, provenance-bearing release for DSPACE application
+`3.1.0`. The legacy chart `3.1.0` must not be overwritten or used where modern immutable source
+provenance is required. A human operator will create `chart-v3.1.1` only after this change merges.
+The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
 matches it exactly; ordinary `main` and `v3` pushes never publish charts. Publication checks GHCR
 twice and fails closed unless the coordinate is authoritatively absent, so an existing chart
 coordinate cannot be replaced. Chart version `3.0.1` is permanently tombstoned and cannot be
@@ -173,7 +176,7 @@ evidence only even though exact digest equality with the immutable image index i
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.1.0 \
+  --version 3.1.1 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
   --set image.tag=v3.1.0

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -26,6 +26,12 @@ Use immutable branch-SHA tags or image digests for staging, production approvals
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
 be the audit record for a production deploy.
 
+Chart `3.1.1` is the chart-only provenance-bearing coordinate for DSPACE application `3.1.0`.
+Legacy chart `3.1.0` lacks the modern immutable source-revision provenance and must neither be
+overwritten nor used where that provenance is required. After the chart `3.1.1` preparation PR
+merges, a human operator must tag its exact merge commit as `chart-v3.1.1`; this preparation does
+not create or publish the tag.
+
 ## Runtime source verification contract
 
 Before approving an already deployed runtime, set its expected full revision, public URL, and

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -76,6 +76,10 @@ describe('independent DSPACE application and chart coordinates', () => {
   it('passes current repository coordinates and reports both groups', () =>
     withFixture((root) => {
       const { application, chart } = currentVersions(root);
+      expect({ application, chart }).toEqual({
+        application: '3.1.0',
+        chart: '3.1.1',
+      });
       const result = runGuard(root);
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain(
@@ -83,6 +87,21 @@ describe('independent DSPACE application and chart coordinates', () => {
       );
       expect(result.stdout).toContain(`chart version ${chart}`);
     }));
+
+  it('accepts chart-v3.1.1 for the chart-only application 3.1.0 release', () => {
+    const result = spawnSync(
+      'node',
+      [join(repoRoot, 'scripts/check-release-consistency.mjs'), '--verify-chart-local'],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, CHART_TAG: 'chart-v3.1.1' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('applicationVersion=3.1.0');
+    expect(result.stdout).toContain('chartVersion=3.1.1');
+  });
 
   it('permits chart 3.0.2 with application 3.0.1', () =>
     withFixture((root) => {
@@ -312,7 +331,7 @@ describe('staged Helm chart provenance', () => {
     mkdirSync(source);
     writeFileSync(
       join(source, 'Chart.yaml'),
-      'apiVersion: v2\nname: dspace\nversion: 4.5.6\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+      'apiVersion: v2\nname: dspace\nversion: 3.1.1\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
     );
     try {
       run(source, staged);
@@ -332,12 +351,16 @@ describe('staged Helm chart provenance', () => {
       expect(
         verifyChart({
           chartYaml: stagedYaml,
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
       ).toMatchObject({
+        version: '3.1.1',
+        appVersion: '3.1.0',
         'org.opencontainers.image.source': SOURCE_REPOSITORY,
+        'org.opencontainers.image.revision': revision,
+        'org.opencontainers.image.version': '3.1.0',
       });
       expect(readFileSync(join(source, 'Chart.yaml'), 'utf8')).toBe(before);
     }));
@@ -346,7 +369,7 @@ describe('staged Helm chart provenance', () => {
     'rejects non-strict chart SemVer %s',
     (version) =>
       chartFixture((source, staged) => {
-        replace(source, 'Chart.yaml', 'version: 4.5.6', `version: ${version}`);
+        replace(source, 'Chart.yaml', 'version: 3.1.1', `version: ${version}`);
         expect(() =>
           stageChart({ sourceDir: source, destinationDir: staged, revision })
         ).toThrow(/chart version/);
@@ -400,7 +423,7 @@ describe('staged Helm chart provenance', () => {
   );
 
   it.each([
-    ['version', 'version: 4.5.6', 'version: 4.5.7'],
+    ['version', 'version: 3.1.1', 'version: 3.1.2'],
     ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
     ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
     ['revision', revision, 'f'.repeat(40)],
@@ -417,7 +440,7 @@ describe('staged Helm chart provenance', () => {
       expect(() =>
         verifyChart({
           chartYaml: join(staged, 'Chart.yaml'),
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
@@ -446,7 +469,7 @@ describe('staged Helm chart provenance', () => {
         expect(() =>
           verifyChart({
             chartYaml,
-            version: '4.5.6',
+            version: '3.1.1',
             appVersion: '3.1.0',
             revision,
           })

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -29,9 +29,9 @@ function coordinateTree(run: (root: string) => void) {
   });
   writeFileSync(
     join(root, 'charts/dspace/Chart.yaml'),
-    'version: 4.2.0\nappVersion: "3.1.0"\n'
+    'version: 3.1.1\nappVersion: "3.1.0"\n'
   );
-  writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.0\n');
+  writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.1\n');
   try {
     run(root);
   } finally {
@@ -44,7 +44,7 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) =>
       expect(readLocalCoordinates(root)).toEqual({
         applicationVersion: '3.1.0',
-        chartVersion: '4.2.0',
+        chartVersion: '3.1.1',
       })
     ));
 
@@ -72,14 +72,14 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) => {
       writeFileSync(
         join(root, 'charts/dspace/Chart.yaml'),
-        'version: 4.2.0\nappVersion: "3.1.1"\n'
+        'version: 3.1.1\nappVersion: "3.1.1"\n'
       );
       expect(() => readLocalCoordinates(root)).toThrow('chart appVersion');
     }));
 
   it('rejects documented chart-version drift', () =>
     coordinateTree((root) => {
-      writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.1\n');
+      writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.2\n');
       expect(() => readLocalCoordinates(root)).toThrow('documented chart version');
     }));
 
@@ -151,13 +151,13 @@ describe('release coordinate consistency', () => {
       git('commit', '-qm', 'release');
       const approved = git('rev-parse', 'HEAD');
       git('tag', '-a', 'v3.1.0', '-m', 'application release');
-      git('tag', '-a', 'chart-v4.2.0', '-m', 'chart release');
+      git('tag', '-a', 'chart-v3.1.1', '-m', 'chart release');
       git('update-ref', 'refs/remotes/origin/main', approved);
       expect(
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: approved,
           branch: 'main',
         }).sourceRevision
@@ -166,10 +166,10 @@ describe('release coordinate consistency', () => {
       git('add', 'new');
       git('commit', '-qm', 'later');
       const later = git('rev-parse', 'HEAD');
-      git('tag', '-f', 'chart-v4.2.0', later);
+      git('tag', '-f', 'chart-v3.1.1', later);
       git('checkout', '-q', approved);
       expect(() => validateReleaseSource({
-        root, releaseTag: 'v3.1.0', chartTag: 'chart-v4.2.0',
+        root, releaseTag: 'v3.1.0', chartTag: 'chart-v3.1.1',
         sourceRevision: approved, branch: 'main',
       })).toThrow('chart release tag does not peel');
       git('checkout', '-q', later);
@@ -177,7 +177,7 @@ describe('release coordinate consistency', () => {
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: git('rev-parse', 'HEAD'),
           branch: 'main',
         })
@@ -185,8 +185,8 @@ describe('release coordinate consistency', () => {
     }));
 
   it.each([
-    ['release tag', 'v3.1.1', 'chart-v4.2.0'],
-    ['chart release tag', 'v3.1.0', 'chart-v4.2.1'],
+    ['release tag', 'v3.1.1', 'chart-v3.1.1'],
+    ['chart release tag', 'v3.1.0', 'chart-v3.1.2'],
   ])('rejects a %s/version mismatch', (message, releaseTag, chartTag) =>
     coordinateTree((root) => {
       const git = (...args: string[]) =>


### PR DESCRIPTION
### Motivation

- The legacy GHCR chart `3.1.0` lacks full source-revision provenance required by the modern Sugarkube verifier so a chart-only provenance-bearing coordinate is needed. 
- We must publish a new chart coordinate rather than weaken verification or overwrite `3.1.0`, while keeping the DSPACE application metadata and image coordinates at `3.1.0`.

### Description

- Advance only the Helm chart version to `3.1.1` in `charts/dspace/Chart.yaml` and pin the Sugarkube chart coordinate in `docs/apps/dspace.version` to `3.1.1`.  
- Preserve `appVersion: "3.1.0"` and the default image tag `v3.1.0` in `charts/dspace/values.yaml` so application coordinates are unchanged.  
- Add targeted tests and assertions to `tests/helmChartReleaseVersion.test.ts` and `tests/releaseConsistency.test.ts` that assert chart/application decoupling, acceptance of `CHART_TAG=chart-v3.1.1`, and staged provenance verification behavior.  
- Update release/docs text in `docs/charts.md` and `docs/ops/sugarkube-release.md` to state that `3.1.1` is a chart-only provenance-bearing release for application `3.1.0`, that legacy `3.1.0` must not be overwritten, and that a human operator will create the `chart-v3.1.1` tag after this PR merges.

### Testing

- Changed files: `charts/dspace/Chart.yaml`, `docs/apps/dspace.version`, `docs/charts.md`, `docs/ops/sugarkube-release.md`, `tests/helmChartReleaseVersion.test.ts`, and `tests/releaseConsistency.test.ts`.
- Ran `bash scripts/check-dspace-chart-version.sh` and it succeeded, confirming local coordinate alignment.  
- Ran `CHART_TAG=chart-v3.1.1 node scripts/check-release-consistency.mjs --verify-chart-local` and it succeeded, confirming the tag name `chart-v3.1.1` is accepted against the prepared coordinates.  
- Linted the chart with `helm lint charts/dspace` (Helm v3.12.3 used to match CI) and it passed (only informational icon recommendation).  
- Ran unit tests `pnpm exec vitest run tests/helmChartReleaseVersion.test.ts tests/releaseConsistency.test.ts` and all updated tests passed (both test files and their assertions succeeded).  
- Verified `node scripts/check-release-consistency.mjs --verify-local-fixtures`, `pnpm exec prettier --check` on updated files, and `git diff --check` all succeeded.  

Post-merge operator action: tag the exact merge commit as `chart-v3.1.1` to publish the provenance-bearing chart; this PR does not create or publish the tag or any artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a711933a574832fbda6d0e47b08adf4)