### PR TITLE
Prepare DSPACE application v3.1.1 and chart v3.1.2 (release preparation)

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.1.1
+version: 3.1.2
 description: Helm chart for deploying the DSPACE application
 type: application
-appVersion: "3.1.0"
+appVersion: "3.1.1"

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: ghcr.io/democratizedspace/dspace
-  tag: v3.1.0
+  tag: v3.1.1
   pullPolicy: IfNotPresent
 
 service:

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.1.1
+3.1.2

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -13,7 +13,7 @@ default, matching the `Dockerfile` `EXPOSE` and health check settings.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
 - `image.tag`: Image tag to deploy. Defaults to the human-readable semantic application tag
-  `v3.1.0`; it is not an immutable deployment coordinate. Use a branch-SHA tag or digest when
+  `v3.1.1`; it is not an immutable deployment coordinate. Use a branch-SHA tag or digest when
   recording or proving the exact deployed image.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
@@ -136,7 +136,7 @@ Deploy the chart with a custom host and image tag:
 helm install dspace charts/dspace \
   -f charts/dspace/values.dev.yaml \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.1.1
 ```
 
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
@@ -149,7 +149,7 @@ Helm commands below remain useful for local clusters, development environments, 
 inspection.
 
 The chart is published only by pushing the exact tag `chart-v<chart-version>` (for example,
-`chart-v3.1.1`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
+`chart-v3.1.2`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
 matches it exactly; ordinary `main` and `v3` pushes never publish charts. Publication checks GHCR
 twice and fails closed unless the coordinate is authoritatively absent, so an existing chart
 coordinate cannot be replaced. Chart version `3.0.1` is permanently tombstoned and cannot be
@@ -173,10 +173,10 @@ evidence only even though exact digest equality with the immutable image index i
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.1.1 \
+  --version 3.1.2 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.1.1
 ```
 
 When installing from the OCI registry, you will not have access to

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -18,7 +18,7 @@ setup in their existing runbooks.
   `Chart.yaml:appVersion`
 - **Chart version:** the matching `Chart.yaml:version` and `docs/apps/dspace.version`; this may
   advance independently of the application version
-- **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
+- **Semantic image tag:** `v<application version>`, for example `v3.1.1`; published only for a
   release and human-readable, but not proof of the deployed image
 - **Chart release tag:** exactly `chart-v<chart version>`, pointing to the reviewed immutable commit
 
@@ -96,11 +96,12 @@ tombstoned even if it later appears absent; this does not prohibit a newer chart
 is `3.0.1`. A successful run summary is the audit record for the release tag, full source SHA,
 package SHA-256, and OCI manifest digest.
 
-Chart `3.1.1` is a chart-only, provenance-bearing release for DSPACE application `3.1.0`. The
-legacy `3.1.0` chart lacks the modern immutable source-revision provenance, so it must not be
-overwritten or selected where that provenance is required. After the chart `3.1.1` preparation PR
-merges, a human operator will create `chart-v3.1.1` at the exact reviewed merge commit; preparing
-the coordinate does not create the tag or publish the chart.
+Chart `3.1.2` is a provenance-bearing release for DSPACE application `3.1.1`. The previous
+chart coordinates are immutable; the legacy `3.1.0` chart lacks the modern immutable
+source-revision provenance, so it must not be overwritten or selected where that provenance is
+required. After the application `3.1.1` / chart `3.1.2` preparation PR merges, a human operator
+will create `chart-v3.1.2` at the exact reviewed merge commit; preparing the coordinate does not
+create the tag or publish the chart.
 
 Successful full releases upload the deterministic artifact
 `dspace-release-manifest/dspace-release-manifest.json`. Schema version 1 records
@@ -111,6 +112,31 @@ credentials. The workflow summary includes the immutable image and chart referen
 index and both platform digests. The semantic `vX.Y.Z` alias is verified to resolve to the exact
 same index digest, but the manifest and deployments continue to select the immutable branch-SHA
 tag.
