### PR TITLE
ci-image: add guarded semantic-release recovery mode and robust branch discovery

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,6 +14,11 @@ on:
       - published
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing published application release tag to recover (leave empty for a branch image)
+        required: false
+        default: ''
+        type: string
       branch:
         description: Branch to build and publish the image from
         required: false
@@ -34,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && (github.event_name != 'workflow_dispatch' || github.event.inputs.release_tag == '')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +277,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -547,15 +552,26 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name || github.event.inputs.release_tag }}
       cancel-in-progress: false
     steps:
+      - name: Validate semantic release request
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "Release tag must be a stable vX.Y.Z tag" >&2; exit 1; }
+          release_json="$(gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          jq -e --arg tag "$RELEASE_TAG" '.tag_name == $tag and .draft == false and .published_at != null' <<<"$release_json" >/dev/null || { echo "Release must already exist and be published (not draft)" >&2; exit 1; }
+
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -564,15 +580,37 @@ jobs:
       - name: Authorize release source
         id: source
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Release tag/source mismatch" >&2; exit 1; }
-          git fetch https://github.com/democratizedspace/dspace.git main:refs/remotes/origin/main v3:refs/remotes/origin/v3 --quiet
-          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^(origin/)?(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          [[ "$source_branch" == main || "$source_branch" == v3 ]] || { echo "Unsupported release source" >&2; exit 1; }
+          remote=https://github.com/democratizedspace/dspace.git
+          existing_branches=()
+          for branch in main v3; do
+            set +e
+            git ls-remote --exit-code "$remote" "refs/heads/$branch" >/dev/null
+            status=$?
+            set -e
+            case "$status" in
+              0) existing_branches+=("$branch") ;;
+              2) echo "Allowed branch $branch is authoritatively absent" ;;
+              *) echo "Unable to determine whether allowed branch $branch exists" >&2; exit "$status" ;;
+            esac
+          done
+          ((${#existing_branches[@]} > 0)) || { echo "Neither allowed release branch exists" >&2; exit 1; }
+          fetch_specs=()
+          for branch in "${existing_branches[@]}"; do
+            fetch_specs+=("$branch:refs/remotes/origin/$branch")
+          done
+          git fetch "$remote" "${fetch_specs[@]}" --quiet
+          containing_branches=()
+          for branch in "${existing_branches[@]}"; do
+            git merge-base --is-ancestor "$source_sha" "refs/remotes/origin/$branch" && containing_branches+=("$branch")
+          done
+          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one supported branch" >&2; exit 1; }
+          source_branch="${containing_branches[0]}"
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null
@@ -588,7 +626,7 @@ jobs:
       - name: Validate all local release coordinates
         id: coordinates
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           CHART_TAG: ${{ steps.source.outputs.chart_tag }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
           SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -83,6 +83,38 @@ coordinate. After supplying the missing immutable artifact, rerun the failed rel
 semantic tag already exists, the workflow always refuses to overwrite or move it; investigate and
 cut a new approved release coordinate rather than retrying a mutation.
 
+### Recover a failed semantic publication
+
+Use recovery only for an existing, non-draft published GitHub release whose semantic workflow
+failed before creating its semantic GHCR alias. First prove that the semantic tag is absent using
+the repository's authenticated GHCR manifest check (supply a package-readable token); an
+indeterminate registry response is not absence:
+
+```bash
+GHCR_GUARD_USERNAME=YOUR_GITHUB_USER \
+GHCR_GUARD_PASSWORD="$(gh auth token)" \
+node scripts/ghcr-manifest.mjs check-absent \
+  --owner democratizedspace --repo dspace --tag v3.1.1
+```
+
+Then start a fresh dispatch from the fixed `main` workflow definition—do not rerun the historical
+failed run, because a rerun uses its broken workflow definition:
+
+```bash
+gh workflow run ci-image.yml \
+  --repo democratizedspace/dspace \
+  --ref main \
+  -f release_tag=v3.1.1
+```
+
+Recovery checks out the existing immutable application tag and verifies its published GitHub
+release, allowed source branch, immutable image, and chart provenance. It does not move or recreate
+the application tag or GitHub release. It performs the same two semantic-tag absence guards, exact
+digest alias, verification, and deterministic manifest generation as an ordinary release event.
+After recovery succeeds, an identical dispatch is expected to fail at the semantic-tag guard
+before mutation; never delete or overwrite that tag. This recovery evidence supports #4727 and
+#4730.
+
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.
 2. `.github/workflows/ci-helm.yml` publishes only when an exact `chart-v<chart version>` tag is

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -49,6 +49,14 @@ describe('ci-image.yml triggers', () => {
     // and turn every ordinary release into an expected duplicate-publication failure.
     expect(workflow.on.push.tags).toBeUndefined();
   });
+
+  it('keeps branch dispatch as the default and exposes an optional recovery tag', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
+      required: false,
+      default: '',
+      type: 'string',
+    });
+  });
 });
 
 describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
@@ -57,7 +65,8 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
   it('never runs for release events', () => {
     expect(job.if).toContain("github.event_name == 'push'");
     expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
-    expect(job.if).not.toMatch(/release/);
+    expect(job.if).not.toContain("github.event_name == 'release'");
+    expect(job.if).toContain("github.event.inputs.release_tag == ''");
   });
 
   it('serializes ordinary publication by target branch without workflow SHA', () => {
@@ -258,8 +267,9 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
     }
   });
 
-  it('does not run redundantly for release events', () => {
-    expect(job.if).toBe("github.event_name != 'release'");
+  it('does not run redundantly for release events or semantic recovery', () => {
+    expect(job.if).toContain("github.event_name != 'release'");
+    expect(job.if).toContain("github.event.inputs.release_tag == ''");
   });
 });
 
