### PR TITLE
Add guarded semantic-release recovery dispatch and resilient branch discovery in ci-image.yml

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,6 +14,11 @@ on:
       - published
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing published vX.Y.Z release to recover (leave empty for a branch image)
+        required: false
+        default: ''
+        type: string
       branch:
         description: Branch to build and publish the image from
         required: false
@@ -34,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +277,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -547,20 +552,20 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name || github.event.inputs.release_tag }}
       cancel-in-progress: false
     steps:
       - name: Resolve and authorize published release
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
-            echo "Semantic publication requires a stable vX.Y.Z release tag" >&2
+            echo "Recovery requires a stable vX.Y.Z release tag" >&2
             exit 1
           }
           release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
@@ -571,8 +576,6 @@ jobs:
               exit 1
             }
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-          release_branch="$(jq -r '.target_commitish | select(. == "main" or . == "v3")' <<<"$release_json")"
-          echo "source_branch_hint=$release_branch" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
@@ -587,7 +590,6 @@ jobs:
         id: source
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          SOURCE_BRANCH_HINT: ${{ steps.release.outputs.source_branch_hint }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
@@ -624,17 +626,8 @@ jobs:
               exit "$status"
             fi
           done
-          ((${#containing_branches[@]} > 0)) || { echo "Release source is not contained by a supported branch" >&2; exit 1; }
-          # A release commit can legitimately be reachable from both branches after a merge.
-          # Prefer the release's supported target_commitish, then v3 as a deterministic fallback.
+          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one supported branch" >&2; exit 1; }
           source_branch="${containing_branches[0]}"
-          for branch in "${containing_branches[@]}"; do
-            if [[ -n "$SOURCE_BRANCH_HINT" && "$branch" == "$SOURCE_BRANCH_HINT" ]]; then
-              source_branch="$SOURCE_BRANCH_HINT"
-              break
-            fi
-            [[ "$branch" == v3 ]] && source_branch=v3
-          done
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,6 +14,11 @@ on:
       - published
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing published vX.Y.Z release to recover (leave empty for a branch image)
+        required: false
+        default: ''
+        type: string
       branch:
         description: Branch to build and publish the image from
         required: false
@@ -34,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +277,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -547,15 +552,35 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name || github.event.inputs.release_tag }}
       cancel-in-progress: false
     steps:
+      - name: Resolve and authorize published release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+            echo "Recovery requires a stable vX.Y.Z release tag" >&2
+            exit 1
+          }
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          jq -e --arg tag "$RELEASE_TAG" \
+            '.tag_name == $tag and .draft == false and .published_at != null' \
+            <<<"$release_json" >/dev/null || {
+              echo "Release must already exist and be published (not draft)" >&2
+              exit 1
+            }
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -564,15 +589,45 @@ jobs:
       - name: Authorize release source
         id: source
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Release tag/source mismatch" >&2; exit 1; }
-          git fetch https://github.com/democratizedspace/dspace.git main:refs/remotes/origin/main v3:refs/remotes/origin/v3 --quiet
-          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^(origin/)?(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          [[ "$source_branch" == main || "$source_branch" == v3 ]] || { echo "Unsupported release source" >&2; exit 1; }
+          remote=https://github.com/democratizedspace/dspace.git
+          existing_branches=()
+          for branch in main v3; do
+            set +e
+            git ls-remote --exit-code --heads "$remote" "refs/heads/$branch" >/dev/null
+            status=$?
+            set -e
+            if [[ $status -eq 0 ]]; then
+              existing_branches+=("$branch")
+            elif [[ $status -ne 2 ]]; then
+              echo "Indeterminate discovery failure for allowed branch $branch (exit $status)" >&2
+              exit "$status"
+            fi
+          done
+          ((${#existing_branches[@]} > 0)) || { echo "No supported release branches exist" >&2; exit 1; }
+          for branch in "${existing_branches[@]}"; do
+            git fetch "$remote" "$branch:refs/remotes/origin/$branch" --quiet
+          done
+          containing_branches=()
+          for branch in "${existing_branches[@]}"; do
+            set +e
+            git merge-base --is-ancestor "$source_sha" "refs/remotes/origin/$branch"
+            status=$?
+            set -e
+            if [[ $status -eq 0 ]]; then
+              containing_branches+=("$branch")
+            elif [[ $status -ne 1 ]]; then
+              echo "Indeterminate containment failure for allowed branch $branch (exit $status)" >&2
+              exit "$status"
+            fi
+          done
+          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one supported branch" >&2; exit 1; }
+          source_branch="${containing_branches[0]}"
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null
@@ -588,7 +643,7 @@ jobs:
       - name: Validate all local release coordinates
         id: coordinates
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
           CHART_TAG: ${{ steps.source.outputs.chart_tag }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
           SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,11 +14,6 @@ on:
       - published
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: Existing published vX.Y.Z release to recover (leave empty for a branch image)
-        required: false
-        default: ''
-        type: string
       branch:
         description: Branch to build and publish the image from
         required: false
@@ -39,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
+    if: github.event_name != 'release'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -277,7 +272,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -552,20 +547,20 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
+    if: github.event_name == 'release' && github.event.action == 'published'
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name }}
       cancel-in-progress: false
     steps:
       - name: Resolve and authorize published release
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
-            echo "Recovery requires a stable vX.Y.Z release tag" >&2
+            echo "Semantic publication requires a stable vX.Y.Z release tag" >&2
             exit 1
           }
           release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
@@ -576,6 +571,8 @@ jobs:
               exit 1
             }
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          release_branch="$(jq -r '.target_commitish | select(. == "main" or . == "v3")' <<<"$release_json")"
+          echo "source_branch_hint=$release_branch" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
@@ -590,6 +587,7 @@ jobs:
         id: source
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          SOURCE_BRANCH_HINT: ${{ steps.release.outputs.source_branch_hint }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
@@ -626,8 +624,17 @@ jobs:
               exit "$status"
             fi
           done
-          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one supported branch" >&2; exit 1; }
+          ((${#containing_branches[@]} > 0)) || { echo "Release source is not contained by a supported branch" >&2; exit 1; }
+          # A release commit can legitimately be reachable from both branches after a merge.
+          # Prefer the release's supported target_commitish, then v3 as a deterministic fallback.
           source_branch="${containing_branches[0]}"
+          for branch in "${containing_branches[@]}"; do
+            if [[ -n "$SOURCE_BRANCH_HINT" && "$branch" == "$SOURCE_BRANCH_HINT" ]]; then
+              source_branch="$SOURCE_BRANCH_HINT"
+              break
+            fi
+            [[ "$branch" == v3 ]] && source_branch=v3
+          done
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -79,9 +79,30 @@ The mandatory full-release order is fail-closed:
    verifies digest equality, and emits the combined release manifest.
 
 Publishing the GitHub release before either prerequisite exists fails without creating the semantic
-coordinate. After supplying the missing immutable artifact, rerun the failed release workflow. If a
-semantic tag already exists, the workflow always refuses to overwrite or move it; investigate and
-cut a new approved release coordinate rather than retrying a mutation.
+coordinate. After supplying a missing immutable prerequisite, use the semantic recovery procedure
+below rather than rerunning a historical workflow definition. If a semantic tag already exists,
+the workflow always refuses to overwrite or move it; investigate and cut a new approved release
+coordinate rather than retrying a mutation.
+
+### Recover a failed semantic publication
+
+This recovery is only for an existing, published (non-draft) GitHub application release whose
+semantic workflow failed before publishing its GHCR semantic alias. First prove that the semantic
+tag is authoritatively absent using the authenticated registry evidence procedure. Then dispatch
+the fixed workflow definition from `main` (do not rerun the historical failed workflow run):
+
+```bash
+gh workflow run ci-image.yml \
+  --repo democratizedspace/dspace \
+  --ref main \
+  -f release_tag=v3.1.1
+```
+
+The recovery validates the published release and immutable application tag, source-branch reachability,
+immutable image and chart provenance, and both semantic-tag absence guards before creating the one
+exact alias and deterministic release manifest. It does not move or recreate the application tag or
+GitHub release. An identical dispatch after success is expected to fail at the semantic-tag guard
+before mutation; this is intentional evidence for #4727 and #4730.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -79,10 +79,41 @@ The mandatory full-release order is fail-closed:
    verifies digest equality, and emits the combined release manifest.
 
 Publishing the GitHub release before either prerequisite exists fails without creating the semantic
-coordinate. Do not use a manual workflow dispatch to recover semantic publication: the published
-GitHub release event is the single canonical event permitted to create a semantic alias. Investigate
-the failed run and cut a new approved release coordinate after supplying any missing immutable
-prerequisite. If a semantic tag already exists, the workflow always refuses to overwrite or move it.
+coordinate. After supplying a missing immutable prerequisite, use the semantic recovery procedure
+below rather than rerunning a historical workflow definition. If a semantic tag already exists,
+the workflow always refuses to overwrite or move it; investigate and cut a new approved release
+coordinate rather than retrying a mutation.
+
+### Recover a failed semantic publication
+
+This recovery is only for an existing, published (non-draft) GitHub application release whose
+semantic workflow failed before publishing its GHCR semantic alias. First prove that the semantic
+tag is authoritatively absent with the fail-closed preflight:
+
+```bash
+GHCR_GUARD_USERNAME="$(gh api user --jq .login)" \
+GHCR_GUARD_PASSWORD="$(gh auth token)" \
+node scripts/ghcr-manifest.mjs check-absent \
+  --owner democratizedspace \
+  --repo dspace \
+  --tag v3.1.1
+```
+
+Then dispatch the fixed workflow definition from `main` (do not rerun the historical failed
+workflow run):
+
+```bash
+gh workflow run ci-image.yml \
+  --repo democratizedspace/dspace \
+  --ref main \
+  -f release_tag=v3.1.1
+```
+
+The recovery validates the published release and immutable application tag, source-branch reachability,
+immutable image and chart provenance, and both semantic-tag absence guards before creating the one
+exact alias and deterministic release manifest. It does not move or recreate the application tag or
+GitHub release. An identical dispatch after success is expected to fail at the semantic-tag guard
+before mutation; this is intentional evidence for #4727 and #4730.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -79,30 +79,10 @@ The mandatory full-release order is fail-closed:
    verifies digest equality, and emits the combined release manifest.
 
 Publishing the GitHub release before either prerequisite exists fails without creating the semantic
-coordinate. After supplying a missing immutable prerequisite, use the semantic recovery procedure
-below rather than rerunning a historical workflow definition. If a semantic tag already exists,
-the workflow always refuses to overwrite or move it; investigate and cut a new approved release
-coordinate rather than retrying a mutation.
-
-### Recover a failed semantic publication
-
-This recovery is only for an existing, published (non-draft) GitHub application release whose
-semantic workflow failed before publishing its GHCR semantic alias. First prove that the semantic
-tag is authoritatively absent using the authenticated registry evidence procedure. Then dispatch
-the fixed workflow definition from `main` (do not rerun the historical failed workflow run):
-
-```bash
-gh workflow run ci-image.yml \
-  --repo democratizedspace/dspace \
-  --ref main \
-  -f release_tag=v3.1.1
-```
-
-The recovery validates the published release and immutable application tag, source-branch reachability,
-immutable image and chart provenance, and both semantic-tag absence guards before creating the one
-exact alias and deterministic release manifest. It does not move or recreate the application tag or
-GitHub release. An identical dispatch after success is expected to fail at the semantic-tag guard
-before mutation; this is intentional evidence for #4727 and #4730.
+coordinate. Do not use a manual workflow dispatch to recover semantic publication: the published
+GitHub release event is the single canonical event permitted to create a semantic alias. Investigate
+the failed run and cut a new approved release coordinate after supplying any missing immutable
+prerequisite. If a semantic tag already exists, the workflow always refuses to overwrite or move it.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -50,17 +50,13 @@ describe('ci-image.yml triggers', () => {
     expect(workflow.on.push.tags).toBeUndefined();
   });
 
-  it('keeps an empty manual recovery tag on the ordinary branch-image path', () => {
-    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
-      type: 'string',
-      required: false,
-      default: '',
-    });
+  it('keeps manual dispatch limited to the ordinary branch-image path', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toBeUndefined();
     expect(workflow.jobs.image.if).toContain(
-      "github.event.inputs.release_tag == ''"
+      "github.event_name == 'workflow_dispatch'"
     );
-    expect(workflow.jobs['local-build'].if).toContain(
-      "github.event.inputs.release_tag != ''"
+    expect(workflow.jobs['semantic-release'].if).not.toContain(
+      "github.event_name == 'workflow_dispatch'"
     );
   });
 });
@@ -274,26 +270,21 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
 
   it('does not run redundantly for release events', () => {
     expect(job.if).toContain("github.event_name != 'release'");
-    expect(job.if).toContain(
-      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
-    );
+    expect(job.if).not.toContain('release_tag');
   });
 });
 
-describe('ci-image.yml "semantic-release" job (normal and recovery alias path)', () => {
+describe('ci-image.yml "semantic-release" job', () => {
   const job = workflow.jobs['semantic-release'];
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('accepts published release events or explicit recovery dispatches and serializes by tag', () => {
-    expect(job.if).toContain(
+  it('accepts only published release events and serializes by tag', () => {
+    expect(job.if).toBe(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
-    expect(job.if).toContain(
-      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
-    );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
-    expect(job.concurrency.group).toContain('github.event.inputs.release_tag');
+    expect(job.concurrency.group).not.toContain('github.event.inputs');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
 
@@ -303,7 +294,10 @@ describe('ci-image.yml "semantic-release" job (normal and recovery alias path)',
     expect(release.run).toContain('gh api');
     expect(release.run).toContain('.draft == false');
     expect(release.run).toContain('.published_at != null');
-    expect(release.env.RELEASE_TAG).toContain('event.inputs.release_tag');
+    expect(release.run).toContain('.target_commitish');
+    expect(release.env.RELEASE_TAG).toBe(
+      '${{ github.event.release.tag_name }}'
+    );
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
@@ -320,7 +314,11 @@ describe('ci-image.yml "semantic-release" job (normal and recovery alias path)',
     expect(authorization.run).toContain('refs/remotes/origin/$branch');
     expect(authorization.run).toContain('git ls-remote --exit-code --heads');
     expect(authorization.run).toContain('elif [[ $status -ne 2 ]]');
-    expect(authorization.run).toContain('${#containing_branches[@]} == 1');
+    expect(authorization.run).toContain('${#containing_branches[@]} > 0');
+    expect(authorization.env.SOURCE_BRANCH_HINT).toBe(
+      '${{ steps.release.outputs.source_branch_hint }}'
+    );
+    expect(authorization.run).toContain('"$branch" == "$SOURCE_BRANCH_HINT"');
     expect(authorization.run).not.toContain('|| true');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
@@ -340,7 +338,8 @@ describe('ci-image.yml "semantic-release" job (normal and recovery alias path)',
     expect(run).toContain('for branch in "${existing_branches[@]}"');
     expect(run).toContain('git merge-base --is-ancestor');
     expect(run).toContain('elif [[ $status -ne 1 ]]');
-    expect(run).toContain('${#containing_branches[@]} == 1');
+    expect(run).toContain('${#containing_branches[@]} > 0');
+    expect(run).toContain('[[ "$branch" == v3 ]] && source_branch=v3');
   });
 
   it('pins Node before invoking the release consistency gate', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
@@ -35,6 +43,71 @@ function stepIndex(job: any, predicate: (step: any) => boolean): number {
   return findSteps(job).findIndex(predicate);
 }
 
+function runShell(run: string, env: Record<string, string> = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'ci-image-workflow-'));
+  const bin = join(directory, 'bin');
+  mkdirSync(bin);
+  const output = join(directory, 'output');
+  const log = join(directory, 'calls.log');
+  writeFileSync(output, '');
+  writeFileSync(log, '');
+  const executable = (name: string, body: string) => {
+    const path = join(bin, name);
+    writeFileSync(path, `#!/usr/bin/env bash\n${body}`);
+    chmodSync(path, 0o755);
+  };
+  executable(
+    'gh',
+    'echo gh >> "$MOCK_LOG"\nprintf \'%s\\n\' "$MOCK_RELEASE_JSON"\n'
+  );
+  executable(
+    'git',
+    `echo "$*" >> "$MOCK_LOG"
+if [[ "$1 $2" == "rev-parse HEAD" ]]; then echo "$MOCK_SOURCE_SHA"; exit 0; fi
+if [[ "$1" == "rev-parse" && "$2" == *'^'{commit} ]]; then echo "$MOCK_SOURCE_SHA"; exit 0; fi
+if [[ "$1" == "ls-remote" ]]; then
+  [[ "${'$'}*" == *refs/heads/main* ]] && exit "${'$'}MOCK_MAIN_LS"
+  exit "${'$'}MOCK_V3_LS"
+fi
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1 $2" == "merge-base --is-ancestor" ]]; then
+  [[ "${'$'}*" == *origin/main* ]] && exit "${'$'}MOCK_MAIN_MERGE"
+  exit "${'$'}MOCK_V3_MERGE"
+fi
+if [[ "$1" == "rev-parse" ]]; then echo 1111111111111111111111111111111111111111; exit 0; fi
+exit 99
+`
+  );
+  mkdirSync(join(directory, 'charts', 'dspace'), { recursive: true });
+  writeFileSync(
+    join(directory, 'charts', 'dspace', 'Chart.yaml'),
+    'version: 3.0.0\n'
+  );
+  const result = spawnSync('bash', ['-c', run], {
+    cwd: directory,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      GITHUB_OUTPUT: output,
+      GITHUB_REPOSITORY: 'democratizedspace/dspace',
+      MOCK_LOG: log,
+      MOCK_RELEASE_JSON: '{}',
+      MOCK_SOURCE_SHA: '0123456789abcdef0123456789abcdef01234567',
+      MOCK_MAIN_LS: '2',
+      MOCK_V3_LS: '2',
+      MOCK_MAIN_MERGE: '1',
+      MOCK_V3_MERGE: '1',
+      ...env,
+    },
+  });
+  return {
+    ...result,
+    calls: readFileSync(log, 'utf8'),
+    output: readFileSync(output, 'utf8'),
+  };
+}
+
 describe('ci-image.yml triggers', () => {
   it('keeps ordinary branch coverage on main and v3, with no tag-push trigger', () => {
     expect(workflow.on.push.branches).toEqual(['v3', 'main']);
@@ -43,21 +116,45 @@ describe('ci-image.yml triggers', () => {
   });
 
   it('has exactly one canonical semantic-publication event: a published release', () => {
-    expect(workflow.on.release).toBeTruthy();
-    expect(workflow.on.release.types).toContain('published');
+    expect(workflow.on.release).toEqual({ types: ['published'] });
     // No push.tags trigger alongside release: published — that combination would race
     // and turn every ordinary release into an expected duplicate-publication failure.
     expect(workflow.on.push.tags).toBeUndefined();
   });
 
-  it('keeps manual dispatch limited to the ordinary branch-image path', () => {
-    expect(workflow.on.workflow_dispatch.inputs.release_tag).toBeUndefined();
-    expect(workflow.jobs.image.if).toContain(
-      "github.event_name == 'workflow_dispatch'"
+  it('keeps an empty manual recovery tag on the ordinary branch-image path', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
+      type: 'string',
+      required: false,
+      default: '',
+    });
+    expect(workflow.jobs.image.if).toBe(
+      "github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')"
     );
-    expect(workflow.jobs['semantic-release'].if).not.toContain(
-      "github.event_name == 'workflow_dispatch'"
+    expect(workflow.jobs['local-build'].if).toBe(
+      "github.event_name != 'release' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')"
     );
+    expect(workflow.jobs['semantic-release'].if).toBe(
+      "(github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')"
+    );
+  });
+
+  it('routes empty dispatches to both branch jobs and valid recovery only to semantic release', () => {
+    const enabled = (releaseTag: string) => ({
+      localBuild: releaseTag === '',
+      image: releaseTag === '',
+      semanticRelease: releaseTag !== '',
+    });
+    expect(enabled('')).toEqual({
+      localBuild: true,
+      image: true,
+      semanticRelease: false,
+    });
+    expect(enabled('v3.1.1')).toEqual({
+      localBuild: false,
+      image: false,
+      semanticRelease: true,
+    });
   });
 });
 
@@ -270,34 +367,61 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
 
   it('does not run redundantly for release events', () => {
     expect(job.if).toContain("github.event_name != 'release'");
-    expect(job.if).not.toContain('release_tag');
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
+    );
   });
 });
 
-describe('ci-image.yml "semantic-release" job', () => {
+describe('ci-image.yml "semantic-release" job (normal and recovery alias path)', () => {
   const job = workflow.jobs['semantic-release'];
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('accepts only published release events and serializes by tag', () => {
+  it('accepts published release events or explicit recovery dispatches and serializes by tag', () => {
     expect(job.if).toBe(
-      "github.event_name == 'release' && github.event.action == 'published'"
+      "(github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')"
     );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
-    expect(job.concurrency.group).not.toContain('github.event.inputs');
+    expect(job.concurrency.group).toContain('github.event.inputs.release_tag');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
   });
 
   it('requires a stable tag belonging to an existing published, non-draft GitHub release', () => {
     const release = named('Resolve and authorize published release');
-    expect(release.run).toContain('^v(0|[1-9][0-9]*)\\.');
-    expect(release.run).toContain('gh api');
-    expect(release.run).toContain('.draft == false');
-    expect(release.run).toContain('.published_at != null');
-    expect(release.run).toContain('.target_commitish');
-    expect(release.env.RELEASE_TAG).toBe(
-      '${{ github.event.release.tag_name }}'
-    );
+    const valid = JSON.stringify({
+      tag_name: 'v3.1.1',
+      draft: false,
+      published_at: '2026-08-05T00:00:00Z',
+    });
+    const passed = runShell(release.run, {
+      RELEASE_TAG: 'v3.1.1',
+      MOCK_RELEASE_JSON: valid,
+    });
+    expect(passed.status).toBe(0);
+    expect(passed.output).toBe('tag=v3.1.1\n');
+    expect(passed.calls).toBe('gh\n');
+
+    for (const tag of ['', '3.1.1', 'v3.1.1-rc.1']) {
+      const failed = runShell(release.run, {
+        RELEASE_TAG: tag,
+        MOCK_RELEASE_JSON: valid,
+      });
+      expect(failed.status).not.toBe(0);
+      expect(failed.calls).toBe('');
+    }
+    for (const releaseJson of [
+      { tag_name: 'v3.1.1', draft: true, published_at: '2026-08-05T00:00:00Z' },
+      { tag_name: 'v3.1.1', draft: false, published_at: null },
+    ]) {
+      const failed = runShell(release.run, {
+        RELEASE_TAG: 'v3.1.1',
+        MOCK_RELEASE_JSON: JSON.stringify(releaseJson),
+      });
+      expect(failed.status).not.toBe(0);
+      expect(failed.calls).toBe('gh\n');
+      expect(failed.output).toBe('');
+    }
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
@@ -314,11 +438,7 @@ describe('ci-image.yml "semantic-release" job', () => {
     expect(authorization.run).toContain('refs/remotes/origin/$branch');
     expect(authorization.run).toContain('git ls-remote --exit-code --heads');
     expect(authorization.run).toContain('elif [[ $status -ne 2 ]]');
-    expect(authorization.run).toContain('${#containing_branches[@]} > 0');
-    expect(authorization.env.SOURCE_BRANCH_HINT).toBe(
-      '${{ steps.release.outputs.source_branch_hint }}'
-    );
-    expect(authorization.run).toContain('"$branch" == "$SOURCE_BRANCH_HINT"');
+    expect(authorization.run).toContain('${#containing_branches[@]} == 1');
     expect(authorization.run).not.toContain('|| true');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
@@ -329,17 +449,48 @@ describe('ci-image.yml "semantic-release" job', () => {
     expect(JSON.stringify(job)).not.toContain('pnpm install');
   });
 
-  it('discovers main and v3 independently and fails closed on absence or indeterminate errors', () => {
-    const run = named('Authorize release source').run;
-    expect(run).toContain('for branch in main v3');
-    expect(run).toContain('existing_branches+=("$branch")');
-    expect(run).toContain('elif [[ $status -ne 2 ]]');
-    expect(run).toContain('No supported release branches exist');
-    expect(run).toContain('for branch in "${existing_branches[@]}"');
-    expect(run).toContain('git merge-base --is-ancestor');
-    expect(run).toContain('elif [[ $status -ne 1 ]]');
-    expect(run).toContain('${#containing_branches[@]} > 0');
-    expect(run).toContain('[[ "$branch" == v3 ]] && source_branch=v3');
+  it.each([
+    ['main', { MOCK_MAIN_LS: '0', MOCK_V3_LS: '2', MOCK_MAIN_MERGE: '0' }],
+    ['v3', { MOCK_MAIN_LS: '2', MOCK_V3_LS: '0', MOCK_V3_MERGE: '0' }],
+  ])('authorizes the sole existing containing branch: %s', (branch, env) => {
+    const result = runShell(named('Authorize release source').run, {
+      RELEASE_TAG: 'v3.1.1',
+      ...env,
+    });
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(`source_branch=${branch}\n`);
+    expect(result.calls.match(/^fetch .*$/gm)).toEqual([
+      `fetch https://github.com/democratizedspace/dspace.git ${branch}:refs/remotes/origin/${branch} --quiet`,
+    ]);
+  });
+
+  it.each([
+    ['neither branch exists', {}],
+    ['branch discovery is indeterminate', { MOCK_MAIN_LS: '3' }],
+    [
+      'containment is indeterminate even when the other branch contains the source',
+      {
+        MOCK_MAIN_LS: '0',
+        MOCK_V3_LS: '0',
+        MOCK_MAIN_MERGE: '3',
+        MOCK_V3_MERGE: '0',
+      },
+    ],
+    [
+      'both branches contain the source',
+      {
+        MOCK_MAIN_LS: '0',
+        MOCK_V3_LS: '0',
+        MOCK_MAIN_MERGE: '0',
+        MOCK_V3_MERGE: '0',
+      },
+    ],
+  ])('fails closed when %s', (_case, env) => {
+    const result = runShell(named('Authorize release source').run, {
+      RELEASE_TAG: 'v3.1.1',
+      ...env,
+    });
+    expect(result.status).not.toBe(0);
   });
 
   it('pins Node before invoking the release consistency gate', () => {

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -49,6 +49,20 @@ describe('ci-image.yml triggers', () => {
     // and turn every ordinary release into an expected duplicate-publication failure.
     expect(workflow.on.push.tags).toBeUndefined();
   });
+
+  it('keeps an empty manual recovery tag on the ordinary branch-image path', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
+      type: 'string',
+      required: false,
+      default: '',
+    });
+    expect(workflow.jobs.image.if).toContain(
+      "github.event.inputs.release_tag == ''"
+    );
+    expect(workflow.jobs['local-build'].if).toContain(
+      "github.event.inputs.release_tag != ''"
+    );
+  });
 });
 
 describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
@@ -57,7 +71,7 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
   it('never runs for release events', () => {
     expect(job.if).toContain("github.event_name == 'push'");
     expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
-    expect(job.if).not.toMatch(/release/);
+    expect(job.if).not.toContain("github.event_name == 'release'");
   });
 
   it('serializes ordinary publication by target branch without workflow SHA', () => {
@@ -259,33 +273,55 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
   });
 
   it('does not run redundantly for release events', () => {
-    expect(job.if).toBe("github.event_name != 'release'");
+    expect(job.if).toContain("github.event_name != 'release'");
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
+    );
   });
 });
 
-describe('ci-image.yml "semantic-release" job (release-only alias path)', () => {
+describe('ci-image.yml "semantic-release" job (normal and recovery alias path)', () => {
   const job = workflow.jobs['semantic-release'];
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('is release-only and serialized by semantic tag', () => {
-    expect(job.if).toBe(
+  it('accepts published release events or explicit recovery dispatches and serializes by tag', () => {
+    expect(job.if).toContain(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
+    );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
+    expect(job.concurrency.group).toContain('github.event.inputs.release_tag');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('requires a stable tag belonging to an existing published, non-draft GitHub release', () => {
+    const release = named('Resolve and authorize published release');
+    expect(release.run).toContain('^v(0|[1-9][0-9]*)\\.');
+    expect(release.run).toContain('gh api');
+    expect(release.run).toContain('.draft == false');
+    expect(release.run).toContain('.published_at != null');
+    expect(release.env.RELEASE_TAG).toContain('event.inputs.release_tag');
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
     const checkout = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkout.with.ref).toContain('github.event.release.tag_name');
+    expect(checkout.with.ref).toBe('${{ steps.release.outputs.tag }}');
     expect(checkout.with['persist-credentials']).toBe(false);
     const authorization = named('Authorize release source');
-    expect(authorization.env.RELEASE_TAG).toContain('release.tag_name');
+    expect(authorization.env.RELEASE_TAG).toBe(
+      '${{ steps.release.outputs.tag }}'
+    );
     expect(authorization.run).toContain(
       'git rev-parse "${RELEASE_TAG}^{commit}"'
     );
-    expect(authorization.run).toContain('refs/remotes/origin/main');
+    expect(authorization.run).toContain('refs/remotes/origin/$branch');
+    expect(authorization.run).toContain('git ls-remote --exit-code --heads');
+    expect(authorization.run).toContain('elif [[ $status -ne 2 ]]');
+    expect(authorization.run).toContain('${#containing_branches[@]} == 1');
+    expect(authorization.run).not.toContain('|| true');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
     );
@@ -293,6 +329,18 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
       steps.indexOf(named('Validate all local release coordinates'))
     );
     expect(JSON.stringify(job)).not.toContain('pnpm install');
+  });
+
+  it('discovers main and v3 independently and fails closed on absence or indeterminate errors', () => {
+    const run = named('Authorize release source').run;
+    expect(run).toContain('for branch in main v3');
+    expect(run).toContain('existing_branches+=("$branch")');
+    expect(run).toContain('elif [[ $status -ne 2 ]]');
+    expect(run).toContain('No supported release branches exist');
+    expect(run).toContain('for branch in "${existing_branches[@]}"');
+    expect(run).toContain('git merge-base --is-ancestor');
+    expect(run).toContain('elif [[ $status -ne 1 ]]');
+    expect(run).toContain('${#containing_branches[@]} == 1');
   });
 
   it('pins Node before invoking the release consistency gate', () => {


### PR DESCRIPTION
### Motivation

The DSPACE `v3.1.1` semantic-release run failed before any GHCR mutation because `Authorize release source` unconditionally fetched both supported branches:

~~~bash
git fetch https://github.com/democratizedspace/dspace.git \
  main:refs/remotes/origin/main \
  v3:refs/remotes/origin/v3 \
  --quiet
~~~

`main` exists but `v3` does not, so Git exited 128 with `fatal: couldn't find remote ref v3`. Operators also need a guarded way to recover an already-published immutable application release without moving or recreating its Git tag or GitHub release.

### Changes

- Added an optional `workflow_dispatch` string input, `release_tag`.
  - Empty input preserves the ordinary manual branch-image path.
  - Non-empty input skips `local-build` and branch-image publication and runs only the existing `semantic-release` job.
- Added fail-closed recovery authorization:
  - requires a strict stable `vX.Y.Z` tag;
  - requires an existing published, non-draft GitHub release;
  - checks out the validated immutable tag;
  - verifies the tag peels to the checked-out source SHA.
- Replaced the unconditional branch fetch with independent `main`/`v3` discovery:
  - exit 2 from `git ls-remote --exit-code` is treated as authoritative absence;
  - authentication, transport, and other indeterminate failures remain fatal;
  - only existing allowed branches are fetched;
  - `git merge-base` status 1 is treated as non-containment, while other errors fail closed;
  - the source must be contained by exactly one supported branch.
- Reused the existing semantic-release implementation, preserving:
  - immutable image and chart provenance checks;
  - both authenticated semantic-tag absence guards;
  - exactly one semantic-alias mutation;
  - digest-equality verification;
  - deterministic `dspace-release-manifest.json` emission, validation, upload, and summary.
- Added executable workflow tests using deterministic temporary `git` and `gh` mocks. Coverage includes missing branches, indeterminate discovery and containment failures, dual containment, dispatch routing, strict tag validation, and draft or unpublished releases.
- Documented the authenticated GHCR preflight and fresh fixed-`main` recovery procedure.

### Files changed

- `.github/workflows/ci-image.yml`
- `tests/ciImageWorkflow.test.ts`
- `docs/ops/sugarkube-release.md`

### Verification

- `npm run test:root -- tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts` — 53 tests passed.
- `node scripts/check-release-consistency.mjs --verify-local-fixtures` — passed.
- `npm run lint` — passed.
- `npm run link-check` — passed.
- `git diff --check` — passed.

### Post-merge recovery procedure

First prove that the semantic GHCR tag is authoritatively absent:

~~~bash
GHCR_GUARD_USERNAME="$(gh api user --jq .login)" \
GHCR_GUARD_PASSWORD="$(gh auth token)" \
node scripts/ghcr-manifest.mjs check-absent \
  --owner democratizedspace \
  --repo dspace \
  --tag v3.1.1
~~~

Then use a fresh dispatch from the fixed workflow definition on `main`; do not rerun historical failed run `31054063757`:

~~~bash
gh workflow run ci-image.yml \
  --repo democratizedspace/dspace \
  --ref main \
  -f release_tag=v3.1.1
~~~

An identical dispatch after successful recovery is expected to fail at the existing semantic-tag guard before mutation.

No Git tag, GitHub release, package, image, chart, artifact, Helm release, or Kubernetes resource was created, moved, recreated, published, or otherwise mutated while implementing or verifying this PR.

Refs #4727 and #4730.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73bed15460832f9203e427d8412cf2)