### PR TITLE
Prepare provenance-bearing Helm chart 3.1.1 (app v3.1.0)

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.1.0
+version: 3.1.1
 description: Helm chart for deploying the DSPACE application
 type: application
 appVersion: "3.1.0"

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.1.0
+3.1.1

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -149,11 +149,16 @@ Helm commands below remain useful for local clusters, development environments, 
 inspection.
 
 The chart is published only by pushing the exact tag `chart-v<chart-version>` (for example,
-`chart-v3.1.0`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
+`chart-v3.1.1`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
 matches it exactly; ordinary `main` and `v3` pushes never publish charts. Publication checks GHCR
 twice and fails closed unless the coordinate is authoritatively absent, so an existing chart
 coordinate cannot be replaced. Chart version `3.0.1` is permanently tombstoned and cannot be
 republished even if it appears absent (a later chart may still use application `appVersion: 3.0.1`).
+
+Chart `3.1.1` is a chart-only, provenance-bearing release of DSPACE application `3.1.0`; it does
+not change the application or its default `v3.1.0` image coordinate. The legacy `3.1.0` chart must
+not be overwritten or used where modern immutable source-revision provenance is required. After
+this preparation PR merges, a human operator will tag its exact merge commit as `chart-v3.1.1`.
 
 The workflow stages provenance annotations without changing the tracked chart and records the full
 source SHA, packaged archive digest, and OCI manifest digest in its successful run summary. The OCI
@@ -173,7 +178,7 @@ evidence only even though exact digest equality with the immutable image index i
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.1.0 \
+  --version 3.1.1 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
   --set image.tag=v3.1.0

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -76,6 +76,10 @@ describe('independent DSPACE application and chart coordinates', () => {
   it('passes current repository coordinates and reports both groups', () =>
     withFixture((root) => {
       const { application, chart } = currentVersions(root);
+      expect({ application, chart }).toEqual({
+        application: '3.1.0',
+        chart: '3.1.1',
+      });
       const result = runGuard(root);
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain(
@@ -83,6 +87,24 @@ describe('independent DSPACE application and chart coordinates', () => {
       );
       expect(result.stdout).toContain(`chart version ${chart}`);
     }));
+
+  it('accepts the chart-only release tag for the current coordinates', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, 'scripts/check-release-consistency.mjs'),
+        '--verify-chart-local',
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, CHART_TAG: 'chart-v3.1.1' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('applicationVersion=3.1.0');
+    expect(result.stdout).toContain('chartVersion=3.1.1');
+  });
 
   it('permits chart 3.0.2 with application 3.0.1', () =>
     withFixture((root) => {
@@ -312,7 +334,7 @@ describe('staged Helm chart provenance', () => {
     mkdirSync(source);
     writeFileSync(
       join(source, 'Chart.yaml'),
-      'apiVersion: v2\nname: dspace\nversion: 4.5.6\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+      'apiVersion: v2\nname: dspace\nversion: 3.1.1\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
     );
     try {
       run(source, staged);
@@ -332,12 +354,16 @@ describe('staged Helm chart provenance', () => {
       expect(
         verifyChart({
           chartYaml: stagedYaml,
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
       ).toMatchObject({
         'org.opencontainers.image.source': SOURCE_REPOSITORY,
+        'org.opencontainers.image.revision': revision,
+        'org.opencontainers.image.version': '3.1.0',
+        version: '3.1.1',
+        appVersion: '3.1.0',
       });
       expect(readFileSync(join(source, 'Chart.yaml'), 'utf8')).toBe(before);
     }));
@@ -346,7 +372,7 @@ describe('staged Helm chart provenance', () => {
     'rejects non-strict chart SemVer %s',
     (version) =>
       chartFixture((source, staged) => {
-        replace(source, 'Chart.yaml', 'version: 4.5.6', `version: ${version}`);
+        replace(source, 'Chart.yaml', 'version: 3.1.1', `version: ${version}`);
         expect(() =>
           stageChart({ sourceDir: source, destinationDir: staged, revision })
         ).toThrow(/chart version/);
@@ -400,7 +426,7 @@ describe('staged Helm chart provenance', () => {
   );
 
   it.each([
-    ['version', 'version: 4.5.6', 'version: 4.5.7'],
+    ['version', 'version: 3.1.1', 'version: 3.1.2'],
     ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
     ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
     ['revision', revision, 'f'.repeat(40)],
@@ -417,7 +443,7 @@ describe('staged Helm chart provenance', () => {
       expect(() =>
         verifyChart({
           chartYaml: join(staged, 'Chart.yaml'),
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
@@ -446,7 +472,7 @@ describe('staged Helm chart provenance', () => {
         expect(() =>
           verifyChart({
             chartYaml,
-            version: '4.5.6',
+            version: '3.1.1',
             appVersion: '3.1.0',
             revision,
           })

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -29,9 +29,9 @@ function coordinateTree(run: (root: string) => void) {
   });
   writeFileSync(
     join(root, 'charts/dspace/Chart.yaml'),
-    'version: 4.2.0\nappVersion: "3.1.0"\n'
+    'version: 3.1.1\nappVersion: "3.1.0"\n'
   );
-  writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.0\n');
+  writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.1\n');
   try {
     run(root);
   } finally {
@@ -44,7 +44,7 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) =>
       expect(readLocalCoordinates(root)).toEqual({
         applicationVersion: '3.1.0',
-        chartVersion: '4.2.0',
+        chartVersion: '3.1.1',
       })
     ));
 
@@ -72,14 +72,14 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) => {
       writeFileSync(
         join(root, 'charts/dspace/Chart.yaml'),
-        'version: 4.2.0\nappVersion: "3.1.1"\n'
+        'version: 3.1.1\nappVersion: "3.1.1"\n'
       );
       expect(() => readLocalCoordinates(root)).toThrow('chart appVersion');
     }));
 
   it('rejects documented chart-version drift', () =>
     coordinateTree((root) => {
-      writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.1\n');
+      writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.2\n');
       expect(() => readLocalCoordinates(root)).toThrow('documented chart version');
     }));
 
@@ -151,13 +151,13 @@ describe('release coordinate consistency', () => {
       git('commit', '-qm', 'release');
       const approved = git('rev-parse', 'HEAD');
       git('tag', '-a', 'v3.1.0', '-m', 'application release');
-      git('tag', '-a', 'chart-v4.2.0', '-m', 'chart release');
+      git('tag', '-a', 'chart-v3.1.1', '-m', 'chart release');
       git('update-ref', 'refs/remotes/origin/main', approved);
       expect(
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: approved,
           branch: 'main',
         }).sourceRevision
@@ -166,10 +166,10 @@ describe('release coordinate consistency', () => {
       git('add', 'new');
       git('commit', '-qm', 'later');
       const later = git('rev-parse', 'HEAD');
-      git('tag', '-f', 'chart-v4.2.0', later);
+      git('tag', '-f', 'chart-v3.1.1', later);
       git('checkout', '-q', approved);
       expect(() => validateReleaseSource({
-        root, releaseTag: 'v3.1.0', chartTag: 'chart-v4.2.0',
+        root, releaseTag: 'v3.1.0', chartTag: 'chart-v3.1.1',
         sourceRevision: approved, branch: 'main',
       })).toThrow('chart release tag does not peel');
       git('checkout', '-q', later);
@@ -177,7 +177,7 @@ describe('release coordinate consistency', () => {
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: git('rev-parse', 'HEAD'),
           branch: 'main',
         })
@@ -185,8 +185,8 @@ describe('release coordinate consistency', () => {
     }));
 
   it.each([
-    ['release tag', 'v3.1.1', 'chart-v4.2.0'],
-    ['chart release tag', 'v3.1.0', 'chart-v4.2.1'],
+    ['release tag', 'v3.1.1', 'chart-v3.1.1'],
+    ['chart release tag', 'v3.1.0', 'chart-v3.1.2'],
   ])('rejects a %s/version mismatch', (message, releaseTag, chartTag) =>
     coordinateTree((root) => {
       const git = (...args: string[]) =>


### PR DESCRIPTION
### Motivation

- The legacy published chart `3.1.0` lacks `org.opencontainers.image.revision` provenance and is rejected by modern verification, so a chart-only, provenance-bearing coordinate must be prepared without changing the application artifacts. 
- Create a non-overwriting chart coordinate that records full source-revision provenance while preserving the DSPACE `3.1.0` application identity and image defaults.

### Description

- Bump the Helm chart coordinate in `charts/dspace/Chart.yaml` to `version: 3.1.1` while keeping `appVersion: "3.1.0"` and the chart default image tag `v3.1.0` unchanged. 
- Update the Sugarkube pin `docs/apps/dspace.version` to `3.1.1` and update `docs/charts.md` to document that `3.1.1` is a chart-only provenance-bearing release for application `3.1.0` and that `chart-v3.1.0` must not be overwritten. 
- Add focused test adjustments and additions to explicitly exercise the supported chart/application decoupling and the chart-only tag: `tests/helmChartReleaseVersion.test.ts` and `tests/releaseConsistency.test.ts` are updated to assert chart `3.1.1` with application `3.1.0` and to verify `CHART_TAG=chart-v3.1.1` acceptance and staged provenance metadata. 
- No application code, `package.json` versions, lockfile, image coordinates, templates, or behavior were changed, and no Git tags or GHCR publication were performed in this PR.

### Testing

- Ran `bash scripts/check-dspace-chart-version.sh` which passed and reported aligned coordinates for application `3.1.0` and chart `3.1.1`.
- Verified local chart-tag validation with `CHART_TAG=chart-v3.1.1 node scripts/check-release-consistency.mjs --verify-chart-local` which passed and emitted `applicationVersion=3.1.0` and `chartVersion=3.1.1`.
- Exercised staging/provenance tooling with `node scripts/stage-helm-chart.mjs charts/dspace <tmpdir> 018687f5a7f4de45508c6e36eb28afb3e44da24d` and then `stage-helm-chart.mjs verify`, which confirmed the staged `Chart.yaml` contains provenance annotations and preserves `appVersion: 3.1.0` (pass).
- Ran unit tests `pnpm exec vitest run tests/helmChartReleaseVersion.test.ts tests/releaseConsistency.test.ts` which passed (all 67 tests green), and ran `pnpm exec prettier --check` which reported no formatting issues.
- `helm lint charts/dspace` could not be executed in this environment because `helm` is unavailable (`helm: command not found`), so linting should be verified in CI or locally by a maintainer.

Changed files: `charts/dspace/Chart.yaml`, `docs/apps/dspace.version`, `docs/charts.md`, `tests/helmChartReleaseVersion.test.ts`, `tests/releaseConsistency.test.ts`.

Post-merge action: a human operator should create the tag `chart-v3.1.1` at the exact reviewed merge commit to publish the provenance-bearing chart; this PR does not create or push the tag or publish any artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7119498828832fa90bd8b3b99ded81)