### PR TITLE
Harden branch image publication guards and fix verifier mount

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -355,13 +355,6 @@ jobs:
           echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
           echo "revision=${GIT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
         with:
@@ -369,6 +362,79 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build image for SHA verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha
+
+      - name: Assert build SHA is baked into frontend bundle
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD/scripts:/scripts:ro" \
+            dspace-verify:latest \
+            node /scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD:/verification-repo:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /verification-repo/scripts/verify-chat-build-stamp.mjs
+
+      - name: Compare runtime identity with OCI revision
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$label_revision" = "$EXPECTED_SHA"
+          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
+          trap 'docker rm -f "$container"' EXIT
+          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
+          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refuse existing branch-SHA image tag before push attempt 1
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SHA_IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          tag="${SHA_IMAGE_TAG##*:}"
+          node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo dspace --tag "$tag"
 
       - name: Build and push image (attempt 1)
         id: build_push_1
@@ -397,9 +463,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+      - name: Refuse existing branch-SHA image tag before push attempt 2
+        id: retry_guard
+        if: steps.build_push_1.outcome == 'failure'
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SHA_IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          tag="${SHA_IMAGE_TAG##*:}"
+          node scripts/ghcr-manifest.mjs check-absent --owner democratizedspace --repo dspace --tag "$tag"
+
       - name: Build and push image (attempt 2)
         id: build_push_2
-        if: steps.build_push_1.outcome == 'failure'
+        if: steps.build_push_1.outcome == 'failure' && steps.retry_guard.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -423,66 +501,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
-
-      - name: Build image for SHA verification
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
-            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha
-
-      - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Compare runtime identity with OCI revision
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
-          test "$label_revision" = "$EXPECTED_SHA"
-          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
-          trap 'docker rm -f "$container"' EXIT
-          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
-          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
-          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
 
       - name: Summarize published image tags
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -26,6 +26,13 @@ Use immutable branch-SHA tags or image digests for staging, production approvals
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
 be the audit record for a production deploy.
 
+If an ordinary branch image workflow publishes its immutable branch-SHA coordinate but then fails
+later in the same run, treat that coordinate as failed-run evidence only. Do not rerun the failed
+workflow, overwrite the tag, delete it, or select it for staging, production, rollback, chart
+publication, or semantic release evidence. First fix the workflow through a new reviewed commit;
+only the new commit's branch-SHA image becomes a release candidate after that complete workflow run
+succeeds.
+
 ## Runtime source verification contract
 
 Before approving an already deployed runtime, set its expected full revision, public URL, and

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -108,6 +108,95 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     }
   });
 
