### PR TITLE
Retry Playwright navigation timeouts with bounded overall timeout in `navigateWithRetry`

### DIFF
--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -27,7 +27,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
 const DEFAULT_MAX_LOG_ATTEMPTS = 4;
-const DEFAULT_MAX_DURATION_MS = 10_000;
+const DEFAULT_PER_ATTEMPT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_DURATION_MS = 35_000;
 const UUID_FALLBACK_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 type CryptoLike = { randomUUID?: () => string };
 type IndexedDbRequest<T = unknown> = {
@@ -89,6 +90,37 @@ async function wait(page: Page, ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+type NavigateWithRetryOptions = {
+    attempts?: number;
+    delayMs?: number;
+    maxLogAttempts?: number;
+    maxDurationMs?: number;
+    perAttemptTimeoutMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+};
+
+function isPlaywrightNavigationTimeout(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    if (error.name === 'TimeoutError') {
+        return true;
+    }
+
+    return /^page\.goto: Timeout \d+ms exceeded\./.test(error.message);
+}
+
+function isRetryableNavigationError(error: unknown): boolean {
+    const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
+
+    return (
+        isPlaywrightNavigationTimeout(error) ||
+        CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))
+    );
+}
+
 export async function navigateWithRetry(
     page: Page,
     url: string,
@@ -97,28 +129,36 @@ export async function navigateWithRetry(
         delayMs = DEFAULT_RETRY_DELAY_MS,
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
-    }: { attempts?: number; delayMs?: number; maxLogAttempts?: number; maxDurationMs?: number } = {}
+        perAttemptTimeoutMs = DEFAULT_PER_ATTEMPT_TIMEOUT_MS,
+        now = () => Date.now(),
+        sleep = (ms) => wait(page, ms),
+    }: NavigateWithRetryOptions = {}
 ): Promise<void> {
     let lastError: unknown;
-    const startedAt = Date.now();
+    const startedAt = now();
     let suppressedLogCount = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
+        const elapsedBeforeAttemptMs = now() - startedAt;
+        const remainingDurationMs = maxDurationMs - elapsedBeforeAttemptMs;
+
+        if (!Number.isFinite(remainingDurationMs) || remainingDurationMs <= 0) {
+            break;
+        }
+
         try {
-            await page.goto(url, { waitUntil: 'domcontentloaded' });
+            await page.goto(url, {
+                waitUntil: 'domcontentloaded',
+                timeout: Math.min(perAttemptTimeoutMs, remainingDurationMs),
+            });
             return;
         } catch (error) {
             lastError = error;
 
-            const message =
-                error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
-            const isRetryable = CONNECTION_REFUSED_PATTERNS.some((pattern) =>
-                message.includes(pattern)
-            );
-
-            const elapsedMs = Date.now() - startedAt;
-
-            const exceededDuration = Number.isFinite(maxDurationMs) && elapsedMs > maxDurationMs;
+            const elapsedMs = now() - startedAt;
+            const remainingAfterAttemptMs = maxDurationMs - elapsedMs;
+            const exceededDuration = remainingAfterAttemptMs <= 0;
+            const isRetryable = isRetryableNavigationError(error);
 
             if (!isRetryable || attempt === attempts || exceededDuration) {
                 const wrappedError =
@@ -134,9 +174,18 @@ export async function navigateWithRetry(
             }
 
             const backoffDelay = delayMs * attempt;
+            if (backoffDelay <= 0 || backoffDelay > remainingAfterAttemptMs) {
+                const wrappedError =
+                    error instanceof Error
+                        ? error
+                        : new Error(`Failed to navigate to ${url}: ${String(error)}`);
+                wrappedError.message = `${wrappedError.message} while navigating to ${url} after ${elapsedMs}ms (limit ${maxDurationMs}ms)`;
+                throw wrappedError;
+            }
+
             if (attempt <= maxLogAttempts) {
                 console.warn(
-                    `Retrying navigation to ${url} after connection refusal (attempt ${attempt} of ${attempts})`
+                    `Retrying navigation to ${url} after transient navigation failure (attempt ${attempt} of ${attempts})`
                 );
             } else {
                 suppressedLogCount += 1;
@@ -147,7 +196,7 @@ export async function navigateWithRetry(
                     );
                 }
             }
-            await wait(page, backoffDelay);
+            await sleep(backoffDelay);
         }
     }
 

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,48 +1,212 @@
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
 
