### PR TITLE
Harden branch image publication gates

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -273,6 +273,11 @@ jobs:
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      # Serialize the absence check plus push for a branch/SHA coordinate so two ordinary
+      # publication runs cannot both observe the immutable tag as absent before pushing.
+      group: dspace-image-${{ github.event.inputs.branch || github.ref_name }}-${{ github.sha }}
+      cancel-in-progress: false
     outputs:
       image-tag: ${{ steps.tags.outputs.sha_tag }}
     steps:
@@ -392,6 +397,7 @@ jobs:
             org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Assert build SHA is baked into frontend bundle
         env:
@@ -422,7 +428,18 @@ jobs:
           test "$label_revision" = "$EXPECTED_SHA"
           container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
           trap 'docker rm -f "$container"' EXIT
-          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          rm -f /tmp/build-info.json
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json; then
+              break
+            fi
+            sleep 2
+          done
+          if [ ! -s /tmp/build-info.json ]; then
+            echo "/build-info.json did not become reachable or returned an empty response" >&2
+            docker logs "$container" >&2 || true
+            exit 1
+          fi
           test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
           curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
 

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -370,6 +370,74 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Build image for SHA verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha
+
+      - name: Assert build SHA is baked into frontend bundle
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD:/verification-repo:ro" \
+            dspace-verify:latest \
+            node /verification-repo/scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD:/verification-repo:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /verification-repo/scripts/verify-chat-build-stamp.mjs
+
+      - name: Compare runtime identity with OCI revision
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$label_revision" = "$EXPECTED_SHA"
+          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
+          trap 'docker rm -f "$container"' EXIT
+          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
+          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
+
+      - name: Ensure immutable SHA tag is absent before push attempt 1
+        id: check_sha_absent_1
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${IMAGE_TAG##*:}"
+
       - name: Build and push image (attempt 1)
         id: build_push_1
         continue-on-error: true
@@ -397,9 +465,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+      - name: Ensure immutable SHA tag is absent before push attempt 2
+        id: check_sha_absent_2
+        if: steps.build_push_1.outcome == 'failure'
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${IMAGE_TAG##*:}"
+
       - name: Build and push image (attempt 2)
         id: build_push_2
-        if: steps.build_push_1.outcome == 'failure'
+        if: steps.build_push_1.outcome == 'failure' && steps.check_sha_absent_2.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -423,66 +504,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
-
-      - name: Build image for SHA verification
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
-            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha
-
-      - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Compare runtime identity with OCI revision
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
-          test "$label_revision" = "$EXPECTED_SHA"
-          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
-          trap 'docker rm -f "$container"' EXIT
-          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
-          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
-          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
 
       - name: Summarize published image tags
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -274,9 +274,10 @@ jobs:
     # exclusively by the semantic-release job below.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     concurrency:
-      # Serialize the absence check plus push for a branch/SHA coordinate so two ordinary
-      # publication runs cannot both observe the immutable tag as absent before pushing.
-      group: dspace-image-${{ github.event.inputs.branch || github.ref_name }}-${{ github.sha }}
+      # Serialize the absence check plus push by target branch. workflow_dispatch can
+      # choose a checkout branch independently of github.sha, so branch-scoped locking
+      # keeps runs for the same published tag namespace from racing.
+      group: dspace-image-${{ github.event.inputs.branch || github.ref_name }}
       cancel-in-progress: false
     outputs:
       image-tag: ${{ steps.tags.outputs.sha_tag }}

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -26,6 +26,13 @@ Use immutable branch-SHA tags or image digests for staging, production approvals
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
 be the audit record for a production deploy.
 
+If an ordinary branch-image workflow publishes its immutable SHA coordinate but fails in a later
+validation or evidence step, treat that coordinate as failed-run evidence only. Do not rerun the
+failed workflow, overwrite the SHA tag, move it, delete it, or select it for release promotion.
+Instead, fix the workflow or source problem through a new reviewed commit; only that new commit's
+`<branch>-<shortsha>` image may become the release candidate after its complete image workflow
+succeeds.
+
 ## Runtime source verification contract
 
 Before approving an already deployed runtime, set its expected full revision, public URL, and

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -60,6 +60,13 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(job.if).not.toMatch(/release/);
   });
 