+  it('invokes the chat verifier from a repository-preserving mount', () => {
+    const step = findSteps(job).find(
+      (candidate) => candidate.name === 'Verify chat build stamp inside image'
+    );
+    expect(step.run).toContain('-v "$PWD:/verification-repo:ro"');
+    expect(step.run).toContain(
+      'node /verification-repo/scripts/verify-chat-build-stamp.mjs'
+    );
+    expect(step.run).toContain('-e VERIFY_REPO_ROOT=/app');
+    expect(step.run).toContain(
+      '-e VERIFY_BUILD_META_PATH=/app/build_meta.json'
+    );
+    expect(step.run).not.toContain('node /scripts/verify-chat-build-stamp.mjs');
+  });
+
+  it('runs local image construction and identity checks before the first registry mutation', () => {
+    const steps = findSteps(job);
+    const firstPush = steps.find(
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    const firstPushIndex = steps.indexOf(firstPush);
+
+    for (const name of [
+      'Build image for SHA verification',
+      'Assert build SHA is baked into frontend bundle',
+      'Verify chat build stamp inside image',
+      'Compare runtime identity with OCI revision',
+      'Refuse existing branch-SHA image tag before push attempt 1',
+    ]) {
+      expect(stepIndex(job, (step) => step.name === name)).toBeLessThan(
+        firstPushIndex
+      );
+    }
+
+    const localBuild = steps.find(
+      (step) => step.name === 'Build image for SHA verification'
+    );
+    expect(localBuild.with.push).toBe(false);
+    expect(localBuild.with.tags).toBe('dspace-verify:latest');
+  });
+
+  it('checks authoritative SHA-tag absence immediately before each push attempt', () => {
+    const steps = findSteps(job);
+    const firstGuard = steps.find(
+      (step) =>
+        step.name ===
+        'Refuse existing branch-SHA image tag before push attempt 1'
+    );
+    const firstPush = steps.find(
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    const retryGuard = steps.find(
+      (step) =>
+        step.name ===
+        'Refuse existing branch-SHA image tag before push attempt 2'
+    );
+    const secondPush = steps.find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+
+    expect(steps.indexOf(firstGuard)).toBe(steps.indexOf(firstPush) - 1);
+    expect(steps.indexOf(retryGuard)).toBe(steps.indexOf(secondPush) - 1);
+    for (const guard of [firstGuard, retryGuard]) {
+      expect(guard.env.GHCR_GUARD_USERNAME).toBe('${{ github.actor }}');
+      expect(guard.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
+      expect(guard.env.SHA_IMAGE_TAG).toBe('${{ steps.tags.outputs.sha_tag }}');
+      expect(guard.run).toContain(
+        'node scripts/ghcr-manifest.mjs check-absent'
+      );
+      expect(guard.run).toContain('tag="${SHA_IMAGE_TAG##*:}"');
+      expect(guard.run).not.toContain('${{ steps.tags.outputs.sha_tag }}');
+    }
+  });
+
+  it('requires a failed first attempt and successful retry guard before attempt 2', () => {
+    const retryGuard = findSteps(job).find(
+      (step) =>
+        step.name ===
+        'Refuse existing branch-SHA image tag before push attempt 2'
+    );
+    const secondPush = findSteps(job).find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+    expect(retryGuard.if).toBe("steps.build_push_1.outcome == 'failure'");
+    expect(secondPush.if).toBe(
+      "steps.build_push_1.outcome == 'failure' && steps.retry_guard.outcome == 'success'"
+    );
+  });
+
   it('compares runtime JSON and HTML identity with the OCI revision', () => {
     const step = findSteps(job).find(
       (candidate) =>


### PR DESCRIPTION
### Motivation

- Fix the ordinary branch-image workflow failure observed in run 31031795887 which left `ghcr.io/democratizedspace/dspace:main-12413ac` as a failed-run orphan; root cause was the in-container `/scripts` mount breaking repository-relative imports used by the verifier.  Treat `main-12413ac` and run 31031795887 as preserved failed-run evidence and do not reuse or overwrite that coordinate.  
- Ensure local validation gates run before any registry mutation so a partially-successful run cannot leave a published immutable SHA behind or be overwritten by a retry.  
- Refs #4727 and Refs #4730.

### Description

- Reworked the ordinary branch `image` job in `.github/workflows/ci-image.yml` so the `dspace-verify:latest` image is built locally before any GHCR push and the following verification gates run prior to registry mutation: full build-SHA assertion, chat build-stamp verification, and runtime JSON/HTML identity comparison.  
- Fixed the chat build-stamp verifier invocation by mounting the checked-out repo read-only at `/verification-repo` and invoking `node /verification-repo/scripts/verify-chat-build-stamp.mjs`, while continuing to set `VERIFY_REPO_ROOT=/app` and `VERIFY_BUILD_META_PATH=/app/build_meta.json` so the verifier inspects the runtime image, not host build output.  This replaces the broken `-v "$PWD/scripts:/scripts:ro"` pattern.  
- Added fail-closed authoritative GHCR absence guards using `scripts/ghcr-manifest.mjs check-absent` immediately before push attempt 1 and again immediately before push attempt 2, with credentials and tag values passed via environment variables; attempt 2 now requires both a failed first push and a successful retry guard.  
- Preserved multi-arch publication (`linux/amd64,linux/arm64`) and both intended tags (`<branch>-<short-sha>` and `<branch>-latest`), and kept application version and chart version unchanged.  
- Added focused regression coverage in `tests/ciImageWorkflow.test.ts` asserting the corrected verifier mount, absence of the broken `/scripts` invocation, pre-push validation ordering, the SHA-tag absence guards immediately before each push, and the retry-guard condition.  
- Added a short operator guidance paragraph to `docs/ops/sugarkube-release.md` documenting that if an ordinary branch workflow publishes a SHA coordinate then fails, operators must not rerun or reuse that coordinate and must instead fix the workflow and use the next successful branch-SHA image.

### Testing

- `pnpm install --frozen-lockfile` — succeeded.  
- `pnpm exec vitest run tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts --config vitest.config.mts --maxWorkers=1` — all tests passed (2 files, 43 tests total passed).  
- `CHART_TAG=chart-v3.1.2 node scripts/check-release-consistency.mjs --verify-chart-local` — passed.  
- `node scripts/check-release-consistency.mjs --verify-local-fixtures` — passed.  
- `npx prettier --check .github/workflows/ci-image.yml tests/ciImageWorkflow.test.ts docs/ops/sugarkube-release.md` — passed.  
- `npm run lint` — executed (frontend lint ran) with no blocking failures in this environment.  
- Docker environment not available here (`docker: command not found`), so I could not perform an actual local `dspace-verify:latest` build/run; the workflow regression tests cover the ordering and guards that prevent the prior failure mode.  

Notes: the change is intentionally minimal and targeted to the `ci-image.yml` job, its regression tests, and the narrow operator guidance; application runtime behavior and `appVersion`/`Chart.yaml` remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a737f3d673c832f8d0ab750f6e4a789)