### PR TITLE
Retry Playwright navigation timeouts in navigateWithRetry

### DIFF
--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -24,10 +24,13 @@ const CONNECTION_REFUSED_PATTERNS = [
     'Connection refused',
 ];
 
+const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\b/;
+
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
+const DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
-const DEFAULT_MAX_DURATION_MS = 10_000;
+const DEFAULT_MAX_DURATION_MS = 35_000;
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
@@ -89,6 +92,42 @@ async function wait(page: Page, ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+type NavigateWithRetryOptions = {
+    attempts?: number;
+    delayMs?: number;
+    maxLogAttempts?: number;
+    maxDurationMs?: number;
+    attemptTimeoutMs?: number;
+    now?: () => number;
+};
+
+function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeout' | null {
+    const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
+
+    if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
+        return 'connection refusal';
+    }
+
+    if (error instanceof Error && error.name === 'TimeoutError') {
+        return 'timeout';
+    }
+
+    if (PLAYWRIGHT_GOTO_TIMEOUT_PATTERN.test(message)) {
+        return 'timeout';
+    }
+
+    return null;
+}
+
+function decorateNavigationError(error: unknown, url: string, reason: string): Error {
+    const wrappedError =
+        error instanceof Error
+            ? error
+            : new Error(`Failed to navigate to ${url}: ${String(error)}`);
+    wrappedError.message = `${wrappedError.message} while navigating to ${url} ${reason}`;
+    return wrappedError;
+}
+
 export async function navigateWithRetry(
     page: Page,
     url: string,
@@ -97,46 +136,66 @@ export async function navigateWithRetry(
         delayMs = DEFAULT_RETRY_DELAY_MS,
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
-    }: { attempts?: number; delayMs?: number; maxLogAttempts?: number; maxDurationMs?: number } = {}
+        attemptTimeoutMs = DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS,
+        now = () => Date.now(),
+    }: NavigateWithRetryOptions = {}
 ): Promise<void> {
     let lastError: unknown;
-    const startedAt = Date.now();
+    const startedAt = now();
     let suppressedLogCount = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
+        const elapsedBeforeAttemptMs = now() - startedAt;
+        const remainingBeforeAttemptMs = Number.isFinite(maxDurationMs)
+            ? maxDurationMs - elapsedBeforeAttemptMs
+            : Number.POSITIVE_INFINITY;
+
+        if (remainingBeforeAttemptMs <= 0) {
+            throw decorateNavigationError(
+                lastError,
+                url,
+                `after ${elapsedBeforeAttemptMs}ms (limit ${maxDurationMs}ms)`
+            );
+        }
+
+        const navigationTimeoutMs = Math.min(remainingBeforeAttemptMs, attemptTimeoutMs);
+
         try {
-            await page.goto(url, { waitUntil: 'domcontentloaded' });
+            await page.goto(url, {
+                waitUntil: 'domcontentloaded',
+                timeout: navigationTimeoutMs,
+            });
             return;
         } catch (error) {
             lastError = error;
 
-            const message =
-                error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
-            const isRetryable = CONNECTION_REFUSED_PATTERNS.some((pattern) =>
-                message.includes(pattern)
-            );
+            const retryReason = getNavigationRetryReason(error);
+            const elapsedMs = now() - startedAt;
+            const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
+                ? maxDurationMs - elapsedMs
+                : Number.POSITIVE_INFINITY;
+            const exceededDuration = remainingAfterAttemptMs <= 0;
 
-            const elapsedMs = Date.now() - startedAt;
-
-            const exceededDuration = Number.isFinite(maxDurationMs) && elapsedMs > maxDurationMs;
-
-            if (!isRetryable || attempt === attempts || exceededDuration) {
-                const wrappedError =
-                    error instanceof Error
-                        ? error
-                        : new Error(`Failed to navigate to ${url}: ${String(error)}`);
+            if (!retryReason || attempt === attempts || exceededDuration) {
                 const reason = exceededDuration
                     ? `after ${elapsedMs}ms (limit ${maxDurationMs}ms)`
                     : `after ${attempt} attempt${attempt === 1 ? '' : 's'}`;
 
-                wrappedError.message = `${wrappedError.message} while navigating to ${url} ${reason}`;
-                throw wrappedError;
+                throw decorateNavigationError(error, url, reason);
             }
 
             const backoffDelay = delayMs * attempt;
+            if (backoffDelay > 0 && remainingAfterAttemptMs <= backoffDelay) {
+                throw decorateNavigationError(
+                    error,
+                    url,
+                    `after ${elapsedMs}ms (limit ${maxDurationMs}ms)`
+                );
+            }
+
             if (attempt <= maxLogAttempts) {
                 console.warn(
-                    `Retrying navigation to ${url} after connection refusal (attempt ${attempt} of ${attempts})`
+                    `Retrying navigation to ${url} after ${retryReason} (attempt ${attempt} of ${attempts})`
                 );
             } else {
                 suppressedLogCount += 1;
@@ -147,7 +206,10 @@ export async function navigateWithRetry(
                     );
                 }
             }
-            await wait(page, backoffDelay);
+
+            if (backoffDelay > 0) {
+                await wait(page, backoffDelay);
+            }
         }
     }
 

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -24,7 +24,7 @@ const CONNECTION_REFUSED_PATTERNS = [
     'Connection refused',
 ];
 
