### PR TITLE
Allow exact 3.1.0 legacy token.place remote-chat smoke profile

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -205,8 +205,11 @@ When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.
 
-The immutable 3.0.1 recovery artifact predates those surfaces. It may be checked only with this
-explicit legacy invocation:
+Two immutable artifacts predate those surfaces and expose the strict legacy
+`/build-meta.json` identity contract. They may be checked only with these exact compatibility
+profiles.
+
+The 3.0.1 recovery profile pairs legacy build identity with the legacy inline OpenAI chat UI:
 
 ```bash
 DSPACE_SMOKE_BASE_URL=https://democratized.space \
@@ -217,10 +220,26 @@ DSPACE_EXPECTED_PROVIDER=openai \
 npm run qa:remote-chat-smoke
 ```
 
+The exact 3.1.0 staging profile pairs legacy build identity with the modern token.place settings
+chat UI:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=018687f5a7f4de45508c6e36eb28afb3e44da24d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
 `legacy-build-meta-v1` verifies the same-origin `/build-meta.json` response and is fail-closed to
-exactly application version `3.0.1` and source revision
-`1a31a569aff2dbeb238e8c2688b9e85140d2077d`. This mode exists solely to verify that immutable
-recovery artifact. It must not become a general fallback: the harness never selects it
+exactly the allowlisted version, source revision, and provider tuple. Build identity and chat UI
+are independent contracts: legacy identity selects the inline OpenAI UI only for the exact
+3.0.1/OpenAI profile, while the exact 3.1.0/token.place profile and all modern identity profiles
+use the modern settings UI. These modes exist solely to verify those immutable compatibility
+profiles. They must not become a general fallback: the harness never selects legacy identity
 automatically after a missing or malformed modern identity response.
 
 The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
@@ -228,8 +247,8 @@ blocks service workers and unexpected provider traffic, and fulfills token.place
 Playwright. It sends no live chat request or user secret and does not mutate server or shared
 production state. It returns nonzero on build identity, hydration, provider routing/origin/model,
 submission, classified availability, or secret-safety drift. Modern OpenAI verification proves
-that OpenAI is discoverable through settings and missing-key gated. The exact legacy 3.0.1 contract
-instead proves that OpenAI is the default, configures only a hard-coded fake sentinel through the
+that OpenAI is discoverable through settings and missing-key gated. The exact legacy
+3.0.1/OpenAI contract instead proves that OpenAI is the default, configures only a hard-coded fake sentinel through the
 inline `/chat` key form, and requires one mocked successful OpenAI response; it does not imply that
 the immutable application has modern settings or missing-key behavior. Both modes deny unmatched
 or live provider traffic and require no real credential. This is the DSPACE-side harness only, not

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,8 +1,14 @@
 export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type ChatProvider = 'token-place' | 'openai';
 export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
 
