### PR TITLE
Harden branch-image publication guards and run local verification before any GHCR mutation

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -355,13 +355,6 @@ jobs:
           echo "source=${REPO_URL}" >> "$GITHUB_OUTPUT"
           echo "revision=${GIT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
         with:
@@ -369,6 +362,81 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build image for SHA verification
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          platforms: linux/amd64
+          provenance: false
+          load: true
+          tags: dspace-verify:latest
+          build-args: |
+            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
+            GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
+            ENFORCE_VITE_GIT_SHA=1
+            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
+            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+          cache-from: type=gha
+
+      - name: Assert build SHA is baked into frontend bundle
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          docker run --rm \
+            -e EXPECTED_SHA \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD/scripts:/scripts:ro" \
+            dspace-verify:latest \
+            node /scripts/verify-build-sha.mjs /app/dist
+
+      - name: Verify chat build stamp inside image
+        run: |
+          docker run --rm \
+            -e VERIFY_REPO_ROOT=/app \
+            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
+            -v "$PWD:/verification-repo:ro" \
+            -w /app \
+            dspace-verify:latest \
+            node /verification-repo/scripts/verify-chat-build-stamp.mjs
+
+      - name: Compare runtime identity with OCI revision
+        env:
+          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
+        run: |
+          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          test "$label_revision" = "$EXPECTED_SHA"
+          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
+          trap 'docker rm -f "$container"' EXIT
+          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
+          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
+          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Guard immutable image tag absence before push attempt 1
+        id: guard_sha_absent_1
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${IMAGE_TAG##*:}"
 
       - name: Build and push image (attempt 1)
         id: build_push_1
@@ -397,9 +465,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+      - name: Guard immutable image tag absence before push attempt 2
+        id: guard_sha_absent_2
+        if: steps.build_push_1.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GHCR_GUARD_USERNAME: ${{ github.actor }}
+          GHCR_GUARD_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          node scripts/ghcr-manifest.mjs check-absent \
+            --owner democratizedspace \
+            --repo dspace \
+            --tag "${IMAGE_TAG##*:}"
+
       - name: Build and push image (attempt 2)
         id: build_push_2
-        if: steps.build_push_1.outcome == 'failure'
+        if: steps.build_push_1.outcome == 'failure' && steps.guard_sha_absent_2.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -424,66 +506,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
-      - name: Build image for SHA verification
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          platforms: linux/amd64
-          provenance: false
-          load: true
-          tags: dspace-verify:latest
-          build-args: |
-            DSPACE_VERSION=${{ steps.build_version.outputs.value }}
-            GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            VITE_GIT_SHA=${{ steps.tags.outputs.full_sha }}
-            ENFORCE_VITE_GIT_SHA=1
-            BUILD_TIMESTAMP=${{ steps.metadata.outputs.created }}
-            DSPACE_IMAGE=${{ steps.tags.outputs.sha_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ steps.metadata.outputs.source }}
-            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
-            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
-          cache-from: type=gha
-
-      - name: Assert build SHA is baked into frontend bundle
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          docker run --rm \
-            -e EXPECTED_SHA \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            dspace-verify:latest \
-            node /scripts/verify-build-sha.mjs /app/dist
-
-      - name: Verify chat build stamp inside image
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        run: |
-          docker run --rm \
-            -e VERIFY_REPO_ROOT=/app \
-            -e VERIFY_BUILD_META_PATH=/app/build_meta.json \
-            -v "$PWD/scripts:/scripts:ro" \
-            -w /app \
-            dspace-verify:latest \
-            node /scripts/verify-chat-build-stamp.mjs
-
-      - name: Compare runtime identity with OCI revision
-        if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
-        env:
-          EXPECTED_SHA: ${{ steps.tags.outputs.full_sha }}
-        run: |
-          label_revision="$(docker image inspect dspace-verify:latest --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
-          test "$label_revision" = "$EXPECTED_SHA"
-          container="$(docker run -d -p 18080:8080 dspace-verify:latest)"
-          trap 'docker rm -f "$container"' EXIT
-          for attempt in $(seq 1 30); do curl -fsS http://127.0.0.1:18080/build-info.json > /tmp/build-info.json && break; sleep 2; done
-          test "$(node -p "JSON.parse(require('fs').readFileSync('/tmp/build-info.json')).revision")" = "$label_revision"
-          curl -fsS http://127.0.0.1:18080/ | grep -F "name=\"dspace-build-revision\" content=\"${label_revision}\""
-
       - name: Summarize published image tags
         if: steps.build_push_1.outcome == 'success' || steps.build_push_2.outcome == 'success'
         run: |
@@ -502,7 +524,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if both image pushes failed
-        if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome == 'failure'
+        if: steps.build_push_1.outcome == 'failure' && steps.build_push_2.outcome != 'success'
         run: exit 1
 
   semantic-release:

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -26,6 +26,12 @@ Use immutable branch-SHA tags or image digests for staging, production approvals
 records. Mutable branch tags and release-only semantic tags are convenient for humans but must not
 be the audit record for a production deploy.
 
+If an ordinary branch-image workflow publishes its immutable SHA coordinate but fails a later gate,
+treat that coordinate as preserved failed-run evidence. Do not rerun the failed workflow, overwrite
+or move that branch-SHA tag, or select it for staging, release, promotion, or rollback. Fix the
+workflow through a new reviewed commit; only after the new commit's complete image workflow
+succeeds may its new `<branch>-<shortsha>` image become the candidate.
+
 ## Runtime source verification contract
 
 Before approving an already deployed runtime, set its expected full revision, public URL, and

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -108,6 +108,105 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
     }
   });
 
