### PR TITLE
Allow DSPACE 3.1.0 legacy token.place chat smoke profile

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -205,8 +205,9 @@ When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.
 
-The immutable 3.0.1 recovery artifact predates those surfaces. It may be checked only with this
-explicit legacy invocation:
+Two immutable artifacts predate those surfaces and may be checked only with exact legacy
+compatibility invocations. The 3.0.1 recovery profile uses legacy build identity and the legacy
+inline OpenAI chat UI:
 
 ```bash
 DSPACE_SMOKE_BASE_URL=https://democratized.space \
@@ -217,11 +218,28 @@ DSPACE_EXPECTED_PROVIDER=openai \
 npm run qa:remote-chat-smoke
 ```
 
+The immutable 3.1.0 token.place staging profile also uses legacy build identity, but its chat UI is
+the modern settings-based token.place UI:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=018687f5a7f4de45508c6e36eb28afb3e44da24d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
 `legacy-build-meta-v1` verifies the same-origin `/build-meta.json` response and is fail-closed to
-exactly application version `3.0.1` and source revision
-`1a31a569aff2dbeb238e8c2688b9e85140d2077d`. This mode exists solely to verify that immutable
-recovery artifact. It must not become a general fallback: the harness never selects it
-automatically after a missing or malformed modern identity response.
+an exact allowlist: application version `3.0.1` at source revision
+`1a31a569aff2dbeb238e8c2688b9e85140d2077d` with provider `openai`, or application version `3.1.0`
+at source revision `018687f5a7f4de45508c6e36eb28afb3e44da24d` with provider `token-place`. Build
+identity and chat UI are independent contracts: legacy build identity does not imply the legacy
+inline OpenAI UI except for the exact 3.0.1/OpenAI recovery profile. These are exact compatibility
+profiles, not a general legacy fallback: the harness never selects legacy identity automatically
+after a missing or malformed modern identity response.
 
 The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,8 +1,14 @@
 export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type SupportedProvider = 'token-place' | 'openai';
 export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
 
-export function chatUiContractFor(identityContract: IdentityContract): ChatUiContract {
-    return identityContract === 'legacy-build-meta-v1'
-        ? 'legacy-inline-openai-v1'
-        : 'modern-settings-v1';
+export function chatUiContractFor(
+    identityContract: IdentityContract,
+    expectedProvider: SupportedProvider
+): ChatUiContract {
+    if (identityContract === 'legacy-build-meta-v1' && expectedProvider === 'openai') {
+        return 'legacy-inline-openai-v1';
+    }
+
+    return 'modern-settings-v1';
 }

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,7 +4,11 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
-import { chatUiContractFor, type IdentityContract } from './remote-chat-smoke-contract';
+import {
+    chatUiContractFor,
+    type IdentityContract,
+    type SupportedProvider,
+} from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -24,8 +28,8 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
-const chatUiContract = chatUiContractFor(identityContract);
-const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
+const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as SupportedProvider;
+const chatUiContract = chatUiContractFor(identityContract, expectedProvider);
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
 const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -7,10 +7,18 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
 const defaultIdentityContract = 'build-info-v1';
-const legacyIdentityCoordinates = {
-  version: '3.0.1',
-  revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
-};
+const legacyIdentityProfiles = [
+  {
+    version: '3.0.1',
+    revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
+    provider: 'openai',
+  },
+  {
+    version: '3.1.0',
+    revision: '018687f5a7f4de45508c6e36eb28afb3e44da24d',
+    provider: 'token-place',
+  },
+];
 
 const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
@@ -119,13 +127,16 @@ export function parseAndValidateArgs(argv, env = process.env) {
   ) {
     throw new Error('validation: identity contract is unsupported');
   }
-  if (
-    result.identityContract === 'legacy-build-meta-v1' &&
-    (result.expectedVersion !== legacyIdentityCoordinates.version ||
-      result.expectedRevision !== legacyIdentityCoordinates.revision ||
-      result.expectedProvider !== 'openai')
-  ) {
-    throw new Error('validation: legacy identity contract is restricted');
+  if (result.identityContract === 'legacy-build-meta-v1') {
+    const legacyProfileAllowed = legacyIdentityProfiles.some(
+      (profile) =>
+        result.expectedVersion === profile.version &&
+        result.expectedRevision === profile.revision &&
+        result.expectedProvider === profile.provider
+    );
+    if (!legacyProfileAllowed) {
+      throw new Error('validation: legacy identity contract is restricted');
+    }
   }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
     throw new Error(

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -4,9 +4,14 @@ import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract
 
 describe('remote chat smoke UI contract selection', () => {
   it.each([
-    ['build-info-v1', 'modern-settings-v1'],
-    ['legacy-build-meta-v1', 'legacy-inline-openai-v1'],
-  ] as const)('maps %s to %s', (identityContract, expected) => {
-    expect(chatUiContractFor(identityContract)).toBe(expected);
-  });
+    ['legacy-build-meta-v1', 'openai', 'legacy-inline-openai-v1'],
+    ['legacy-build-meta-v1', 'token-place', 'modern-settings-v1'],
+    ['build-info-v1', 'openai', 'modern-settings-v1'],
+    ['build-info-v1', 'token-place', 'modern-settings-v1'],
+  ] as const)(
+    'maps %s with %s to %s',
+    (identityContract, provider, expected) => {
+      expect(chatUiContractFor(identityContract, provider)).toBe(expected);
+    }
+  );
 });

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -6,6 +6,7 @@ import {
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
 const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
+const tokenPlaceLegacyRevision = '018687f5a7f4de45508c6e36eb28afb3e44da24d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -51,7 +52,7 @@ describe('remote chat smoke input validation', () => {
     ).toBe('build-info-v1');
   });
 
