### PR TITLE
ci-image: add semantic-release recovery dispatch and robust branch discovery

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,6 +14,11 @@ on:
       - published
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing published stable release tag to recover (leave empty for a branch image)
+        required: false
+        default: ''
+        type: string
       branch:
         description: Branch to build and publish the image from
         required: false
@@ -34,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && (github.event_name != 'workflow_dispatch' || github.event.inputs.release_tag == '')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +277,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag == '')
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -547,15 +552,15 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name || github.event.inputs.release_tag }}
       cancel-in-progress: false
     steps:
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -564,15 +569,40 @@ jobs:
       - name: Authorize release source
         id: source
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
         run: |
           set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo "Release tag must be a stable vX.Y.Z tag" >&2; exit 1; }
+          release_json="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          jq -e --arg tag "$RELEASE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false' <<<"$release_json" >/dev/null || { echo "Release must already exist and be published (not draft or prerelease)" >&2; exit 1; }
           source_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Release tag/source mismatch" >&2; exit 1; }
-          git fetch https://github.com/democratizedspace/dspace.git main:refs/remotes/origin/main v3:refs/remotes/origin/v3 --quiet
-          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^(origin/)?(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          [[ "$source_branch" == main || "$source_branch" == v3 ]] || { echo "Unsupported release source" >&2; exit 1; }
+          remote_url="https://github.com/democratizedspace/dspace.git"
+          existing_branches=()
+          for branch in main v3; do
+            set +e
+            remote_ref="$(git ls-remote --exit-code "$remote_url" "refs/heads/$branch" 2>"/tmp/ls-remote-$branch.err")"
+            status=$?
+            set -e
+            case "$status" in
+              0)
+                [[ "$remote_ref" =~ ^[0-9a-f]{40}[[:space:]]refs/heads/$branch$ ]] || { echo "Indeterminate $branch branch response" >&2; exit 1; }
+                git fetch "$remote_url" "refs/heads/$branch:refs/remotes/origin/$branch" --quiet
+                existing_branches+=("$branch")
+                ;;
+              2) echo "Allowed release branch $branch is authoritatively absent" ;;
+              *) cat "/tmp/ls-remote-$branch.err" >&2; echo "Could not determine whether allowed branch $branch exists" >&2; exit 1 ;;
+            esac
+          done
+          ((${#existing_branches[@]} > 0)) || { echo "Neither allowed release branch exists" >&2; exit 1; }
+          containing_branches=()
+          for branch in "${existing_branches[@]}"; do
+            git merge-base --is-ancestor "$source_sha" "refs/remotes/origin/$branch" && containing_branches+=("$branch")
+          done
+          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one supported branch" >&2; exit 1; }
+          source_branch="${containing_branches[0]}"
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null
@@ -588,7 +618,7 @@ jobs:
       - name: Validate all local release coordinates
         id: coordinates
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           CHART_TAG: ${{ steps.source.outputs.chart_tag }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
           SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -132,6 +132,29 @@ Required post-merge evidence for Refs #4727 and Refs #4730:
 4. `dspace-release-manifest.json` agrees with the full source SHA, immutable image tag and digest,
    both platform digests, chart `3.1.2` digest/provenance, and semantic tag evidence.
 
+#### Recover a failed semantic publication
+
+Use this recovery only when the immutable application tag and a non-draft, published GitHub
+release already exist, but their semantic workflow failed before publishing the semantic GHCR
+alias and release manifest. First prove that the semantic GHCR tag is authoritatively absent; do
+not dispatch recovery if the lookup is unauthorized, unavailable, or otherwise indeterminate.
+
+Start a **fresh dispatch using the fixed workflow definition from `main`** (do not rerun the
+historical failed workflow run):
+
+```bash
+gh workflow run ci-image.yml \
+  --repo democratizedspace/dspace \
+  --ref main \
+  -f release_tag=v3.1.1
+```
+
+Recovery checks out and verifies the existing immutable application tag; it does not move or
+recreate that tag or the GitHub release. It verifies the allowed source branch and existing image
+and chart provenance, then reuses the normal semantic publication and manifest path. After a
+successful recovery, an identical dispatch is expected to fail at the semantic-tag absence guard
+before mutation. This fail-closed retry behavior is required evidence for #4727 and #4730.
+
 Successful full releases upload the deterministic artifact
 `dspace-release-manifest/dspace-release-manifest.json`. Schema version 1 records
 `applicationVersion`, the complete `sourceRevision`, immutable tag-only `imageTag`, image-index

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -49,6 +49,20 @@ describe('ci-image.yml triggers', () => {
     // and turn every ordinary release into an expected duplicate-publication failure.
     expect(workflow.on.push.tags).toBeUndefined();
   });
+
+  it('keeps an empty manual release tag on the ordinary branch-image path', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
+      required: false,
+      default: '',
+      type: 'string',
+    });
+    expect(workflow.jobs.image.if).toContain(
+      "github.event.inputs.release_tag == ''"
+    );
+    expect(workflow.jobs['local-build'].if).toContain(
+      "github.event.inputs.release_tag == ''"
+    );
+  });
 });
 
 describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