-const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\b/;
+const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\.(?:\r?\n|$)/;
 
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
@@ -140,6 +140,12 @@ export async function navigateWithRetry(
         now = () => Date.now(),
     }: NavigateWithRetryOptions = {}
 ): Promise<void> {
+    if (!Number.isFinite(attemptTimeoutMs) || attemptTimeoutMs <= 0) {
+        throw new Error(
+            `attemptTimeoutMs must be a finite positive number, received ${attemptTimeoutMs}`
+        );
+    }
+
     let lastError: unknown;
     const startedAt = now();
     let suppressedLogCount = 0;

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
@@ -38,6 +38,10 @@ describe('navigateWithRetry', () => {
 
   afterEach(() => {
     consoleWarnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
   });
 
   it('retries a Playwright navigation timeout before succeeding', async () => {

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -79,6 +79,61 @@ describe('navigateWithRetry', () => {
     expect(page.goto).toHaveBeenCalledTimes(2);
   });
 
+  it('retries the stable Playwright goto timeout message with a call log before succeeding', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: Timeout 15000ms exceeded.\nCall log:\n  - navigating to "/"'
+      ),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a near-match Playwright goto timeout message with unrelated trailing text', async () => {
+    const page = createMockPage([
+      new Error('page.goto: Timeout 15000ms exceeded. unrelated trailing text'),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+      })
+    ).rejects.toThrow('after 1 attempt');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does not retry the legacy navigation timeout message', async () => {
+    const page = createMockPage([
+      new Error('page.goto: Navigation timeout of 30000ms exceeded'),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+      })
+    ).rejects.toThrow('after 1 attempt');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
   it('retries connection refusal before succeeding', async () => {
     const page = createMockPage([
       new Error('net::ERR_CONNECTION_REFUSED'),
@@ -126,6 +181,9 @@ describe('navigateWithRetry', () => {
       nowMs += 7_000;
       throw createTimeoutError();
     });
+    page.waitForTimeout.mockImplementationOnce(async (ms: number) => {
+      nowMs += ms;
+    });
 
     await expect(
       navigateWithRetry(page, '/', {
@@ -137,15 +195,38 @@ describe('navigateWithRetry', () => {
       })
     ).resolves.toBeUndefined();
 
+    expect(page.waitForTimeout).toHaveBeenCalledWith(100);
     expect(page.goto).toHaveBeenNthCalledWith(1, '/', {
       waitUntil: 'domcontentloaded',
       timeout: 10_000,
     });
     expect(page.goto).toHaveBeenNthCalledWith(2, '/', {
       waitUntil: 'domcontentloaded',
-      timeout: 3_000,
+      timeout: 2_900,
     });
   });
+
+  it.each([
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])(
+    'rejects invalid attemptTimeoutMs value %s before attempting navigation',
+    async (attemptTimeoutMs) => {
+      const page = createMockPage(['success']);
+
+      await expect(
+        navigateWithRetry(page, '/', {
+          attemptTimeoutMs,
+        })
+      ).rejects.toThrow('attemptTimeoutMs must be a finite positive number');
+
+      expect(page.goto).not.toHaveBeenCalled();
+      expect(page.waitForTimeout).not.toHaveBeenCalled();
+    }
+  );
 
   it('does not sleep or begin another attempt when the retry backoff would exhaust the budget', async () => {
     let nowMs = 0;

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,48 +1,213 @@
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-function createMockPage(failures: number): Page {
-    let callCount = 0;
-    const goto = vi.fn(async () => {
-        callCount += 1;
-        if (callCount <= failures) {
-            throw new Error('net::ERR_CONNECTION_REFUSED');
-        }
-    });
+type MockPage = Page & {
+  goto: ReturnType<typeof vi.fn>;
+  waitForTimeout: ReturnType<typeof vi.fn>;
+};
 
-    const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+function createMockPage(outcomes: Array<unknown | 'success'>): MockPage {
+  const pendingOutcomes = [...outcomes];
+  const goto = vi.fn(async () => {
+    const outcome = pendingOutcomes.shift() ?? 'success';
+    if (outcome !== 'success') {
+      throw outcome;
+    }
+  });
 
-    return {
-        goto,
-        waitForTimeout,
-    } as unknown as Page;
+  const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    goto,
+    waitForTimeout,
+  } as unknown as MockPage;
+}
+
+function createTimeoutError(
+  message = 'page.goto: Timeout 15000ms exceeded.'
+): Error {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
 }
 
 describe('navigateWithRetry', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    it('handles a handful of connection refusals before succeeding with default retries', async () => {
-        const page = createMockPage(3);
+  afterEach(() => {
+    consoleWarnSpy.mockClear();
+  });
 
-        await expect(navigateWithRetry(page, 'http://127.0.0.1:3000')).resolves.toBeUndefined();
+  it('retries a Playwright navigation timeout before succeeding', async () => {
+    const page = createMockPage([createTimeoutError(), 'success']);
 
-        expect(page.goto).toHaveBeenCalledTimes(4);
-        expect(page.waitForTimeout).toHaveBeenCalled();
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 300,
+        maxDurationMs: 20_000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.waitForTimeout).toHaveBeenCalledWith(300);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to / after timeout (attempt 1 of 2)'
+    );
+  });
+
+  it('retries the stable Playwright goto timeout message shape before succeeding', async () => {
+    const page = createMockPage([
+      new Error('page.goto: Timeout 15000ms exceeded.'),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries connection refusal before succeeding', async () => {
+    const page = createMockPage([
+      new Error('net::ERR_CONNECTION_REFUSED'),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, 'http://127.0.0.1:3000', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 10_000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('succeeds on the first attempt without sleeping or logging', async () => {
+    const page = createMockPage(['success']);
+
+    await expect(navigateWithRetry(page, '/')).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails non-retryable navigation errors immediately', async () => {
+    const navigationError = new Error(
+      'page.goto: net::ERR_CERT_AUTHORITY_INVALID'
+    );
+    const page = createMockPage([navigationError, 'success']);
+
+    await expect(navigateWithRetry(page, '/')).rejects.toThrow(navigationError);
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('bounds each page.goto timeout by the remaining overall duration', async () => {
+    let nowMs = 1_000;
+    const page = createMockPage(['success']);
+    page.goto.mockImplementationOnce(async () => {
+      nowMs += 7_000;
+      throw createTimeoutError();
     });
 
-    it('propagates the last error after exhausting retries', async () => {
-        const page = createMockPage(Number.POSITIVE_INFINITY);
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 100,
+        maxDurationMs: 10_000,
+        attemptTimeoutMs: 20_000,
+        now: () => nowMs,
+      })
+    ).resolves.toBeUndefined();
 
-        await expect(
-            navigateWithRetry(page, 'http://127.0.0.1:3000', { attempts: 2, delayMs: 1 })
-        ).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+    expect(page.goto).toHaveBeenNthCalledWith(1, '/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 10_000,
+    });
+    expect(page.goto).toHaveBeenNthCalledWith(2, '/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 3_000,
+    });
+  });
 
-        expect(page.goto).toHaveBeenCalledTimes(2);
+  it('does not sleep or begin another attempt when the retry backoff would exhaust the budget', async () => {
+    let nowMs = 0;
+    const page = createMockPage([createTimeoutError(), 'success']);
+    page.goto.mockImplementationOnce(async () => {
+      nowMs = 950;
+      throw createTimeoutError();
     });
 
-    afterAll(() => {
-        consoleWarnSpy.mockRestore();
-    });
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 100,
+        maxDurationMs: 1_000,
+        now: () => nowMs,
+      })
+    ).rejects.toThrow('limit 1000ms');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('stops after exhausting the configured attempt count', async () => {
+    const page = createMockPage([
+      new Error('page.goto: net::ERR_CONNECTION_REFUSED'),
+      createTimeoutError(),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+      })
+    ).rejects.toThrow('after 2 attempts');
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses retry logs after the configured log limit', async () => {
+    const page = createMockPage([
+      new Error('page.goto: net::ERR_CONNECTION_REFUSED'),
+      new Error('page.goto: net::ERR_CONNECTION_REFUSED'),
+      createTimeoutError(),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 4,
+        delayMs: 1,
+        maxLogAttempts: 1,
+        maxDurationMs: 20_000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      1,
+      'Retrying navigation to / after connection refusal (attempt 1 of 4)'
+    );
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      2,
+      'Suppressing further retry logs for /; attempts 2-4 will retry silently'
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- Playwright `page.goto()` timeouts were not classified as retryable causing transient navigation failures (e.g., during `clearUserData()` in the remote-chat smoke harness) to fail immediately.
- The helper also used inconsistent timeout accounting where an attempt could consume more time than the helper's overall budget, preventing any meaningful retry.

### Description
- Update `navigateWithRetry` to treat genuine Playwright navigation timeouts as retryable by checking `error.name === 'TimeoutError'` and a narrow fallback regex for the stable Playwright timeout message; connection-refused cases remain retryable and other errors remain fail-closed. (changed file: `frontend/e2e/test-helpers.ts`)
- Make timeout accounting consistent by injecting `now()` for deterministic timing in tests, capping each `page.goto()` with the lesser of the remaining overall budget and a per-attempt cap, and skipping backoff/attempts when the remaining budget is insufficient. (changed file: `frontend/e2e/test-helpers.ts`)
- Increase the helper's default overall budget to allow at least one meaningful retry while keeping per-attempt timeouts bounded (`DEFAULT_MAX_DURATION_MS = 35000` and per-attempt cap `15_000ms`), and preserve suppressed/bounded logging behavior. (changed file: `frontend/e2e/test-helpers.ts`)
- Add deterministic Vitest tests that use a mock `Page` and injected `now()` to cover timeout-retry, connection-refusal retry, first-attempt success, non-retryable error immediates, per-attempt timeout bounding, duration exhaustion preventing further retries, attempt-count exhaustion, and log suppression. (new/updated tests: `tests/navigateWithRetry.test.ts`, existing `tests/purgeClientStateRetry.test.ts` left in place)

### Testing
- Ran the focused helper test suite with: `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts --config vitest.config.mts`, which passed (all tests green).
- Verified remote-chat smoke contract harness logic remains compatible with: `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts --config vitest.config.mts`, which passed.
- Ran type checks with: `npm run type-check`, which succeeded.
- Verified formatting with Prettier: `pnpm exec prettier --check tests/navigateWithRetry.test.ts frontend/e2e/test-helpers.ts`, which reported no style issues.
- Ran `git diff --check` to ensure no whitespace/conflict markers, which reported clean.

Changed files: `frontend/e2e/test-helpers.ts`, `tests/navigateWithRetry.test.ts`.

Residual risk / follow-ups: the compatibility fallback uses a narrow regex for Playwright's legacy timeout message shape; if Playwright changes message shapes in future versions we may need to update that fallback, but the primary detection uses the `TimeoutError` type where available. Defaults (35s overall, 15s per-attempt cap) were chosen to let one meaningful retry in CI; if CI environments require different timing, these small defaults can be tuned later without changing retry semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7258312b20832fb415928b5b8d4a22)