### PR TITLE
Prepare provenance-bearing Helm chart 3.1.1

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.1.0
+version: 3.1.1
 description: Helm chart for deploying the DSPACE application
 type: application
 appVersion: "3.1.0"

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.1.0
+3.1.1

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -148,8 +148,13 @@ For the standard Sugarkube staging and production flow, use the
 Helm commands below remain useful for local clusters, development environments, and manual chart
 inspection.
 
+Chart `3.1.1` is a chart-only, provenance-bearing release for DSPACE application `3.1.0`. The
+legacy `3.1.0` chart must not be overwritten or selected where modern immutable source provenance
+is required. After this change merges, a human operator will tag the exact merge commit as
+`chart-v3.1.1`; this preparation does not create or publish that tag.
+
 The chart is published only by pushing the exact tag `chart-v<chart-version>` (for example,
-`chart-v3.1.0`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
+`chart-v3.1.1`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
 matches it exactly; ordinary `main` and `v3` pushes never publish charts. Publication checks GHCR
 twice and fails closed unless the coordinate is authoritatively absent, so an existing chart
 coordinate cannot be replaced. Chart version `3.0.1` is permanently tombstoned and cannot be
@@ -173,7 +178,7 @@ evidence only even though exact digest equality with the immutable image index i
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.1.0 \
+  --version 3.1.1 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
   --set image.tag=v3.1.0

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -76,6 +76,10 @@ describe('independent DSPACE application and chart coordinates', () => {
   it('passes current repository coordinates and reports both groups', () =>
     withFixture((root) => {
       const { application, chart } = currentVersions(root);
+      expect({ application, chart }).toEqual({
+        application: '3.1.0',
+        chart: '3.1.1',
+      });
       const result = runGuard(root);
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain(
@@ -83,6 +87,21 @@ describe('independent DSPACE application and chart coordinates', () => {
       );
       expect(result.stdout).toContain(`chart version ${chart}`);
     }));
+
+  it('accepts chart-v3.1.1 for the chart-only application 3.1.0 release', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['scripts/check-release-consistency.mjs', '--verify-chart-local'],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, CHART_TAG: 'chart-v3.1.1' },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('applicationVersion=3.1.0');
+    expect(result.stdout).toContain('chartVersion=3.1.1');
+  });
 
   it('permits chart 3.0.2 with application 3.0.1', () =>
     withFixture((root) => {
@@ -312,7 +331,7 @@ describe('staged Helm chart provenance', () => {
     mkdirSync(source);
     writeFileSync(
       join(source, 'Chart.yaml'),
-      'apiVersion: v2\nname: dspace\nversion: 4.5.6\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+      'apiVersion: v2\nname: dspace\nversion: 3.1.1\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
     );
     try {
       run(source, staged);
@@ -327,17 +346,21 @@ describe('staged Helm chart provenance', () => {
       stageChart({ sourceDir: source, destinationDir: staged, revision });
       const stagedYaml = join(staged, 'Chart.yaml');
       const chart = parse(readFileSync(stagedYaml, 'utf8'));
+      expect(chart.version).toBe('3.1.1');
+      expect(chart.appVersion).toBe('3.1.0');
       expect(chart.description).toBe('retained');
       expect(chart.annotations['example.org/existing']).toBe('retained');
       expect(
         verifyChart({
           chartYaml: stagedYaml,
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
       ).toMatchObject({
         'org.opencontainers.image.source': SOURCE_REPOSITORY,
+        'org.opencontainers.image.revision': revision,
+        'org.opencontainers.image.version': '3.1.0',
       });
       expect(readFileSync(join(source, 'Chart.yaml'), 'utf8')).toBe(before);
     }));
@@ -346,7 +369,7 @@ describe('staged Helm chart provenance', () => {
     'rejects non-strict chart SemVer %s',
     (version) =>
       chartFixture((source, staged) => {
-        replace(source, 'Chart.yaml', 'version: 4.5.6', `version: ${version}`);
+        replace(source, 'Chart.yaml', 'version: 3.1.1', `version: ${version}`);
         expect(() =>
           stageChart({ sourceDir: source, destinationDir: staged, revision })
         ).toThrow(/chart version/);
@@ -400,7 +423,7 @@ describe('staged Helm chart provenance', () => {
   );
 
   it.each([
-    ['version', 'version: 4.5.6', 'version: 4.5.7'],
+    ['version', 'version: 3.1.1', 'version: 3.1.2'],
     ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
     ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
     ['revision', revision, 'f'.repeat(40)],
@@ -417,7 +440,7 @@ describe('staged Helm chart provenance', () => {
       expect(() =>
         verifyChart({
           chartYaml: join(staged, 'Chart.yaml'),
-          version: '4.5.6',
+          version: '3.1.1',
           appVersion: '3.1.0',
           revision,
         })
@@ -446,7 +469,7 @@ describe('staged Helm chart provenance', () => {
         expect(() =>
           verifyChart({
             chartYaml,
-            version: '4.5.6',
+            version: '3.1.1',
             appVersion: '3.1.0',
             revision,
           })

--- a/tests/releaseConsistency.test.ts
+++ b/tests/releaseConsistency.test.ts
@@ -29,9 +29,9 @@ function coordinateTree(run: (root: string) => void) {
   });
   writeFileSync(
     join(root, 'charts/dspace/Chart.yaml'),
-    'version: 4.2.0\nappVersion: "3.1.0"\n'
+    'version: 3.1.1\nappVersion: "3.1.0"\n'
   );
-  writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.0\n');
+  writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.1\n');
   try {
     run(root);
   } finally {
@@ -44,7 +44,7 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) =>
       expect(readLocalCoordinates(root)).toEqual({
         applicationVersion: '3.1.0',
-        chartVersion: '4.2.0',
+        chartVersion: '3.1.1',
       })
     ));
 
@@ -72,14 +72,14 @@ describe('release coordinate consistency', () => {
     coordinateTree((root) => {
       writeFileSync(
         join(root, 'charts/dspace/Chart.yaml'),
-        'version: 4.2.0\nappVersion: "3.1.1"\n'
+        'version: 3.1.1\nappVersion: "3.1.1"\n'
       );
       expect(() => readLocalCoordinates(root)).toThrow('chart appVersion');
     }));
 
   it('rejects documented chart-version drift', () =>
     coordinateTree((root) => {
-      writeFileSync(join(root, 'docs/apps/dspace.version'), '4.2.1\n');
+      writeFileSync(join(root, 'docs/apps/dspace.version'), '3.1.2\n');
       expect(() => readLocalCoordinates(root)).toThrow('documented chart version');
     }));
 
@@ -151,13 +151,13 @@ describe('release coordinate consistency', () => {
       git('commit', '-qm', 'release');
       const approved = git('rev-parse', 'HEAD');
       git('tag', '-a', 'v3.1.0', '-m', 'application release');
-      git('tag', '-a', 'chart-v4.2.0', '-m', 'chart release');
+      git('tag', '-a', 'chart-v3.1.1', '-m', 'chart release');
       git('update-ref', 'refs/remotes/origin/main', approved);
       expect(
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: approved,
           branch: 'main',
         }).sourceRevision
@@ -166,10 +166,10 @@ describe('release coordinate consistency', () => {
       git('add', 'new');
       git('commit', '-qm', 'later');
       const later = git('rev-parse', 'HEAD');
-      git('tag', '-f', 'chart-v4.2.0', later);
+      git('tag', '-f', 'chart-v3.1.1', later);
       git('checkout', '-q', approved);
       expect(() => validateReleaseSource({
-        root, releaseTag: 'v3.1.0', chartTag: 'chart-v4.2.0',
+        root, releaseTag: 'v3.1.0', chartTag: 'chart-v3.1.1',
         sourceRevision: approved, branch: 'main',
       })).toThrow('chart release tag does not peel');
       git('checkout', '-q', later);
@@ -177,7 +177,7 @@ describe('release coordinate consistency', () => {
         validateReleaseSource({
           root,
           releaseTag: 'v3.1.0',
-          chartTag: 'chart-v4.2.0',
+          chartTag: 'chart-v3.1.1',
           sourceRevision: git('rev-parse', 'HEAD'),
           branch: 'main',
         })
@@ -185,8 +185,8 @@ describe('release coordinate consistency', () => {
     }));
 
   it.each([
-    ['release tag', 'v3.1.1', 'chart-v4.2.0'],
-    ['chart release tag', 'v3.1.0', 'chart-v4.2.1'],
+    ['release tag', 'v3.1.1', 'chart-v3.1.1'],
+    ['chart release tag', 'v3.1.0', 'chart-v3.1.2'],
   ])('rejects a %s/version mismatch', (message, releaseTag, chartTag) =>
     coordinateTree((root) => {
       const git = (...args: string[]) =>


### PR DESCRIPTION
### Motivation

- The canonical GHCR chart `3.1.0` was published by legacy tooling and lacks full source-revision OCI provenance, so publish a new, provenance-bearing chart coordinate without changing the DSPACE application artifacts.

### Description

- Bump only the Helm chart coordinate in `charts/dspace/Chart.yaml` from `3.1.0` to `3.1.1` while preserving `appVersion: "3.1.0"` and all application metadata and image tags. 
- Update the Sugarkube chart pin in `docs/apps/dspace.version` to `3.1.1` and update `docs/charts.md` with a concise note that `3.1.1` is a chart-only, provenance-bearing release and that `chart-v3.1.1` must be created by a human after merge. 
- Adjust focused tests in `tests/helmChartReleaseVersion.test.ts` and `tests/releaseConsistency.test.ts` to assert the chart/application decoupling (chart `3.1.1`, application `3.1.0`), add a focused check that `CHART_TAG=chart-v3.1.1` is accepted by local chart validation, and exercise `scripts/stage-helm-chart.mjs` provenance behaviour with the staged chart fixture. 
- No changes were made to application code, package versions, `appVersion`, `values.yaml` image tag defaults (`v3.1.0`), CI publish workflows, GHCR, or any packaged chart artifacts.

### Testing

- Ran `bash scripts/check-dspace-chart-version.sh` and observed: `DSPACE release coordinates are aligned: application version 3.1.0 (v3.1.0); chart version 3.1.1.` (success). 
- Ran `CHART_TAG=chart-v3.1.1 node scripts/check-release-consistency.mjs --verify-chart-local` and observed `applicationVersion=3.1.0` and `chartVersion=3.1.1` on stdout (success). 
- Linted the chart with Helm v3.12.3 (`helm lint charts/dspace`) and saw `1 chart(s) linted, 0 chart(s) failed` (success). 
- Ran the focused test suite with Vitest (`pnpm exec vitest run tests/helmChartReleaseVersion.test.ts tests/releaseConsistency.test.ts`) and all tests passed after the focused adjustments (final run: 67 tests passed). 
- Ran `node scripts/check-release-consistency.mjs --verify-local-fixtures` and observed the network-free fixture success message (success), and ran `git diff --check` with no issues (success).

Changed files: `charts/dspace/Chart.yaml`, `docs/apps/dspace.version`, `docs/charts.md`, `tests/helmChartReleaseVersion.test.ts`, `tests/releaseConsistency.test.ts` (commit `Prepare Helm chart 3.1.1`).

Post-merge operation: a human operator must create the tag `chart-v3.1.1` at the exact reviewed merge commit to publish the provenance-bearing chart; this PR does not create tags or publish artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71194c4df8832fb45d3e233a36ea93)