+
+## Operator handoff for application 3.1.1 / chart 3.1.2
+
+Refs #4727 and Refs #4730. After this preparation merges to `main`, use the reviewed merge
+commit as the single source SHA for all release evidence. Do not create any release coordinate
+until the preceding gate has succeeded for that exact commit.
+
+Expected coordinates:
+
+- Branch image tag: `main-<merge-short-sha>` from the immutable multi-platform branch build.
+- Chart tag: `chart-v3.1.2`, pointing at the same full merge SHA.
+- Application release tag: `v3.1.1`, pointing at the same full merge SHA.
+- Semantic image alias: `ghcr.io/democratizedspace/dspace:v3.1.1`, created exactly once as a
+  digest alias of the verified `main-<merge-short-sha>` image.
+
+Post-merge evidence to capture before closing #4727/#4730:
+
+1. The first semantic publication for `v3.1.1` succeeds exactly once after the immutable
+   branch-SHA image and `chart-v3.1.2` chart have both published from the same commit.
+2. Rerunning the semantic-release job for `v3.1.1` fails at the GHCR existence guard before any
+   publication or retagging step.
+3. The `v3.1.1` semantic digest remains byte-for-byte unchanged across that rerun.
+4. `dspace-release-manifest.json` agrees with the approved source SHA, `main-<merge-short-sha>`
+   image tag and digest, platform evidence, chart version `3.1.2`, chart digest, and semantic tag
+   `v3.1.1`.
 
 ## Deploy staging
 
@@ -151,11 +177,11 @@ From the Sugarkube checkout, promote the approved version or immutable branch-SH
 
 ```bash
 cd ~/sugarkube
-just dspace-oci-promote-prod tag=3.1.0
+just dspace-oci-promote-prod tag=3.1.1
 ```
 
-The bare `3.1.0` value is the existing Sugarkube compatibility/version promote form. The image
-workflow publishes the release-only semantic application tag as `v3.1.0`; it is human-readable but
+The bare `3.1.1` value is the existing Sugarkube compatibility/version promote form. The image
+workflow publishes the release-only semantic application tag as `v3.1.1`; it is human-readable but
 not immutable deployment proof. Branch-SHA tags such as `main-REPLACE_SHORTSHA` or
 `v3-REPLACE_SHORTSHA` (or a digest) are the required audit path for exact image promotion and
 rollback.
