### PR TITLE
Add atomic remote chat smoke result contract

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -263,6 +263,32 @@ DSPACE_EXPECTED_TOKEN_PLACE_MODEL=qwen3-8b-instruct \
 npm run qa:remote-chat-smoke
 ```
 
+Sugarkube's synthetic metrics consumer reads an opt-in, atomically published result. Run the
+repository tooling from a checkout pinned at the same full immutable commit SHA supplied as
+`--runner-revision`; do not run a moving branch or an operator-host wrapper. For example, the
+3.1.0 legacy compatibility profile is invoked as:
+
+```bash
+node scripts/run-remote-chat-smoke.mjs \
+  --base-url https://staging.democratized.space \
+  --expected-version 3.1.0 \
+  --expected-revision 018687f5a7f4de45508c6e36eb28afb3e44da24d \
+  --identity-contract legacy-build-meta-v1 \
+  --expected-provider token-place \
+  --expected-token-place-origin https://staging.token.place \
+  --expected-token-place-model llama-3.1-8b-instruct \
+  --runner-revision <FULL_IMMUTABLE_DSPACE_COMMIT_SHA> \
+  --result-file /run/dspace-chat/result.json
+```
+
+The result options must be supplied together. After Playwright completes, the runner replaces the
+result atomically with schema version 1, journey `/chat`, the completion timestamp, the pinned
+runner revision, `transport: "intercepted"`, `mutationEnabled: false`, and a `passed` boolean. A
+completed failed test publishes `passed: false` and retains Playwright's nonzero status. Validation,
+launch, interruption, and other incomplete-execution failures leave any existing result untouched;
+publication failure after a completed test fails closed. Omitting both result options preserves the
+original runner behavior and writes no result.
+
 When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-info-v1`
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { dirname, join } from 'node:path';
+import { open, rename, unlink } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -36,7 +37,11 @@ const definitions = {
     'expected-token-place-model',
     'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
   ],
+  resultFile: ['result-file'],
+  runnerRevision: ['runner-revision'],
 };
+
+const optionalDefinitions = new Set(['resultFile', 'runnerRevision']);
 
 export function parseAndValidateArgs(argv, env = process.env) {
   const flags = new Map();
@@ -71,12 +76,33 @@ export function parseAndValidateArgs(argv, env = process.env) {
     result.identityContract = defaultIdentityContract;
   }
   const missing = Object.entries(definitions)
-    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .filter(
+      ([key]) =>
+        !result[key] &&
+        !key.startsWith('expectedTokenPlace') &&
+        !optionalDefinitions.has(key)
+    )
     .map(([, [, environment]]) => environment);
   if (missing.length)
     throw new Error(
       `validation: missing required input(s): ${missing.join(', ')}`
     );
+
+  const resultFileSupplied = flags.has(definitions.resultFile[0]);
+  const runnerRevisionSupplied = flags.has(definitions.runnerRevision[0]);
+  if (resultFileSupplied !== runnerRevisionSupplied) {
+    throw new Error(
+      'validation: --result-file and --runner-revision must be supplied together'
+    );
+  }
+  if (resultFileSupplied && !result.resultFile) {
+    throw new Error('validation: --result-file requires a value');
+  }
+  if (resultFileSupplied && !/^[0-9a-f]{40}$/.test(result.runnerRevision)) {
+    throw new Error(
+      'validation: runner revision must be a lowercase full 40-character Git SHA'
+    );
+  }
 
   let base;
   try {
@@ -214,14 +240,92 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
   };
 }
 
