### PR TITLE
Fix bounded Playwright navigation timeout retries

### DIFF
--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -27,7 +27,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
-const DEFAULT_MAX_DURATION_MS = 10_000;
+const DEFAULT_NAVIGATION_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_DURATION_MS = 35_000;
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
@@ -89,6 +90,34 @@ async function wait(page: Page, ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+type NavigateWithRetryOptions = {
+    attempts?: number;
+    delayMs?: number;
+    maxLogAttempts?: number;
+    maxDurationMs?: number;
+    perAttemptTimeoutMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+};
+
+function isRetryableNavigationError(error: unknown): { retryable: boolean; reason: string } {
+    const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
+
+    if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
+        return { retryable: true, reason: 'connection refusal' };
+    }
+
+    if (error instanceof Error && error.name === 'TimeoutError') {
+        return { retryable: true, reason: 'navigation timeout' };
+    }
+
+    if (/^page\.goto: (?:Timeout|Navigation timeout of) \d+ms exceeded\.?$/m.test(message)) {
+        return { retryable: true, reason: 'navigation timeout' };
+    }
+
+    return { retryable: false, reason: 'non-retryable error' };
+}
+
 export async function navigateWithRetry(
     page: Page,
     url: string,
@@ -97,35 +126,52 @@ export async function navigateWithRetry(
         delayMs = DEFAULT_RETRY_DELAY_MS,
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
-    }: { attempts?: number; delayMs?: number; maxLogAttempts?: number; maxDurationMs?: number } = {}
+        perAttemptTimeoutMs = DEFAULT_NAVIGATION_TIMEOUT_MS,
+        now = () => Date.now(),
+        sleep,
+    }: NavigateWithRetryOptions = {}
 ): Promise<void> {
     let lastError: unknown;
-    const startedAt = Date.now();
+    const startedAt = now();
     let suppressedLogCount = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
+        const elapsedBeforeAttemptMs = now() - startedAt;
+        const remainingBeforeAttemptMs = Number.isFinite(maxDurationMs)
+            ? maxDurationMs - elapsedBeforeAttemptMs
+            : Number.POSITIVE_INFINITY;
+
+        if (remainingBeforeAttemptMs <= 0) {
+            const timeoutError = new Error(
+                `Timed out before navigating to ${url} after ${elapsedBeforeAttemptMs}ms (limit ${maxDurationMs}ms)`
+            );
+            if (lastError instanceof Error) {
+                timeoutError.cause = lastError;
+            }
+            throw timeoutError;
+        }
+
+        const timeout = Math.max(1, Math.min(perAttemptTimeoutMs, remainingBeforeAttemptMs));
+
         try {
-            await page.goto(url, { waitUntil: 'domcontentloaded' });
+            await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
             return;
         } catch (error) {
             lastError = error;
 
-            const message =
-                error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
-            const isRetryable = CONNECTION_REFUSED_PATTERNS.some((pattern) =>
-                message.includes(pattern)
-            );
+            const { retryable, reason: retryReason } = isRetryableNavigationError(error);
+            const elapsedMs = now() - startedAt;
+            const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
+                ? maxDurationMs - elapsedMs
+                : Number.POSITIVE_INFINITY;
+            const exhaustedDuration = remainingAfterAttemptMs <= 0;
 
-            const elapsedMs = Date.now() - startedAt;
-
-            const exceededDuration = Number.isFinite(maxDurationMs) && elapsedMs > maxDurationMs;
-
-            if (!isRetryable || attempt === attempts || exceededDuration) {
+            if (!retryable || attempt === attempts || exhaustedDuration) {
                 const wrappedError =
                     error instanceof Error
                         ? error
                         : new Error(`Failed to navigate to ${url}: ${String(error)}`);
-                const reason = exceededDuration
+                const reason = exhaustedDuration
                     ? `after ${elapsedMs}ms (limit ${maxDurationMs}ms)`
                     : `after ${attempt} attempt${attempt === 1 ? '' : 's'}`;
 
@@ -134,9 +180,18 @@ export async function navigateWithRetry(
             }
 
             const backoffDelay = delayMs * attempt;
+            if (remainingAfterAttemptMs <= backoffDelay) {
+                const wrappedError =
+                    error instanceof Error
+                        ? error
+                        : new Error(`Failed to navigate to ${url}: ${String(error)}`);
+                wrappedError.message = `${wrappedError.message} while navigating to ${url} after ${elapsedMs}ms (limit ${maxDurationMs}ms; insufficient budget for ${backoffDelay}ms retry backoff)`;
+                throw wrappedError;
+            }
+
             if (attempt <= maxLogAttempts) {
                 console.warn(
-                    `Retrying navigation to ${url} after connection refusal (attempt ${attempt} of ${attempts})`
+                    `Retrying navigation to ${url} after ${retryReason} (attempt ${attempt} of ${attempts})`
                 );
             } else {
                 suppressedLogCount += 1;
@@ -147,7 +202,11 @@ export async function navigateWithRetry(
                     );
                 }
             }
-            await wait(page, backoffDelay);
+            if (sleep) {
+                await sleep(backoffDelay);
+            } else {
+                await wait(page, backoffDelay);
+            }
         }
     }
 

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,48 +1,247 @@
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-function createMockPage(failures: number): Page {
-    let callCount = 0;
-    const goto = vi.fn(async () => {
-        callCount += 1;
-        if (callCount <= failures) {
-            throw new Error('net::ERR_CONNECTION_REFUSED');
-        }
-    });
+type MockPage = Page & {
+  goto: ReturnType<typeof vi.fn>;
+  waitForTimeout: ReturnType<typeof vi.fn>;
+};
 
-    const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+function timeoutError(message = 'page.goto: Timeout 15000ms exceeded.'): Error {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
+}
 
-    return {
-        goto,
-        waitForTimeout,
-    } as unknown as Page;
+function createMockPage(results: Array<unknown>): MockPage {
+  const queue = [...results];
+  const goto = vi.fn(async () => {
+    const next = queue.shift();
+    if (next instanceof Error) {
+      throw next;
+    }
+  });
+
+  const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    goto,
+    waitForTimeout,
+  } as unknown as MockPage;
+}
+
+function createClock(start = 0): {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let current = start;
+  return {
+    now: () => current,
+    sleep: vi.fn(async (ms: number) => {
+      current += ms;
+    }),
+  };
 }
 
 describe('navigateWithRetry', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    it('handles a handful of connection refusals before succeeding with default retries', async () => {
-        const page = createMockPage(3);
+  afterEach(() => {
+    consoleWarnSpy.mockClear();
+  });
 
-        await expect(navigateWithRetry(page, 'http://127.0.0.1:3000')).resolves.toBeUndefined();
+  it('retries a navigation timeout before succeeding', async () => {
+    const page = createMockPage([timeoutError(), undefined]);
+    const clock = createClock();
 
-        expect(page.goto).toHaveBeenCalledTimes(4);
-        expect(page.waitForTimeout).toHaveBeenCalled();
+    await expect(
+      navigateWithRetry(page, '/', {
+        delayMs: 50,
+        now: clock.now,
+        sleep: clock.sleep,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.goto).toHaveBeenNthCalledWith(1, '/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    });
+    expect(clock.sleep).toHaveBeenCalledWith(50);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to / after navigation timeout (attempt 1 of 6)'
+    );
+  });
+
+  it('retries a narrowly matched Playwright timeout message before succeeding', async () => {
+    const page = createMockPage([
+      new Error('page.goto: Timeout 15000ms exceeded.'),
+      undefined,
+    ]);
+    const clock = createClock();
+
+    await navigateWithRetry(page, '/', {
+      delayMs: 1,
+      now: clock.now,
+      sleep: clock.sleep,
     });
 
-    it('propagates the last error after exhausting retries', async () => {
-        const page = createMockPage(Number.POSITIVE_INFINITY);
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
 
-        await expect(
-            navigateWithRetry(page, 'http://127.0.0.1:3000', { attempts: 2, delayMs: 1 })
-        ).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+  it('retries connection refusal before succeeding', async () => {
+    const page = createMockPage([
+      new Error('page.goto: net::ERR_CONNECTION_REFUSED'),
+      undefined,
+    ]);
+    const clock = createClock();
 
-        expect(page.goto).toHaveBeenCalledTimes(2);
+    await navigateWithRetry(page, 'http://127.0.0.1:3000', {
+      delayMs: 25,
+      now: clock.now,
+      sleep: clock.sleep,
     });
 
-    afterAll(() => {
-        consoleWarnSpy.mockRestore();
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(clock.sleep).toHaveBeenCalledWith(25);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to http://127.0.0.1:3000 after connection refusal (attempt 1 of 6)'
+    );
+  });
+
+  it('returns after a successful first attempt without retrying or sleeping', async () => {
+    const page = createMockPage([undefined]);
+    const clock = createClock();
+
+    await navigateWithRetry(page, '/', { now: clock.now, sleep: clock.sleep });
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(clock.sleep).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails immediately for non-retryable navigation errors', async () => {
+    const navigationError = new Error(
+      'page.goto: net::ERR_CERT_AUTHORITY_INVALID'
+    );
+    const page = createMockPage([navigationError, undefined]);
+    const clock = createClock();
+
+    await expect(
+      navigateWithRetry(page, '/', { now: clock.now, sleep: clock.sleep })
+    ).rejects.toThrow(navigationError);
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(clock.sleep).not.toHaveBeenCalled();
+  });
+
+  it('bounds the per-attempt timeout by the remaining overall duration', async () => {
+    let current = 1_000;
+    const now = vi.fn(() => current);
+    const page = createMockPage([undefined]);
+
+    await navigateWithRetry(page, '/', {
+      maxDurationMs: 10_000,
+      perAttemptTimeoutMs: 15_000,
+      now,
+      sleep: vi.fn(),
     });
+
+    expect(page.goto).toHaveBeenCalledWith('/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 10_000,
+    });
+  });
+
+  it('does not sleep or begin another attempt when backoff would exhaust the budget', async () => {
+    let current = 0;
+    const page = createMockPage([timeoutError(), undefined]);
+    page.goto.mockImplementationOnce(async () => {
+      current = 9_960;
+      throw timeoutError();
+    });
+    const sleep = vi.fn(async (ms: number) => {
+      current += ms;
+    });
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        delayMs: 50,
+        maxDurationMs: 10_000,
+        now: () => current,
+        sleep,
+      })
+    ).rejects.toThrow('insufficient budget for 50ms retry backoff');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('does not begin another attempt after duration exhaustion', async () => {
+    let current = 0;
+    const page = createMockPage([timeoutError(), undefined]);
+    page.goto.mockImplementationOnce(async () => {
+      current = 10_000;
+      throw timeoutError();
+    });
+    const sleep = vi.fn();
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        delayMs: 1,
+        maxDurationMs: 10_000,
+        now: () => current,
+        sleep,
+      })
+    ).rejects.toThrow('limit 10000ms');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('stops after the configured attempt count is exhausted', async () => {
+    const page = createMockPage([timeoutError(), timeoutError(), undefined]);
+    const clock = createClock();
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        now: clock.now,
+        sleep: clock.sleep,
+      })
+    ).rejects.toThrow('after 2 attempts');
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(clock.sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses retry logs after the configured visible retry count', async () => {
+    const page = createMockPage([
+      new Error('net::ERR_CONNECTION_REFUSED'),
+      new Error('net::ERR_CONNECTION_REFUSED'),
+      new Error('net::ERR_CONNECTION_REFUSED'),
+      undefined,
+    ]);
+    const clock = createClock();
+
+    await navigateWithRetry(page, '/', {
+      attempts: 4,
+      delayMs: 1,
+      maxLogAttempts: 1,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      1,
+      'Retrying navigation to / after connection refusal (attempt 1 of 4)'
+    );
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      2,
+      'Suppressing further retry logs for /; attempts 2-4 will retry silently'
+    );
+  });
 });

--- a/tests/purgeClientStateRetry.test.ts
+++ b/tests/purgeClientStateRetry.test.ts
@@ -5,8 +5,9 @@ vi.mock('/src/utils/gameState/common.js', () => ({}), { virtual: true });
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-describe('navigateWithRetry', () => {
+describe('navigateWithRetry preview-server retry compatibility', () => {
   const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
   it('retries navigation when the preview server is not ready', async () => {
     const goto = vi
       .fn(async () => undefined as Awaited<ReturnType<Page['goto']>>)
@@ -35,7 +36,7 @@ describe('navigateWithRetry', () => {
 
   it('rethrows non retryable navigation errors', async () => {
     const navigationError = new Error(
-      'page.goto: Navigation timeout of 30000ms exceeded'
+      'page.goto: net::ERR_CERT_AUTHORITY_INVALID'
     );
     const page = {
       goto: vi.fn(async () => {


### PR DESCRIPTION
### Motivation
- Remote-chat smoke runs were failing when a transient `page.goto()` navigation timed out because the helper did not treat Playwright navigation timeouts as retryable and its overall budget was smaller than a single Playwright navigation timeout. 
- The goal is to reliably retry bounded transient navigation timeouts (and keep existing connection-refused retries) while keeping all waits, attempts, and logs strictly bounded.

### Description
- Add a narrow retry predicate `isRetryableNavigationError` that treats `TimeoutError` (via `error.name === 'TimeoutError'`) and a tightly-scoped `page.goto` timeout-message fallback as retryable, while preserving non-retryable failures. 
- Make per-attempt time accounting explicit by adding a configurable `perAttemptTimeoutMs`, passing `timeout` to `page.goto()`, computing the remaining overall budget before each attempt, and refusing to start/sleep when insufficient budget remains. 
- Increase default overall budget so a single Playwright navigation timeout can be meaningfully retried and include retry backoff inside that same `maxDurationMs` budget. 
- Add deterministic Vitest tests (injected `now`/`sleep` hooks and mock `Page`) that cover timeout-then-success, message-shape timeout-then-success, connection-refusal-then-success, immediate non-retryable failure, per-attempt timeout bounding, backoff/exhaustion behavior, attempt exhaustion, and retry log suppression.
- Files changed: `frontend/e2e/test-helpers.ts`, `tests/navigateWithRetry.test.ts`, and `tests/purgeClientStateRetry.test.ts`.

### Testing
- Ran focused helper tests with: `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` and they passed (2 files, 12 tests; all passed). 
- Verified remote-chat smoke contract tests with: `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and they passed (2 files, 38 tests; all passed). 
- Performed type checking with: `npm run type-check` and it completed successfully. 
- Ensured formatting with Prettier via: `pnpm exec prettier --check frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` and fixed/verified formatting; check passed. 
- Ran repository diff check: `git diff --check` with no whitespace or diff-check errors. 

Residual risk and follow-ups:
- The timeout detection uses `error.name === 'TimeoutError'` and a narrow `page.goto` message regex fallback to remain conservative; if Playwright changes error shapes in future releases the fallback may need updates. 
- Defaults were adjusted (`DEFAULT_NAVIGATION_TIMEOUT_MS = 15000`, `DEFAULT_MAX_DURATION_MS = 35000`) to allow a meaningful retry; these defaults are conservative but can be tuned if CI environments require different budgets. 
- I attempted to create a PR with the local branch, but the environment's GitHub CLI was not authenticated; the branch/commit is ready for review and can be pushed/PR-created from an authenticated environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72583c89f8832fbfeaa330df07a889)