-  it('accepts the legacy identity contract only for the recovery coordinates', () => {
+  it('accepts the exact 3.0.1 OpenAI legacy identity profile', () => {
     const legacyEnv = {
       ...completeEnv,
       DSPACE_EXPECTED_VERSION: '3.0.1',
@@ -70,24 +71,56 @@ describe('remote chat smoke input validation', () => {
     );
   });
 
+  it('accepts the exact 3.1.0 token.place legacy identity profile and propagates smoke settings', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_EXPECTED_VERSION: '3.1.0',
+      DSPACE_EXPECTED_REVISION: tokenPlaceLegacyRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: 'token-place',
+      DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+      DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+    });
+    expect(options.identityContract).toBe('legacy-build-meta-v1');
+    expect(options.expectedProvider).toBe('token-place');
+    expect(options.expectedTokenPlaceOrigin).toBe('https://token.place');
+    expect(options.expectedTokenPlaceModel).toBe('llama-3.1-8b-instruct');
+    expect(buildSmokeEnv(options, {})).toMatchObject({
+      PW_WORKERS: '1',
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+      DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+    });
+  });
+
   it.each([
-    ['3.0.2', recoveryRevision],
-    ['3.0.1', revision],
+    ['3.0.2', recoveryRevision, 'openai'],
+    ['3.0.1', revision, 'openai'],
+    ['3.0.1', recoveryRevision, 'token-place'],
+    ['3.1.1', tokenPlaceLegacyRevision, 'token-place'],
+    ['3.1.0', revision, 'token-place'],
+    ['3.1.0', tokenPlaceLegacyRevision, 'openai'],
   ])(
-    'rejects legacy identity for version %s and revision %s',
-    (version, sha) => {
-      expect(() =>
-        parseAndValidateArgs([], {
-          ...completeEnv,
-          DSPACE_EXPECTED_VERSION: version,
-          DSPACE_EXPECTED_REVISION: sha,
-          DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
-        })
-      ).toThrow('legacy identity contract is restricted');
+    'rejects legacy identity for version %s, revision %s, and provider %s',
+    (version, sha, provider) => {
+      const env = {
+        ...completeEnv,
+        DSPACE_EXPECTED_VERSION: version,
+        DSPACE_EXPECTED_REVISION: sha,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+        DSPACE_EXPECTED_PROVIDER: provider,
+      };
+      if (provider === 'openai') {
+        delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+        delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+      }
+      expect(() => parseAndValidateArgs([], env)).toThrow(
+        'legacy identity contract is restricted'
+      );
     }
   );
 
-  it('rejects token.place for the legacy OpenAI-only UI contract', () => {
+  it('rejects 3.0.1 with token.place legacy identity', () => {
     expect(() =>
       parseAndValidateArgs([], {
         ...completeEnv,
@@ -205,14 +238,24 @@ describe('remote chat smoke input validation', () => {
 
   it('keeps malformed-input diagnostics bounded and free of supplied values', () => {
     const sentinel = 'operator-private-query-sentinel';
-    for (const argv of [
-      [sentinel],
-      [`--unknown=${sentinel}`],
-      [`--identity-contract=${sentinel}`],
-    ]) {
+    const cases = [
+      { argv: [sentinel], env: completeEnv },
+      { argv: [`--unknown=${sentinel}`], env: completeEnv },
+      { argv: [`--identity-contract=${sentinel}`], env: completeEnv },
+      {
+        argv: [],
+        env: {
+          ...completeEnv,
+          DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+          DSPACE_EXPECTED_PROVIDER: 'token-place',
+          DSPACE_EXPECTED_TOKEN_PLACE_MODEL: sentinel,
+        },
+      },
+    ];
+    for (const { argv, env } of cases) {
       let message = '';
       try {
-        parseAndValidateArgs(argv, completeEnv);
+        parseAndValidateArgs(argv, env);
       } catch (error) {
         message = String(error.message);
       }


### PR DESCRIPTION
### Motivation

- Sugarkube now selects a legacy build identity profile for the immutable DSPACE 3.1.0 artifact, but the smoke harness only allowed the single 3.0.1/OpenAI legacy tuple, causing valid 3.1.0/token.place runs to be rejected before Playwright starts.
- The change must allow that exact 3.1.0 legacy invocation while preserving the fail-closed legacy restriction, token.place validation, and the modern default behavior for other releases.

### Description

- Replace the single hard-coded 3.0.1 legacy restriction with a small exact allowlist of legacy profiles (`3.0.1`+OpenAI and `3.1.0`+token-place) in `scripts/run-remote-chat-smoke.mjs` so legacy identity is accepted only for those exact tuples. 
- Decouple build identity → chat UI mapping by changing `frontend/e2e/remote-chat-smoke-contract.ts` to `chatUiContractFor(identityContract, expectedProvider)` so legacy identity no longer implies the legacy inline OpenAI UI; the 3.0.1/OpenAI profile maps to `legacy-inline-openai-v1` while 3.1.0/token.place and all modern identity cases map to `modern-settings-v1`.
- Update the Playwright spec callers and tests (`frontend/e2e/remote-chat-smoke.spec.ts`, `scripts/tests/run-remote-chat-smoke.test.ts`, `scripts/tests/remote-chat-smoke-contract.test.ts`) to cover the new exact 3.1.0 legacy profile, one-field drifts, token.place origin/model propagation, and UI-contract mapping.
- Document the exact 3.1.0 legacy invocation and clarify that build identity and chat UI are independent contracts in `docs/ops/sugarkube-release.md`; preserve all existing token.place validation rules and `PW_WORKERS=1` forwarding.

### Testing

- `node --check scripts/run-remote-chat-smoke.mjs` — success (syntax OK).
- `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` — all tests passed (2 files, 35 tests total).
- Format and lint checks: `npx prettier --check ...` and `npx prettier --config frontend/.prettierrc --check ...` — success; `npm run lint` — success; `npm run check` and `npm run type-check` — success.

All checks above completed in this environment with no changes to deployments, images, charts, or secrets; git diff shows the six modified files and `git diff --check` reported no whitespace/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723e0e72a8832f92ff89d7c6432554)