-export function chatUiContractFor(identityContract: IdentityContract): ChatUiContract {
-    return identityContract === 'legacy-build-meta-v1'
-        ? 'legacy-inline-openai-v1'
-        : 'modern-settings-v1';
+export function chatUiContractFor(
+    identityContract: IdentityContract,
+    provider: ChatProvider
+): ChatUiContract {
+    if (identityContract === 'legacy-build-meta-v1' && provider === 'openai') {
+        return 'legacy-inline-openai-v1';
+    }
+
+    return 'modern-settings-v1';
 }

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,7 +4,11 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
-import { chatUiContractFor, type IdentityContract } from './remote-chat-smoke-contract';
+import {
+    chatUiContractFor,
+    type ChatProvider,
+    type IdentityContract,
+} from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -24,8 +28,8 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
-const chatUiContract = chatUiContractFor(identityContract);
-const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
+const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as ChatProvider;
+const chatUiContract = chatUiContractFor(identityContract, expectedProvider);
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
 const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -7,10 +7,20 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
 const defaultIdentityContract = 'build-info-v1';
-const legacyIdentityCoordinates = {
-  version: '3.0.1',
-  revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
-};
+const legacyIdentityProfiles = [
+  {
+    version: '3.0.1',
+    revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
+    provider: 'openai',
+    identityContract: 'legacy-build-meta-v1',
+  },
+  {
+    version: '3.1.0',
+    revision: '018687f5a7f4de45508c6e36eb28afb3e44da24d',
+    provider: 'token-place',
+    identityContract: 'legacy-build-meta-v1',
+  },
+];
 
 const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
@@ -119,18 +129,23 @@ export function parseAndValidateArgs(argv, env = process.env) {
   ) {
     throw new Error('validation: identity contract is unsupported');
   }
-  if (
-    result.identityContract === 'legacy-build-meta-v1' &&
-    (result.expectedVersion !== legacyIdentityCoordinates.version ||
-      result.expectedRevision !== legacyIdentityCoordinates.revision ||
-      result.expectedProvider !== 'openai')
-  ) {
-    throw new Error('validation: legacy identity contract is restricted');
-  }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
     throw new Error(
       'validation: expected provider must be token-place or openai'
     );
+  }
+
+  if (
+    result.identityContract === 'legacy-build-meta-v1' &&
+    !legacyIdentityProfiles.some(
+      (profile) =>
+        profile.identityContract === result.identityContract &&
+        profile.version === result.expectedVersion &&
+        profile.revision === result.expectedRevision &&
+        profile.provider === result.expectedProvider
+    )
+  ) {
+    throw new Error('validation: legacy identity contract is restricted');
   }
 
   if (result.expectedProvider === 'token-place') {

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -4,9 +4,14 @@ import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract
 
 describe('remote chat smoke UI contract selection', () => {
   it.each([
-    ['build-info-v1', 'modern-settings-v1'],
-    ['legacy-build-meta-v1', 'legacy-inline-openai-v1'],
-  ] as const)('maps %s to %s', (identityContract, expected) => {
-    expect(chatUiContractFor(identityContract)).toBe(expected);
-  });
+    ['legacy-build-meta-v1', 'openai', 'legacy-inline-openai-v1'],
+    ['legacy-build-meta-v1', 'token-place', 'modern-settings-v1'],
+    ['build-info-v1', 'openai', 'modern-settings-v1'],
+    ['build-info-v1', 'token-place', 'modern-settings-v1'],
+  ] as const)(
+    'maps %s with %s to %s',
+    (identityContract, provider, expected) => {
+      expect(chatUiContractFor(identityContract, provider)).toBe(expected);
+    }
+  );
 });

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -6,6 +6,7 @@ import {
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
 const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
+const legacyTokenPlaceRevision = '018687f5a7f4de45508c6e36eb28afb3e44da24d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -51,7 +52,7 @@ describe('remote chat smoke input validation', () => {
     ).toBe('build-info-v1');
   });
 
