### PR TITLE
Add opt-in atomic /chat result contract to run-remote-chat-smoke.mjs

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -282,12 +282,15 @@ node scripts/run-remote-chat-smoke.mjs \
 ```
 
 The two result options are paired and opt-in; omitting both preserves the existing runner behavior.
-After Playwright completes, the runner atomically replaces the result with schema version 1, the
+The destination directory (for example, `/run/dspace-chat`) must already exist and be writable by
+the operator account; the runner neither creates it nor recursively creates parent directories.
+After Playwright exits and the selected `/chat` journey fixture confirms that the test body ran to
+teardown, the runner atomically replaces the result with schema version 1, the
 `/chat` journey, the completion timestamp, the pinned runner revision, intercepted transport,
 mutation disabled, and `passed` reflecting Playwright's exit status. A completed failing test still
 publishes `passed: false` and retains the test's nonzero status. Validation, launch, interruption,
-and other incomplete-execution failures do not replace a prior result. Publication failure after a
-completed run fails closed with a nonzero runner status.
+missing or invalid completion evidence, and other incomplete-execution failures do not replace a
+prior result. Publication failure after a completed run fails closed with a nonzero runner status.
 
 When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-info-v1`
 contract. That contract requires same-origin `/build-info.json` identity (including the exact

--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -263,6 +263,32 @@ DSPACE_EXPECTED_TOKEN_PLACE_MODEL=qwen3-8b-instruct \
 npm run qa:remote-chat-smoke
 ```
 
+For the scheduled Sugarkube release-integrity probe, opt in to the versioned machine-readable
+result contract by pinning the DSPACE checkout/tooling and passing that same full immutable commit
+SHA as `--runner-revision`:
+
+```bash
+git checkout <FULL_IMMUTABLE_DSPACE_COMMIT_SHA>
+node scripts/run-remote-chat-smoke.mjs \
+  --base-url https://staging.democratized.space \
+  --expected-version 3.1.0 \
+  --expected-revision 018687f5a7f4de45508c6e36eb28afb3e44da24d \
+  --identity-contract legacy-build-meta-v1 \
+  --expected-provider token-place \
+  --expected-token-place-origin https://staging.token.place \
+  --expected-token-place-model llama-3.1-8b-instruct \
+  --runner-revision <FULL_IMMUTABLE_DSPACE_COMMIT_SHA> \
+  --result-file /run/dspace-chat/result.json
+```
+
+The two result options are paired and opt-in; omitting both preserves the existing runner behavior.
+After Playwright completes, the runner atomically replaces the result with schema version 1, the
+`/chat` journey, the completion timestamp, the pinned runner revision, intercepted transport,
+mutation disabled, and `passed` reflecting Playwright's exit status. A completed failing test still
+publishes `passed: false` and retains the test's nonzero status. Validation, launch, interruption,
+and other incomplete-execution failures do not replace a prior result. Publication failure after a
+completed run fails closed with a nonzero runner status.
+
 When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-info-v1`
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,6 +1,5 @@
 import { constants, publicEncrypt, webcrypto } from 'node:crypto';
 import { createRequire } from 'node:module';
-import { writeFile } from 'node:fs/promises';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -10,6 +9,7 @@ import {
     type IdentityContract,
     type SmokeProvider,
 } from './remote-chat-smoke-contract';
+import { writeRemoteChatSmokeCompletion } from '../../scripts/remote-chat-smoke-completion.mjs';
 
 const JSEncrypt = createRequire(import.meta.url)(
     'jsencrypt'
@@ -39,7 +39,6 @@ const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';
 const requestedOrigin = remoteChatSmokeEnabled ? new URL(process.env.BASE_URL!).origin : undefined;
 const fault = process.env.DSPACE_REMOTE_CHAT_SMOKE_FAULT;
 const completionMarkerFile = process.env.DSPACE_REMOTE_CHAT_SMOKE_COMPLETION_FILE;
-const completionMarker = 'dspace-remote-chat-smoke-journey-complete-v1\n';
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -312,11 +311,7 @@ const journeyTest = test.extend<{ markJourneyEntered: () => void }>({
             entered = true;
         });
         if (entered && completionMarkerFile) {
-            await writeFile(completionMarkerFile, completionMarker, {
-                encoding: 'utf8',
-                mode: 0o600,
-                flag: 'wx',
-            });
+            await writeRemoteChatSmokeCompletion(completionMarkerFile);
         }
     },
 });

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -38,8 +38,8 @@ const expectedResolvedModel =
 const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';
 const requestedOrigin = remoteChatSmokeEnabled ? new URL(process.env.BASE_URL!).origin : undefined;
 const fault = process.env.DSPACE_REMOTE_CHAT_SMOKE_FAULT;
-const executionFile = process.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE;
-const executionToken = process.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN;
+const completionMarkerFile = process.env.DSPACE_REMOTE_CHAT_SMOKE_COMPLETION_FILE;
+const completionMarker = 'dspace-remote-chat-smoke-journey-complete-v1\n';
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -303,12 +303,27 @@ async function selectOpenAI(page: Page, key?: string) {
     }
 }
 
