### PR TITLE
Add opt-in atomic /chat smoke result publication (Sugarkube contract)

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -312,6 +312,36 @@ the immutable application has modern settings or missing-key behavior. Both mode
 or live provider traffic and require no real credential. This is the DSPACE-side harness only, not
 Sugarkube's promotion gate.
 
+### Sugarkube synthetic result publication
+
+The runner can optionally publish the bounded result consumed by Sugarkube's DSPACE chat synthetic
+metrics collector. The operator must pin the DSPACE repository and runner tooling at the same full,
+immutable commit SHA supplied to `--runner-revision`; do not run a moving branch or supply a SHA for
+different tooling. A pinned staging invocation for the immutable 3.1.0 compatibility profile is:
+
+```bash
+git checkout --detach <FULL_IMMUTABLE_DSPACE_COMMIT_SHA>
+node scripts/run-remote-chat-smoke.mjs \
+  --base-url https://staging.democratized.space \
+  --expected-version 3.1.0 \
+  --expected-revision 018687f5a7f4de45508c6e36eb28afb3e44da24d \
+  --identity-contract legacy-build-meta-v1 \
+  --expected-provider token-place \
+  --expected-token-place-origin https://staging.token.place \
+  --expected-token-place-model llama-3.1-8b-instruct \
+  --runner-revision <FULL_IMMUTABLE_DSPACE_COMMIT_SHA> \
+  --result-file /run/dspace-chat/result.json
+```
+
+The two result options are paired and opt-in. After Playwright completes, the runner atomically
+replaces the result with schema version 1, journey `/chat`, the completion timestamp, the pinned
+runner revision, `transport: "intercepted"`, `mutationEnabled: false`, and `passed` derived from the
+Playwright exit status. A completed test failure publishes `passed: false` and retains Playwright's
+nonzero status. Validation, launch, signal, or other incomplete-execution failures do not replace a
+previous result (and create none if it did not exist), so the consumer can detect staleness. Result
+publication failure after a completed smoke fails closed with a nonzero runner status. Without both
+options, the runner does not publish a result and retains its existing behavior.
+
 Record the approved immutable tag, chart version, and workflow run links in the release notes or QA
 checklist for the release.
 

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { dirname, join } from 'node:path';
+import { open, rename, unlink } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -36,6 +38,8 @@ const definitions = {
     'expected-token-place-model',
     'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
   ],
