### PR TITLE
Allow exact legacy token.place profile for remote chat smoke (3.1.0)

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -205,8 +205,11 @@ When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.
 
-The immutable 3.0.1 recovery artifact predates those surfaces. It may be checked only with this
-explicit legacy invocation:
+Two immutable artifacts predate the modern identity surfaces and may be checked only with exact
+legacy-identity compatibility invocations.
+
+The immutable 3.0.1 recovery artifact uses legacy build identity and the legacy inline OpenAI chat
+UI:
 
 ```bash
 DSPACE_SMOKE_BASE_URL=https://democratized.space \
@@ -217,11 +220,26 @@ DSPACE_EXPECTED_PROVIDER=openai \
 npm run qa:remote-chat-smoke
 ```
 
-`legacy-build-meta-v1` verifies the same-origin `/build-meta.json` response and is fail-closed to
-exactly application version `3.0.1` and source revision
-`1a31a569aff2dbeb238e8c2688b9e85140d2077d`. This mode exists solely to verify that immutable
-recovery artifact. It must not become a general fallback: the harness never selects it
-automatically after a missing or malformed modern identity response.
+The immutable 3.1.0 token.place staging artifact uses legacy build identity while retaining the
+modern token.place settings-based chat UI:
+
+```bash
+DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
+DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_REVISION=018687f5a7f4de45508c6e36eb28afb3e44da24d \
+DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
+DSPACE_EXPECTED_PROVIDER=token-place \
+DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
+DSPACE_EXPECTED_TOKEN_PLACE_MODEL=llama-3.1-8b-instruct \
+npm run qa:remote-chat-smoke
+```
+
+`legacy-build-meta-v1` verifies the same-origin `/build-meta.json` response. Build identity and
+chat UI are independent contracts: the exact 3.0.1/OpenAI profile maps to the legacy inline OpenAI
+UI, while the exact 3.1.0/token.place profile maps to the modern settings UI. These are exact
+compatibility profiles, not a general legacy fallback. Any version, revision, provider, or identity
+contract drift fails closed, and the harness never selects legacy identity automatically after a
+missing or malformed modern identity response.
 
 The command is non-destructive: it uses a new isolated browser context, clears browser-held state,
 blocks service workers and unexpected provider traffic, and fulfills token.place transport inside

--- a/frontend/e2e/remote-chat-smoke-contract.ts
+++ b/frontend/e2e/remote-chat-smoke-contract.ts
@@ -1,8 +1,14 @@
 export type IdentityContract = 'build-info-v1' | 'legacy-build-meta-v1';
+export type ChatProvider = 'token-place' | 'openai';
 export type ChatUiContract = 'modern-settings-v1' | 'legacy-inline-openai-v1';
 
-export function chatUiContractFor(identityContract: IdentityContract): ChatUiContract {
-    return identityContract === 'legacy-build-meta-v1'
-        ? 'legacy-inline-openai-v1'
-        : 'modern-settings-v1';
+export function chatUiContractFor(
+    identityContract: IdentityContract,
+    provider: ChatProvider
+): ChatUiContract {
+    if (identityContract === 'legacy-build-meta-v1' && provider === 'openai') {
+        return 'legacy-inline-openai-v1';
+    }
+
+    return 'modern-settings-v1';
 }

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -4,7 +4,11 @@ import { createRequire } from 'node:module';
 import { expect, test, type Page } from '@playwright/test';
 
 import { clearUserData, waitForHydration } from './test-helpers';
-import { chatUiContractFor, type IdentityContract } from './remote-chat-smoke-contract';
+import {
+    chatUiContractFor,
+    type ChatProvider,
+    type IdentityContract,
+} from './remote-chat-smoke-contract';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -24,8 +28,8 @@ function normalizeIdentityContract(value: string | undefined): IdentityContract 
 }
 
 const identityContract = normalizeIdentityContract(process.env.DSPACE_EXPECTED_IDENTITY_CONTRACT);
