### PR TITLE
Harden branch-image workflow: pre-push verification, GHCR absence guards, and verifier mount fix

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -355,13 +355,6 @@ jobs:
           echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
           echo "revision=${GIT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
         with:
@@ -369,6 +362,81 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build image for SHA verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha
+
+      - name: Assert build SHA is baked into frontend bundle
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD/scripts:/scripts:ro" \
+            dspace-verify:latest \
+            node /scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD:/verification-repo:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /verification-repo/scripts/verify-chat-build-stamp.mjs
+
+      - name: Compare runtime identity with OCI revision
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$label_revision" = "$EXPECTED_SHA"
+          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
+          trap 'docker rm -f "$container"' EXIT
+          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
+          curl -fsS http://127.0.0.1:18080/ | grep -F 'name="dspace-build-revision" content="'"${label_revision}"'"'
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+
+      - name: Refuse existing branch-SHA tag before push attempt 1
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SHA_TAG_ONLY: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${SHA_TAG_ONLY##*:}"
 
       - name: Build and push image (attempt 1)
         id: build_push_1
@@ -397,9 +465,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+      - name: Refuse existing branch-SHA tag before push attempt 2
+        id: retry_guard
+        if: steps.build_push_1.outcome == 'failure'
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          SHA_TAG_ONLY: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${SHA_TAG_ONLY##*:}"
+
       - name: Build and push image (attempt 2)
         id: build_push_2
-        if: steps.build_push_1.outcome == 'failure'
+        if: steps.build_push_1.outcome == 'failure' && steps.retry_guard.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -423,66 +505,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
-
-      - name: Build image for SHA verification
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
-            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha
-
-      - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Compare runtime identity with OCI revision
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
-          test "$label_revision" = "$EXPECTED_SHA"
-          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
-          trap 'docker rm -f "$container"' EXIT
-          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
-          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
-          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
 
       - name: Summarize published image tags
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -76,6 +76,13 @@ coordinate. After supplying the missing immutable artifact, rerun the failed rel
 semantic tag already exists, the workflow always refuses to overwrite or move it; investigate and
 cut a new approved release coordinate rather than retrying a mutation.
 
+If an ordinary branch-image workflow publishes its immutable branch-SHA coordinate but fails a later
+workflow step, preserve that coordinate as failed-run evidence. Do not rerun the failed workflow,
+overwrite the tag, move the tag, or select that coordinate for staging, production, chart tagging,
+or semantic release publication. Fix the workflow through a new reviewed commit; only after that
+new commit's complete image workflow succeeds may its new `<branch>-<shortsha>` coordinate become
+the release candidate.
+
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
 2. `.github/workflows/ci-helm.yml` publishes only when an exact `chart-v<chart version>` tag is

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -108,6 +108,63 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     }
   });
 