+  it('serializes ordinary publication by branch and workflow SHA', () => {
+    expect(job.concurrency.group).toBe(
+      'dspace-image-${{ github.event.inputs.branch || github.ref_name }}-${{ github.sha }}'
+    );
+    expect(job.concurrency['cancel-in-progress']).toBe(false);
+  });
+
   it('never computes or publishes a semantic version tag', () => {
     const serialized = JSON.stringify(job);
     expect(serialized).not.toMatch(/version_tag/);
@@ -115,6 +122,8 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     );
     expect(step.run).toContain('org.opencontainers.image.revision');
     expect(step.run).toContain('/build-info.json');
+    expect(step.run).toContain('if [ ! -s /tmp/build-info.json ]; then');
+    expect(step.run).toContain('docker logs "$container"');
     expect(step.run).toContain('dspace-build-revision');
     expect(step.env.EXPECTED_SHA).toBe('${{ steps.tags.outputs.full_sha }}');
     expect(step.run).toContain('test "$label_revision" = "$EXPECTED_SHA"');
@@ -170,6 +179,10 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     );
     expect(verifyBuild.with.push).toBe(false);
     expect(verifyBuild.with.tags).toBe('dspace-verify:latest');
+    expect(verifyBuild.with['cache-from']).toBe('type=gha');
+    expect(verifyBuild.with['cache-to']).toBe(
+      'type=gha,mode=max,ignore-error=true'
+    );
   });
 
   it('guards the immutable SHA tag immediately before both push attempts', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -120,6 +120,100 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(step.run).toContain('test "$label_revision" = "$EXPECTED_SHA"');
   });
 
