### PR TITLE
Retry bounded Playwright navigation timeouts

### DIFF
--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -27,7 +27,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
-const DEFAULT_MAX_DURATION_MS = 10_000;
+const DEFAULT_MAX_DURATION_MS = 35_000;
+const MIN_RETRY_BUDGET_MS = 1;
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
@@ -89,6 +90,36 @@ async function wait(page: Page, ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+type NavigateWithRetryOptions = {
+    attempts?: number;
+    delayMs?: number;
+    maxLogAttempts?: number;
+    maxDurationMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+};
+
+function isNavigationTimeoutError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    if (error.name === 'TimeoutError') {
+        return true;
+    }
+
+    return /^page\.goto: Timeout \d+ms exceeded\./.test(error.message);
+}
+
+function isRetryableNavigationError(error: unknown): boolean {
+    const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
+
+    return (
+        isNavigationTimeoutError(error) ||
+        CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))
+    );
+}
+
 export async function navigateWithRetry(
     page: Page,
     url: string,
@@ -97,30 +128,34 @@ export async function navigateWithRetry(
         delayMs = DEFAULT_RETRY_DELAY_MS,
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
-    }: { attempts?: number; delayMs?: number; maxLogAttempts?: number; maxDurationMs?: number } = {}
+        now = Date.now,
+        sleep,
+    }: NavigateWithRetryOptions = {}
 ): Promise<void> {
     let lastError: unknown;
-    const startedAt = Date.now();
+    const startedAt = now();
     let suppressedLogCount = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
+        const elapsedBeforeAttemptMs = now() - startedAt;
+        const remainingDurationMs = Number.isFinite(maxDurationMs)
+            ? Math.max(0, maxDurationMs - elapsedBeforeAttemptMs)
+            : Number.POSITIVE_INFINITY;
+
+        if (remainingDurationMs < MIN_RETRY_BUDGET_MS) {
+            break;
+        }
+
         try {
-            await page.goto(url, { waitUntil: 'domcontentloaded' });
+            await page.goto(url, { waitUntil: 'domcontentloaded', timeout: remainingDurationMs });
             return;
         } catch (error) {
             lastError = error;
 
-            const message =
-                error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
-            const isRetryable = CONNECTION_REFUSED_PATTERNS.some((pattern) =>
-                message.includes(pattern)
-            );
+            const elapsedMs = now() - startedAt;
+            const exceededDuration = Number.isFinite(maxDurationMs) && elapsedMs >= maxDurationMs;
 
-            const elapsedMs = Date.now() - startedAt;
-
-            const exceededDuration = Number.isFinite(maxDurationMs) && elapsedMs > maxDurationMs;
-
-            if (!isRetryable || attempt === attempts || exceededDuration) {
+            if (!isRetryableNavigationError(error) || attempt === attempts || exceededDuration) {
                 const wrappedError =
                     error instanceof Error
                         ? error
@@ -134,9 +169,17 @@ export async function navigateWithRetry(
             }
 
             const backoffDelay = delayMs * attempt;
+            const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
+                ? Math.max(0, maxDurationMs - elapsedMs)
+                : Number.POSITIVE_INFINITY;
+
+            if (backoffDelay >= remainingAfterAttemptMs) {
+                break;
+            }
+
             if (attempt <= maxLogAttempts) {
                 console.warn(
-                    `Retrying navigation to ${url} after connection refusal (attempt ${attempt} of ${attempts})`
+                    `Retrying navigation to ${url} after transient navigation failure (attempt ${attempt} of ${attempts})`
                 );
             } else {
                 suppressedLogCount += 1;
@@ -147,13 +190,17 @@ export async function navigateWithRetry(
                     );
                 }
             }
-            await wait(page, backoffDelay);
+            await (sleep ? sleep(backoffDelay) : wait(page, backoffDelay));
         }
     }
 
-    throw lastError instanceof Error
-        ? lastError
-        : new Error(`Failed to navigate to ${url}: ${String(lastError)}`);
+    const elapsedMs = now() - startedAt;
+    const wrappedError =
+        lastError instanceof Error
+            ? lastError
+            : new Error(`Failed to navigate to ${url}: ${String(lastError)}`);
+    wrappedError.message = `${wrappedError.message} while navigating to ${url} after ${elapsedMs}ms (limit ${maxDurationMs}ms)`;
+    throw wrappedError;
 }
 
 /**

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,48 +1,226 @@
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-function createMockPage(failures: number): Page {
-    let callCount = 0;
-    const goto = vi.fn(async () => {
-        callCount += 1;
-        if (callCount <= failures) {
-            throw new Error('net::ERR_CONNECTION_REFUSED');
+type GotoCall = { url: string; timeout?: number; waitUntil?: string };
+
+function createTimeoutError(message = 'page.goto: Timeout 15000ms exceeded.') {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+function createHarness(
+  outcomes: Array<'success' | Error>,
+  durations: number[] = outcomes.map(() => 0)
+): {
+  page: Page;
+  calls: GotoCall[];
+  sleeps: number[];
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let currentTime = 0;
+  const calls: GotoCall[] = [];
+  const sleeps: number[] = [];
+  let index = 0;
+
+  const page = {
+    goto: vi.fn(
+      async (
+        url: string,
+        options?: { waitUntil?: string; timeout?: number }
+      ) => {
+        calls.push({
+          url,
+          waitUntil: options?.waitUntil,
+          timeout: options?.timeout,
+        });
+        const duration = durations[index] ?? 0;
+        const outcome = outcomes[index] ?? 'success';
+        index += 1;
+        currentTime += duration;
+
+        if (outcome instanceof Error) {
+          throw outcome;
         }
-    });
+      }
+    ),
+    waitForTimeout: vi.fn(async (ms: number) => {
+      sleeps.push(ms);
+      currentTime += ms;
+    }),
+  } as unknown as Page;
 
-    const waitForTimeout = vi.fn().mockResolvedValue(undefined);
-
-    return {
-        goto,
-        waitForTimeout,
-    } as unknown as Page;
+  return {
+    page,
+    calls,
+    sleeps,
+    now: () => currentTime,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      currentTime += ms;
+    },
+  };
 }
 
 describe('navigateWithRetry', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    it('handles a handful of connection refusals before succeeding with default retries', async () => {
-        const page = createMockPage(3);
+  afterEach(() => {
+    consoleWarnSpy.mockClear();
+  });
 
-        await expect(navigateWithRetry(page, 'http://127.0.0.1:3000')).resolves.toBeUndefined();
+  it('retries a Playwright navigation timeout before succeeding', async () => {
+    const harness = createHarness(
+      [createTimeoutError(), 'success'],
+      [15_000, 100]
+    );
 
-        expect(page.goto).toHaveBeenCalledTimes(4);
-        expect(page.waitForTimeout).toHaveBeenCalled();
+    await navigateWithRetry(harness.page, '/', {
+      maxDurationMs: 35_000,
+      delayMs: 300,
+      now: harness.now,
+      sleep: harness.sleep,
     });
 
-    it('propagates the last error after exhausting retries', async () => {
-        const page = createMockPage(Number.POSITIVE_INFINITY);
+    expect(harness.page.goto).toHaveBeenCalledTimes(2);
+    expect(harness.sleeps).toEqual([300]);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(harness.calls.map((call) => call.timeout)).toEqual([35_000, 19_700]);
+  });
 
-        await expect(
-            navigateWithRetry(page, 'http://127.0.0.1:3000', { attempts: 2, delayMs: 1 })
-        ).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+  it('retries a connection refusal before succeeding', async () => {
+    const harness = createHarness([
+      new Error(
+        'page.goto: net::ERR_CONNECTION_REFUSED at http://127.0.0.1:3000/'
+      ),
+      'success',
+    ]);
 
-        expect(page.goto).toHaveBeenCalledTimes(2);
+    await navigateWithRetry(harness.page, '/', {
+      maxDurationMs: 10_000,
+      delayMs: 250,
+      now: harness.now,
+      sleep: harness.sleep,
     });
 
-    afterAll(() => {
-        consoleWarnSpy.mockRestore();
+    expect(harness.page.goto).toHaveBeenCalledTimes(2);
+    expect(harness.sleeps).toEqual([250]);
+  });
+
+  it('keeps successful first-attempt navigation unchanged except for bounded timeout', async () => {
+    const harness = createHarness(['success']);
+
+    await navigateWithRetry(harness.page, '/chat', {
+      maxDurationMs: 12_000,
+      now: harness.now,
     });
+
+    expect(harness.page.goto).toHaveBeenCalledTimes(1);
+    expect(harness.calls).toEqual([
+      { url: '/chat', waitUntil: 'domcontentloaded', timeout: 12_000 },
+    ]);
+    expect(harness.sleeps).toEqual([]);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails non-retryable navigation errors immediately', async () => {
+    const certificateError = new Error(
+      'page.goto: net::ERR_CERT_AUTHORITY_INVALID'
+    );
+    const harness = createHarness([certificateError, 'success']);
+
+    await expect(
+      navigateWithRetry(harness.page, '/', {
+        now: harness.now,
+        sleep: harness.sleep,
+      })
+    ).rejects.toThrow(certificateError);
+
+    expect(harness.page.goto).toHaveBeenCalledTimes(1);
+    expect(harness.sleeps).toEqual([]);
+  });
+
+  it('bounds each navigation timeout by the remaining overall duration', async () => {
+    const harness = createHarness(
+      [new Error('page.goto: Timeout 15000ms exceeded.'), 'success'],
+      [1_200, 0]
+    );
+
+    await navigateWithRetry(harness.page, '/', {
+      maxDurationMs: 2_000,
+      delayMs: 300,
+      now: harness.now,
+      sleep: harness.sleep,
+    });
+
+    expect(harness.calls.map((call) => call.timeout)).toEqual([2_000, 500]);
+  });
+
+  it('does not begin another attempt or backoff when the duration budget is exhausted', async () => {
+    const harness = createHarness(
+      [createTimeoutError(), 'success'],
+      [1_000, 0]
+    );
+
+    await expect(
+      navigateWithRetry(harness.page, '/', {
+        maxDurationMs: 1_000,
+        delayMs: 1,
+        now: harness.now,
+        sleep: harness.sleep,
+      })
+    ).rejects.toThrow('limit 1000ms');
+
+    expect(harness.page.goto).toHaveBeenCalledTimes(1);
+    expect(harness.sleeps).toEqual([]);
+  });
+
+  it('stops after exhausting the configured attempt count', async () => {
+    const harness = createHarness([
+      createTimeoutError(),
+      createTimeoutError(),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(harness.page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 10_000,
+        now: harness.now,
+        sleep: harness.sleep,
+      })
+    ).rejects.toThrow('after 2 attempts');
+
+    expect(harness.page.goto).toHaveBeenCalledTimes(2);
+    expect(harness.sleeps).toEqual([1]);
+  });
+
+  it('suppresses retry logs after the configured maximum', async () => {
+    const harness = createHarness([
+      createTimeoutError(),
+      createTimeoutError(),
+      createTimeoutError(),
+      'success',
+    ]);
+
+    await navigateWithRetry(harness.page, '/', {
+      attempts: 4,
+      delayMs: 1,
+      maxLogAttempts: 1,
+      maxDurationMs: 10_000,
+      now: harness.now,
+      sleep: harness.sleep,
+    });
+
+    expect(harness.page.goto).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy.mock.calls[0]?.[0]).toContain('Retrying navigation');
+    expect(consoleWarnSpy.mock.calls[1]?.[0]).toContain(
+      'Suppressing further retry logs'
+    );
+  });
 });

--- a/tests/purgeClientStateRetry.test.ts
+++ b/tests/purgeClientStateRetry.test.ts
@@ -5,8 +5,9 @@ vi.mock('/src/utils/gameState/common.js', () => ({}), { virtual: true });
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-describe('navigateWithRetry', () => {
+describe('navigateWithRetry preview readiness retry', () => {
   const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
   it('retries navigation when the preview server is not ready', async () => {
     const goto = vi
       .fn(async () => undefined as Awaited<ReturnType<Page['goto']>>)
@@ -33,9 +34,9 @@ describe('navigateWithRetry', () => {
     expect(waitForTimeout).toHaveBeenCalledTimes(1);
   });
 
-  it('rethrows non retryable navigation errors', async () => {
+  it('rethrows non-timeout non-retryable navigation errors', async () => {
     const navigationError = new Error(
-      'page.goto: Navigation timeout of 30000ms exceeded'
+      'page.goto: net::ERR_CERT_AUTHORITY_INVALID'
     );
     const page = {
       goto: vi.fn(async () => {


### PR DESCRIPTION
### Motivation
- Remote chat smoke runs occasionally failed during `clearUserData()` because `navigateWithRetry()` let a single Playwright `page.goto()` consume more time than the helper's overall budget and did not treat Playwright navigation timeouts as retryable.
- The intent is to retry bounded transient navigation timeouts (and preserve existing connection-refused retries) without creating unbounded waits or retrying non-transient failures.

### Description
- Increase the helper's default overall budget from `10_000` ms to `35_000` ms and add a `MIN_RETRY_BUDGET_MS` guard so a normal Playwright 15s navigation timeout can leave room for at least one retry. (edited `frontend/e2e/test-helpers.ts`)
- Classify retryable navigation failures by detecting Playwright timeouts via `error.name === 'TimeoutError'` and a narrowly-scoped `page.goto: Timeout <n>ms exceeded.` compatibility regex, while preserving existing connection-refused pattern matching. (new helper functions in `frontend/e2e/test-helpers.ts`)
- Make timeout accounting consistent by computing remaining overall duration before each attempt, passing that remaining budget as the explicit `timeout` to `page.goto()`, refusing to start another attempt or backoff when insufficient budget remains, and adding injected `now`/`sleep` hooks for deterministic tests. (changes to `navigateWithRetry` in `frontend/e2e/test-helpers.ts`)
- Preserve bounded/suppressed retry logging semantics and keep non-retryable failures fail-closed, and add deterministic Vitest unit tests covering timeout retry, connection refusal retry, first-attempt success, non-retryable immediate failure, per-attempt timeout bounding, duration exhaustion, attempt exhaustion, and log suppression. (added `tests/navigateWithRetry.test.ts`, updated `tests/purgeClientStateRetry.test.ts`)

### Testing
- Ran the focused helper tests with `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` and all tests passed. (10 tests passed total)
- Verified remote-chat smoke harness test helpers with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` and both suites passed. (38 tests passed total)
- Type checking via `npm run type-check` succeeded without errors. 
- Formatting checks with Prettier on the modified files using `pnpm exec prettier --check tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts frontend/e2e/test-helpers.ts` reported all files as matching formatting rules. 
- Ran `git diff --check` (no whitespace/format errors) and created a commit locally; note: PR creation via GitHub CLI was not completed in this environment due to missing `gh` authentication, so publishing the branch/PR requires an authenticated environment. 

Files changed: `frontend/e2e/test-helpers.ts`, `tests/navigateWithRetry.test.ts`, `tests/purgeClientStateRetry.test.ts`.

Residual risk: CI will still need to validate the change on real ARM staging environments and with full Playwright browsers in case other platform-specific navigation behaviors surface, but the unit tests exercise the new timeout accounting deterministically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72583ea5dc832fa6aee734a201a6a8)