### PR TITLE
Prepare DSPACE application 3.1.1 and chart 3.1.2 release metadata

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.1.1
+version: 3.1.2
 description: Helm chart for deploying the DSPACE application
 type: application
-appVersion: "3.1.0"
+appVersion: "3.1.1"

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: ghcr.io/democratizedspace/dspace
-  tag: v3.1.0
+  tag: v3.1.1
   pullPolicy: IfNotPresent
 
 service:

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.1.1
+3.1.2

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -13,7 +13,7 @@ default, matching the `Dockerfile` `EXPOSE` and health check settings.
 - `nameOverride` / `fullnameOverride`: Optional overrides for release naming.
 - `image.repository`: Defaults to `ghcr.io/democratizedspace/dspace`.
 - `image.tag`: Image tag to deploy. Defaults to the human-readable semantic application tag
-  `v3.1.0`; it is not an immutable deployment coordinate. Use a branch-SHA tag or digest when
+  `v3.1.1`; it is not an immutable deployment coordinate. Use a branch-SHA tag or digest when
   recording or proving the exact deployed image.
 - `image.pullPolicy`: Defaults to `IfNotPresent`.
 - `service.type`: Kubernetes service type. Defaults to `ClusterIP`.
@@ -66,9 +66,9 @@ development:
 
 ```yaml
 metrics:
-    enabled: false
+  enabled: false
 serviceMonitor:
-    enabled: false
+  enabled: false
 ```
 
 Sugarkube staging can opt in with a pre-created Secret. The chart never stores or renders the token
@@ -80,18 +80,18 @@ required for this contract and `bearerTokenSecret` remains compatible with older
 ```yaml
 environment: staging
 metrics:
-    enabled: true
-    path: /metrics
-    auth:
-        existingSecret: dspace-staging-metrics-token
-        secretKey: token
+  enabled: true
+  path: /metrics
+  auth:
+    existingSecret: dspace-staging-metrics-token
+    secretKey: token
 serviceMonitor:
-    enabled: true
-    interval: 30s
-    scrapeTimeout: 10s
-    additionalLabels:
-        release: kube-prometheus-stack
-    cluster: sugarkube
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube
 ```
 
 The normal public ingress still routes `/` to the DSPACE service and does not create a separate
@@ -136,7 +136,7 @@ Deploy the chart with a custom host and image tag:
 helm install dspace charts/dspace \
   -f charts/dspace/values.dev.yaml \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.1.1
 ```
 
 Replace `dspace.example.com` with a domain routed to your Traefik ingress controller.
@@ -149,7 +149,7 @@ Helm commands below remain useful for local clusters, development environments, 
 inspection.
 
 The chart is published only by pushing the exact tag `chart-v<chart-version>` (for example,
-`chart-v3.1.1`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
+`chart-v3.1.2`). The tag must point to the reviewed immutable commit whose `Chart.yaml:version`
 matches it exactly; ordinary `main` and `v3` pushes never publish charts. Publication checks GHCR
 twice and fails closed unless the coordinate is authoritatively absent, so an existing chart
 coordinate cannot be replaced. Chart version `3.0.1` is permanently tombstoned and cannot be
@@ -173,10 +173,10 @@ evidence only even though exact digest equality with the immutable image index i
 
 ```bash
 helm install dspace oci://ghcr.io/democratizedspace/charts/dspace \