+  it('verifies the chat build stamp through a repository-preserving mount', () => {
+    const step = findSteps(job).find(
+      (candidate) => candidate.name === 'Verify chat build stamp inside image'
+    );
+    expect(step.run).toContain('-e VERIFY_REPO_ROOT=/app');
+    expect(step.run).toContain(
+      '-e VERIFY_BUILD_META_PATH=/app/build_meta.json'
+    );
+    expect(step.run).toContain('-v "$PWD:/verification-repo:ro"');
+    expect(step.run).toContain(
+      'node /verification-repo/scripts/verify-chat-build-stamp.mjs'
+    );
+    expect(step.run).not.toContain('node /scripts/verify-chat-build-stamp.mjs');
+    expect(step.run).not.toContain('-v "$PWD/scripts:/scripts:ro"');
+  });
+
+  it('keeps the broken /scripts chat verifier invocation out of the branch image job', () => {
+    expect(JSON.stringify(job)).not.toContain(
+      'node /scripts/verify-chat-build-stamp.mjs'
+    );
+  });
+
+  it('runs local image construction and identity gates before the first registry mutation', () => {
+    const buildVerify = stepIndex(
+      job,
+      (step) => step.name === 'Build image for SHA verification'
+    );
+    const fullSha = stepIndex(
+      job,
+      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
+    );
+    const chatStamp = stepIndex(
+      job,
+      (step) => step.name === 'Verify chat build stamp inside image'
+    );
+    const runtimeIdentity = stepIndex(
+      job,
+      (step) => step.name === 'Compare runtime identity with OCI revision'
+    );
+    const login = stepIndex(job, (step) => step.name === 'Log in to GHCR');
+    const firstPush = stepIndex(
+      job,
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+
+    expect(buildVerify).toBeGreaterThan(-1);
+    expect(buildVerify).toBeLessThan(fullSha);
+    expect(fullSha).toBeLessThan(chatStamp);
+    expect(chatStamp).toBeLessThan(runtimeIdentity);
+    expect(runtimeIdentity).toBeLessThan(login);
+    expect(login).toBeLessThan(firstPush);
+
+    const verifyStep = findSteps(job)[buildVerify];
+    expect(verifyStep.with.push).toBe(false);
+    expect(verifyStep.with.tags).toBe('dspace-verify:latest');
+  });
+
   it('compares runtime JSON and HTML identity with the OCI revision', () => {
     const step = findSteps(job).find(
       (candidate) =>
@@ -118,6 +175,40 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     expect(step.run).toContain('dspace-build-revision');
     expect(step.env.EXPECTED_SHA).toBe('${{ steps.tags.outputs.full_sha }}');
     expect(step.run).toContain('test "$label_revision" = "$EXPECTED_SHA"');
+  });
+
+  it('guards the immutable branch-SHA tag immediately before each push attempt', () => {
+    const steps = findSteps(job);
+    const guard1 = steps.find(
+      (step) =>
+        step.name === 'Refuse existing branch-SHA tag before push attempt 1'
+    );
+    const push1 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    const guard2 = steps.find(
+      (step) =>
+        step.name === 'Refuse existing branch-SHA tag before push attempt 2'
+    );
+    const push2 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+
+    expect(steps.indexOf(guard1)).toBe(steps.indexOf(push1) - 1);
+    expect(steps.indexOf(guard2)).toBe(steps.indexOf(push2) - 1);
+    for (const guard of [guard1, guard2]) {
+      expect(guard.run).toContain('scripts/ghcr-manifest.mjs check-absent');
+      expect(guard.run).toContain('--owner democratizedspace');
+      expect(guard.run).toContain('--repo dspace');
+      expect(guard.run).toContain('--tag "${SHA_TAG_ONLY##*:}"');
+      expect(guard.env.GHCR_GUARD_USERNAME).toBe('${{ github.actor }}');
+      expect(guard.env.GHCR_GUARD_PASSWORD).toContain('secrets.GITHUB_TOKEN');
+      expect(guard.env.SHA_TAG_ONLY).toBe('${{ steps.tags.outputs.sha_tag }}');
+    }
+    expect(guard2.if).toBe("steps.build_push_1.outcome == 'failure'");
+    expect(push2.if).toBe(
+      "steps.build_push_1.outcome == 'failure' && steps.retry_guard.outcome == 'success'"
+    );
   });
 
   it('uses the checked-out commit rather than the dispatch event SHA', () => {


### PR DESCRIPTION
### Motivation

- Fix a failing ordinary branch-image run (GitHub Actions run `31031795887`) where the workflow published `ghcr.io/democratizedspace/dspace:main-12413ac` and then failed verification because the in-container verifier resolved repository-relative imports against `/`.
- Prevent partial/failed runs from leaving an overwritable or reused branch-SHA coordinate in the registry and make retries fail-closed rather than potentially overwrite a partially-created immutable tag.
- Preserve existing publication conventions (immutable `<branch>-<shortsha>` and mutable `<branch>-latest`) while ensuring all local validation gates run before any registry mutation.

### Description

- Reordered the ordinary branch-image job so the local verification image `dspace-verify:latest` is built and the three local gates (full SHA assertion, chat build-stamp verification, and runtime JSON/HTML identity comparison) run before GHCR login and any push attempt by moving them ahead of login/push steps in `.github/workflows/ci-image.yml`.
- Fixed in-container verifier layout by mounting the checked-out repository read-only at `/verification-repo` and invoking `node /verification-repo/scripts/verify-chat-build-stamp.mjs` while keeping `VERIFY_REPO_ROOT=/app` and `VERIFY_BUILD_META_PATH=/app/build_meta.json`, so repository-relative imports (for example `package.json` and `frontend/src/utils/buildIdentity.js`) resolve from the mounted repo but the verifier still inspects the built runtime under `/app`.
- Added fail-closed authoritative absence guards using `node scripts/ghcr-manifest.mjs check-absent` immediately before push attempt 1 and again immediately before attempt 2, passing credentials and tag values through environment variables and requiring attempt 2 only when attempt 1 failed and the retry guard succeeded.
- Preserved multi-arch publication (`linux/amd64,linux/arm64`) and the mutable `latest` tag behavior; attempt 2 cannot overwrite a partially-created branch-SHA tag.
- Added focused regression tests in `tests/ciImageWorkflow.test.ts` that assert the verifier mount is repository-preserving, the broken `/scripts` invocation is absent, local image construction and all identity/build-stamp checks run before the first push, the two pre-push GHCR absence guards exist and are placed immediately before each push attempt, and the retry condition requires both a failed first attempt and a successful retry guard.
- Updated operator guidance in `docs/ops/sugarkube-release.md` to instruct operators to preserve orphaned failed-run branch-SHA coordinates as evidence and to require a new reviewed commit/workflow success before selecting a new release candidate. The PR keeps `application` and `chart` versions unchanged per constraints.

### Testing

- Ran `pnpm install --frozen-lockfile` successfully.
- Ran unit/flow checks with `pnpm exec vitest run tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts --config vitest.config.mts --maxWorkers=1` and both test files passed (total: 43 tests passed).
- Ran release consistency checks: `CHART_TAG=chart-v3.1.2 node scripts/check-release-consistency.mjs --verify-chart-local` and `node scripts/check-release-consistency.mjs --verify-local-fixtures`, both succeeded and reported expected `applicationVersion=3.1.1` / `chartVersion=3.1.2` and fixture success.
- Verified formatting with `pnpm exec prettier --check .github/workflows/ci-image.yml tests/ciImageWorkflow.test.ts docs/ops/sugarkube-release.md` and `npm run lint`; both checks passed.
- Attempted local Docker verification build and corrected in-container `verify-chat-build-stamp` invocation by running a local `docker build` and `docker run` command, but Docker is unavailable in this environment (`docker unavailable: command not found`), so the runtime image build/execute verification was not executed here; the CI job will exercise the Docker gates.

Notes and follow-ups

- The workflow change preserves the mutable `main-latest` behavior and the semantic-release job unchanged; semantic-release immutability protections remain intact.
- Per the incident evidence, `main-12413ac` and run `31031795887` are treated as preserved failed-run evidence and must not be rerun, overwritten, or selected; the next successful merge SHA (not `12413ac`) will provide the branch-SHA candidate after its workflow fully succeeds.
- Files changed: `.github/workflows/ci-image.yml`, `tests/ciImageWorkflow.test.ts`, and `docs/ops/sugarkube-release.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a737f40a044832fa4b8c7559bc271fb)