-  it('accepts the legacy identity contract only for the recovery coordinates', () => {
+  it('accepts the legacy identity contract for the 3.0.1 OpenAI recovery coordinates', () => {
     const legacyEnv = {
       ...completeEnv,
       DSPACE_EXPECTED_VERSION: '3.0.1',
@@ -70,24 +71,55 @@ describe('remote chat smoke input validation', () => {
     );
   });
 
-  it.each([
-    ['3.0.2', recoveryRevision],
-    ['3.0.1', revision],
-  ])(
-    'rejects legacy identity for version %s and revision %s',
-    (version, sha) => {
-      expect(() =>
-        parseAndValidateArgs([], {
-          ...completeEnv,
-          DSPACE_EXPECTED_VERSION: version,
-          DSPACE_EXPECTED_REVISION: sha,
-          DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
-        })
-      ).toThrow('legacy identity contract is restricted');
-    }
-  );
+  it('accepts the 3.1.0 token.place legacy identity compatibility profile', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.1.0',
+      DSPACE_EXPECTED_REVISION: legacyTokenPlaceRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: 'token-place',
+      DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+      DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+    });
+    expect(options).toMatchObject({
+      identityContract: 'legacy-build-meta-v1',
+      expectedProvider: 'token-place',
+      expectedTokenPlaceOrigin: 'https://token.place',
+      expectedTokenPlaceModel: 'llama-3.1-8b-instruct',
+    });
+    expect(buildSmokeEnv(options, {})).toMatchObject({
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+      DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+      PW_WORKERS: '1',
+    });
+  });
 
-  it('rejects token.place for the legacy OpenAI-only UI contract', () => {
+  it.each([
+    ['3.0.1 version drift', '3.0.2', recoveryRevision, 'openai'],
+    ['3.0.1 revision drift', '3.0.1', revision, 'openai'],
+    ['3.0.1 provider drift', '3.0.1', recoveryRevision, 'token-place'],
+    ['3.1.0 version drift', '3.1.1', legacyTokenPlaceRevision, 'token-place'],
+    ['3.1.0 revision drift', '3.1.0', revision, 'token-place'],
+    ['3.1.0 provider drift', '3.1.0', legacyTokenPlaceRevision, 'openai'],
+  ])('rejects legacy identity for %s', (_label, version, sha, provider) => {
+    const env = {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: version,
+      DSPACE_EXPECTED_REVISION: sha,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: provider,
+    };
+    if (provider === 'openai') {
+      delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+      delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+    }
+    expect(() => parseAndValidateArgs([], env)).toThrow(
+      'legacy identity contract is restricted'
+    );
+  });
+
+  it('rejects 3.0.1 with token.place and 3.1.0 with OpenAI legacy pairings', () => {
     expect(() =>
       parseAndValidateArgs([], {
         ...completeEnv,
@@ -96,6 +128,18 @@ describe('remote chat smoke input validation', () => {
         DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
       })
     ).toThrow('legacy identity contract is restricted');
+    const openAiEnv = {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.1.0',
+      DSPACE_EXPECTED_REVISION: legacyTokenPlaceRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: 'openai',
+    };
+    delete openAiEnv.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+    delete openAiEnv.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+    expect(() => parseAndValidateArgs([], openAiEnv)).toThrow(
+      'legacy identity contract is restricted'
+    );
   });
 
   it('rejects unknown, empty, and contradictory identity contracts', () => {


### PR DESCRIPTION
### Motivation

- The remote chat smoke runner rejects a valid immutable 3.1.0 staging artifact that exposes the legacy `/build-meta.json` identity but uses the modern token.place chat UI, so allow that exact compatibility profile without weakening the existing 3.0.1 recovery-only restriction.

### Description

- Add an explicit allowlist of legacy identity profiles in `scripts/run-remote-chat-smoke.mjs` containing the exact tuples for 3.0.1/OpenAI and 3.1.0/token-place and change validation to match all profile fields exactly. 
- Decouple build identity → chat UI mapping by extending `frontend/e2e/remote-chat-smoke-contract.ts` to accept the `provider` and map legacy+OpenAI → `legacy-inline-openai-v1` while legacy+token.place and modern identities map to `modern-settings-v1`. 
- Update the Playwright spec callers (`frontend/e2e/remote-chat-smoke.spec.ts`) and tests (`scripts/tests/run-remote-chat-smoke.test.ts`, `scripts/tests/remote-chat-smoke-contract.test.ts`) to cover the new 3.1.0/token.place legacy profile, field-drift rejection cases, and UI-contract mapping. 
- Document the exact 3.1.0 legacy-identity/token.place invocation and clarify that build identity and chat UI are independent in `docs/ops/sugarkube-release.md` while keeping token.place origin/model validation, `PW_WORKERS=1`, and all secret-safety bounds unchanged.

### Testing

- Ran JavaScript syntax check: `node --check scripts/run-remote-chat-smoke.mjs` (passed). 
- Ran unit tests: `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` (all tests passed). 
- Ensured formatting: `pnpm exec prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts docs/ops/sugarkube-release.md` and `cd frontend && pnpm exec prettier --check e2e/remote-chat-smoke-contract.ts e2e/remote-chat-smoke.spec.ts` (both passed after formatting). 
- Ran lint and repository checks: `npm run lint` and `git diff --check` (both passed). 

Files changed: `scripts/run-remote-chat-smoke.mjs`, `frontend/e2e/remote-chat-smoke-contract.ts`, `frontend/e2e/remote-chat-smoke.spec.ts`, `scripts/tests/run-remote-chat-smoke.test.ts`, `scripts/tests/remote-chat-smoke-contract.test.ts`, and `docs/ops/sugarkube-release.md`.

Residual notes: this is a narrowly scoped allowlist for two exact compatibility profiles only and does not introduce runtime probing, general legacy fallback behavior, or any provider credentials; no deployment, image, chart, Kubernetes, Sugarkube, or release artifacts were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723e108c04832f870dbc5403b54edf)