-  --version 3.1.1 \
+  --version 3.1.2 \
   --set ingress.enabled=true \
   --set ingress.host=dspace.example.com \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.1.1
 ```
 
 When installing from the OCI registry, you will not have access to

--- a/docs/ops/dspace-3.1.1-release-handoff.md
+++ b/docs/ops/dspace-3.1.1-release-handoff.md
@@ -1,0 +1,42 @@
+# DSPACE 3.1.1 release handoff
+
+This repository preparation advances DSPACE to application `3.1.1` and chart `3.1.2` without
+creating tags, GitHub releases, GHCR artifacts, or deployment changes. It exists so the post-merge
+release run can provide the remaining operational evidence for [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727)
+and [DSPACE #4730](https://github.com/democratizedspace/dspace/issues/4730).
+
+## Expected coordinates after merge
+
+Replace `MERGE_SHA` with the exact reviewed merge commit on `main` and `SHORT_SHA` with its first
+seven hexadecimal characters.
+
+- Branch image tag: `ghcr.io/democratizedspace/dspace:main-SHORT_SHA`
+- Chart tag: `chart-v3.1.2`
+- Chart OCI coordinate: `oci://ghcr.io/democratizedspace/charts/dspace --version 3.1.2`
+- Application release tag: `v3.1.1`
+- Semantic image alias: `ghcr.io/democratizedspace/dspace:v3.1.1`
+- Release manifest artifact: `dspace-release-manifest/dspace-release-manifest.json`
+
+## Required post-merge release evidence
+
+1. Confirm `main` published and verified the immutable multi-platform branch-SHA image
+   `main-SHORT_SHA`, and that both `linux/amd64` and `linux/arm64` platform configs identify
+   `MERGE_SHA`.
+2. Create `chart-v3.1.2` at `MERGE_SHA` only after the branch image exists, then confirm the chart
+   workflow published exactly one immutable chart whose OCI metadata records chart version `3.1.2`,
+   app version `3.1.1`, and source revision `MERGE_SHA`.
+3. Publish the GitHub application release `v3.1.1` only after the image and chart prerequisites are
+   verified from the same source revision.
+4. Confirm the first semantic publication succeeds exactly once and creates
+   `ghcr.io/democratizedspace/dspace:v3.1.1` as a digest-preserving alias of
+   `ghcr.io/democratizedspace/dspace:main-SHORT_SHA`.
+5. Rerun the semantic release job and confirm it fails at the GHCR existence guard before any
+   publication or mutation attempt.
+6. Re-read the semantic image digest after the rerun and confirm it remains unchanged.
+7. Download `dspace-release-manifest.json` and confirm it agrees with the source revision, immutable
+   image tag, image index digest, platform evidence, chart version, chart digest, and semantic tag.
+
+Do not mutate staging, production, or rollback coordinates as part of this repository preparation.
+
+Refs #4727
+Refs #4730

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -18,7 +18,7 @@ setup in their existing runbooks.
   `Chart.yaml:appVersion`
 - **Chart version:** the matching `Chart.yaml:version` and `docs/apps/dspace.version`; this may
   advance independently of the application version
-- **Semantic image tag:** `v<application version>`, for example `v3.1.0`; published only for a
+- **Semantic image tag:** `v<application version>`, for example `v3.1.1`; published only for a
   release and human-readable, but not proof of the deployed image
 - **Chart release tag:** exactly `chart-v<chart version>`, pointing to the reviewed immutable commit
 
@@ -96,11 +96,13 @@ tombstoned even if it later appears absent; this does not prohibit a newer chart
 is `3.0.1`. A successful run summary is the audit record for the release tag, full source SHA,
 package SHA-256, and OCI manifest digest.
 
-Chart `3.1.1` is a chart-only, provenance-bearing release for DSPACE application `3.1.0`. The
+Chart `3.1.2` is the provenance-bearing chart for DSPACE application `3.1.1`. The
 legacy `3.1.0` chart lacks the modern immutable source-revision provenance, so it must not be
-overwritten or selected where that provenance is required. After the chart `3.1.1` preparation PR
-merges, a human operator will create `chart-v3.1.1` at the exact reviewed merge commit; preparing
+overwritten or selected where that provenance is required. After the application `3.1.1` preparation PR
+merges, a human operator will create `chart-v3.1.2` at the exact reviewed merge commit; preparing
 the coordinate does not create the tag or publish the chart.
+
+For the application `3.1.1` / chart `3.1.2` patch release, use the focused [DSPACE 3.1.1 release handoff](./dspace-3.1.1-release-handoff.md) to collect the post-merge #4727/#4730 evidence without changing the release ordering above.
 
 Successful full releases upload the deterministic artifact
 `dspace-release-manifest/dspace-release-manifest.json`. Schema version 1 records
@@ -151,11 +153,11 @@ From the Sugarkube checkout, promote the approved version or immutable branch-SH
 
 ```bash
 cd ~/sugarkube
-just dspace-oci-promote-prod tag=3.1.0
+just dspace-oci-promote-prod tag=3.1.1
 ```
 
-The bare `3.1.0` value is the existing Sugarkube compatibility/version promote form. The image
-workflow publishes the release-only semantic application tag as `v3.1.0`; it is human-readable but
+The bare `3.1.1` value is the existing Sugarkube compatibility/version promote form. The image
+workflow publishes the release-only semantic application tag as `v3.1.1`; it is human-readable but
 not immutable deployment proof. Branch-SHA tags such as `main-REPLACE_SHORTSHA` or
 `v3-REPLACE_SHORTSHA` (or a digest) are the required audit path for exact image promotion and
 rollback.