+const journeyTest = test.extend<{ markJourneyEntered: () => void }>({
+    markJourneyEntered: async ({ page }, use) => {
+        // Depending on page ensures setup cannot begin until Chromium and the page fixture exist.
+        void page;
+        let entered = false;
+        await use(() => {
+            entered = true;
+        });
+        if (entered && completionMarkerFile) {
+            await writeFile(completionMarkerFile, completionMarker, {
+                encoding: 'utf8',
+                mode: 0o600,
+                flag: 'wx',
+            });
+        }
+    },
+});
+
 test.describe('release-aware remote chat smoke', () => {
     test.skip(!remoteChatSmokeEnabled, 'Requires explicit release expectations.');
     test.beforeEach(async ({ context, page }) => {
-        if (executionFile && executionToken) {
-            await writeFile(executionFile, executionToken, { encoding: 'utf8', mode: 0o600 });
-        }
         await context.clearCookies();
         await clearUserData(page);
     });
@@ -364,18 +379,82 @@ test.describe('release-aware remote chat smoke', () => {
         ).toHaveAttribute('content', expectedRevision);
     });
 
-    test('routing/configuration and submission: approved default journey', async ({ page }) => {
-        if (expectedProvider === 'openai') {
-            let openAICalls = 0;
-            let credentialPresent = false;
-            await installProviderDenyRules(page);
-            const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
+    journeyTest(
+        'routing/configuration and submission: approved default journey',
+        async ({ page, markJourneyEntered }) => {
+            markJourneyEntered();
+            if (expectedProvider === 'openai') {
+                let openAICalls = 0;
+                let credentialPresent = false;
+                await installProviderDenyRules(page);
+                const fakeKey = 'sk-dspace-ci-sentinel-not-a-real-credential'; // scan-secrets: ignore
 
-            if (chatUiContract === 'legacy-inline-openai-v1') {
+                if (chatUiContract === 'legacy-inline-openai-v1') {
+                    await page.route('https://api.openai.com/v1/responses', async (route) => {
+                        openAICalls += 1;
+                        credentialPresent =
+                            route.request().headers().authorization === `Bearer ${fakeKey}`;
+                        await route.fulfill({
+                            status: 200,
+                            contentType: 'application/json',
+                            body: JSON.stringify({
+                                id: 'resp_smoke',
+                                object: 'response',
+                                status: 'completed',
+                                output: [
+                                    {
+                                        type: 'message',
+                                        role: 'assistant',
+                                        content: [
+                                            {
+                                                type: 'output_text',
+                                                text: 'DSPACE OpenAI smoke reply.',
+                                            },
+                                        ],
+                                    },
+                                ],
+                            }),
+                        });
+                    });
+                    let panel = await openExpectedPanel(page, 'openai');
+                    await expect(page.getByTestId('token-place-disabled-banner')).toBeVisible();
+                    await expect(
+                        page.locator('[data-testid="chat-panel"][data-provider="token-place"]')
+                    ).toHaveCount(0);
+                    await page.locator('.api-container form input[type="text"]').fill(fakeKey);
+                    await page
+                        .locator('.api-container form')
+                        .getByRole('button', { name: 'Submit' })
+                        .click();
+                    panel = await openExpectedPanel(page, 'openai');
+                    await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
+                    await panel.getByRole('button', { name: 'Send' }).click();
+                    await expect(
+                        panel.getByText('DSPACE OpenAI smoke reply.'),
+                        'submission: no mocked OpenAI reply'
+                    ).toBeVisible();
+                    expect({ openAICalls, credentialPresent }).toEqual({
+                        openAICalls: 1,
+                        credentialPresent: true,
+                    });
+                    return;
+                }
+
+                let panel = await openExpectedPanel(page);
+                await panel.getByRole('textbox').fill('Key gate smoke');
+                await panel.getByRole('button', { name: 'Send' }).click();
+                await expect(
+                    panel.locator('.chat-error'),
+                    'routing/configuration: OpenAI key gate'
+                ).toHaveAttribute('data-error-type', 'missing-key');
+                expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(
+                    0
+                );
+                await selectOpenAI(page, fakeKey);
                 await page.route('https://api.openai.com/v1/responses', async (route) => {
                     openAICalls += 1;
                     credentialPresent =
-                        route.request().headers().authorization === `Bearer ${fakeKey}`;
+                        route.request().headers().authorization?.startsWith('Bearer ') === true;
                     await route.fulfill({
                         status: 200,
                         contentType: 'application/json',
@@ -395,17 +474,7 @@ test.describe('release-aware remote chat smoke', () => {
                         }),
                     });
                 });
-                let panel = await openExpectedPanel(page, 'openai');
-                await expect(page.getByTestId('token-place-disabled-banner')).toBeVisible();
-                await expect(
-                    page.locator('[data-testid="chat-panel"][data-provider="token-place"]')
-                ).toHaveCount(0);
-                await page.locator('.api-container form input[type="text"]').fill(fakeKey);
-                await page
-                    .locator('.api-container form')
-                    .getByRole('button', { name: 'Submit' })
-                    .click();
-                panel = await openExpectedPanel(page, 'openai');
+                panel = await openExpectedPanel(page);
                 await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
                 await panel.getByRole('button', { name: 'Send' }).click();
                 await expect(
@@ -418,93 +487,50 @@ test.describe('release-aware remote chat smoke', () => {
                 });
                 return;
             }
-
-            let panel = await openExpectedPanel(page);
-            await panel.getByRole('textbox').fill('Key gate smoke');
+            const configResponse = await page.request.get('/config.json');
+            expect(
+                new URL(configResponse.url()).origin,
+                'routing/configuration: /config.json origin drift'
+            ).toBe(requestedOrigin);
+            expect(
+                configResponse.status(),
+                'routing/configuration: /config.json did not return 200'
+            ).toBe(200);
+            const config = await configResponse.json();
+            expect(
+                new URL(config.tokenPlace.url).origin,
+                'routing/configuration: token.place configured origin drift'
+            ).toBe(expectedOrigin);
+            expect(
+                config.tokenPlace.model,
+                'routing/configuration: token.place configured model drift'
+            ).toBe(expectedModel);
+            const evidence = await installSuccessfulRelay(page);
+            const panel = await openExpectedPanel(page);
+            await panel.getByRole('textbox').fill('Deterministic remote chat smoke');
             await panel.getByRole('button', { name: 'Send' }).click();
+            if (fault === 'submission') throw new Error('submission: injected bounded CI fault');
             await expect(
-                panel.locator('.chat-error'),
-                'routing/configuration: OpenAI key gate'
-            ).toHaveAttribute('data-error-type', 'missing-key');
-            expect(openAICalls, 'secret-safety: missing-key flow made a provider request').toBe(0);
-            await selectOpenAI(page, fakeKey);
-            await page.route('https://api.openai.com/v1/responses', async (route) => {
-                openAICalls += 1;
-                credentialPresent =
-                    route.request().headers().authorization?.startsWith('Bearer ') === true;
-                await route.fulfill({
-                    status: 200,
-                    contentType: 'application/json',
-                    body: JSON.stringify({
-                        id: 'resp_smoke',
-                        object: 'response',
-                        status: 'completed',
-                        output: [
-                            {
-                                type: 'message',
-                                role: 'assistant',
-                                content: [
-                                    { type: 'output_text', text: 'DSPACE OpenAI smoke reply.' },
-                                ],
-                            },
-                        ],
-                    }),
-                });
-            });
-            panel = await openExpectedPanel(page);
-            await panel.getByRole('textbox').fill('Mocked OpenAI smoke');
-            await panel.getByRole('button', { name: 'Send' }).click();
-            await expect(
-                panel.getByText('DSPACE OpenAI smoke reply.'),
-                'submission: no mocked OpenAI reply'
+                panel.getByText('DSPACE smoke reply.'),
+                'submission: no mocked relay reply'
             ).toBeVisible();
-            expect({ openAICalls, credentialPresent }).toEqual({
-                openAICalls: 1,
-                credentialPresent: true,
-            });
-            return;
+            expect(evidence.originsMatch, 'routing/configuration: token.place origin drift').toBe(
+                true
+            );
+            expect(evidence.credentialsPresent, 'secret-safety: provider credential was sent').toBe(
+                false
+            );
+            expect(
+                evidence.dispatchModelMatches,
+                'routing/configuration: encrypted dispatch model drift'
+            ).toBe(true);
+            expect(evidence.paths.filter((path) => path !== 'complete')).toEqual([
+                'select',
+                'dispatch',
+                'retrieve',
+            ]);
         }
-        const configResponse = await page.request.get('/config.json');
-        expect(
-            new URL(configResponse.url()).origin,
-            'routing/configuration: /config.json origin drift'
-        ).toBe(requestedOrigin);
-        expect(
-            configResponse.status(),
-            'routing/configuration: /config.json did not return 200'
-        ).toBe(200);
-        const config = await configResponse.json();
-        expect(
-            new URL(config.tokenPlace.url).origin,
-            'routing/configuration: token.place configured origin drift'
-        ).toBe(expectedOrigin);
-        expect(
-            config.tokenPlace.model,
-            'routing/configuration: token.place configured model drift'
-        ).toBe(expectedModel);
-        const evidence = await installSuccessfulRelay(page);
-        const panel = await openExpectedPanel(page);
-        await panel.getByRole('textbox').fill('Deterministic remote chat smoke');
-        await panel.getByRole('button', { name: 'Send' }).click();
-        if (fault === 'submission') throw new Error('submission: injected bounded CI fault');
-        await expect(
-            panel.getByText('DSPACE smoke reply.'),
-            'submission: no mocked relay reply'
-        ).toBeVisible();
-        expect(evidence.originsMatch, 'routing/configuration: token.place origin drift').toBe(true);
-        expect(evidence.credentialsPresent, 'secret-safety: provider credential was sent').toBe(
-            false
-        );
-        expect(
-            evidence.dispatchModelMatches,
-            'routing/configuration: encrypted dispatch model drift'
-        ).toBe(true);
-        expect(evidence.paths.filter((path) => path !== 'complete')).toEqual([
-            'select',
-            'dispatch',
-            'retrieve',
-        ]);
-    });
+    );
 
     test('provider availability: controlled token.place failure is classified and bounded', async ({
         page,

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -1,5 +1,6 @@
 import { constants, publicEncrypt, webcrypto } from 'node:crypto';
 import { createRequire } from 'node:module';
+import { writeFile } from 'node:fs/promises';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -37,6 +38,8 @@ const expectedResolvedModel =
 const remoteChatSmokeEnabled = process.env.REMOTE_CHAT_SMOKE === '1';
 const requestedOrigin = remoteChatSmokeEnabled ? new URL(process.env.BASE_URL!).origin : undefined;
 const fault = process.env.DSPACE_REMOTE_CHAT_SMOKE_FAULT;
+const executionFile = process.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE;
+const executionToken = process.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -303,6 +306,9 @@ async function selectOpenAI(page: Page, key?: string) {
 test.describe('release-aware remote chat smoke', () => {
     test.skip(!remoteChatSmokeEnabled, 'Requires explicit release expectations.');
     test.beforeEach(async ({ context, page }) => {
+        if (executionFile && executionToken) {
+            await writeFile(executionFile, executionToken, { encoding: 'utf8', mode: 0o600 });
+        }
         await context.clearCookies();
         await clearUserData(page);
     });

--- a/scripts/remote-chat-smoke-completion.mjs
+++ b/scripts/remote-chat-smoke-completion.mjs
@@ -1,0 +1,12 @@
+import { writeFile } from 'node:fs/promises';
+
+export const remoteChatSmokeCompletionMarker =
+  'dspace-remote-chat-smoke-journey-complete-v1\n';
+
+export async function writeRemoteChatSmokeCompletion(file) {
+  await writeFile(file, remoteChatSmokeCompletionMarker, {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'w',
+  });
+}

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { open, rename, unlink } from 'node:fs/promises';
+import { open, readFile, rename, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
@@ -74,7 +75,8 @@ export function parseAndValidateArgs(argv, env = process.env) {
   const result = {};
   for (const [key, [flag, environment]] of Object.entries(definitions)) {
     // Explicit flags deterministically take precedence over the environment.
-    result[key] = flags.get(flag) ?? env[environment]?.trim();
+    result[key] =
+      flags.get(flag) ?? (environment ? env[environment]?.trim() : undefined);
   }
   if (
     !flags.has(definitions.identityContract[0]) &&
@@ -213,7 +215,11 @@ export function parseAndValidateArgs(argv, env = process.env) {
   return result;
 }
 
-export function buildSmokeEnv(options, baseEnv = process.env) {
+export function buildSmokeEnv(
+  options,
+  baseEnv = process.env,
+  executionEvidence
+) {
   // Node exposes bracketed IPv6 URL hostnames as "[::1]"; normalize them before
   // deciding whether Playwright should manage the local preview server.
   const hostname = new URL(options.baseURL).hostname.replace(/^\[|\]$/g, '');
@@ -234,6 +240,8 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',
     DSPACE_REMOTE_CHAT_SMOKE_FAULT: options.fault || '',
+    DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE: executionEvidence?.file || '',
+    DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN: executionEvidence?.token || '',
   };
 }
 
@@ -281,6 +289,19 @@ export function runSmoke(
 ) {
   return new Promise((resolve) => {
     let launchFailed = false;
+    const executionEvidence = options.resultFile
+      ? {
+          file: join(
+            tmpdir(),
+            `dspace-chat-smoke.${process.pid}.${randomBytes(8).toString('hex')}.executed`
+          ),
+          token: randomBytes(32).toString('hex'),
+        }
+      : undefined;
+    const removeExecutionEvidence = () =>
+      executionEvidence
+        ? unlink(executionEvidence.file).catch(() => {})
+        : Promise.resolve();
     let child;
     try {
       child = spawnImpl(
@@ -291,25 +312,45 @@ export function runSmoke(
           'e2e/remote-chat-smoke.spec.ts',
           '--project=chromium',
         ],
-        { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+        {
+          cwd: frontendDir,
+          env: buildSmokeEnv(options, process.env, executionEvidence),
+          stdio: 'inherit',
+        }
       );
     } catch (error) {
+      void removeExecutionEvidence();
       resolve({ kind: 'launch-failure', exitCode: 1, error });
       return;
     }
     child.once('error', (error) => {
       launchFailed = true;
+      void removeExecutionEvidence();
       resolve({ kind: 'launch-failure', exitCode: 1, error });
     });
     child.once('exit', async (code, signal) => {
       if (launchFailed) return;
       if (signal) {
+        await removeExecutionEvidence();
         resolve({ kind: 'signal', signal });
         relaySignal(signal);
         return;
       }
       const exitCode = code ?? 1;
       if (options.resultFile) {
+        let executed = false;
+        try {
+          executed =
+            (await readFile(executionEvidence.file, 'utf8')) ===
+            executionEvidence.token;
+        } catch {
+          // A missing or malformed marker means Playwright did not enter a smoke test body.
+        }
+        await removeExecutionEvidence();
+        if (!executed) {
+          resolve({ kind: 'incomplete', exitCode: exitCode || 1 });
+          return;
+        }
         try {
           await publishResultImpl(
             options.resultFile,

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { open, readFile, rename, unlink } from 'node:fs/promises';
+import {
+  mkdtemp,
+  open,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -10,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const frontendDir = join(scriptDir, '..', 'frontend');
 const defaultIdentityContract = 'build-info-v1';
+const completionMarker = 'dspace-remote-chat-smoke-journey-complete-v1\n';
 const legacyIdentityProfiles = [
   {
     version: '3.0.1',
@@ -240,8 +249,9 @@ export function buildSmokeEnv(
     DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: options.expectedTokenPlaceOrigin || '',
     DSPACE_EXPECTED_TOKEN_PLACE_MODEL: options.expectedTokenPlaceModel || '',
     DSPACE_REMOTE_CHAT_SMOKE_FAULT: options.fault || '',
-    DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE: executionEvidence?.file || '',
-    DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN: executionEvidence?.token || '',
+    ...(executionEvidence
+      ? { DSPACE_REMOTE_CHAT_SMOKE_COMPLETION_FILE: executionEvidence.file }
+      : {}),
   };
 }
 
@@ -279,7 +289,7 @@ export async function publishResult(
   }
 }
 
-export function runSmoke(
+export async function runSmoke(
   options,
   {
     spawnImpl = spawn,
@@ -287,20 +297,22 @@ export function runSmoke(
     relaySignal = (signal) => process.kill(process.pid, signal),
   } = {}
 ) {
+  const evidenceDirectory = options.resultFile
+    ? await mkdtemp(join(tmpdir(), 'dspace-chat-smoke-'))
+    : undefined;
   return new Promise((resolve) => {
     let launchFailed = false;
-    const executionEvidence = options.resultFile
-      ? {
-          file: join(
-            tmpdir(),
-            `dspace-chat-smoke.${process.pid}.${randomBytes(8).toString('hex')}.executed`
-          ),
-          token: randomBytes(32).toString('hex'),
-        }
+    let launchError;
+    // Some filesystems expose modification times at one-second granularity.
+    const evidenceNotBefore = Date.now() - 2000;
+    const executionEvidence = evidenceDirectory
+      ? { file: join(evidenceDirectory, 'completion') }
       : undefined;
     const removeExecutionEvidence = () =>
-      executionEvidence
-        ? unlink(executionEvidence.file).catch(() => {})
+      evidenceDirectory
+        ? rm(evidenceDirectory, { recursive: true, force: true }).catch(
+            () => {}
+          )
         : Promise.resolve();
     let child;
     try {
@@ -319,17 +331,21 @@ export function runSmoke(
         }
       );
     } catch (error) {
-      void removeExecutionEvidence();
-      resolve({ kind: 'launch-failure', exitCode: 1, error });
+      void removeExecutionEvidence().then(() =>
+        resolve({ kind: 'launch-failure', exitCode: 1, error })
+      );
       return;
     }
     child.once('error', (error) => {
       launchFailed = true;
-      void removeExecutionEvidence();
-      resolve({ kind: 'launch-failure', exitCode: 1, error });
+      launchError = error;
     });
-    child.once('exit', async (code, signal) => {
-      if (launchFailed) return;
+    child.once('close', async (code, signal) => {
+      if (launchFailed) {
+        await removeExecutionEvidence();
+        resolve({ kind: 'launch-failure', exitCode: 1, error: launchError });
+        return;
+      }
       if (signal) {
         await removeExecutionEvidence();
         resolve({ kind: 'signal', signal });
@@ -340,11 +356,18 @@ export function runSmoke(
       if (options.resultFile) {
         let executed = false;
         try {
-          executed =
-            (await readFile(executionEvidence.file, 'utf8')) ===
-            executionEvidence.token;
+          const markerStat = await stat(executionEvidence.file);
+          if (
+            markerStat.isFile() &&
+            markerStat.size === Buffer.byteLength(completionMarker) &&
+            markerStat.mtimeMs >= evidenceNotBefore
+          ) {
+            executed =
+              (await readFile(executionEvidence.file, 'utf8')) ===
+              completionMarker;
+          }
         } catch {
-          // A missing or malformed marker means Playwright did not enter a smoke test body.
+          // Missing, malformed, or unreadable evidence means the journey did not complete.
         }
         await removeExecutionEvidence();
         if (!executed) {
@@ -358,7 +381,7 @@ export function runSmoke(
             exitCode === 0
           );
         } catch {
-          resolve({ kind: 'publication-failure', exitCode: 1 });
+          resolve({ kind: 'publication-failure', exitCode: exitCode || 1 });
           return;
         }
       }
@@ -394,6 +417,10 @@ export async function main(argv = process.argv.slice(2)) {
     console.error(`[qa:remote-chat-smoke] launch: ${outcome.error.message}`);
   } else if (outcome.kind === 'publication-failure') {
     console.error('[qa:remote-chat-smoke] result publication failed');
+  } else if (outcome.kind === 'incomplete') {
+    console.error(
+      '[qa:remote-chat-smoke] journey completion was not confirmed; result preserved'
+    );
   }
   if ('exitCode' in outcome) process.exitCode = outcome.exitCode;
   return outcome.exitCode;

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { dirname, join } from 'node:path';
+import { open, rename, unlink } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -36,7 +38,17 @@ const definitions = {
     'expected-token-place-model',
     'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
   ],
+  resultFile: ['result-file'],
+  runnerRevision: ['runner-revision'],
 };
+
+const requiredKeys = new Set([
+  'baseURL',
+  'expectedVersion',
+  'expectedRevision',
+  'identityContract',
+  'expectedProvider',
+]);
 
 export function parseAndValidateArgs(argv, env = process.env) {
   const flags = new Map();
@@ -71,12 +83,23 @@ export function parseAndValidateArgs(argv, env = process.env) {
     result.identityContract = defaultIdentityContract;
   }
   const missing = Object.entries(definitions)
-    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .filter(([key]) => requiredKeys.has(key) && !result[key])
     .map(([, [, environment]]) => environment);
   if (missing.length)
     throw new Error(
       `validation: missing required input(s): ${missing.join(', ')}`
     );
+
+  if (Boolean(result.resultFile) !== Boolean(result.runnerRevision)) {
+    throw new Error(
+      'validation: --result-file and --runner-revision must be supplied together'
+    );
+  }
+  if (result.runnerRevision && !/^[0-9a-f]{40}$/.test(result.runnerRevision)) {
+    throw new Error(
+      'validation: runner revision must be a lowercase full 40-character Git SHA'
+    );
+  }
 
   let base;
   try {
@@ -214,14 +237,103 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
   };
 }
 
-export function main(argv = process.argv.slice(2)) {
+export async function publishResult(
+  resultFile,
+  runnerRevision,
+  passed,
+  now = Date.now
+) {
+  const result = {
+    schemaVersion: 1,
+    journey: '/chat',
+    passed,
+    executedAt: Math.floor(now() / 1000),
+    runnerRevision,
+    transport: 'intercepted',
+    mutationEnabled: false,
+  };
+  const temporaryFile = join(
+    dirname(resultFile),
+    `.${basename(resultFile)}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
+  );
+  let handle;
+  try {
+    handle = await open(temporaryFile, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(result)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryFile, resultFile);
+  } catch (error) {
+    if (handle) await handle.close().catch(() => {});
+    await unlink(temporaryFile).catch(() => {});
+    throw error;
+  }
+}
+
+export function runSmoke(
+  options,
+  {
+    spawnImpl = spawn,
+    publishResultImpl = publishResult,
+    relaySignal = (signal) => process.kill(process.pid, signal),
+  } = {}
+) {
+  return new Promise((resolve) => {
+    let launchFailed = false;
+    let child;
+    try {
+      child = spawnImpl(
+        'node',
+        [
+          './node_modules/@playwright/test/cli.js',
+          'test',
+          'e2e/remote-chat-smoke.spec.ts',
+          '--project=chromium',
+        ],
+        { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+      );
+    } catch (error) {
+      resolve({ kind: 'launch-failure', exitCode: 1, error });
+      return;
+    }
+    child.once('error', (error) => {
+      launchFailed = true;
+      resolve({ kind: 'launch-failure', exitCode: 1, error });
+    });
+    child.once('exit', async (code, signal) => {
+      if (launchFailed) return;
+      if (signal) {
+        resolve({ kind: 'signal', signal });
+        relaySignal(signal);
+        return;
+      }
+      const exitCode = code ?? 1;
+      if (options.resultFile) {
+        try {
+          await publishResultImpl(
+            options.resultFile,
+            options.runnerRevision,
+            exitCode === 0
+          );
+        } catch {
+          resolve({ kind: 'publication-failure', exitCode: 1 });
+          return;
+        }
+      }
+      resolve({ kind: 'completed', exitCode });
+    });
+  });
+}
+
+export async function main(argv = process.argv.slice(2)) {
   let options;
   try {
     options = parseAndValidateArgs(argv);
   } catch (error) {
     console.error(`[qa:remote-chat-smoke] ${error.message}`);
     process.exitCode = 2;
-    return;
+    return 2;
   }
   console.log(`[qa:remote-chat-smoke] target=${options.baseURL}`);
   console.log(
@@ -236,24 +348,14 @@ export function main(argv = process.argv.slice(2)) {
   console.log(
     '[qa:remote-chat-smoke] transport=intercepted; profile=isolated; mutation=disabled'
   );
-  const child = spawn(
-    'node',
-    [
-      './node_modules/@playwright/test/cli.js',
-      'test',
-      'e2e/remote-chat-smoke.spec.ts',
-      '--project=chromium',
-    ],
-    { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
-  );
-  child.on('error', (error) => {
-    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
-    process.exitCode = 1;
-  });
-  child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    else process.exitCode = code ?? 1;
-  });
+  const outcome = await runSmoke(options);
+  if (outcome.kind === 'launch-failure') {
+    console.error(`[qa:remote-chat-smoke] launch: ${outcome.error.message}`);
+  } else if (outcome.kind === 'publication-failure') {
+    console.error('[qa:remote-chat-smoke] result publication failed');
+  }
+  if ('exitCode' in outcome) process.exitCode = outcome.exitCode;
+  return outcome.exitCode;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -34,6 +34,21 @@ function childThat(event: 'exit' | 'error', ...args: unknown[]) {
   return child;
 }
 
+function completedChild(
+  settings: { env: Record<string, string> },
+  exitCode: number
+) {
+  const child = new EventEmitter();
+  queueMicrotask(async () => {
+    await writeFile(
+      settings.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE,
+      settings.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN
+    );
+    child.emit('exit', exitCode, null);
+  });
+  return child;
+}
+
 describe('remote chat smoke UI contract selection', () => {
   it.each([
     ['legacy-build-meta-v1', 'openai', 'legacy-inline-openai-v1'],
@@ -62,7 +77,8 @@ describe('remote chat smoke result contract', () => {
     await writeFile(resultFile, '{"stale":true}\n');
 
     const outcome = await runSmoke(options(resultFile), {
-      spawnImpl: () => childThat('exit', 0, null) as never,
+      spawnImpl: (_command, _args, settings) =>
+        completedChild(settings, 0) as never,
       publishResultImpl: (file, sha, passed) =>
         publishResult(file, sha, passed, () => 1785988800123),
     });
@@ -98,7 +114,8 @@ describe('remote chat smoke result contract', () => {
     const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
     const resultFile = join(directory, 'result.json');
     const outcome = await runSmoke(options(resultFile), {
-      spawnImpl: () => childThat('exit', 17, null) as never,
+      spawnImpl: (_command, _args, settings) =>
+        completedChild(settings, 17) as never,
     });
     expect(outcome).toEqual({ kind: 'completed', exitCode: 17 });
     expect(JSON.parse(await readFile(resultFile, 'utf8')).passed).toBe(false);
@@ -130,6 +147,20 @@ describe('remote chat smoke result contract', () => {
     });
   });
 
+  it.each([0, 1])(
+    'preserves an existing result when Playwright exits %i before a test body runs',
+    async (childExitCode) => {
+      const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+      const resultFile = join(directory, 'result.json');
+      await writeFile(resultFile, 'existing-result\n');
+      const outcome = await runSmoke(options(resultFile), {
+        spawnImpl: () => childThat('exit', childExitCode, null) as never,
+      });
+      expect(outcome).toEqual({ kind: 'incomplete', exitCode: 1 });
+      expect(await readFile(resultFile, 'utf8')).toBe('existing-result\n');
+    }
+  );
+
   it('preserves an existing result when launch throws synchronously', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
     const resultFile = join(directory, 'result.json');
@@ -145,7 +176,8 @@ describe('remote chat smoke result contract', () => {
 
   it('fails closed when publication fails after completion', async () => {
     const outcome = await runSmoke(options('/unwritten/result.json'), {
-      spawnImpl: () => childThat('exit', 0, null) as never,
+      spawnImpl: (_command, _args, settings) =>
+        completedChild(settings, 0) as never,
       publishResultImpl: async () => {
         throw new Error('sensitive implementation detail');
       },

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -1,6 +1,38 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
 
 import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract';
+import {
+  parseAndValidateArgs,
+  publishResult,
+  runSmoke,
+} from '../run-remote-chat-smoke.mjs';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const completeEnv = {
+  DSPACE_SMOKE_BASE_URL: 'https://staging.example.test',
+  DSPACE_EXPECTED_VERSION: '3.1.1',
+  DSPACE_EXPECTED_REVISION: revision,
+  DSPACE_EXPECTED_PROVIDER: 'openai',
+};
+
+function options(resultFile?: string) {
+  return parseAndValidateArgs(
+    resultFile
+      ? [`--result-file=${resultFile}`, `--runner-revision=${revision}`]
+      : [],
+    completeEnv
+  );
+}
+
+function childThat(event: 'exit' | 'error', ...args: unknown[]) {
+  const child = new EventEmitter();
+  queueMicrotask(() => child.emit(event, ...args));
+  return child;
+}
 
 describe('remote chat smoke UI contract selection', () => {
   it.each([
@@ -10,5 +42,137 @@ describe('remote chat smoke UI contract selection', () => {
     ['build-info-v1', 'token-place', 'modern-settings-v1'],
   ] as const)('maps %s + %s to %s', (identityContract, provider, expected) => {
     expect(chatUiContractFor(identityContract, provider)).toBe(expected);
+  });
+});
+
+describe('remote chat smoke result contract', () => {
+  it('leaves an existing result untouched on validation failure', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    await writeFile(resultFile, 'existing-result\n');
+    expect(() =>
+      parseAndValidateArgs([`--result-file=${resultFile}`], completeEnv)
+    ).toThrow('--result-file and --runner-revision');
+    expect(await readFile(resultFile, 'utf8')).toBe('existing-result\n');
+  });
+
+  it('atomically replaces a result with the exact successful schema and restrictive mode', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    await writeFile(resultFile, '{"stale":true}\n');
+
+    const outcome = await runSmoke(options(resultFile), {
+      spawnImpl: () => childThat('exit', 0, null) as never,
+      publishResultImpl: (file, sha, passed) =>
+        publishResult(file, sha, passed, () => 1785988800123),
+    });
+
+    expect(outcome).toEqual({ kind: 'completed', exitCode: 0 });
+    const raw = await readFile(resultFile, 'utf8');
+    expect(raw).toBe(
+      `${JSON.stringify({
+        schemaVersion: 1,
+        journey: '/chat',
+        passed: true,
+        executedAt: 1785988800,
+        runnerRevision: revision,
+        transport: 'intercepted',
+        mutationEnabled: false,
+      })}\n`
+    );
+    expect(Object.keys(JSON.parse(raw))).toEqual([
+      'schemaVersion',
+      'journey',
+      'passed',
+      'executedAt',
+      'runnerRevision',
+      'transport',
+      'mutationEnabled',
+    ]);
+    if (process.platform !== 'win32') {
+      expect((await stat(resultFile)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('publishes passed false and retains a completed child failure status', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    const outcome = await runSmoke(options(resultFile), {
+      spawnImpl: () => childThat('exit', 17, null) as never,
+    });
+    expect(outcome).toEqual({ kind: 'completed', exitCode: 17 });
+    expect(JSON.parse(await readFile(resultFile, 'utf8')).passed).toBe(false);
+  });
+
+  it.each([
+    ['launch failure', () => childThat('error', new Error('spawn failed'))],
+    ['signal', () => childThat('exit', null, 'SIGTERM')],
+  ])('preserves an existing result after %s', async (_name, spawnImpl) => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    await writeFile(resultFile, 'existing-result\n');
+    const relaySignal = vi.fn();
+    await runSmoke(options(resultFile), {
+      spawnImpl: spawnImpl as never,
+      relaySignal,
+    });
+    expect(await readFile(resultFile, 'utf8')).toBe('existing-result\n');
+  });
+
+  it('does not create a result when launch never completes', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    await runSmoke(options(resultFile), {
+      spawnImpl: () => childThat('error', new Error('spawn failed')) as never,
+    });
+    await expect(readFile(resultFile)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('preserves an existing result when launch throws synchronously', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    await writeFile(resultFile, 'existing-result\n');
+    const outcome = await runSmoke(options(resultFile), {
+      spawnImpl: () => {
+        throw new Error('spawn failed');
+      },
+    });
+    expect(outcome).toMatchObject({ kind: 'launch-failure', exitCode: 1 });
+    expect(await readFile(resultFile, 'utf8')).toBe('existing-result\n');
+  });
+
+  it('fails closed when publication fails after completion', async () => {
+    const outcome = await runSmoke(options('/unwritten/result.json'), {
+      spawnImpl: () => childThat('exit', 0, null) as never,
+      publishResultImpl: async () => {
+        throw new Error('sensitive implementation detail');
+      },
+    });
+    expect(outcome).toEqual({ kind: 'publication-failure', exitCode: 1 });
+  });
+
+  it('keeps legacy execution serial, intercepted, mutation-disabled, and output-free', async () => {
+    let invocation:
+      | { args: string[]; settings: { env: Record<string, string> } }
+      | undefined;
+    const outcome = await runSmoke(options(), {
+      spawnImpl: (_command, args, settings) => {
+        invocation = { args, settings } as typeof invocation;
+        return childThat('exit', 0, null) as never;
+      },
+    });
+    expect(outcome).toEqual({ kind: 'completed', exitCode: 0 });
+    expect(invocation?.args).toEqual([
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ]);
+    expect(invocation?.settings.env).toMatchObject({
+      PW_WORKERS: '1',
+      REMOTE_CHAT_SMOKE: '1',
+    });
   });
 });

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, stat, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -28,9 +28,12 @@ function options(resultFile?: string) {
   );
 }
 
-function childThat(event: 'exit' | 'error', ...args: unknown[]) {
+function childThat(event: 'close' | 'error', ...args: unknown[]) {
   const child = new EventEmitter();
-  queueMicrotask(() => child.emit(event, ...args));
+  queueMicrotask(() => {
+    child.emit(event, ...args);
+    if (event === 'error') child.emit('close', null, null);
+  });
   return child;
 }
 
@@ -41,10 +44,10 @@ function completedChild(
   const child = new EventEmitter();
   queueMicrotask(async () => {
     await writeFile(
-      settings.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_FILE,
-      settings.env.DSPACE_REMOTE_CHAT_SMOKE_EXECUTION_TOKEN
+      settings.env.DSPACE_REMOTE_CHAT_SMOKE_COMPLETION_FILE,
+      'dspace-remote-chat-smoke-journey-complete-v1\n'
     );
-    child.emit('exit', exitCode, null);
+    child.emit('close', exitCode, null);
   });
   return child;
 }
@@ -123,7 +126,7 @@ describe('remote chat smoke result contract', () => {
 
   it.each([
     ['launch failure', () => childThat('error', new Error('spawn failed'))],
-    ['signal', () => childThat('exit', null, 'SIGTERM')],
+    ['signal', () => childThat('close', null, 'SIGTERM')],
   ])('preserves an existing result after %s', async (_name, spawnImpl) => {
     const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
     const resultFile = join(directory, 'result.json');
@@ -154,10 +157,57 @@ describe('remote chat smoke result contract', () => {
       const resultFile = join(directory, 'result.json');
       await writeFile(resultFile, 'existing-result\n');
       const outcome = await runSmoke(options(resultFile), {
-        spawnImpl: () => childThat('exit', childExitCode, null) as never,
+        spawnImpl: () => childThat('close', childExitCode, null) as never,
       });
       expect(outcome).toEqual({ kind: 'incomplete', exitCode: 1 });
       expect(await readFile(resultFile, 'utf8')).toBe('existing-result\n');
+    }
+  );
+
+  it('creates no result when a numeric exit has no completion evidence', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const resultFile = join(directory, 'result.json');
+    const outcome = await runSmoke(options(resultFile), {
+      spawnImpl: () => childThat('close', 9, null) as never,
+    });
+    expect(outcome).toEqual({ kind: 'incomplete', exitCode: 9 });
+    await expect(readFile(resultFile)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it.each([
+    ['malformed', async (file: string) => writeFile(file, 'not-the-marker')],
+    ['oversized', async (file: string) => writeFile(file, 'x'.repeat(1024))],
+    [
+      'stale',
+      async (file: string) => {
+        await writeFile(file, 'dspace-remote-chat-smoke-journey-complete-v1\n');
+        await utimes(file, 1, 1);
+      },
+    ],
+  ])(
+    'rejects and cleans up %s completion evidence',
+    async (_name, writeEvidence) => {
+      const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+      const resultFile = join(directory, 'result.json');
+      let markerFile = '';
+      const outcome = await runSmoke(options(resultFile), {
+        spawnImpl: (_command, _args, settings) => {
+          markerFile = settings.env.DSPACE_REMOTE_CHAT_SMOKE_COMPLETION_FILE;
+          const child = new EventEmitter();
+          queueMicrotask(async () => {
+            await writeEvidence(markerFile);
+            child.emit('close', 0, null);
+          });
+          return child as never;
+        },
+      });
+      expect(outcome).toEqual({ kind: 'incomplete', exitCode: 1 });
+      await expect(stat(markerFile)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(readFile(resultFile)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
     }
   );
 
@@ -192,7 +242,7 @@ describe('remote chat smoke result contract', () => {
     const outcome = await runSmoke(options(), {
       spawnImpl: (_command, args, settings) => {
         invocation = { args, settings } as typeof invocation;
-        return childThat('exit', 0, null) as never;
+        return childThat('close', 0, null) as never;
       },
     });
     expect(outcome).toEqual({ kind: 'completed', exitCode: 0 });

--- a/scripts/tests/remote-chat-smoke-contract.test.ts
+++ b/scripts/tests/remote-chat-smoke-contract.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { chatUiContractFor } from '../../frontend/e2e/remote-chat-smoke-contract';
 import {
+  remoteChatSmokeCompletionMarker,
+  writeRemoteChatSmokeCompletion,
+} from '../remote-chat-smoke-completion.mjs';
+import {
   parseAndValidateArgs,
   publishResult,
   runSmoke,
@@ -64,6 +68,21 @@ describe('remote chat smoke UI contract selection', () => {
 });
 
 describe('remote chat smoke result contract', () => {
+  it('publishes the completion marker idempotently for Playwright retries', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-completion-'));
+    const markerFile = join(directory, 'completion');
+
+    await writeRemoteChatSmokeCompletion(markerFile);
+    await writeRemoteChatSmokeCompletion(markerFile);
+
+    expect(await readFile(markerFile, 'utf8')).toBe(
+      remoteChatSmokeCompletionMarker
+    );
+    if (process.platform !== 'win32') {
+      expect((await stat(markerFile)).mode & 0o777).toBe(0o600);
+    }
+  });
+
   it('leaves an existing result untouched on validation failure', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
     const resultFile = join(directory, 'result.json');

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -221,6 +221,15 @@ describe('remote chat smoke input validation', () => {
     expect(options.expectedVersion).toBe('3.2.0');
   });
 
+  it('does not read CLI-only options from an ambient undefined environment key', () => {
+    const options = parseAndValidateArgs([], {
+      ...completeEnv,
+      undefined: '/unexpected/result.json',
+    });
+    expect(options.resultFile).toBeUndefined();
+    expect(options.runnerRevision).toBeUndefined();
+  });
+
   it('requires result output options as a pair', () => {
     expect(() =>
       parseAndValidateArgs(['--result-file=/tmp/result.json'], completeEnv)

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -221,6 +221,45 @@ describe('remote chat smoke input validation', () => {
     expect(options.expectedVersion).toBe('3.2.0');
   });
 
+  it('requires result output options as a pair', () => {
+    expect(() =>
+      parseAndValidateArgs(['--result-file=/tmp/result.json'], completeEnv)
+    ).toThrow('--result-file and --runner-revision');
+    expect(() =>
+      parseAndValidateArgs(['--runner-revision', revision], completeEnv)
+    ).toThrow('--result-file and --runner-revision');
+  });
+
+  it.each([
+    revision.toUpperCase(),
+    revision.slice(1),
+    `${revision}0`,
+    'x'.repeat(40),
+  ])('rejects malformed runner revision %s', (runnerRevision) => {
+    expect(() =>
+      parseAndValidateArgs(
+        [
+          '--result-file=/tmp/result.json',
+          `--runner-revision=${runnerRevision}`,
+        ],
+        completeEnv
+      )
+    ).toThrow('lowercase full 40-character Git SHA');
+  });
+
+  it('accepts paired result output options without changing the smoke environment', () => {
+    const legacy = parseAndValidateArgs([], completeEnv);
+    const withResult = parseAndValidateArgs(
+      ['--result-file=/tmp/result.json', `--runner-revision=${revision}`],
+      completeEnv
+    );
+    expect(withResult).toMatchObject({
+      resultFile: '/tmp/result.json',
+      runnerRevision: revision,
+    });
+    expect(buildSmokeEnv(withResult, {})).toEqual(buildSmokeEnv(legacy, {}));
+  });
+
   it.each([
     [
       { ...completeEnv, DSPACE_EXPECTED_REVISION: revision.slice(0, 7) },


### PR DESCRIPTION
### Motivation

Provide a repository-owned, machine-readable result for Sugarkube’s intercepted `/chat` release-integrity probe without an operator-host wrapper. The feature remains opt-in and preserves the existing isolated, single-worker, mutation-disabled smoke behavior.

### Result contract

Paired options were added to `scripts/run-remote-chat-smoke.mjs`:

- `--result-file`
- `--runner-revision`

Supplying either requires both, and the runner revision must be exactly 40 lowercase hexadecimal characters.

After Playwright completes with valid journey-completion evidence, the runner atomically publishes JSON containing exactly:

~~~json
{
  "schemaVersion": 1,
  "journey": "/chat",
  "passed": true,
  "executedAt": 1785988800,
  "runnerRevision": "0123456789abcdef0123456789abcdef01234567",
  "transport": "intercepted",
  "mutationEnabled": false
}
~~~

The file is written with a trailing newline through a restrictive `0600` temporary file in the destination directory and renamed into place only after the write succeeds.

### Completion and failure semantics

- The approved `/chat` journey emits exact, bounded lifecycle evidence only after the page fixture is available and the test body has been entered.
- Completion-marker writes are idempotent across Playwright retries and retain restrictive permissions.
- A completed successful smoke publishes `passed: true`.
- A completed failing smoke publishes `passed: false` and preserves the child’s nonzero exit status.
- Validation errors, invalid revisions, launch failures, signals, configuration/import/browser/page failures, and missing, stale, malformed, or oversized completion evidence preserve an existing result and create no result when none existed.
- Result-publication failure after a completed smoke reports a bounded error and exits nonzero.
- Invocations without the paired result options retain the existing behavior.
- Intercepted transport, isolated profile, mutation-disabled execution, one Playwright worker, and the prohibition on real provider credentials or mutation remain intact.

### Documentation

`docs/ops/sugarkube-release.md` documents the pinned invocation and requires operators to run repository/tooling from the same full immutable SHA supplied as `runnerRevision`. The result directory must already exist and be writable by the operator.

### Testing

- `npx vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts` — 61 tests passed
- Prettier checks for the changed runner, helper, tests, Playwright spec, and operations documentation
- `npm run lint`
- `npm run type-check`
- `npm run coverage`
- `node scripts/link-check.mjs`
- `git diff --check`
- Secret scan over the patch against the PR base
- All latest-head GitHub workflows passed: `CI`, `tests`, `link-check`, `ci-sentinel`, `Build & Publish Container`, and `Build and publish GHCR image`

References futuroptimist/sugarkube#2329 without closing it.

No application behavior, deployment state, application/chart version, image publication coordinate, release tag, provider configuration, Helm/Kubernetes state, or GitHub release workflow was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7621ddb898832f9b0bd91cf3b3c7ae)