@@ -268,24 +278,41 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('is release-only and serialized by semantic tag', () => {
-    expect(job.if).toBe(
+  it('accepts published releases or non-empty recovery dispatches and serializes by resolved tag', () => {
+    expect(job.if).toContain(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
+    );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
+    expect(job.concurrency.group).toContain('github.event.inputs.release_tag');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
     const checkout = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkout.with.ref).toContain('github.event.release.tag_name');
+    expect(checkout.with.ref).toBe(
+      '${{ github.event.release.tag_name || github.event.inputs.release_tag }}'
+    );
     expect(checkout.with['persist-credentials']).toBe(false);
     const authorization = named('Authorize release source');
     expect(authorization.env.RELEASE_TAG).toContain('release.tag_name');
     expect(authorization.run).toContain(
       'git rev-parse "${RELEASE_TAG}^{commit}"'
     );
-    expect(authorization.run).toContain('refs/remotes/origin/main');
+    expect(authorization.run).toContain('refs/remotes/origin/$branch');
+    expect(authorization.run).toContain('git ls-remote --exit-code');
+    expect(authorization.run).toContain('2) echo');
+    expect(authorization.run).toContain(
+      'Unable to determine whether allowed branch $branch exists'
+    );
+    expect(authorization.run).toContain(
+      'Neither allowed release branch exists'
+    );
+    expect(authorization.run).toContain('${#containing_branches[@]} == 1');
+    expect(authorization.run).toContain('git merge-base --is-ancestor');
+    expect(authorization.run).not.toContain('|| true');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
     );
@@ -293,6 +320,26 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
       steps.indexOf(named('Validate all local release coordinates'))
     );
     expect(JSON.stringify(job)).not.toContain('pnpm install');
+  });
+
+  it('requires a strict stable tag and an already-published non-draft GitHub release', () => {
+    const validation = named('Validate semantic release request');
+    expect(validation.env.RELEASE_TAG).toBe(
+      '${{ github.event.release.tag_name || github.event.inputs.release_tag }}'
+    );
+    expect(validation.run).toContain(
+      '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
+    );
+    expect(validation.run).toContain(
+      'gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}"'
+    );
+    expect(validation.run).toContain('.draft == false');
+    expect(validation.run).toContain('.published_at != null');
+    expect(steps.indexOf(validation)).toBeLessThan(
+      steps.indexOf(
+        named('Checkout tagged commit without persisted credentials')
+      )
+    );
   });
 
   it('pins Node before invoking the release consistency gate', () => {


### PR DESCRIPTION
### Motivation

- The `Authorize release source` step unconditionally fetched both `main` and `v3`, causing `git` to exit 128 when an allowed branch (for example `v3`) was authoritatively absent and failing the workflow early.
- Operators need a safe, auditable way to recover a semantic publication that failed before the semantic GHCR alias was created, without moving/recreating tags or releases.
- Keep the existing branch-image dispatch behavior unchanged while adding a guarded manual recovery path that reuses the existing semantic-release implementation.

### Description

- Added an optional `workflow_dispatch` string input `release_tag` to `.github/workflows/ci-image.yml`, where an empty value preserves ordinary branch-image dispatch and a non-empty `vX.Y.Z` value selects semantic recovery mode.
- Made `local-build` and `image` jobs skip when a non-empty `release_tag` is provided so semantic recovery runs only the semantic-release path.
- Introduced a pre-check `Validate semantic release request` step that requires a strict stable `vX.Y.Z` tag and verifies the corresponding GitHub release is already published (not draft) via `gh api` + `jq` before checking out the tag.
- Rewrote `Authorize release source` to discover allowed release branches safely: use `git ls-remote --exit-code` per allowed branch to treat exit code 2 as an authoritative absence, fail on indeterminate/auth/transport errors, fetch only existing branches, and require the checked-out tagged commit to be contained by exactly one supported branch (`main` or `v3`).
- Kept the existing semantic-release path intact: both preflight and final `--pre-semantic` GHCR absence guards, immutable image/chart provenance checks, a single `docker buildx imagetools create` alias mutation, digest equality verification, deterministic `dspace-release-manifest.json` emission/validation, and upload remain unchanged.
- Added tests covering the new dispatch input, recovery validation, authoritative branch discovery logic, and preservation of ordinary branch behavior in `tests/ciImageWorkflow.test.ts` and updated docs with a concise recovery runbook entry in `docs/ops/sugarkube-release.md`.
- Files changed: `.github/workflows/ci-image.yml`, `tests/ciImageWorkflow.test.ts`, and `docs/ops/sugarkube-release.md`.

### Testing

- Ran `npm run test:root -- tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts` and all tests passed: 46 tests, 2 files (success).
- Ran `node scripts/check-release-consistency.mjs --verify-local-fixtures` (network-free fixtures) and it passed.
- Ran formatting and checks: `npx prettier --check` (fixed minor style), `npm run lint` (frontend lint) and `npm run link-check`; all completed successfully.
- Verified `git diff --check` and repository status; working tree is clean on branch `work` and commit `425398b` was created locally.

Post-merge recovery command (exact):

```bash
gh workflow run ci-image.yml \
  --repo democratizedspace/dspace \
  --ref main \
  -f release_tag=v3.1.1
```

Notes and constraints respected: the root cause and fix target only the workflow/validation logic; no application version, chart version, tag, GitHub release, GHCR image, Helm chart, or other remote artifact was created, moved, deleted, or mutated by this change; no workflows were triggered during this work. This recovery flow documents and preserves the existing duplicate-guard behavior described in #4727 and #4730.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73beb91118832f84f57e5637f5df93)