@@ -184,7 +186,7 @@ the runtime under test). Replace the revision with the approved full 40-characte
 ```bash
 # Staging
 DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
-DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_VERSION=3.1.1 \
 DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
 DSPACE_EXPECTED_PROVIDER=token-place \
 DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://staging.token.place \
@@ -193,7 +195,7 @@ npm run qa:remote-chat-smoke
 
 # Production (run only after the staging result and promotion are approved)
 DSPACE_SMOKE_BASE_URL=https://democratized.space \
-DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_VERSION=3.1.1 \
 DSPACE_EXPECTED_REVISION=REPLACE_WITH_APPROVED_40_CHARACTER_SHA \
 DSPACE_EXPECTED_PROVIDER=token-place \
 DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN=https://token.place \
@@ -229,7 +231,7 @@ legacy-identity token.place invocation:
 
 ```bash
 DSPACE_SMOKE_BASE_URL=https://staging.democratized.space \
-DSPACE_EXPECTED_VERSION=3.1.0 \
+DSPACE_EXPECTED_VERSION=3.1.1 \
 DSPACE_EXPECTED_REVISION=018687f5a7f4de45508c6e36eb28afb3e44da24d \
 DSPACE_EXPECTED_IDENTITY_CONTRACT=legacy-build-meta-v1 \
 DSPACE_EXPECTED_PROVIDER=token-place \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dspace",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "type": "module",
     "description": "A free and open source web-based space exploration idle game",
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspace",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspace",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@dspace/feature-flags": "file:packages/feature-flags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": "20 || >=22"