+  it('runs all local image validation gates before the first registry mutation', () => {
+    const buildVerify = stepIndex(
+      job,
+      (step) => step.name === 'Build image for SHA verification'
+    );
+    const assertSha = stepIndex(
+      job,
+      (step) => step.name === 'Assert build SHA is baked into frontend bundle'
+    );
+    const chatStamp = stepIndex(
+      job,
+      (step) => step.name === 'Verify chat build stamp inside image'
+    );
+    const identity = stepIndex(
+      job,
+      (step) => step.name === 'Compare runtime identity with OCI revision'
+    );
+    const login = stepIndex(job, (step) => step.name === 'Log in to GHCR');
+    const guard1 = stepIndex(
+      job,
+      (step) =>
+        step.name === 'Guard immutable image tag absence before push attempt 1'
+    );
+    const push1 = stepIndex(
+      job,
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+
+    expect(buildVerify).toBeGreaterThan(-1);
+    expect(assertSha).toBeGreaterThan(buildVerify);
+    expect(chatStamp).toBeGreaterThan(assertSha);
+    expect(identity).toBeGreaterThan(chatStamp);
+    expect(login).toBeGreaterThan(identity);
+    expect(guard1).toBe(login + 1);
+    expect(push1).toBe(guard1 + 1);
+
+    const buildStep = findSteps(job)[buildVerify];
+    expect(buildStep.with.push).toBe(false);
+    expect(buildStep.with.load).toBe(true);
+    expect(buildStep.with.tags).toBe('dspace-verify:latest');
+    expect(findSteps(job)[assertSha].run).toContain(
+      'verify-build-sha.mjs /app/dist'
+    );
+    expect(findSteps(job)[chatStamp].run).toContain(
+      'node /verification-repo/scripts/verify-chat-build-stamp.mjs'
+    );
+    expect(findSteps(job)[identity].run).toContain('/build-info.json');
+  });
+
+  it('invokes chat stamp verification from a repository-preserving mount, not /scripts', () => {
+    const step = findSteps(job).find(
+      (candidate) => candidate.name === 'Verify chat build stamp inside image'
+    );
+    expect(step.run).toContain('-v "$PWD:/verification-repo:ro"');
+    expect(step.run).toContain('VERIFY_REPO_ROOT=/app');
+    expect(step.run).toContain('VERIFY_BUILD_META_PATH=/app/build_meta.json');
+    expect(step.run).toContain(
+      'node /verification-repo/scripts/verify-chat-build-stamp.mjs'
+    );
+    expect(step.run).not.toContain('-v "$PWD/scripts:/scripts:ro"');
+    expect(step.run).not.toContain('node /scripts/verify-chat-build-stamp.mjs');
+  });
+
+  it('guards immutable branch-SHA absence immediately before each push attempt', () => {
+    const steps = findSteps(job);
+    const guard1 = steps.find(
+      (step) =>
+        step.name === 'Guard immutable image tag absence before push attempt 1'
+    );
+    const guard2 = steps.find(
+      (step) =>
+        step.name === 'Guard immutable image tag absence before push attempt 2'
+    );
+    const push1 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 1)'
+    );
+    const push2 = steps.find(
+      (step) => step.name === 'Build and push image (attempt 2)'
+    );
+
+    expect(steps.indexOf(guard1)).toBe(steps.indexOf(push1) - 1);
+    expect(steps.indexOf(guard2)).toBe(steps.indexOf(push2) - 1);
+    for (const guard of [guard1, guard2]) {
+      expect(guard.env.GHCR_GUARD_USERNAME).toBe('${{ github.actor }}');
+      expect(guard.env.GHCR_GUARD_PASSWORD).toBe('${{ secrets.GITHUB_TOKEN }}');
+      expect(guard.env.IMAGE_TAG).toBe('${{ steps.tags.outputs.sha_tag }}');
+      expect(guard.run).toContain('ghcr-manifest.mjs check-absent');
+      expect(guard.run).toContain('--owner democratizedspace');
+      expect(guard.run).toContain('--repo dspace');
+      expect(guard.run).toContain('--tag "${IMAGE_TAG##*:}"');
+      expect(guard.run).not.toContain('${{ secrets.GITHUB_TOKEN }}');
+    }
+    expect(guard2.if).toBe("steps.build_push_1.outcome == 'failure'");
+    expect(guard2['continue-on-error']).toBe(true);
+    expect(push2.if).toBe(
+      "steps.build_push_1.outcome == 'failure' && steps.guard_sha_absent_2.outcome == 'success'"
+    );
+  });
+
   it('compares runtime JSON and HTML identity with the OCI revision', () => {
     const step = findSteps(job).find(
       (candidate) =>


### PR DESCRIPTION
### Motivation

- Fix a workflow failure where the in-container verifier imported `/scripts/write-build-meta.mjs` but the host `scripts` directory was bind-mounted at `/scripts`, causing repository-relative imports (for example `/package.json`) to resolve incorrectly and leaving an orphaned immutable tag (`main-12413ac`) from run `31031795887` as preserved failed-run evidence. Refs #4727, Refs #4730.
- Ensure all local image validation gates run before any registry mutation so a failed verification cannot leave or be followed by a partially-created or overwritten branch-SHA coordinate.

### Description

- Build a verification image `dspace-verify:latest` locally (single-arch load) and run the full local validation flow before logging in to GHCR or attempting any push, moving the three gates (full build-SHA assertion, chat build-stamp verification, runtime JSON/HTML identity comparison) ahead of publication in `.github/workflows/ci-image.yml`.
- Fix the in-container verifier invocation by mounting the checked-out repository read-only at `/verification-repo` and invoking `node /verification-repo/scripts/verify-chat-build-stamp.mjs` while still scanning runtime paths under `/app` (via `VERIFY_REPO_ROOT=/app` and `VERIFY_BUILD_META_PATH=/app/build_meta.json`).
- Add authoritative, fail-closed GHCR absence checks using `scripts/ghcr-manifest.mjs check-absent` immediately before push attempt 1 and again before attempt 2, passing credentials and tag values through environment variables and requiring attempt 2 to have both a failed attempt 1 and a successful retry guard before running.
- Preserve multi-arch publication and both intended tags (`<branch>-<shortsha>` and `<branch>-latest`) for push attempts, and keep the semantic-release alias protections unchanged.
- Add focused regression tests in `tests/ciImageWorkflow.test.ts` that verify the verifier mount layout, that the `/scripts` mount is not used, that all local checks run before any GHCR mutation, and that absence guards appear immediately before each push attempt.
- Update operator runbook `docs/ops/sugarkube-release.md` to instruct operators that an immutable branch-SHA published by a failed workflow (concrete evidence: run `31031795887` and `main-12413ac`) must be treated as preserved failed-run evidence and must not be rerun, overwritten, or selected; only a new reviewed commit whose workflow completes may become the candidate.

### Testing

- Ran dependency installation with `pnpm install --frozen-lockfile --reporter=append-only` which completed successfully. (passed)
- Executed targeted unit/workflow tests with `pnpm exec vitest run tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts --config vitest.config.mts --maxWorkers=1` and both files passed. (passed)
- Verified release-consistency fixtures via `CHART_TAG=chart-v3.1.2 node scripts/check-release-consistency.mjs --verify-chart-local` and `node scripts/check-release-consistency.mjs --verify-local-fixtures` which succeeded. (passed)
- Ran formatting checks with `pnpm exec prettier --check tests/ciImageWorkflow.test.ts .github/workflows/ci-image.yml docs/ops/sugarkube-release.md` and `pnpm exec prettier --write` for updated files; Prettier checks passed. (passed)
- Ran lint with `npm run lint` which completed successfully. (passed)
- Docker-based end-to-end in-container verification (`docker build -t dspace-verify:latest . && docker run --rm -v "$PWD:/verification-repo:ro" -e VERIFY_REPO_ROOT=/app -e VERIFY_BUILD_META_PATH=/app/build_meta.json dspace-verify:latest node /verification-repo/scripts/verify-chat-build-stamp.mjs`) could not be executed in this environment because Docker is unavailable, so the corrected in-container invocation is covered by the new workflow regression tests instead. (not run here)

Notes: The changes are narrowly scoped to the image workflow, tests, and a small runbook clarification; application version and chart version were left unchanged and no GHCR artifacts were created, deleted, or modified as part of this work. The concrete preserved failed-run evidence is `main-12413ac` from workflow run `31031795887` and the next successful merge SHA — not `12413ac` — will be the release candidate once its workflow fully succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a737f4281d0832fbff81316ab62a3cd)