-export function main(argv = process.argv.slice(2)) {
+export async function writeResultFile(resultFile, runnerRevision, passed) {
+  const destinationDirectory = dirname(resultFile);
+  const destinationName = basename(resultFile);
+  const payload = `${JSON.stringify({
+    schemaVersion: 1,
+    journey: '/chat',
+    passed,
+    executedAt: Math.floor(Date.now() / 1000),
+    runnerRevision,
+    transport: 'intercepted',
+    mutationEnabled: false,
+  })}\n`;
+  let temporaryPath;
+  let handle;
+  try {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      temporaryPath = join(
+        destinationDirectory,
+        `.${destinationName}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`
+      );
+      try {
+        handle = await open(temporaryPath, 'wx', 0o600);
+        break;
+      } catch (error) {
+        if (error.code !== 'EEXIST' || attempt === 9) throw error;
+      }
+    }
+    await handle.writeFile(payload, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryPath, resultFile);
+    temporaryPath = undefined;
+  } finally {
+    await handle?.close().catch(() => {});
+    if (temporaryPath) await unlink(temporaryPath).catch(() => {});
+  }
+}
+
+export function runPlaywright(options, spawnImpl = spawn) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnImpl(
+        'node',
+        [
+          './node_modules/@playwright/test/cli.js',
+          'test',
+          'e2e/remote-chat-smoke.spec.ts',
+          '--project=chromium',
+        ],
+        { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+      );
+    } catch {
+      console.error('[qa:remote-chat-smoke] launch failed');
+      resolve({ completed: false, code: 1 });
+      return;
+    }
+    let launchFailed = false;
+    child.once('error', (error) => {
+      launchFailed = true;
+      console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
+      resolve({ completed: false, code: 1 });
+    });
+    child.once('close', (code, signal) => {
+      if (!launchFailed)
+        resolve({ completed: !signal, code: code ?? 1, signal });
+    });
+  });
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  {
+    spawnImpl = spawn,
+    publishResult = writeResultFile,
+    forwardSignal = (signal) => process.kill(process.pid, signal),
+  } = {}
+) {
   let options;
   try {
     options = parseAndValidateArgs(argv);
   } catch (error) {
     console.error(`[qa:remote-chat-smoke] ${error.message}`);
     process.exitCode = 2;
-    return;
+    return 2;
   }
   console.log(`[qa:remote-chat-smoke] target=${options.baseURL}`);
   console.log(
@@ -236,24 +340,26 @@ export function main(argv = process.argv.slice(2)) {
   console.log(
     '[qa:remote-chat-smoke] transport=intercepted; profile=isolated; mutation=disabled'
   );
-  const child = spawn(
-    'node',
-    [
-      './node_modules/@playwright/test/cli.js',
-      'test',
-      'e2e/remote-chat-smoke.spec.ts',
-      '--project=chromium',
-    ],
-    { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
-  );
-  child.on('error', (error) => {
-    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
-    process.exitCode = 1;
-  });
-  child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    else process.exitCode = code ?? 1;
-  });
+  const outcome = await runPlaywright(options, spawnImpl);
+  if (outcome.signal) {
+    forwardSignal(outcome.signal);
+    return 1;
+  }
+  if (outcome.completed && options.resultFile) {
+    try {
+      await publishResult(
+        options.resultFile,
+        options.runnerRevision,
+        outcome.code === 0
+      );
+    } catch {
+      console.error('[qa:remote-chat-smoke] result publication failed');
+      process.exitCode = 1;
+      return 1;
+    }
+  }
+  process.exitCode = outcome.code;
+  return outcome.code;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { access, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildSmokeEnv,
+  main,
   parseAndValidateArgs,
+  writeResultFile,
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
@@ -15,6 +21,29 @@ const completeEnv = {
   DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN: 'https://token.place',
   DSPACE_EXPECTED_TOKEN_PLACE_MODEL: 'qwen3-8b-instruct',
 };
+
+const runnerArgs = [
+  '--base-url=https://staging.example.test',
+  '--expected-version=3.2.0',
+  `--expected-revision=${revision}`,
+  '--expected-provider=openai',
+];
+
+function completingSpawn(
+  code: number | null,
+  signal: NodeJS.Signals | null = null
+) {
+  return vi.fn((..._args: unknown[]) => {
+    const child = new EventEmitter();
+    queueMicrotask(() => child.emit('close', code, signal));
+    return child;
+  });
+}
+
+afterEach(() => {
+  process.exitCode = 0;
+  vi.restoreAllMocks();
+});
 
 describe('remote chat smoke input validation', () => {
   it('selects serial Playwright execution by default', () => {
@@ -221,6 +250,34 @@ describe('remote chat smoke input validation', () => {
     expect(options.expectedVersion).toBe('3.2.0');
   });
 
+  it('requires the result options as a pair and validates a lowercase full SHA', () => {
+    expect(() =>
+      parseAndValidateArgs(
+        [...runnerArgs, '--result-file=/tmp/result.json'],
+        {}
+      )
+    ).toThrow('must be supplied together');
+    expect(() =>
+      parseAndValidateArgs([...runnerArgs, `--runner-revision=${revision}`], {})
+    ).toThrow('must be supplied together');
+    for (const invalid of [
+      revision.slice(1),
+      revision.toUpperCase(),
+      `${revision}0`,
+    ]) {
+      expect(() =>
+        parseAndValidateArgs(
+          [
+            ...runnerArgs,
+            '--result-file=/tmp/result.json',
+            `--runner-revision=${invalid}`,
+          ],
+          {}
+        )
+      ).toThrow('lowercase full 40-character');
+    }
+  });
+
   it.each([
     [
       { ...completeEnv, DSPACE_EXPECTED_REVISION: revision.slice(0, 7) },
@@ -313,5 +370,182 @@ describe('remote chat smoke input validation', () => {
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
     expect(parseAndValidateArgs([], env).expectedProvider).toBe('openai');
+  });
+});
+
+describe('remote chat smoke result publication', () => {
+  it('publishes passed true after a successful completed smoke', async () => {
+    const publishResult = vi.fn().mockResolvedValue(undefined);
+    expect(
+      await main(
+        [
+          ...runnerArgs,
+          '--result-file=/tmp/result.json',
+          `--runner-revision=${revision}`,
+        ],
+        { spawnImpl: completingSpawn(0), publishResult }
+      )
+    ).toBe(0);
+    expect(publishResult).toHaveBeenCalledWith(
+      '/tmp/result.json',
+      revision,
+      true
+    );
+  });
+
+  it('atomically replaces a result with the exact successful schema and restrictive mode', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const destination = join(directory, 'result.json');
+    await writeFile(destination, '{"stale":true}\n');
+
+    await writeResultFile(destination, revision, true);
+
+    const raw = await readFile(destination, 'utf8');
+    const result = JSON.parse(raw);
+    expect(raw.endsWith('\n')).toBe(true);
+    expect(Object.keys(result)).toEqual([
+      'schemaVersion',
+      'journey',
+      'passed',
+      'executedAt',
+      'runnerRevision',
+      'transport',
+      'mutationEnabled',
+    ]);
+    expect(result).toEqual({
+      schemaVersion: 1,
+      journey: '/chat',
+      passed: true,
+      executedAt: expect.any(Number),
+      runnerRevision: revision,
+      transport: 'intercepted',
+      mutationEnabled: false,
+    });
+    expect(Number.isInteger(result.executedAt)).toBe(true);
+    if (process.platform !== 'win32') {
+      expect((await stat(destination)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('publishes passed false and preserves a completed child failure status', async () => {
+    const publishResult = vi.fn().mockResolvedValue(undefined);
+    const code = await main(
+      [
+        ...runnerArgs,
+        '--result-file=/tmp/result.json',
+        `--runner-revision=${revision}`,
+      ],
+      { spawnImpl: completingSpawn(7), publishResult }
+    );
+    expect(code).toBe(7);
+    expect(process.exitCode).toBe(7);
+    expect(publishResult).toHaveBeenCalledWith(
+      '/tmp/result.json',
+      revision,
+      false
+    );
+  });
+
+  it('does not publish on validation failure, launch failure, or signal', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    for (const [args, spawnImpl] of [
+      [[...runnerArgs, '--result-file=/tmp/result.json'], completingSpawn(0)],
+      [
+        [
+          ...runnerArgs,
+          '--result-file=/tmp/result.json',
+          `--runner-revision=${revision}`,
+        ],
+        () => {
+          throw new Error('private launch detail');
+        },
+      ],
+    ] as const) {
+      const publishResult = vi.fn();
+      await main(args, { spawnImpl, publishResult });
+      expect(publishResult).not.toHaveBeenCalled();
+    }
+
+    const publishResult = vi.fn();
+    const forwardSignal = vi.fn();
+    await main(
+      [
+        ...runnerArgs,
+        '--result-file=/tmp/result.json',
+        `--runner-revision=${revision}`,
+      ],
+      {
+        spawnImpl: completingSpawn(null, 'SIGTERM'),
+        publishResult,
+        forwardSignal,
+      }
+    );
+    expect(publishResult).not.toHaveBeenCalled();
+    expect(forwardSignal).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('preserves an existing result and creates none when execution is incomplete', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-incomplete-'));
+    const existing = join(directory, 'existing.json');
+    const absent = join(directory, 'absent.json');
+    await writeFile(existing, '{"known":"stale"}\n');
+    const launchFailure = () => {
+      throw new Error('launch failure');
+    };
+
+    for (const destination of [existing, absent]) {
+      await main(
+        [
+          ...runnerArgs,
+          `--result-file=${destination}`,
+          `--runner-revision=${revision}`,
+        ],
+        { spawnImpl: launchFailure }
+      );
+    }
+
+    expect(await readFile(existing, 'utf8')).toBe('{"known":"stale"}\n');
+    await expect(access(absent)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('fails closed with a bounded diagnostic when result publication fails', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const code = await main(
+      [
+        ...runnerArgs,
+        '--result-file=/unwritable/result.json',
+        `--runner-revision=${revision}`,
+      ],
+      {
+        spawnImpl: completingSpawn(0),
+        publishResult: vi.fn().mockRejectedValue(new Error('secret detail')),
+      }
+    );
+    expect(code).toBe(1);
+    expect(error).toHaveBeenCalledWith(
+      '[qa:remote-chat-smoke] result publication failed'
+    );
+    expect(error.mock.calls.flat().join(' ')).not.toContain('secret detail');
+  });
+
+  it('keeps legacy invocations output-free and preserves serial intercepted guarantees', async () => {
+    const spawnImpl = completingSpawn(0);
+    expect(await main(runnerArgs, { spawnImpl })).toBe(0);
+    const [, playwrightArgs, spawnOptions] = spawnImpl.mock.calls[0] as [
+      string,
+      string[],
+      { env: Record<string, string> },
+    ];
+    expect(playwrightArgs).toEqual([
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ]);
+    expect(spawnOptions.env).toMatchObject({
+      PW_WORKERS: '1',
+      REMOTE_CHAT_SMOKE: '1',
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Provide an opt-in, repository-native producer for the Sugarkube synthetic-metrics consumer so the existing isolated `/chat` Playwright smoke can emit a bounded machine-readable result. 
- Preserve every existing remote-smoke invariant (intercepted transport, isolated profile, mutation disabled, single Playwright worker, no provider credentials or mutation) while adding the opt-in contract. 
- The change implements the producer side required by futuroptimist/sugarkube#2329 without closing that issue. 

### Description
- Add paired CLI options `--result-file` and `--runner-revision` to `scripts/run-remote-chat-smoke.mjs` and require both when either is supplied. 
- Validate `runnerRevision` as exactly 40 lowercase hexadecimal characters and perform paired-option validation with bounded diagnostics. 
- After Playwright completes, atomically publish a single-line JSON file (temporary file with restrictive `0o600` permissions, `fsync`/close, then `rename`) containing exactly these keys and no others: `schemaVersion: 1`, `journey: "/chat"`, `passed` (true only on successful Playwright exit), `executedAt` (integer Unix seconds), `runnerRevision` (the supplied SHA), `transport: "intercepted"`, and `mutationEnabled: false`. 
- Do not overwrite an existing valid result on pre-execution failures (validation failure, launch failure, interruption/signal, or other incomplete execution), write `passed:false` for completed child failures while preserving the runner exit status, and fail closed if atomic publication fails after a completed smoke. 
- Factor behavior into `runPlaywright` and `writeResultFile` helpers, add focused unit tests, and document the pinned invocation pattern in `docs/ops/sugarkube-release.md` (example invocation includes `--runner-revision <FULL_IMMUTABLE_DSPACE_COMMIT_SHA> --result-file /run/dspace-chat/result.json`). 

### Testing
- Ran the focused test suite: `npx vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts` and all tests passed (46 tests passed). 
- Ran type checking and linting: `npm run type-check` and `npm run lint` both succeeded. 
- Ran repository checks: `git diff --check` and secret scan via `git diff | python3 scripts/scan-secrets.py` produced no new findings. 
- Notes: changes are committed on branch `codex/remote-chat-result-contract` (commit `bc0a934`) and no deployment, application/chart version, image publication, provider configuration, Helm/Kubernetes state, release tag, or GitHub release workflow was changed; creating the remote PR from this environment failed due to missing GitHub credentials, so the branch and commit are ready for an external push/PR creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7621e7dc10832fb6d24697dced247e)