+  it('invokes image verifiers from a repository-preserving mount, not a scripts-only mount', () => {
+    const serialized = JSON.stringify(job);
+    const shaStep = findSteps(job).find(
+      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
+    );
+    const chatStep = findSteps(job).find(
+      (step) => step.name === 'Verify chat build stamp inside image'
+    );
+
+    expect(shaStep.run).toContain('-v "$PWD:/verification-repo:ro"');
+    expect(shaStep.run).toContain(
+      'node /verification-repo/scripts/verify-build-sha.mjs /app/dist'
+    );
+    expect(chatStep.run).toContain('-v "$PWD:/verification-repo:ro"');
+    expect(chatStep.run).toContain('-e VERIFY_REPO_ROOT=/app');
+    expect(chatStep.run).toContain(
+      '-e VERIFY_BUILD_META_PATH=/app/build_meta.json'
+    );
+    expect(chatStep.run).toContain(
+      'node /verification-repo/scripts/verify-chat-build-stamp.mjs'
+    );
+    expect(serialized).not.toContain('$PWD/scripts:/scripts:ro');
+    expect(serialized).not.toContain(
+      'node /scripts/verify-chat-build-stamp.mjs'
+    );
+  });
+
+  it('builds and locally validates the runtime image before the first registry mutation', () => {
+    const steps = findSteps(job);
+    const firstPush = stepIndex(
+      job,
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    for (const name of [
+      'Build image for SHA verification',
+      'Assert build SHA is baked into frontend bundle',
+      'Verify chat build stamp inside image',
+      'Compare runtime identity with OCI revision',
+    ]) {
+      expect(stepIndex(job, (step) => step.name === name)).toBeGreaterThan(-1);
+      expect(stepIndex(job, (step) => step.name === name)).toBeLessThan(
+        firstPush
+      );
+    }
+
+    const verifyBuild = steps.find(
+      (step) => step.name === 'Build image for SHA verification'
+    );
+    expect(verifyBuild.with.push).toBe(false);
+    expect(verifyBuild.with.tags).toBe('dspace-verify:latest');
+  });
+
+  it('guards the immutable SHA tag immediately before both push attempts', () => {
+    const steps = findSteps(job);
+    const guard1 = steps.find(
+      (step) =>
+        step.name === 'Ensure immutable SHA tag is absent before push attempt 1'
+    );
+    const guard2 = steps.find(
+      (step) =>
+        step.name === 'Ensure immutable SHA tag is absent before push attempt 2'
+    );
+    const push1 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    const push2 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+
+    expect(steps.indexOf(guard1)).toBe(steps.indexOf(push1) - 1);
+    expect(steps.indexOf(guard2)).toBe(steps.indexOf(push2) - 1);
+    for (const guard of [guard1, guard2]) {
+      expect(guard.run).toContain('scripts/ghcr-manifest.mjs check-absent');
+      expect(guard.env.GHCR_GUARD_USERNAME).toBe('${{ github.actor }}');
+      expect(guard.env.GHCR_GUARD_PASSWORD).toBe('${{ secrets.GITHUB_TOKEN }}');
+      expect(guard.env.IMAGE_TAG).toBe('${{ steps.tags.outputs.sha_tag }}');
+      expect(guard.run).toContain('--tag "${IMAGE_TAG##*:}"');
+      expect(guard.run).not.toContain('${{ secrets.GITHUB_TOKEN }}');
+    }
+  });
+
+  it('requires a failed first push and successful retry guard before attempt 2', () => {
+    const guard2 = findSteps(job).find(
+      (step) =>
+        step.name === 'Ensure immutable SHA tag is absent before push attempt 2'
+    );
+    const push2 = findSteps(job).find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+    expect(guard2.if).toBe("steps.build_push_1.outcome == 'failure'");
+    expect(push2.if).toBe(
+      "steps.build_push_1.outcome == 'failure' && steps.check_sha_absent_2.outcome == 'success'"
+    );
+  });
   it('uses the checked-out commit rather than the dispatch event SHA', () => {
     const serialized = JSON.stringify(job);
     expect(serialized).not.toContain('GIT_SHA=${{ github.sha }}');

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -60,10 +60,11 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(job.if).not.toMatch(/release/);
   });
 
-  it('serializes ordinary publication by branch and workflow SHA', () => {
+  it('serializes ordinary publication by target branch without workflow SHA', () => {
     expect(job.concurrency.group).toBe(
-      'dspace-image-${{ github.event.inputs.branch || github.ref_name }}-${{ github.sha }}'
+      'dspace-image-${{ github.event.inputs.branch || github.ref_name }}'
     );
+    expect(job.concurrency.group).not.toContain('github.sha');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
 


### PR DESCRIPTION
### Motivation

GitHub Actions run `31031795887` exposed a repository-layout bug after its first image push had already created `ghcr.io/democratizedspace/dspace:main-12413ac`. The workflow mounted only `$PWD/scripts` at `/scripts`, so imports from `write-build-meta.mjs` resolved repository-relative paths against `/` and failed to find `/package.json`.

Treat `main-12413ac` as preserved failed-run evidence. It must not be rerun, overwritten, moved, deleted, reused, or selected for promotion.

### Changes

- Build `dspace-verify:latest` and run all three local validation gates before any registry mutation:
  - full build-SHA verification;
  - chat build-stamp verification;
  - runtime JSON/HTML identity comparison with the OCI revision.
- Mount the checked-out repository read-only at `/verification-repo` and invoke `node /verification-repo/scripts/verify-chat-build-stamp.mjs`, while retaining `VERIFY_REPO_ROOT=/app` and `VERIFY_BUILD_META_PATH=/app/build_meta.json`.
- Run the authoritative fail-closed GHCR absence guard immediately before each multi-platform push attempt.
- Require attempt 2 to follow both a failed attempt 1 and a successful second absence guard.
- Serialize ordinary publication by target branch with `cancel-in-progress: false`. This covers manual dispatches whose selected checkout branch can differ from the event SHA and prevents concurrent runs from racing between the absence check and push.
- Preserve both intended tags (`<branch>-<shortsha>` and `<branch>-latest`) and both target platforms (`linux/amd64` and `linux/arm64`).
- Refresh the GHA build cache from the pre-publication verification build.
- Emit an explicit failure and container logs if `/build-info.json` never becomes reachable or remains empty.
- Add focused workflow regression coverage for the corrected mount, validation ordering, authoritative guards, retry predicate, publication serialization, cache behavior, tags, platforms, and unchanged semantic-release protections.
- Update `docs/ops/sugarkube-release.md` with generic operator guidance for preserving branch-SHA coordinates left by failed workflows.

Application version `3.1.1`, chart version `3.1.2`, and chart `appVersion: "3.1.1"` remain unchanged. This PR does not change application runtime behavior or create, publish, delete, or mutate any release or GHCR artifact.

### Verification

The following completed successfully:

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts --config vitest.config.mts --maxWorkers=1`
- `CHART_TAG=chart-v3.1.2 node scripts/check-release-consistency.mjs --verify-chart-local`
- `node scripts/check-release-consistency.mjs --verify-local-fixtures`
- `pnpm exec prettier --check .github/workflows/ci-image.yml tests/ciImageWorkflow.test.ts docs/ops/sugarkube-release.md`
- `npm run lint`
- `git diff --check`

All latest-head workflows completed successfully at `9c17f88a8564e3de9502c5400e782889f48d9895`: `CI`, `tests`, `ci-sentinel`, `link-check`, `Build & Publish Container`, and `Build and publish GHCR image`.

Docker was unavailable in the original local execution environment, so the optional local `dspace-verify:latest` container invocation was not run there. The latest-head GitHub image workflow completed its Docker build and smoke validation successfully; publication jobs were skipped for the pull-request event as intended.

### Release evidence

Run `31031795887` and `main-12413ac` remain preserved failed-run evidence. The next successful merge SHA—not `12413ac`—becomes the release candidate only after its complete ordinary image workflow succeeds.

Refs #4727  
Refs #4730

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a737f33a0e8832f933d4595ff13afca)