@@ -184,7 +210,7 @@ the runtime under test). Replace the revision with the approved full 40-characte
 ```bash
 # Staging
 DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
-DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_VERSION=3.1.1 \
 DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
 DSPACE_EXPECTED_PROVIDER=token-place \
 DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://staging.token.place \
@@ -193,7 +219,7 @@ npm run qa:remote-chat-smoke
 
 # Production (run only after the staging result and promotion are approved)
 DSPACE_SMOKE_BASE_URL=https://democratized.space \
-DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_VERSION=3.1.1 \
 DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
 DSPACE_EXPECTED_PROVIDER=token-place \
 DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dspace",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "type": "module",
     "description": "A free and open source web-based space exploration idle game",
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspace",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspace",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@dspace/feature-flags": "file:packages/feature-flags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": "20 || >=22"

--- a/scripts/check-release-consistency.mjs
+++ b/scripts/check-release-consistency.mjs
@@ -210,22 +210,22 @@ export async function run(mode) {
   if (mode === '--verify-local-fixtures') {
     const revision = '0123456789abcdef0123456789abcdef01234567';
     const value = releaseManifest({
-      applicationVersion: '3.1.0',
+      applicationVersion: '3.1.1',
       sourceRevision: revision,
       imageTag: 'main-0123456',
       imageDigest: `sha256:${'1'.repeat(64)}`,
       chartVersion: '4.2.0',
       chartDigest: `sha256:${'2'.repeat(64)}`,
-      semanticTag: 'v3.1.0',
+      semanticTag: 'v3.1.1',
     });
     const expected =
-      '{"schemaVersion":1,"app":"dspace","applicationVersion":"3.1.0",' +
+      '{"schemaVersion":1,"app":"dspace","applicationVersion":"3.1.1",' +
       '"sourceRevision":"0123456789abcdef0123456789abcdef01234567",' +
       '"imageTag":"main-0123456","imageDigest":"sha256:' +
       '1111111111111111111111111111111111111111111111111111111111111111",' +
       '"chartVersion":"4.2.0","chartDigest":"sha256:' +
       '2222222222222222222222222222222222222222222222222222222222222222",' +
-      '"semanticTag":"v3.1.0"}';
+      '"semanticTag":"v3.1.1"}';
     if (JSON.stringify(value) !== expected)
       fail('fixture manifest is not deterministic');
     if (JSON.stringify(releaseManifest(JSON.parse(expected))) !== expected)

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -4,7 +4,7 @@ import { assertBuildMetaComplete } from '../scripts/write-build-meta.mjs';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const valid = {
-  version: '3.1.0',
+  version: '3.1.1',
   revision: SHA,
   shortRevision: SHA.slice(0, 7),
   buildTimestamp: '2026-07-29T12:00:00Z',
@@ -76,7 +76,7 @@ describe('canonical public build identity', () => {
     for (const movable of [
       'ghcr.io/democratizedspace/dspace:latest',
       'ghcr.io/democratizedspace/dspace:main-latest',
-      'ghcr.io/democratizedspace/dspace:v3.1.0',
+      'ghcr.io/democratizedspace/dspace:v3.1.1',
       'ghcr.io/democratizedspace/dspace:main-fffffff',
     ]) {
       expect(() =>

--- a/tests/buildInfoEndpoint.test.ts
+++ b/tests/buildInfoEndpoint.test.ts
@@ -15,7 +15,7 @@ vi.mock('../frontend/src/utils/serverLogger', () => ({
 describe('runtime build identity endpoints', () => {
   beforeEach(() => {
     filePayload = {
-      version: '3.1.0',
+      version: '3.1.1',
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',
@@ -32,7 +32,7 @@ describe('runtime build identity endpoints', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(await response.json()).toEqual({
-      version: '3.1.0',
+      version: '3.1.1',
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -73,22 +73,22 @@ const withFixture = (check: (root: string) => void) => {
 };
 
 describe('independent DSPACE application and chart coordinates', () => {
-  it('pins chart 3.1.1 to application 3.1.0 without changing the image coordinate', () => {
+  it('pins chart 3.1.2 to application 3.1.1 without changing the image coordinate', () => {
     const chart = parse(
       readFileSync(join(repoRoot, 'charts/dspace/Chart.yaml'), 'utf8')
     );
     const values = parse(
       readFileSync(join(repoRoot, 'charts/dspace/values.yaml'), 'utf8')
     );
-    expect(chart.version).toBe('3.1.1');
-    expect(chart.appVersion).toBe('3.1.0');
-    expect(values.image.tag).toBe('v3.1.0');
+    expect(chart.version).toBe('3.1.2');
+    expect(chart.appVersion).toBe('3.1.1');
+    expect(values.image.tag).toBe('v3.1.1');
     expect(
       readFileSync(join(repoRoot, 'docs/apps/dspace.version'), 'utf8')
-    ).toMatch(/^3\.1\.1$/m);
+    ).toMatch(/^3\.1\.2$/m);
   });
 
-  it('accepts the chart-v3.1.1 release tag for the local chart coordinates', () => {
+  it('accepts the chart-v3.1.2 release tag for the local chart coordinates', () => {
     const result = spawnSync(
       process.execPath,
       [
@@ -97,13 +97,13 @@ describe('independent DSPACE application and chart coordinates', () => {
       ],
       {
         cwd: repoRoot,
-        env: { ...process.env, CHART_TAG: 'chart-v3.1.1', GITHUB_OUTPUT: '' },
+        env: { ...process.env, CHART_TAG: 'chart-v3.1.2', GITHUB_OUTPUT: '' },
         encoding: 'utf8',
       }
     );
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('applicationVersion=3.1.0');
-    expect(result.stdout).toContain('chartVersion=3.1.1');
+    expect(result.stdout).toContain('applicationVersion=3.1.1');
+    expect(result.stdout).toContain('chartVersion=3.1.2');
   });
 
   it('passes current repository coordinates and reports both groups', () =>
@@ -345,7 +345,7 @@ describe('staged Helm chart provenance', () => {
     mkdirSync(source);
     writeFileSync(
       join(source, 'Chart.yaml'),
-      'apiVersion: v2\nname: dspace\nversion: 3.1.1\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+      'apiVersion: v2\nname: dspace\nversion: 3.1.2\nappVersion: "3.1.1"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
     );
     try {
       run(source, staged);
@@ -361,8 +361,8 @@ describe('staged Helm chart provenance', () => {
       const stagedYaml = join(staged, 'Chart.yaml');
       const chart = parse(readFileSync(stagedYaml, 'utf8'));
       expect(chart.description).toBe('retained');
-      expect(chart.version).toBe('3.1.1');
-      expect(chart.appVersion).toBe('3.1.0');
+      expect(chart.version).toBe('3.1.2');
+      expect(chart.appVersion).toBe('3.1.1');
       expect(chart.annotations['example.org/existing']).toBe('retained');
       expect(chart.annotations['org.opencontainers.image.source']).toBe(
         SOURCE_REPOSITORY
@@ -371,13 +371,13 @@ describe('staged Helm chart provenance', () => {
         revision
       );
       expect(chart.annotations['org.opencontainers.image.version']).toBe(
-        '3.1.0'
+        '3.1.1'
       );
       expect(
         verifyChart({
           chartYaml: stagedYaml,
-          version: '3.1.1',
-          appVersion: '3.1.0',
+          version: '3.1.2',
+          appVersion: '3.1.1',
           revision,
         })
       ).toMatchObject({
@@ -390,7 +390,7 @@ describe('staged Helm chart provenance', () => {
     'rejects non-strict chart SemVer %s',
     (version) =>
       chartFixture((source, staged) => {
-        replace(source, 'Chart.yaml', 'version: 3.1.1', `version: ${version}`);
+        replace(source, 'Chart.yaml', 'version: 3.1.2', `version: ${version}`);
         expect(() =>
           stageChart({ sourceDir: source, destinationDir: staged, revision })
         ).toThrow(/chart version/);
@@ -404,7 +404,7 @@ describe('staged Helm chart provenance', () => {
         replace(
           source,
           'Chart.yaml',
-          'appVersion: "3.1.0"',
+          'appVersion: "3.1.1"',
           `appVersion: "${appVersion}"`
         );
         expect(() =>
@@ -444,14 +444,14 @@ describe('staged Helm chart provenance', () => {
   );
 
   it.each([
-    ['version', 'version: 3.1.1', 'version: 3.1.2'],
-    ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
+    ['version', 'version: 3.1.2', 'version: 3.1.3'],
+    ['appVersion', 'appVersion: 3.1.1', 'appVersion: 3.1.2'],
     ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
     ['revision', revision, 'f'.repeat(40)],
     [
       'application version',
-      'org.opencontainers.image.version: 3.1.0',
       'org.opencontainers.image.version: 3.1.1',
+      'org.opencontainers.image.version: 3.1.2',
     ],
   ])('rejects tampered packaged %s metadata', (_field, search, value) =>
     chartFixture((source, staged) => {
@@ -461,8 +461,8 @@ describe('staged Helm chart provenance', () => {
       expect(() =>
         verifyChart({
           chartYaml: join(staged, 'Chart.yaml'),
-          version: '3.1.1',
-          appVersion: '3.1.0',
+          version: '3.1.2',
+          appVersion: '3.1.1',
           revision,
         })
       ).toThrow(/mismatch/);
@@ -490,8 +490,8 @@ describe('staged Helm chart provenance', () => {
         expect(() =>
           verifyChart({
             chartYaml,
-            version: '3.1.1',
-            appVersion: '3.1.0',
+            version: '3.1.2',
+            appVersion: '3.1.1',
             revision,
           })
         ).toThrow(/revision mismatch/);

--- a/tests/packageMetadataSync.test.ts
+++ b/tests/packageMetadataSync.test.ts
@@ -38,7 +38,7 @@ describe('sync-package metadata script', () => {
     const { rootPackagePath, targetPackagePath, cleanup } = setupWorkspace(
       {
         name: 'dspace',
-        version: '3.1.0',
+        version: '3.1.1',
         description: 'Root description',
         license: 'Apache-2.0',
       },
@@ -64,7 +64,7 @@ describe('sync-package metadata script', () => {
       expect(updates).toEqual(['name', 'version', 'description', 'license']);
       expect(updated).toMatchObject({
         name: 'dspace',
-        version: '3.1.0',
+        version: '3.1.1',
         description: 'Root description',
         license: 'Apache-2.0',
       });
@@ -76,7 +76,7 @@ describe('sync-package metadata script', () => {
   it('does not rewrite the frontend manifest when metadata already matches', () => {
     const manifest = {
       name: 'dspace',
-      version: '3.1.0',
+      version: '3.1.1',
       description: 'Root description',
       license: 'Apache-2.0',
     };


### PR DESCRIPTION
### Motivation
- Prepare the repository surfaces for the next genuine patch application release so the post-merge release run can produce the immutable image, provenance-bearing chart, and deterministic release manifest needed to close Refs #4727 and Refs #4730.
- Advance application and chart coordinates only because `main` contains legitimate fixes since the prior application coordinate, and the release contract requires independent chart versioning and preserved provenance.

### Description
- Bump application version to `3.1.1` in the root and frontend package metadata and update lock metadata accordingly (`package.json`, `frontend/package.json`, `package-lock.json`, `pnpm-lock.yaml`).
- Advance Helm chart to `charts/dspace/Chart.yaml` `version: 3.1.2` and `appVersion: "3.1.1"`, update the chart default image tag in `charts/dspace/values.yaml` to `v3.1.1`, and update `docs/apps/dspace.version` to `3.1.2`.
- Update release & chart documentation to reflect the new coordinates and installation examples, and add a concise operator handoff in `docs/ops/sugarkube-release.md` that records the expected branch image tag, chart tag, application release tag, semantic alias, and the four post-merge evidence checks required for Refs #4727 and #4730.
- Update release-consistency fixtures and coordinate-sensitive tests and helpers to the new values, including `scripts/check-release-consistency.mjs` and the affected tests under `tests/` to assert the `3.1.1` application / `3.1.2` chart pairing.

### Testing
- `bash scripts/check-dspace-chart-version.sh` — passed and reported alignment: application version `3.1.1` (v3.1.1) and chart version `3.1.2`.
- `node scripts/check-release-consistency.mjs --verify-local-fixtures` — passed (`Release consistency fixtures passed (network-free)`).
- `npm run test:root -- tests/releaseConsistency.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts tests/helmChartReleaseVersion.test.ts` — passed (all tests in the run passed).
- `npm run lint` — passed with no lint errors.
- `npm run type-check` — passed (`tsc --noEmit` successful).
- `npm run build` — passed (Astro/Vite client and server build completed).
- `node scripts/link-check.mjs` — passed (all local markdown links resolved).
- `git diff --check` — no whitespace or diff-check problems detected.
- `git diff main...HEAD | python3 scripts/scan-secrets.py` — run and no secrets flagged by repository scanner.

Notes and follow-ups:
- The PR preparation diff is focused to version coordinates, docs, fixtures, and tests only; no release tag, GitHub release, or GHCR publication was performed here per the release contract.
- The operator handoff inserted in `docs/ops/sugarkube-release.md` documents the exact expected coordinates and post-merge evidence that the release pipeline must produce for Refs #4727 and #4730; a human operator must create the `chart-v3.1.2` and `v3.1.1` semantic release artifacts from the reviewed merge commit during the release run.
- I attempted to open the pull request from this environment but GitHub authentication is not available here, so please open the PR against `main` with these changes if your workflow requires it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72cb7f3ae8832fac3364b9e0ad9a35)