-function createMockPage(failures: number): Page {
-    let callCount = 0;
-    const goto = vi.fn(async () => {
-        callCount += 1;
-        if (callCount <= failures) {
-            throw new Error('net::ERR_CONNECTION_REFUSED');
-        }
-    });
+type GotoResult = Awaited<ReturnType<Page['goto']>>;
 
-    const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+function timeoutError(message = 'page.goto: Timeout 15000ms exceeded.'): Error {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
+}
 
-    return {
-        goto,
-        waitForTimeout,
-    } as unknown as Page;
+function createPage(
+  outcomes: Array<Error | undefined>,
+  onGoto?: () => void
+): Page {
+  const goto = vi.fn(async () => {
+    onGoto?.();
+    const outcome = outcomes.shift();
+    if (outcome) {
+      throw outcome;
+    }
+    return undefined as GotoResult;
+  });
+
+  const waitForTimeout = vi.fn(
+    async () => undefined as Awaited<ReturnType<Page['waitForTimeout']>>
+  );
+
+  return { goto, waitForTimeout } as unknown as Page;
 }
 
 describe('navigateWithRetry', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    it('handles a handful of connection refusals before succeeding with default retries', async () => {
-        const page = createMockPage(3);
+  afterEach(() => {
+    consoleWarnSpy.mockClear();
+  });
 
-        await expect(navigateWithRetry(page, 'http://127.0.0.1:3000')).resolves.toBeUndefined();
+  it('retries a Playwright navigation timeout before succeeding', async () => {
+    let currentTime = 0;
+    const page = createPage([timeoutError(), undefined]);
 
-        expect(page.goto).toHaveBeenCalledTimes(4);
-        expect(page.waitForTimeout).toHaveBeenCalled();
+    await navigateWithRetry(page, '/', {
+      attempts: 2,
+      delayMs: 100,
+      maxDurationMs: 20_000,
+      now: () => currentTime,
+      sleep: async (ms) => {
+        currentTime += ms;
+      },
     });
 
-    it('propagates the last error after exhausting retries', async () => {
-        const page = createMockPage(Number.POSITIVE_INFINITY);
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.goto).toHaveBeenNthCalledWith(1, '/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    });
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
 
-        await expect(
-            navigateWithRetry(page, 'http://127.0.0.1:3000', { attempts: 2, delayMs: 1 })
-        ).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+  it('retries connection refusal before succeeding', async () => {
+    let currentTime = 0;
+    const page = createPage([
+      new Error('page.goto: net::ERR_CONNECTION_REFUSED'),
+      undefined,
+    ]);
 
-        expect(page.goto).toHaveBeenCalledTimes(2);
+    await navigateWithRetry(page, '/', {
+      attempts: 2,
+      delayMs: 25,
+      now: () => currentTime,
+      sleep: async (ms) => {
+        currentTime += ms;
+      },
     });
 
-    afterAll(() => {
-        consoleWarnSpy.mockRestore();
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a successful first navigation', async () => {
+    const page = createPage([undefined]);
+
+    await navigateWithRetry(page, '/');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails non-retryable navigation errors immediately', async () => {
+    const error = new Error('page.goto: net::ERR_CERT_AUTHORITY_INVALID');
+    const page = createPage([error, undefined]);
+
+    await expect(navigateWithRetry(page, '/', { attempts: 3 })).rejects.toThrow(
+      error
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('bounds each navigation timeout by the remaining overall duration', async () => {
+    let currentTime = 7_500;
+    const page = createPage([undefined]);
+
+    await navigateWithRetry(page, '/', {
+      maxDurationMs: 10_000,
+      now: () => currentTime,
     });
+
+    expect(page.goto).toHaveBeenCalledWith('/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 10_000,
+    });
+  });
+
+  it('does not start another attempt when the duration budget is exhausted', async () => {
+    let currentTime = 0;
+    const page = createPage([timeoutError(), undefined], () => {
+      currentTime = 15_000;
+    });
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 3,
+        delayMs: 100,
+        maxDurationMs: 15_000,
+        now: () => currentTime,
+        sleep: async (ms) => {
+          currentTime += ms;
+        },
+      })
+    ).rejects.toThrow('limit 15000ms');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does not sleep when the next backoff does not fit in the remaining budget', async () => {
+    let nowCalls = 0;
+    const page = createPage([new Error('ECONNREFUSED'), undefined]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 3,
+        delayMs: 100,
+        maxDurationMs: 10_000,
+        now: () => (nowCalls++ === 0 ? 0 : 9_950),
+        sleep: async () => {
+          throw new Error('sleep should not be called');
+        },
+      })
+    ).rejects.toThrow('limit 10000ms');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('fails after bounded attempt-count exhaustion', async () => {
+    let currentTime = 0;
+    const page = createPage([
+      new Error('ECONNREFUSED'),
+      new Error('ECONNREFUSED'),
+      undefined,
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 10_000,
+        now: () => currentTime,
+        sleep: async (ms) => {
+          currentTime += ms;
+        },
+      })
+    ).rejects.toThrow('after 2 attempts');
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses retry logs after the configured log limit', async () => {
+    let currentTime = 0;
+    const page = createPage([
+      new Error('ECONNREFUSED'),
+      new Error('ECONNREFUSED'),
+      new Error('ECONNREFUSED'),
+      undefined,
+    ]);
+
+    await navigateWithRetry(page, '/', {
+      attempts: 4,
+      delayMs: 1,
+      maxLogAttempts: 1,
+      maxDurationMs: 10_000,
+      now: () => currentTime,
+      sleep: async (ms) => {
+        currentTime += ms;
+      },
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy.mock.calls[1]?.[0]).toContain(
+      'Suppressing further retry logs'
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- The remote-chat smoke harness observed intermittent `page.goto()` navigation timeouts that were not treated as retryable and could consume the helper's entire budget, causing spurious E2E failures on some platforms. 
- The helper must retry only the narrow set of transient navigation failures (Playwright navigation timeouts and connection-refused), and must account consistently for per-attempt timeouts, backoff, and overall budget so retries remain bounded.

### Description
- Updated `navigateWithRetry()` in `frontend/e2e/test-helpers.ts` to treat Playwright navigation timeouts as retryable by checking `error.name === 'TimeoutError'` and a narrowly-scoped fallback regex for the stable `page.goto` timeout message. 
- Added coherent timeout accounting that computes the remaining overall budget before each attempt, passes an explicit per-attempt `timeout` to `page.goto()` bounded by the remaining budget, and refuses to start another attempt or sleep when the remaining budget is insufficient. 
- Introduced injectable `now` and `sleep` hooks and a `perAttemptTimeoutMs` option to make timing deterministic in tests while preserving defaults; set `DEFAULT_PER_ATTEMPT_TIMEOUT_MS = 15000` and `DEFAULT_MAX_DURATION_MS = 35000` to allow at least one meaningful retry after a normal Playwright navigation timeout. 
- Preserved existing connection-refused retry behavior, fail-closed semantics for non-retryable errors, and bounded/suppressed retry logging. 
- Added deterministic Vitest tests at `tests/navigateWithRetry.test.ts` (no real browser/network required) covering timeout-retry then success, connection-refusal then success, first-attempt success, non-retryable immediate failure, per-attempt timeout bounding, duration exhaustion preventing another attempt/backoff, attempt-count exhaustion, and log suppression.

### Testing
- Ran the focused helper suite with `pnpm exec vitest run tests/navigateWithRetry.test.ts` which passed (all tests passed). 
- Verified the remote-chat smoke contract harness with `pnpm exec vitest run scripts/tests/run-remote-chat-smoke.test.ts scripts/tests/remote-chat-smoke-contract.test.ts` which passed (all tests passed). 
- Performed full TypeScript checks with `npm run type-check` which completed successfully. 
- Verified formatting with `pnpm exec prettier --check --config .prettierrc frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts` which reported files as matching Prettier style. 
- Ran `git diff --check` which reported no whitespace/diff issues. 

Changed files summary: `frontend/e2e/test-helpers.ts` and `tests/navigateWithRetry.test.ts`.

Residual risk and follow-ups: the helper increases the default `MAX_DURATION_MS` and adds a per-attempt timeout default to 15s to allow meaningful retry behavior; these defaults are conservative but can be tuned if CI environments need different budgets. No application logic or external configuration was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7258434f00832f8085232bcccde8ea)