--- a/tests/buildIdentity.test.ts
+++ b/tests/buildIdentity.test.ts
@@ -4,7 +4,7 @@ import { assertBuildMetaComplete } from '../scripts/write-build-meta.mjs';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const valid = {
-  version: '3.1.0',
+  version: '3.1.1',
   revision: SHA,
   shortRevision: SHA.slice(0, 7),
   buildTimestamp: '2026-07-29T12:00:00Z',
@@ -76,7 +76,7 @@ describe('canonical public build identity', () => {
     for (const movable of [
       'ghcr.io/democratizedspace/dspace:latest',
       'ghcr.io/democratizedspace/dspace:main-latest',
-      'ghcr.io/democratizedspace/dspace:v3.1.0',
+      'ghcr.io/democratizedspace/dspace:v3.1.1',
       'ghcr.io/democratizedspace/dspace:main-fffffff',
     ]) {
       expect(() =>

--- a/tests/buildInfoEndpoint.test.ts
+++ b/tests/buildInfoEndpoint.test.ts
@@ -15,7 +15,7 @@ vi.mock('../frontend/src/utils/serverLogger', () => ({
 describe('runtime build identity endpoints', () => {
   beforeEach(() => {
     filePayload = {
-      version: '3.1.0',
+      version: '3.1.1',
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',
@@ -32,7 +32,7 @@ describe('runtime build identity endpoints', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(await response.json()).toEqual({
-      version: '3.1.0',
+      version: '3.1.1',
       revision: SHA,
       shortRevision: SHA.slice(0, 7),
       buildTimestamp: '2026-07-29T12:00:00Z',

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -73,22 +73,22 @@ const withFixture = (check: (root: string) => void) => {
 };
 
 describe('independent DSPACE application and chart coordinates', () => {
-  it('pins chart 3.1.1 to application 3.1.0 without changing the image coordinate', () => {
+  it('pins chart 3.1.2 to application 3.1.1 without changing the image coordinate', () => {
     const chart = parse(
       readFileSync(join(repoRoot, 'charts/dspace/Chart.yaml'), 'utf8')
     );
     const values = parse(
       readFileSync(join(repoRoot, 'charts/dspace/values.yaml'), 'utf8')
     );
-    expect(chart.version).toBe('3.1.1');
-    expect(chart.appVersion).toBe('3.1.0');
-    expect(values.image.tag).toBe('v3.1.0');
+    expect(chart.version).toBe('3.1.2');
+    expect(chart.appVersion).toBe('3.1.1');
+    expect(values.image.tag).toBe('v3.1.1');
     expect(
       readFileSync(join(repoRoot, 'docs/apps/dspace.version'), 'utf8')
-    ).toMatch(/^3\.1\.1$/m);
+    ).toMatch(/^3\.1\.2$/m);
   });
 
-  it('accepts the chart-v3.1.1 release tag for the local chart coordinates', () => {
+  it('accepts the chart-v3.1.2 release tag for the local chart coordinates', () => {
     const result = spawnSync(
       process.execPath,
       [
@@ -97,13 +97,13 @@ describe('independent DSPACE application and chart coordinates', () => {
       ],
       {
         cwd: repoRoot,
-        env: { ...process.env, CHART_TAG: 'chart-v3.1.1', GITHUB_OUTPUT: '' },
+        env: { ...process.env, CHART_TAG: 'chart-v3.1.2', GITHUB_OUTPUT: '' },
         encoding: 'utf8',
       }
     );
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('applicationVersion=3.1.0');
-    expect(result.stdout).toContain('chartVersion=3.1.1');
+    expect(result.stdout).toContain('applicationVersion=3.1.1');
+    expect(result.stdout).toContain('chartVersion=3.1.2');
   });
 
   it('passes current repository coordinates and reports both groups', () =>
@@ -345,7 +345,7 @@ describe('staged Helm chart provenance', () => {
     mkdirSync(source);
     writeFileSync(
       join(source, 'Chart.yaml'),
-      'apiVersion: v2\nname: dspace\nversion: 3.1.1\nappVersion: "3.1.0"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
+      'apiVersion: v2\nname: dspace\nversion: 3.1.2\nappVersion: "3.1.1"\ndescription: retained\nannotations:\n  example.org/existing: retained\n'
     );
     try {
       run(source, staged);
@@ -361,8 +361,8 @@ describe('staged Helm chart provenance', () => {
       const stagedYaml = join(staged, 'Chart.yaml');
       const chart = parse(readFileSync(stagedYaml, 'utf8'));
       expect(chart.description).toBe('retained');
-      expect(chart.version).toBe('3.1.1');
-      expect(chart.appVersion).toBe('3.1.0');
+      expect(chart.version).toBe('3.1.2');
+      expect(chart.appVersion).toBe('3.1.1');
       expect(chart.annotations['example.org/existing']).toBe('retained');
       expect(chart.annotations['org.opencontainers.image.source']).toBe(
         SOURCE_REPOSITORY
@@ -371,13 +371,13 @@ describe('staged Helm chart provenance', () => {
         revision
       );
       expect(chart.annotations['org.opencontainers.image.version']).toBe(
-        '3.1.0'
+        '3.1.1'
       );
       expect(
         verifyChart({
           chartYaml: stagedYaml,
-          version: '3.1.1',
-          appVersion: '3.1.0',
+          version: '3.1.2',
+          appVersion: '3.1.1',
           revision,
         })
       ).toMatchObject({
@@ -390,7 +390,7 @@ describe('staged Helm chart provenance', () => {
     'rejects non-strict chart SemVer %s',
     (version) =>
       chartFixture((source, staged) => {
-        replace(source, 'Chart.yaml', 'version: 3.1.1', `version: ${version}`);
+        replace(source, 'Chart.yaml', 'version: 3.1.2', `version: ${version}`);
         expect(() =>
           stageChart({ sourceDir: source, destinationDir: staged, revision })
         ).toThrow(/chart version/);
@@ -404,7 +404,7 @@ describe('staged Helm chart provenance', () => {
         replace(
           source,
           'Chart.yaml',
-          'appVersion: "3.1.0"',
+          'appVersion: "3.1.1"',
           `appVersion: "${appVersion}"`
         );
         expect(() =>
@@ -444,14 +444,14 @@ describe('staged Helm chart provenance', () => {
   );
 
   it.each([
-    ['version', 'version: 3.1.1', 'version: 3.1.2'],
-    ['appVersion', 'appVersion: 3.1.0', 'appVersion: 3.1.1'],
+    ['version', 'version: 3.1.2', 'version: 3.1.3'],
+    ['appVersion', 'appVersion: 3.1.1', 'appVersion: 3.1.2'],
     ['source', SOURCE_REPOSITORY, 'https://example.invalid/repo'],
     ['revision', revision, 'f'.repeat(40)],
     [
       'application version',
-      'org.opencontainers.image.version: 3.1.0',
       'org.opencontainers.image.version: 3.1.1',
+      'org.opencontainers.image.version: 3.1.2',
     ],
   ])('rejects tampered packaged %s metadata', (_field, search, value) =>
     chartFixture((source, staged) => {
@@ -461,8 +461,8 @@ describe('staged Helm chart provenance', () => {
       expect(() =>
         verifyChart({
           chartYaml: join(staged, 'Chart.yaml'),
-          version: '3.1.1',
-          appVersion: '3.1.0',
+          version: '3.1.2',
+          appVersion: '3.1.1',
           revision,
         })
       ).toThrow(/mismatch/);
@@ -490,8 +490,8 @@ describe('staged Helm chart provenance', () => {
         expect(() =>
           verifyChart({
             chartYaml,
-            version: '3.1.1',
-            appVersion: '3.1.0',
+            version: '3.1.2',
+            appVersion: '3.1.1',
             revision,
           })
         ).toThrow(/revision mismatch/);

--- a/tests/packageMetadataSync.test.ts
+++ b/tests/packageMetadataSync.test.ts
@@ -38,7 +38,7 @@ describe('sync-package metadata script', () => {
     const { rootPackagePath, targetPackagePath, cleanup } = setupWorkspace(
       {
         name: 'dspace',
-        version: '3.1.0',
+        version: '3.1.1',
         description: 'Root description',
         license: 'Apache-2.0',
       },
@@ -64,7 +64,7 @@ describe('sync-package metadata script', () => {
       expect(updates).toEqual(['name', 'version', 'description', 'license']);
       expect(updated).toMatchObject({
         name: 'dspace',
-        version: '3.1.0',
+        version: '3.1.1',
         description: 'Root description',
         license: 'Apache-2.0',
       });
@@ -76,7 +76,7 @@ describe('sync-package metadata script', () => {
   it('does not rewrite the frontend manifest when metadata already matches', () => {
     const manifest = {
       name: 'dspace',
-      version: '3.1.0',
+      version: '3.1.1',
       description: 'Root description',
       license: 'Apache-2.0',
     };


### PR DESCRIPTION
### Motivation
- Advance the repository release coordinates from application `3.1.0` / chart `3.1.1` to application `3.1.1` / chart `3.1.2` so the post-merge release run can supply the remaining operational evidence for Refs #4727 and Refs #4730. 
- Preserve the established release ordering and provenance gates (immutable branch-SHA image → provenance-bearing chart → semantic GitHub release) while only preparing repository metadata. 
- Provide an explicit operator handoff describing the exact branch image tag, chart tag, application release tag, and required post-merge evidence so release engineers can complete the controlled publication steps. 

### Description
- Bumped application version to `3.1.1` in `package.json` and `frontend/package.json` and updated root lock metadata. 
- Advanced the Helm chart to `version: 3.1.2` with `appVersion: "3.1.1"` in `charts/dspace/Chart.yaml` and aligned `charts/dspace/values.yaml` (`image.tag: v3.1.1`) and `docs/apps/dspace.version` to `3.1.2`. 
- Updated release and chart docs in `docs/charts.md` and `docs/ops/sugarkube-release.md`, and added the operator handoff `docs/ops/dspace-3.1.1-release-handoff.md` that enumerates expected coordinates and post-merge evidence steps. 
- Updated tests and fixtures that encode coordinates to the new values (notably `tests/helmChartReleaseVersion.test.ts`, `tests/buildIdentity.test.ts`, `tests/buildInfoEndpoint.test.ts`, and `tests/packageMetadataSync.test.ts`) so CI validates the new coordinates. 
- Created branch `codex/prepare-3.1.1-release` with commit `c82cad985` containing the metadata and docs changes; no tags/releases/publishes were created. 

### Testing
- Ran `bash scripts/check-dspace-chart-version.sh` and it reported alignment: application `3.1.1`; chart `3.1.2` (passed). 
- Ran `node scripts/check-release-consistency.mjs --verify-local-fixtures` and it completed successfully (network-free fixtures passed). 
- Ran the focused test set `npm run test:root -- tests/releaseConsistency.test.ts tests/ciImageWorkflow.test.ts tests/ciHelmWorkflow.test.ts tests/helmChartReleaseVersion.test.ts` and all tests passed. 
- Ran repository checks: `npm run lint`, `npm run type-check`, `npm run build`, `node scripts/link-check.mjs`, `git diff --check`, and `git diff main...HEAD | python3 scripts/scan-secrets.py` and they completed without blocking failures. 
- Attempted GHCR existence guard with `node scripts/ghcr-manifest.mjs check-absent` but it reported missing GHCR guard credentials (`GHCR_GUARD_USERNAME`/`GHCR_GUARD_PASSWORD`) so registry absence checks were not performed in this environment. 
- Created the branch and commit locally (`codex/prepare-3.1.1-release`, commit `c82cad985`) but `git push` / PR creation failed due to missing GitHub credentials in this execution environment, so the changes are committed locally and ready to be pushed and opened as a PR by a user with push/PR permissions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72cb9b3100832f80f0b00f272814d9)