### PR TITLE
ci-image: guarded semantic-release recovery and tolerant branch discovery

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -22,6 +22,11 @@ on:
         options:
           - v3
           - main
+      release_tag:
+        description: Existing published vX.Y.Z release to recover (leave empty for branch image publication)
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -34,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Release publication gets its own build in the semantic-release job below; skip the
     # redundant PR-style validate/smoke pass for release events.
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && !(github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +277,7 @@ jobs:
     # exact class of bug that let branch builds move vX.Y.Z (see DSPACE #4727 and
     # outages/2026-07-23-dspace-production-version-drift.md); semantic tags are published
     # exclusively by the semantic-release job below.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')
     concurrency:
       # Serialize the absence check plus push by target branch. workflow_dispatch can
       # choose a checkout branch independently of github.sha, so branch-scoped locking
@@ -547,15 +552,35 @@ jobs:
   semantic-release:
     name: Publish semantic release image alias and manifest
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     concurrency:
-      group: dspace-semantic-image-${{ github.event.release.tag_name }}
+      group: dspace-semantic-image-${{ github.event.release.tag_name || inputs.release_tag }}
       cancel-in-progress: false
     steps:
+      - name: Validate semantic release request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # scan-secrets: ignore (workflow secret reference)
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+            echo "Release tag must be a stable vX.Y.Z tag" >&2
+            exit 1
+          }
+          if [[ "$EVENT_NAME" == workflow_dispatch ]]; then
+            release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+            jq -e '.draft == false and .published_at != null' <<<"$release_json" >/dev/null || {
+              echo "Recovery requires an existing published, non-draft GitHub release" >&2
+              exit 1
+            }
+          fi
+
       - name: Checkout tagged commit without persisted credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -563,16 +588,34 @@ jobs:
       # any repository-controlled lifecycle command. Tag names are passed only through env.
       - name: Authorize release source
         id: source
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ && "$source_sha" == "$tag_sha" ]] || { echo "Release tag/source mismatch" >&2; exit 1; }
-          git fetch https://github.com/democratizedspace/dspace.git main:refs/remotes/origin/main v3:refs/remotes/origin/v3 --quiet
-          source_branch="$(git branch -r --contains "$source_sha" | sed 's/^[* ]*//' | grep -E '^(origin/)?(main|v3)$' | head -n1 | sed 's#^origin/##')"
-          [[ "$source_branch" == main || "$source_branch" == v3 ]] || { echo "Unsupported release source" >&2; exit 1; }
+          remote=https://github.com/democratizedspace/dspace.git
+          existing_branches=()
+          for branch in main v3; do
+            set +e
+            git ls-remote --exit-code --heads "$remote" "refs/heads/$branch" >/dev/null
+            status=$?
+            set -e
+            case "$status" in
+              0) existing_branches+=("$branch") ;;
+              2) echo "Allowed release branch $branch is authoritatively absent" ;;
+              *) echo "Unable to determine whether allowed release branch $branch exists" >&2; exit "$status" ;;
+            esac
+          done
+          ((${#existing_branches[@]} > 0)) || { echo "No allowed release source branches exist" >&2; exit 1; }
+          for branch in "${existing_branches[@]}"; do
+            git fetch "$remote" "$branch:refs/remotes/origin/$branch" --quiet
+          done
+          containing_branches=()
+          for branch in "${existing_branches[@]}"; do
+            git merge-base --is-ancestor "$source_sha" "refs/remotes/origin/$branch" && containing_branches+=("$branch")
+          done
+          ((${#containing_branches[@]} == 1)) || { echo "Release source must be contained by exactly one allowed branch" >&2; exit 1; }
+          source_branch="${containing_branches[0]}"
           chart_version="$(awk '$1 == "version:" { gsub(/"/, "", $2); print $2; exit }' charts/dspace/Chart.yaml)"
           chart_tag="chart-v${chart_version}"
           git rev-parse "${chart_tag}^{commit}" >/dev/null
@@ -588,7 +631,6 @@ jobs:
       - name: Validate all local release coordinates
         id: coordinates
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
           CHART_TAG: ${{ steps.source.outputs.chart_tag }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
           SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -79,9 +79,31 @@ The mandatory full-release order is fail-closed:
    verifies digest equality, and emits the combined release manifest.
 
 Publishing the GitHub release before either prerequisite exists fails without creating the semantic
-coordinate. After supplying the missing immutable artifact, rerun the failed release workflow. If a
-semantic tag already exists, the workflow always refuses to overwrite or move it; investigate and
-cut a new approved release coordinate rather than retrying a mutation.
+coordinate. After supplying a missing immutable artifact, use the guarded recovery dispatch below
+from the current fixed workflow definition. If a semantic tag already exists, the workflow always
+refuses to overwrite or move it; investigate and cut a new approved release coordinate rather than
+retrying a mutation.
+
+### Recover a failed semantic release publication
+
+Use this recovery only when the immutable application tag and a non-draft, published GitHub release
+already exist, but their semantic workflow failed before publishing the GHCR semantic alias. First
+prove that the semantic GHCR tag is authoritatively absent. Then start a **fresh dispatch from the
+fixed `main` workflow definition**; do not rerun the historical failed workflow, which would reuse
+its broken definition:
+
+```bash
+gh workflow run ci-image.yml \
+  --repo democratizedspace/dspace \
+  --ref main \
+  -f release_tag=v3.1.1
+```
+
+The recovery checks out and verifies the existing immutable tag; it does not move or recreate that
+tag or the GitHub release. It reuses the normal semantic-release provenance checks, two semantic-tag
+absence guards, single digest alias operation, and deterministic release-manifest path. After a
+successful recovery, an identical repeat dispatch is expected to fail at the semantic-tag guard
+before mutation, preserving the fail-closed evidence required by Refs #4727 and #4730.
 
 1. `.github/workflows/ci-image.yml` builds and publishes the multi-arch DSPACE image for `main` and
    `v3` pushes, and can also be run manually for those branches.

--- a/tests/ciImageWorkflow.test.ts
+++ b/tests/ciImageWorkflow.test.ts
@@ -49,6 +49,14 @@ describe('ci-image.yml triggers', () => {
     // and turn every ordinary release into an expected duplicate-publication failure.
     expect(workflow.on.push.tags).toBeUndefined();
   });
+
+  it('offers an optional stable-tag semantic recovery input', () => {
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toMatchObject({
+      required: false,
+      default: '',
+      type: 'string',
+    });
+  });
 });
 
 describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
@@ -57,7 +65,12 @@ describe('ci-image.yml "image" job (ordinary branch publish path)', () => {
   it('never runs for release events', () => {
     expect(job.if).toContain("github.event_name == 'push'");
     expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
-    expect(job.if).not.toMatch(/release/);
+    expect(job.if).not.toContain("github.event_name == 'release'");
+  });
+
+  it('keeps empty manual dispatches on the branch-image path and excludes recovery dispatches', () => {
+    expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(job.if).toContain("inputs.release_tag == ''");
   });
 
   it('serializes ordinary publication by target branch without workflow SHA', () => {
@@ -259,7 +272,8 @@ describe('ci-image.yml "local-build" job (PR path)', () => {
   });
 
   it('does not run redundantly for release events', () => {
-    expect(job.if).toBe("github.event_name != 'release'");
+    expect(job.if).toContain("github.event_name != 'release'");
+    expect(job.if).toContain("inputs.release_tag != ''");
   });
 });
 
@@ -268,24 +282,40 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
   const steps = findSteps(job);
   const named = (name: string) => steps.find((step) => step.name === name);
 
-  it('is release-only and serialized by semantic tag', () => {
-    expect(job.if).toBe(
+  it('supports published releases and non-empty recovery dispatches, serialized by semantic tag', () => {
+    expect(job.if).toContain(
       "github.event_name == 'release' && github.event.action == 'published'"
     );
+    expect(job.if).toContain(
+      "github.event_name == 'workflow_dispatch' && inputs.release_tag != ''"
+    );
     expect(job.concurrency.group).toContain('github.event.release.tag_name');
+    expect(job.concurrency.group).toContain('inputs.release_tag');
     expect(job.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  it('validates recovery tags and requires an existing published release before checkout', () => {
+    const validation = named('Validate semantic release request');
+    const checkout = findStepsUsing(job, 'actions/checkout')[0];
+    expect(validation.run).toContain(
+      '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'
+    );
+    expect(validation.run).toContain('releases/tags/${RELEASE_TAG}');
+    expect(validation.run).toContain(
+      '.draft == false and .published_at != null'
+    );
+    expect(steps.indexOf(validation)).toBeLessThan(steps.indexOf(checkout));
   });
 
   it('authorizes the checked-out source before lifecycle execution', () => {
     const checkout = findStepsUsing(job, 'actions/checkout')[0];
-    expect(checkout.with.ref).toContain('github.event.release.tag_name');
+    expect(checkout.with.ref).toBe('${{ env.RELEASE_TAG }}');
     expect(checkout.with['persist-credentials']).toBe(false);
     const authorization = named('Authorize release source');
-    expect(authorization.env.RELEASE_TAG).toContain('release.tag_name');
     expect(authorization.run).toContain(
       'git rev-parse "${RELEASE_TAG}^{commit}"'
     );
-    expect(authorization.run).toContain('refs/remotes/origin/main');
+    expect(authorization.run).toContain('refs/remotes/origin/$branch');
     expect(authorization.run).not.toContain(
       '${{ github.event.release.tag_name }}'
     );
@@ -293,6 +323,31 @@ describe('ci-image.yml "semantic-release" job (release-only alias path)', () => 
       steps.indexOf(named('Validate all local release coordinates'))
     );
     expect(JSON.stringify(job)).not.toContain('pnpm install');
+  });
+
+  it('distinguishes absent allowed branches from indeterminate discovery failures', () => {
+    const authorization = named('Authorize release source');
+    expect(authorization.run).toContain(
+      'git ls-remote --exit-code --heads "$remote" "refs/heads/$branch"'
+    );
+    expect(authorization.run).toContain(
+      '2) echo "Allowed release branch $branch is authoritatively absent"'
+    );
+    expect(authorization.run).toContain(
+      '*) echo "Unable to determine whether allowed release branch $branch exists" >&2; exit "$status"'
+    );
+    expect(authorization.run).not.toContain('|| true');
+  });
+
+  it('fetches only existing allowed branches and requires exactly one source branch', () => {
+    const run = named('Authorize release source').run;
+    expect(run).toContain('for branch in main v3');
+    expect(run).toContain('((${#existing_branches[@]} > 0))');
+    expect(run).toContain('for branch in "${existing_branches[@]}"');
+    expect(run).toContain('((${#containing_branches[@]} == 1))');
+    expect(run).not.toContain(
+      'main:refs/remotes/origin/main v3:refs/remotes/origin/v3'
+    );
   });
 
   it('pins Node before invoking the release consistency gate', () => {


### PR DESCRIPTION
### Motivation

- The `semantic-release` workflow failed early because `Authorize release source` unconditionally fetched both `main` and `v3`, and an authoritatively absent `v3` caused `git` to exit 128 before any setup; the change makes branch discovery tolerant of an absent allowed branch while still failing closed on indeterminate/auth/transport errors. 
- Provide operators a safe, auditable way to recover a previously-published immutable application release whose semantic publication run failed before creating the semantic GHCR alias, without moving or recreating any tag or GitHub release.

### Description

- Add an optional `workflow_dispatch` input `release_tag` to `.github/workflows/ci-image.yml` and make empty `release_tag` preserve the existing branch-image manual-dispatch behavior while a non-empty `release_tag` selects guarded semantic-recovery mode and skips local/branch image publication. 
- Implement a guarded validation step for recovery that requires a strict stable tag shape (`vX.Y.Z`), verifies the GitHub release is published (non-draft) via `gh api`, and sets `RELEASE_TAG` for subsequent steps; reuse the existing `semantic-release` job for publication. 
- Replace the unconditional `git fetch main v3` in `Authorize release source` with authoritative branch discovery using `git ls-remote --exit-code --heads`, treat exit status `2` as authoritative absence, fetch only the branches that exist, and require the tagged source to be contained by exactly one allowed branch; preserve all downstream provenance, dual semantic-absence guards, single bounded digest alias, and manifest emit/verify steps. 
- Update tests and docs: `tests/ciImageWorkflow.test.ts` expanded to cover `release_tag` behavior, authoritative-absence vs indeterminate failures, selective fetching, and recovery validation; `docs/ops/sugarkube-release.md` adds a concise recovery runbook and the exact recovery example for `v3.1.1` (use a fresh dispatch from `main`). Changed files: `.github/workflows/ci-image.yml`, `tests/ciImageWorkflow.test.ts`, `docs/ops/sugarkube-release.md`.

### Testing

- Ran workflow and consistency tests: `npm run test:root -- tests/ciImageWorkflow.test.ts tests/releaseConsistency.test.ts` — all tests passed (49/49). 
- Verified local release gate fixtures: `node scripts/check-release-consistency.mjs --verify-local-fixtures` — succeeded. 
- Lint, formatting, and link checks: `npm run lint`, `npx prettier --check ...`, and `npm run link-check` — all succeeded. 

Post-merge recovery command (exact):

```bash
gh workflow run ci-image.yml \
  --repo democratizedspace/dspace \
  --ref main \
  -f release_tag=v3.1.1
```

Notes and guarantees

- Root cause: unconditional `git fetch` of both allowed branches caused an authoritative-missing-branch failure (fatal 128) during `Authorize release source` when `v3` did not exist. 
- Separation: ordinary branch-image dispatch remains unchanged for empty `release_tag`; guarded semantic recovery uses the same `semantic-release` job and provenance gates but is only entered for `release` events or non-empty `release_tag` manual dispatches. 
- No tag, GitHub release, image, chart, Helm release, or other deployment artifact was moved, created, republished, or mutated by this change or by the verification runs performed here. 
- This change preserves the two semantic-tag absence guards and single-authoritative aliasing operation required by Refs #4727 and #4730 and intentionally keeps a repeat recovery dispatch failing at the semantic-tag guard after a successful recovery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73bed4913c832f84b1dba7543f3d24)