+  resultFile: ['result-file', null],
+  runnerRevision: ['runner-revision', null],
 };
 
 export function parseAndValidateArgs(argv, env = process.env) {
@@ -62,7 +66,8 @@ export function parseAndValidateArgs(argv, env = process.env) {
   const result = {};
   for (const [key, [flag, environment]] of Object.entries(definitions)) {
     // Explicit flags deterministically take precedence over the environment.
-    result[key] = flags.get(flag) ?? env[environment]?.trim();
+    result[key] =
+      flags.get(flag) ?? (environment ? env[environment]?.trim() : undefined);
   }
   if (
     !flags.has(definitions.identityContract[0]) &&
@@ -71,7 +76,10 @@ export function parseAndValidateArgs(argv, env = process.env) {
     result.identityContract = defaultIdentityContract;
   }
   const missing = Object.entries(definitions)
-    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .filter(
+      ([key, [, environment]]) =>
+        environment && !result[key] && !key.startsWith('expectedTokenPlace')
+    )
     .map(([, [, environment]]) => environment);
   if (missing.length)
     throw new Error(
@@ -122,6 +130,16 @@ export function parseAndValidateArgs(argv, env = process.env) {
   if (!/^[0-9a-f]{40}$/.test(result.expectedRevision)) {
     throw new Error(
       'validation: expected revision must be a lowercase full 40-character Git SHA'
+    );
+  }
+  if (Boolean(result.resultFile) !== Boolean(result.runnerRevision)) {
+    throw new Error(
+      'validation: --result-file and --runner-revision must be supplied together'
+    );
+  }
+  if (result.runnerRevision && !/^[0-9a-f]{40}$/.test(result.runnerRevision)) {
+    throw new Error(
+      'validation: runner revision must be a lowercase full 40-character Git SHA'
     );
   }
   if (
@@ -190,6 +208,99 @@ export function parseAndValidateArgs(argv, env = process.env) {
   return result;
 }
 
+export async function writeResultAtomically(resultFile, result) {
+  const directory = dirname(resultFile);
+  const temporary = join(
+    directory,
+    `.${basename(resultFile)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  let handle;
+  try {
+    handle = await open(temporary, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(result)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporary, resultFile);
+  } catch (error) {
+    if (handle) await handle.close().catch(() => {});
+    await unlink(temporary).catch(() => {});
+    throw error;
+  }
+}
+
+function smokeResult(options, passed, now) {
+  return {
+    schemaVersion: 1,
+    journey: '/chat',
+    passed,
+    executedAt: Math.floor(now() / 1000),
+    runnerRevision: options.runnerRevision,
+    transport: 'intercepted',
+    mutationEnabled: false,
+  };
+}
+
+export function runSmoke(
+  options,
+  {
+    spawnImpl = spawn,
+    publishResult = writeResultAtomically,
+    now = Date.now,
+    relaySignal = (signal) => process.kill(process.pid, signal),
+  } = {}
+) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let child;
+    try {
+      child = spawnImpl(
+        'node',
+        [
+          './node_modules/@playwright/test/cli.js',
+          'test',
+          'e2e/remote-chat-smoke.spec.ts',
+          '--project=chromium',
+        ],
+        { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+      );
+    } catch {
+      console.error('[qa:remote-chat-smoke] launch failed');
+      resolve(1);
+      return;
+    }
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
+      resolve(1);
+    });
+    child.once('exit', async (code, signal) => {
+      if (settled) return;
+      settled = true;
+      if (signal) {
+        relaySignal(signal);
+        resolve(null);
+        return;
+      }
+      const exitCode = code ?? 1;
+      if (options.resultFile) {
+        try {
+          await publishResult(
+            options.resultFile,
+            smokeResult(options, exitCode === 0, now)
+          );
+        } catch {
+          console.error('[qa:remote-chat-smoke] result publication failed');
+          resolve(1);
+          return;
+        }
+      }
+      resolve(exitCode);
+    });
+  });
+}
+
 export function buildSmokeEnv(options, baseEnv = process.env) {
   // Node exposes bracketed IPv6 URL hostnames as "[::1]"; normalize them before
   // deciding whether Playwright should manage the local preview server.
@@ -214,7 +325,7 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
   };
 }
 
-export function main(argv = process.argv.slice(2)) {
+export async function main(argv = process.argv.slice(2)) {
   let options;
   try {
     options = parseAndValidateArgs(argv);
@@ -236,24 +347,8 @@ export function main(argv = process.argv.slice(2)) {
   console.log(
     '[qa:remote-chat-smoke] transport=intercepted; profile=isolated; mutation=disabled'
   );
-  const child = spawn(
-    'node',
-    [
-      './node_modules/@playwright/test/cli.js',
-      'test',
-      'e2e/remote-chat-smoke.spec.ts',
-      '--project=chromium',
-    ],
-    { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
-  );
-  child.on('error', (error) => {
-    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
-    process.exitCode = 1;
-  });
-  child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    else process.exitCode = code ?? 1;
-  });
+  const exitCode = await runSmoke(options);
+  if (exitCode !== null) process.exitCode = exitCode;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
 import {
   buildSmokeEnv,
   parseAndValidateArgs,
+  runSmoke,
+  writeResultAtomically,
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
@@ -313,5 +319,163 @@ describe('remote chat smoke input validation', () => {
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
     expect(parseAndValidateArgs([], env).expectedProvider).toBe('openai');
+  });
+});
+
+const runnerRevision = 'abcdef0123456789abcdef0123456789abcdef01';
+
+function completedChild(
+  code: number | null,
+  signal: NodeJS.Signals | null = null
+) {
+  const child = new EventEmitter();
+  queueMicrotask(() => child.emit('exit', code, signal));
+  return child;
+}
+
+function resultOptions(resultFile: string) {
+  return parseAndValidateArgs(
+    ['--result-file', resultFile, '--runner-revision', runnerRevision],
+    completeEnv
+  );
+}
+
+describe('remote chat smoke result contract', () => {
+  it('requires paired result options and validates the runner full SHA', () => {
+    expect(() =>
+      parseAndValidateArgs(['--result-file', '/tmp/result.json'], completeEnv)
+    ).toThrow('must be supplied together');
+    expect(() =>
+      parseAndValidateArgs(
+        [
+          '--result-file',
+          '/tmp/result.json',
+          '--runner-revision',
+          revision.toUpperCase(),
+        ],
+        completeEnv
+      )
+    ).toThrow('lowercase full 40-character');
+  });
+
+  it('emits the exact successful schema after completed execution', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    const exitCode = await runSmoke(resultOptions(resultFile), {
+      spawnImpl: () => completedChild(0),
+      now: () => 1_785_988_800_999,
+    });
+
+    expect(exitCode).toBe(0);
+    const raw = await readFile(resultFile, 'utf8');
+    expect(raw.endsWith('\n')).toBe(true);
+    const result = JSON.parse(raw);
+    expect(result).toEqual({
+      schemaVersion: 1,
+      journey: '/chat',
+      passed: true,
+      executedAt: 1_785_988_800,
+      runnerRevision,
+      transport: 'intercepted',
+      mutationEnabled: false,
+    });
+    expect(Object.keys(result)).toEqual([
+      'schemaVersion',
+      'journey',
+      'passed',
+      'executedAt',
+      'runnerRevision',
+      'transport',
+      'mutationEnabled',
+    ]);
+    if (process.platform !== 'win32') {
+      expect((await stat(resultFile)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('publishes a failed completed result and retains the child status', async () => {
+    const publishResult = vi.fn().mockResolvedValue(undefined);
+    const options = resultOptions('/tmp/result.json');
+    await expect(
+      runSmoke(options, { spawnImpl: () => completedChild(7), publishResult })
+    ).resolves.toBe(7);
+    expect(publishResult).toHaveBeenCalledWith(
+      options.resultFile,
+      expect.objectContaining({ passed: false })
+    );
+  });
+
+  it('atomically replaces an existing result', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-replace-'));
+    const resultFile = join(directory, 'result.json');
+    await writeFile(resultFile, '{"old":true}\n');
+    await writeResultAtomically(resultFile, { bounded: true });
+    expect(await readFile(resultFile, 'utf8')).toBe('{"bounded":true}\n');
+  });
+
+  it.each([
+    [
+      'launch error',
+      (child: EventEmitter) => child.emit('error', new Error('private detail')),
+    ],
+    ['signal', (child: EventEmitter) => child.emit('exit', null, 'SIGTERM')],
+  ])('preserves an existing result on %s', async (_name, complete) => {
+    const child = new EventEmitter();
+    const publishResult = vi.fn();
+    const relaySignal = vi.fn();
+    const pending = runSmoke(resultOptions('/tmp/result.json'), {
+      spawnImpl: () => child,
+      publishResult,
+      relaySignal,
+    });
+    complete(child);
+    await pending;
+    expect(publishResult).not.toHaveBeenCalled();
+  });
+
+  it('does not publish when launch throws', async () => {
+    const publishResult = vi.fn();
+    await expect(
+      runSmoke(resultOptions('/tmp/result.json'), {
+        spawnImpl: () => {
+          throw new Error('spawn failure');
+        },
+        publishResult,
+      })
+    ).resolves.toBe(1);
+    expect(publishResult).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when publication fails after completion', async () => {
+    await expect(
+      runSmoke(resultOptions('/tmp/result.json'), {
+        spawnImpl: () => completedChild(0),
+        publishResult: () => Promise.reject(new Error('filesystem detail')),
+      })
+    ).resolves.toBe(1);
+  });
+
+  it('preserves legacy execution and serial intercepted invariants', async () => {
+    let invocation: any[] = [];
+    const options = parseAndValidateArgs([], completeEnv);
+    await expect(
+      runSmoke(options, {
+        spawnImpl: (...args: any[]) => {
+          invocation = args;
+          return completedChild(0);
+        },
+      })
+    ).resolves.toBe(0);
+    expect(invocation[1]).toEqual([
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ]);
+    expect(invocation[2].env).toMatchObject({
+      PW_WORKERS: '1',
+      REMOTE_CHAT_SMOKE: '1',
+    });
+    expect(options.resultFile).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Motivation

- Sugarkube's observability consumer requires a repository-produced, machine-readable `/chat` smoke result to drive synthetic metrics and alerting.
- The existing runner runs the intercepted Playwright smoke but does not emit the bounded JSON contract that Sugarkube expects. This PR adds an opt-in producer without changing legacy behavior.

### Description

- Add paired opt-in CLI flags `--result-file` and `--runner-revision`, and require both when either is present. The `runnerRevision` is validated as exactly 40 lowercase hex characters. Changes in `scripts/run-remote-chat-smoke.mjs` and supporting tests implement this.
- After Playwright completes, atomically write a same-directory temporary file (restricted `0o600` perms), sync/close, and `rename` over the destination; write only the bounded JSON plus a trailing newline and clean up the temporary file on failure.
- The produced JSON contains exactly these keys and no others: `schemaVersion: 1`, `journey: "/chat"`, `passed` (true only on zero child exit), `executedAt` (integer UNIX seconds at completion), `runnerRevision` (the supplied full SHA), `transport: "intercepted"`, and `mutationEnabled: false`.
- Preserve existing invariants: intercepted transport, isolated profile, mutation disabled, one Playwright worker (`PW_WORKERS=1`), same Playwright invocation and stdio behavior; validation/launch/signal/incomplete-execution errors do not overwrite an existing result; publication failure after completion fails closed and returns nonzero.
- Files changed: `scripts/run-remote-chat-smoke.mjs`, `scripts/tests/run-remote-chat-smoke.test.ts`, and `docs/ops/sugarkube-release.md` (added invocation example and contract notes).

### Testing

- Ran the focused test suite: `npx vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts`, all tests passed (47 tests).
- Formatting and static checks: `npx prettier --check scripts/run-remote-chat-smoke.mjs scripts/tests/run-remote-chat-smoke.test.ts docs/ops/sugarkube-release.md` passed.
- Lint and type checks: `npm run lint` and `npm run type-check` passed.
- Diff and secret scan: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` produced no findings.

References: implements the producer contract consumed by futuroptimist/sugarkube#2329 (does not close that issue). No application, chart, image, release tag, Helm/Kubernetes, or provider configuration changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7621ec5978832fa2e98f993342c4c5)