@@ -57,7 +71,7 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
   it('never runs for release events', () => {
     expect(job.if).toContain("github.event_name == 'push'");
     expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
-    expect(job.if).not.toMatch(/release/);
+    expect(job.if).not.toContain("github.event_name == 'release'");
   });
 
   it('serializes ordinary publication by target branch without workflow SHA', () => {
@@ -258,8 +272,9 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
     }
   });
 
-  it('does not run redundantly for release events', () => {
-    expect(job.if).toBe("github.event_name != 'release'");
+  it('does not run redundantly for releases or semantic recovery', () => {
+    expect(job.if).toContain("github.event_name != 'release'");
+    expect(job.if).toContain("github.event.inputs.release_tag == ''");
   });
 });
 
@@ -268,12 +283,38 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('is release-only and serialized by semantic tag', () => {
-    expect(job.if).toBe(
+  it('accepts published release events or non-empty recovery dispatches only', () => {
+    expect(job.if).toContain(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != ''"
+    );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
+    expect(job.concurrency.group).toContain('github.event.inputs.release_tag');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('resolves and strictly validates the normal or recovery release tag', () => {
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    const authorization = named('Authorize release source');
+    expect(checkout.with.ref).toBe(
+      '${{ github.event.release.tag_name || github.event.inputs.release_tag }}'
+    );
+    expect(authorization.env.RELEASE_TAG).toBe(checkout.with.ref);
+    expect(authorization.run).toContain(
+      '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
+    );
+  });
+
+  it('requires recovery to target an existing published, non-draft release', () => {
+    const authorization = named('Authorize release source');
+    expect(authorization.run).toContain(
+      'gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}"'
+    );
+    expect(authorization.run).toContain('.draft == false');
+    expect(authorization.run).toContain('.prerelease == false');
+    expect(authorization.env.GH_TOKEN).toBe('${{ secrets.GITHUB_TOKEN }}');
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
@@ -285,7 +326,7 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
     expect(authorization.run).toContain(
       'git rev-parse "${RELEASE_TAG}^{commit}"'
     );
-    expect(authorization.run).toContain('refs/remotes/origin/main');
+    expect(authorization.run).toContain('refs/remotes/origin/$branch');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
     );
@@ -293,6 +334,27 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
       steps.indexOf(named('Validate all local release coordinates'))
     );
     expect(JSON.stringify(job)).not.toContain('pnpm install');
+  });
+
+  it('discovers independently absent allowed branches and fails closed otherwise', () => {
+    const run = named('Authorize release source').run;
+    expect(run).toContain('for branch in main v3');
+    expect(run).toContain('git ls-remote --exit-code');
+    expect(run).toContain(
+      '2) echo "Allowed release branch $branch is authoritatively absent"'
+    );
+    expect(run).toContain(
+      'Could not determine whether allowed branch $branch exists'
+    );
+    expect(run).toContain(
+      'git fetch "$remote_url" "refs/heads/$branch:refs/remotes/origin/$branch"'
+    );
+    expect(run).toContain('((${#existing_branches[@]} > 0))');
+    expect(run).toContain('((${#containing_branches[@]} == 1))');
+    expect(run).not.toContain('|| true');
+    expect(run).not.toContain(
+      'main:refs/remotes/origin/main v3:refs/remotes/origin/v3'
+    );
   });
 
   it('pins Node before invoking the release consistency gate', () => {


### PR DESCRIPTION
### Motivation

- The semantic-release workflow failed when `git fetch` unconditionally requested both `main` and `v3` and the absent `v3` returned fatal error 128, aborting the run before validation or publication; the intent is to tolerate an authoritatively absent allowed branch while still failing closed on transport/authentication/indeterminate errors. 
- Operators need a guarded manual recovery path to publish the semantic alias and deterministic `dspace-release-manifest.json` for an already-published immutable application release without moving or recreating its Git tag or GitHub release.
- Preserve existing branch-image dispatch and the single canonical `release: published` semantic path while avoiding regressions that could re-enable the historical bug referenced by #4727 and #4730.

### Description

- Added an optional `workflow_dispatch` input `release_tag` so an empty value preserves ordinary `local-build`/`image` behavior and a non-empty `release_tag` selects a guarded semantic-recovery mode that runs only the existing `semantic-release` job; concurrency is keyed to the resolved tag. (Changed: `.github/workflows/ci-image.yml`.)
- Replaced the unconditional `git fetch ... main v3` with a safe per-branch probe using `git ls-remote --exit-code` that treats status `2` as authoritative absence, fails closed on other errors, fetches only existing allowed branches, and requires the release source to be contained by exactly one supported branch; also added strict stable-tag validation and an authenticated check that the GitHub release is published (non-draft, non-prerelease) using `gh api` + `jq`. (Changed: `.github/workflows/ci-image.yml`.)
- Reused the existing semantic publication path and all pre/post guards (both preflight and final semantic guards, image/chart provenance checks, single bounded `docker buildx imagetools create`, manifest emission/validation/upload) and added unit tests and docs: updated `tests/ciImageWorkflow.test.ts` for dispatch and branch-discovery behavior and `docs/ops/sugarkube-release.md` with a concise recovery procedure (`gh workflow run ... -f release_tag=v3.1.1`). (Changed: `tests/ciImageWorkflow.test.ts`, `docs/ops/sugarkube-release.md`.)

### Testing

- Ran `npm run test:root -- tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts` and all tests passed: `48 passed (48)` (the CI workflow-style tests and release-consistency fixtures are green).
- Ran `node scripts/check-release-consistency.mjs --verify-local-fixtures` (network-free fixtures) and it succeeded.
- Ran lint and style checks with `npm run lint`, `npx prettier --check .github/workflows/ci-image.yml tests/ciImageWorkflow.test.ts docs/ops/sugarkube-release.md`, and `npm run link-check`, all of which completed without failures; formatting was applied where required.
- Notes: a local commit was created (`Fix semantic release recovery dispatch`) but a PR was not pushed because remote/`make_pr` tooling is unavailable in this environment; no GitHub Actions were triggered during verification.

Post-merge recovery command for `v3.1.1` (use a fresh dispatch from `main`):

`gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main -f release_tag=v3.1.1`

Important guarantees: no tag, GitHub release, GHCR artifact, Helm chart, chart tag, package version, or Kubernetes resource was moved, recreated, published, or mutated by this change; the recovery path explicitly verifies the existing published release and semantic-tag absence before attempting the single bounded alias mutation. References: #4727 and #4730.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73bed1f7ec832fb6c32d46fd9a1ba9)