-const chatUiContract = chatUiContractFor(identityContract);
-const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as 'token-place' | 'openai';
+const expectedProvider = process.env.DSPACE_EXPECTED_PROVIDER as ChatProvider;
+const chatUiContract = chatUiContractFor(identityContract, expectedProvider);
 const expectedOrigin = process.env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
 const expectedModel = process.env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
 const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -7,10 +7,22 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
 const defaultIdentityContract = 'build-info-v1';
-const legacyIdentityCoordinates = {
-  version: '3.0.1',
-  revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
-};
+const legacyIdentityProfiles = [
+  {
+    version: '3.0.1',
+    revision: '1a31a569aff2dbeb238e8c2688b9e85140d2077d',
+    provider: 'openai',
+    identityContract: 'legacy-build-meta-v1',
+    chatUiContract: 'legacy-inline-openai-v1',
+  },
+  {
+    version: '3.1.0',
+    revision: '018687f5a7f4de45508c6e36eb28afb3e44da24d',
+    provider: 'token-place',
+    identityContract: 'legacy-build-meta-v1',
+    chatUiContract: 'modern-settings-v1',
+  },
+];
 
 const definitions = {
   baseURL: ['base-url', 'DSPACE_SMOKE_BASE_URL'],
@@ -119,14 +131,6 @@ export function parseAndValidateArgs(argv, env = process.env) {
   ) {
     throw new Error('validation: identity contract is unsupported');
   }
-  if (
-    result.identityContract === 'legacy-build-meta-v1' &&
-    (result.expectedVersion !== legacyIdentityCoordinates.version ||
-      result.expectedRevision !== legacyIdentityCoordinates.revision ||
-      result.expectedProvider !== 'openai')
-  ) {
-    throw new Error('validation: legacy identity contract is restricted');
-  }
   if (!['token-place', 'openai'].includes(result.expectedProvider)) {
     throw new Error(
       'validation: expected provider must be token-place or openai'
@@ -172,6 +176,19 @@ export function parseAndValidateArgs(argv, env = process.env) {
     throw new Error(
       'validation: token.place origin/model are inapplicable when provider is openai'
     );
+  }
+
+  if (result.identityContract === 'legacy-build-meta-v1') {
+    const matchesAllowedLegacyProfile = legacyIdentityProfiles.some(
+      (profile) =>
+        profile.version === result.expectedVersion &&
+        profile.revision === result.expectedRevision &&
+        profile.provider === result.expectedProvider &&
+        profile.identityContract === result.identityContract
+    );
+    if (!matchesAllowedLegacyProfile) {
+      throw new Error('validation: legacy identity contract is restricted');
+    }
   }
   return result;
 }

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -4,9 +4,14 @@ import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract
 
 describe('remote chat smoke UI contract selection', () => {
   it.each([
-    ['build-info-v1', 'modern-settings-v1'],
-    ['legacy-build-meta-v1', 'legacy-inline-openai-v1'],
-  ] as const)('maps %s to %s', (identityContract, expected) => {
-    expect(chatUiContractFor(identityContract)).toBe(expected);
-  });
+    ['legacy-build-meta-v1', 'openai', 'legacy-inline-openai-v1'],
+    ['legacy-build-meta-v1', 'token-place', 'modern-settings-v1'],
+    ['build-info-v1', 'openai', 'modern-settings-v1'],
+    ['build-info-v1', 'token-place', 'modern-settings-v1'],
+  ] as const)(
+    'maps %s with %s to %s',
+    (identityContract, provider, expected) => {
+      expect(chatUiContractFor(identityContract, provider)).toBe(expected);
+    }
+  );
 });

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -6,6 +6,7 @@ import {
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
 const recoveryRevision = '1a31a569aff2dbeb238e8c2688b9e85140d2077d';
+const tokenPlaceLegacyRevision = '018687f5a7f4de45508c6e36eb28afb3e44da24d';
 const completeEnv = {
   DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
   DSPACE_EXPECTED_VERSION: '3.1.0',
@@ -51,7 +52,7 @@ describe('remote chat smoke input validation', () => {
     ).toBe('build-info-v1');
   });
 
-  it('accepts the legacy identity contract only for the recovery coordinates', () => {
+  it('accepts the exact 3.0.1 OpenAI legacy recovery profile', () => {
     const legacyEnv = {
       ...completeEnv,
       DSPACE_EXPECTED_VERSION: '3.0.1',
@@ -68,6 +69,29 @@ describe('remote chat smoke input validation', () => {
     expect(buildSmokeEnv(options, {}).DSPACE_EXPECTED_IDENTITY_CONTRACT).toBe(
       'legacy-build-meta-v1'
     );
+  });
+
+  it('accepts the exact 3.1.0 token.place legacy compatibility profile', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      DSPACE_EXPECTED_REVISION: tokenPlaceLegacyRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+    });
+    const smokeEnv = buildSmokeEnv(options, {});
+    expect(options).toMatchObject({
+      expectedVersion: '3.1.0',
+      expectedRevision: tokenPlaceLegacyRevision,
+      expectedProvider: 'token-place',
+      identityContract: 'legacy-build-meta-v1',
+      expectedTokenPlaceOrigin: 'https://token.place',
+      expectedTokenPlaceModel: 'llama-3.1-8b-instruct',
+    });
+    expect(smokeEnv).toMatchObject({
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
+      DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'llama-3.1-8b-instruct',
+      PW_WORKERS: '1',
+    });
   });
 
   it.each([
@@ -87,7 +111,7 @@ describe('remote chat smoke input validation', () => {
     }
   );
 
-  it('rejects token.place for the legacy OpenAI-only UI contract', () => {
+  it('rejects 3.0.1 with token.place for the legacy identity contract', () => {
     expect(() =>
       parseAndValidateArgs([], {
         ...completeEnv,
@@ -97,6 +121,97 @@ describe('remote chat smoke input validation', () => {
       })
     ).toThrow('legacy identity contract is restricted');
   });
+
+  it('rejects 3.1.0 with OpenAI for the legacy identity contract', () => {
+    const env = {
+      ...completeEnv,
+      DSPACE_EXPECTED_REVISION: tokenPlaceLegacyRevision,
+      DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      DSPACE_EXPECTED_PROVIDER: 'openai',
+    };
+    delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+    delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+    expect(() => parseAndValidateArgs([], env)).toThrow(
+      'legacy identity contract is restricted'
+    );
+  });
+
+  it.each([
+    [
+      '3.0.1 version drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.0.2',
+        DSPACE_EXPECTED_REVISION: recoveryRevision,
+        DSPACE_EXPECTED_PROVIDER: 'openai',
+      },
+    ],
+    [
+      '3.0.1 revision drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.0.1',
+        DSPACE_EXPECTED_REVISION: revision,
+        DSPACE_EXPECTED_PROVIDER: 'openai',
+      },
+    ],
+    [
+      '3.0.1 provider drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.0.1',
+        DSPACE_EXPECTED_REVISION: recoveryRevision,
+        DSPACE_EXPECTED_PROVIDER: 'token-place',
+      },
+    ],
+    [
+      '3.1.0 version drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.1.1',
+        DSPACE_EXPECTED_REVISION: tokenPlaceLegacyRevision,
+        DSPACE_EXPECTED_PROVIDER: 'token-place',
+      },
+    ],
+    [
+      '3.1.0 revision drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.1.0',
+        DSPACE_EXPECTED_REVISION: revision,
+        DSPACE_EXPECTED_PROVIDER: 'token-place',
+      },
+    ],
+    [
+      '3.1.0 provider drift',
+      {
+        DSPACE_EXPECTED_VERSION: '3.1.0',
+        DSPACE_EXPECTED_REVISION: tokenPlaceLegacyRevision,
+        DSPACE_EXPECTED_PROVIDER: 'openai',
+      },
+    ],
+  ])(
+    'rejects legacy profile %s without echoing supplied values',
+    (_name, drift) => {
+      const env = {
+        ...completeEnv,
+        ...drift,
+        DSPACE_EXPECTED_IDENTITY_CONTRACT: 'legacy-build-meta-v1',
+      };
+      if (env.DSPACE_EXPECTED_PROVIDER === 'openai') {
+        delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
+        delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
+      }
+      let message = '';
+      try {
+        parseAndValidateArgs([], env);
+      } catch (error) {
+        message = String(error.message);
+      }
+      expect(message).toBe(
+        'validation: legacy identity contract is restricted'
+      );
+      expect(message.length).toBeLessThan(100);
+      expect(message).not.toContain(env.DSPACE_EXPECTED_VERSION);
+      expect(message).not.toContain(env.DSPACE_EXPECTED_REVISION);
+      expect(message).not.toContain(env.DSPACE_EXPECTED_PROVIDER);
+    }
+  );
 
   it('rejects unknown, empty, and contradictory identity contracts', () => {
     expect(() =>


### PR DESCRIPTION
### Motivation

- The release-aware remote chat smoke harness was failing a valid immutable staging invocation because legacy identity validation was hard-coded to a single 3.0.1/OpenAI tuple and rejected the 3.1.0/token.place immutable artifact that exposes `legacy-build-meta-v1` identity but a modern token.place chat UI. 
- Make a narrowly scoped compatibility allowlist so the exact 3.1.0/token.place legacy profile passes validation without weakening the existing 3.0.1 recovery contract or changing modern behavior.

### Description

- Add an explicit legacy allowlist (`legacyIdentityProfiles`) and exact-field matching in `scripts/run-remote-chat-smoke.mjs` so `legacy-build-meta-v1` is accepted only for the two exact profiles (3.0.1/OpenAI and 3.1.0/token-place). 
- Decouple chat UI selection from build identity by updating `frontend/e2e/remote-chat-smoke-contract.ts` to pick the UI contract from both identity contract and provider, and update callers in `frontend/e2e/remote-chat-smoke.spec.ts` accordingly. 
- Add and update focused regression tests in `scripts/tests/run-remote-chat-smoke.test.ts` and `scripts/tests/remote-chat-smoke-contract.test.ts` to cover exact acceptance, one-field drift rejections, token.place origin/model propagation, `PW_WORKERS=1`, and chat-UI mapping rules. 
- Document the exact 3.1.0 legacy-identity/token.place invocation and clarify independence of build identity and chat UI in `docs/ops/sugarkube-release.md`. 
- Preserve existing token.place validation and environment propagation semantics (credential-free origin, mandatory model, `PW_WORKERS=1`), and do not introduce any runtime probing or general legacy fallback.

### Testing

- Ran `node --check scripts/run-remote-chat-smoke.mjs` and it reported no syntax errors. (passed) 
- Ran unit tests with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and all tests passed (`2 files, 38 tests passed`). (passed) 
- Verified formatting with `pnpm exec prettier --check ...` on the changed files and `npm run check` / `npm run lint` / `npm run type-check`, all of which completed successfully. (passed) 
- Verified `git diff --check` / repository consistency checks and confirmed only the intended files were changed and no deployment/image/chart/state was modified. (passed)

Files changed: `scripts/run-remote-chat-smoke.mjs`, `scripts/tests/run-remote-chat-smoke.test.ts`, `scripts/tests/remote-chat-smoke-contract.test.ts`, `frontend/e2e/remote-chat-smoke-contract.ts`, `frontend/e2e/remote-chat-smoke.spec.ts`, `docs/ops/sugarkube-release.md`.

No runtime behavior, production images, Helm charts, or deployment candidates were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723e063758832fadc64df741cc0f89)