### PR TITLE
Add opt-in atomic remote-chat smoke result contract

### DIFF
--- a/docs/ops/sugarkube-release.md
+++ b/docs/ops/sugarkube-release.md
@@ -263,6 +263,31 @@ DSPACE_EXPECTED_TOKEN_PLACE_MODEL=qwen3-8b-instruct \
 npm run qa:remote-chat-smoke
 ```
 
+For scheduled Sugarkube observability, opt in to the versioned machine-readable result contract by
+pinning the DSPACE checkout/tooling to one immutable full commit SHA and supplying that same SHA as
+`--runner-revision`. For example, the pinned 3.1.0 staging compatibility check is:
+
+```bash
+node scripts/run-remote-chat-smoke.mjs \
+  --base-url https://staging.democratized.space \
+  --expected-version 3.1.0 \
+  --expected-revision 018687f5a7f4de45508c6e36eb28afb3e44da24d \
+  --identity-contract legacy-build-meta-v1 \
+  --expected-provider token-place \
+  --expected-token-place-origin https://staging.token.place \
+  --expected-token-place-model llama-3.1-8b-instruct \
+  --runner-revision <FULL_IMMUTABLE_DSPACE_COMMIT_SHA> \
+  --result-file /run/dspace-chat/result.json
+```
+
+The paired result options are opt-in. After Playwright completes, the runner atomically replaces
+the result with schema version 1, journey `/chat`, the completion timestamp, the pinned runner
+revision, intercepted transport, mutation disabled, and `passed` reflecting Playwright's status.
+A completed test failure publishes `passed: false` and retains the test's nonzero status. A
+validation, launch, interruption, or other incomplete-execution failure does not replace an older
+result; a publication failure after a completed run fails closed. The JSON contains no Playwright
+output, URLs, credentials, environment values, or free-form diagnostics.
+
 When omitted, `DSPACE_EXPECTED_IDENTITY_CONTRACT` defaults to the modern `build-info-v1`
 contract. That contract requires same-origin `/build-info.json` identity (including the exact
 version, full revision, and derived short revision) and the exact HTML build-revision marker.

--- a/scripts/run-remote-chat-smoke.mjs
+++ b/scripts/run-remote-chat-smoke.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
+import { open, rename, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -36,6 +38,8 @@ const definitions = {
     'expected-token-place-model',
     'DSPACE_EXPECTED_TOKEN_PLACE_MODEL',
   ],
+  resultFile: ['result-file'],
+  runnerRevision: ['runner-revision'],
 };
 
 export function parseAndValidateArgs(argv, env = process.env) {
@@ -71,12 +75,27 @@ export function parseAndValidateArgs(argv, env = process.env) {
     result.identityContract = defaultIdentityContract;
   }
   const missing = Object.entries(definitions)
-    .filter(([key]) => !result[key] && !key.startsWith('expectedTokenPlace'))
+    .filter(
+      ([key]) =>
+        !result[key] &&
+        !key.startsWith('expectedTokenPlace') &&
+        !['resultFile', 'runnerRevision'].includes(key)
+    )
     .map(([, [, environment]]) => environment);
   if (missing.length)
     throw new Error(
       `validation: missing required input(s): ${missing.join(', ')}`
     );
+  if (Boolean(result.resultFile) !== Boolean(result.runnerRevision)) {
+    throw new Error(
+      'validation: --result-file and --runner-revision must be supplied together'
+    );
+  }
+  if (result.runnerRevision && !/^[0-9a-f]{40}$/.test(result.runnerRevision)) {
+    throw new Error(
+      'validation: runner revision must be a lowercase full 40-character Git SHA'
+    );
+  }
 
   let base;
   try {
@@ -214,46 +233,113 @@ export function buildSmokeEnv(options, baseEnv = process.env) {
   };
 }
 
-export function main(argv = process.argv.slice(2)) {
-  let options;
+export async function publishResult(resultFile, runnerRevision, passed) {
+  const temporaryFile = join(
+    dirname(resultFile),
+    `.dspace-chat-result-${process.pid}-${randomBytes(8).toString('hex')}.tmp`
+  );
+  const payload = `${JSON.stringify({
+    schemaVersion: 1,
+    journey: '/chat',
+    passed,
+    executedAt: Math.floor(Date.now() / 1000),
+    runnerRevision,
+    transport: 'intercepted',
+    mutationEnabled: false,
+  })}\n`;
+  let handle;
   try {
-    options = parseAndValidateArgs(argv);
+    handle = await open(temporaryFile, 'wx', 0o600);
+    await handle.writeFile(payload, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryFile, resultFile);
   } catch (error) {
-    console.error(`[qa:remote-chat-smoke] ${error.message}`);
-    process.exitCode = 2;
-    return;
+    await handle?.close().catch(() => {});
+    await unlink(temporaryFile).catch(() => {});
+    throw error;
   }
-  console.log(`[qa:remote-chat-smoke] target=${options.baseURL}`);
-  console.log(
-    `[qa:remote-chat-smoke] expectedVersion=${options.expectedVersion}`
-  );
-  console.log(
-    `[qa:remote-chat-smoke] expectedRevision=${options.expectedRevision}`
-  );
-  console.log(
-    `[qa:remote-chat-smoke] expectedProvider=${options.expectedProvider}`
-  );
-  console.log(
+}
+
+export function runSmoke(options, dependencies = {}) {
+  const spawnChild = dependencies.spawn ?? spawn;
+  const writeResult = dependencies.publishResult ?? publishResult;
+  const runtime = dependencies.process ?? process;
+  const log = dependencies.log ?? console.log;
+  const logError = dependencies.error ?? console.error;
+
+  log(`[qa:remote-chat-smoke] target=${options.baseURL}`);
+  log(`[qa:remote-chat-smoke] expectedVersion=${options.expectedVersion}`);
+  log(`[qa:remote-chat-smoke] expectedRevision=${options.expectedRevision}`);
+  log(`[qa:remote-chat-smoke] expectedProvider=${options.expectedProvider}`);
+  log(
     '[qa:remote-chat-smoke] transport=intercepted; profile=isolated; mutation=disabled'
   );
-  const child = spawn(
-    'node',
-    [
-      './node_modules/@playwright/test/cli.js',
-      'test',
-      'e2e/remote-chat-smoke.spec.ts',
-      '--project=chromium',
-    ],
-    { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
-  );
+  let child;
+  try {
+    child = spawnChild(
+      'node',
+      [
+        './node_modules/@playwright/test/cli.js',
+        'test',
+        'e2e/remote-chat-smoke.spec.ts',
+        '--project=chromium',
+      ],
+      { cwd: frontendDir, env: buildSmokeEnv(options), stdio: 'inherit' }
+    );
+  } catch (error) {
+    if (!options.resultFile) throw error;
+    logError('[qa:remote-chat-smoke] launch failed');
+    runtime.exitCode = 1;
+    return;
+  }
+
+  let launchFailed = false;
   child.on('error', (error) => {
-    console.error(`[qa:remote-chat-smoke] launch: ${error.message}`);
-    process.exitCode = 1;
+    launchFailed = true;
+    logError(`[qa:remote-chat-smoke] launch: ${error.message}`);
+    runtime.exitCode = 1;
   });
-  child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    else process.exitCode = code ?? 1;
+  child.on('exit', async (code, signal) => {
+    if (signal) {
+      runtime.kill(runtime.pid, signal);
+      return;
+    }
+    if (launchFailed || !Number.isInteger(code)) {
+      runtime.exitCode = 1;
+      return;
+    }
+    if (options.resultFile) {
+      try {
+        await writeResult(
+          options.resultFile,
+          options.runnerRevision,
+          code === 0
+        );
+      } catch {
+        logError('[qa:remote-chat-smoke] result publication failed');
+        runtime.exitCode = 1;
+        return;
+      }
+    }
+    runtime.exitCode = code;
   });
+  return child;
+}
+
+export function main(argv = process.argv.slice(2), dependencies = {}) {
+  let options;
+  try {
+    options = parseAndValidateArgs(argv, dependencies.env ?? process.env);
+  } catch (error) {
+    (dependencies.error ?? console.error)(
+      `[qa:remote-chat-smoke] ${error.message}`
+    );
+    (dependencies.process ?? process).exitCode = 2;
+    return;
+  }
+  return runSmoke(options, dependencies);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/tests/run-remote-chat-smoke.test.ts
+++ b/scripts/tests/run-remote-chat-smoke.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
 import {
   buildSmokeEnv,
+  main,
   parseAndValidateArgs,
+  publishResult,
+  runSmoke,
 } from '../run-remote-chat-smoke.mjs';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
@@ -313,5 +327,231 @@ describe('remote chat smoke input validation', () => {
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_ORIGIN;
     delete env.DSPACE_EXPECTED_TOKEN_PLACE_MODEL;
     expect(parseAndValidateArgs([], env).expectedProvider).toBe('openai');
+  });
+
+  it('requires paired result options and validates the runner full SHA', () => {
+    expect(() =>
+      parseAndValidateArgs(['--result-file=/tmp/result.json'], completeEnv)
+    ).toThrow('must be supplied together');
+    expect(() =>
+      parseAndValidateArgs(['--runner-revision', revision], completeEnv)
+    ).toThrow('must be supplied together');
+    for (const invalid of [
+      revision.slice(1),
+      revision.toUpperCase(),
+      `${revision}0`,
+    ]) {
+      expect(() =>
+        parseAndValidateArgs(
+          ['--result-file=/tmp/result.json', '--runner-revision', invalid],
+          completeEnv
+        )
+      ).toThrow('lowercase full 40-character');
+    }
+    expect(
+      parseAndValidateArgs(
+        ['--result-file=/tmp/result.json', '--runner-revision', revision],
+        completeEnv
+      )
+    ).toMatchObject({
+      resultFile: '/tmp/result.json',
+      runnerRevision: revision,
+    });
+  });
+});
+
+function fakeRuntime() {
+  return { exitCode: undefined, kill: vi.fn(), pid: 1234 };
+}
+
+function smokeOptions(resultFile?: string) {
+  return {
+    ...parseAndValidateArgs([], completeEnv),
+    ...(resultFile ? { resultFile, runnerRevision: revision } : {}),
+  };
+}
+
+describe('remote chat smoke result publication', () => {
+  it('atomically replaces a result with the exact successful schema and restrictive mode', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const destination = join(directory, 'result.json');
+    await writeFile(destination, 'stale\n', { mode: 0o666 });
+
+    const child = new EventEmitter();
+    const runtime = fakeRuntime();
+    runSmoke(smokeOptions(destination), {
+      spawn: () => child,
+      process: runtime,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+    child.emit('exit', 0, null);
+    await vi.waitFor(() => expect(runtime.exitCode).toBe(0));
+
+    const raw = await readFile(destination, 'utf8');
+    const result = JSON.parse(raw);
+    expect(raw.endsWith('\n')).toBe(true);
+    expect(Object.keys(result)).toEqual([
+      'schemaVersion',
+      'journey',
+      'passed',
+      'executedAt',
+      'runnerRevision',
+      'transport',
+      'mutationEnabled',
+    ]);
+    expect(result).toEqual({
+      schemaVersion: 1,
+      journey: '/chat',
+      passed: true,
+      executedAt: expect.any(Number),
+      runnerRevision: revision,
+      transport: 'intercepted',
+      mutationEnabled: false,
+    });
+    expect(Number.isInteger(result.executedAt)).toBe(true);
+    if (process.platform !== 'win32') {
+      expect((await stat(destination)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('publishes passed=false after completed failure and retains the child status', async () => {
+    const child = new EventEmitter();
+    const runtime = fakeRuntime();
+    const write = vi.fn().mockResolvedValue(undefined);
+    runSmoke(smokeOptions('/tmp/result.json'), {
+      spawn: () => child,
+      publishResult: write,
+      process: runtime,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+
+    child.emit('exit', 7, null);
+    await vi.waitFor(() =>
+      expect(write).toHaveBeenCalledWith('/tmp/result.json', revision, false)
+    );
+    expect(runtime.exitCode).toBe(7);
+  });
+
+  it.each([
+    [
+      'launch error',
+      (child: EventEmitter) => child.emit('error', new Error('private')),
+    ],
+    ['signal', (child: EventEmitter) => child.emit('exit', null, 'SIGTERM')],
+    [
+      'incomplete exit',
+      (child: EventEmitter) => child.emit('exit', null, null),
+    ],
+  ])('preserves an existing result on %s', async (_case, finish) => {
+    const child = new EventEmitter();
+    const runtime = fakeRuntime();
+    const write = vi.fn();
+    runSmoke(smokeOptions('/tmp/result.json'), {
+      spawn: () => child,
+      publishResult: write,
+      process: runtime,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+    finish(child);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('does not launch or replace a result on validation failure', () => {
+    const runtime = fakeRuntime();
+    const spawn = vi.fn();
+    main(['--result-file=/tmp/result.json'], {
+      env: completeEnv,
+      spawn,
+      process: runtime,
+      error: vi.fn(),
+    });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(runtime.exitCode).toBe(2);
+  });
+
+  it('does not create a result when spawn throws and emits only a bounded error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const destination = join(directory, 'result.json');
+    const runtime = fakeRuntime();
+    const error = vi.fn();
+    const write = vi.fn();
+    runSmoke(smokeOptions(destination), {
+      spawn: () => {
+        throw new Error('secret launch detail');
+      },
+      publishResult: write,
+      process: runtime,
+      log: vi.fn(),
+      error,
+    });
+    expect(write).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith('[qa:remote-chat-smoke] launch failed');
+    expect(runtime.exitCode).toBe(1);
+    await expect(stat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('fails closed with a bounded error when publication fails', async () => {
+    const child = new EventEmitter();
+    const runtime = fakeRuntime();
+    const error = vi.fn();
+    runSmoke(smokeOptions('/unwritable/result.json'), {
+      spawn: () => child,
+      publishResult: vi
+        .fn()
+        .mockRejectedValue(new Error('private path detail')),
+      process: runtime,
+      log: vi.fn(),
+      error,
+    });
+    child.emit('exit', 0, null);
+    await vi.waitFor(() => expect(runtime.exitCode).toBe(1));
+    expect(error).toHaveBeenCalledWith(
+      '[qa:remote-chat-smoke] result publication failed'
+    );
+  });
+
+  it('keeps legacy invocation and serial intercepted mutation-disabled execution unchanged', () => {
+    const child = new EventEmitter();
+    const runtime = fakeRuntime();
+    const spawn = vi.fn((..._args: unknown[]) => child);
+    const write = vi.fn();
+    runSmoke(smokeOptions(), {
+      spawn,
+      publishResult: write,
+      process: runtime,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+    const [command, args, configuration] = spawn.mock.calls[0] as [
+      string,
+      string[],
+      { env: Record<string, string> },
+    ];
+    expect(command).toBe('node');
+    expect(args).toEqual([
+      './node_modules/@playwright/test/cli.js',
+      'test',
+      'e2e/remote-chat-smoke.spec.ts',
+      '--project=chromium',
+    ]);
+    expect(configuration.env).toMatchObject({
+      PW_WORKERS: '1',
+      REMOTE_CHAT_SMOKE: '1',
+    });
+    child.emit('exit', 0, null);
+    expect(write).not.toHaveBeenCalled();
+    expect(runtime.exitCode).toBe(0);
+  });
+
+  it('cleans up a temporary file when atomic replacement fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dspace-chat-result-'));
+    const destination = join(directory, 'result.json');
+    await mkdir(destination);
+    await expect(publishResult(destination, revision, true)).rejects.toThrow();
+    expect(await readdir(directory)).toEqual(['result.json']);
   });
 });


### PR DESCRIPTION
### Motivation

- Provide a repository-owned, machine-readable result producer so Sugarkube can consume a bounded `/chat` synthetic result (schema v1) for observability without changing existing runner semantics.  This implements the producer side required by futuroptimist/sugarkube#2329 (do not close the issue).
- Keep the feature opt-in and preserve all existing invariants: intercepted transport, isolated profile, mutation disabled, one Playwright worker, no live provider credentials or mutation, and unchanged legacy invocation behavior.

### Description

- Add paired CLI options `--result-file` and `--runner-revision` and require that if one is supplied the other is supplied too, with `runnerRevision` validated as exactly 40 lowercase hex characters (`/^[0-9a-f]{40}$/`).
- Implement atomic, same-directory publication via `publishResult()` which: creates a temporary file, writes only the exact JSON payload plus a trailing newline, uses restrictive permissions (`0o600`), syncs and renames the temp file over the destination, and cleans up on failure; the JSON contains exactly the keys `schemaVersion`, `journey`, `passed`, `executedAt`, `runnerRevision`, `transport`, and `mutationEnabled` and nothing else.
- Keep the smoke runner semantics intact by refactoring the execution into `runSmoke()` which spawns Playwright exactly as before (one worker, intercepted/isolated/mutation-disabled env), and only after a completed, unsignaled Playwright run will it attempt result publication; a successful run sets `passed: true`, a completed nonzero exit sets `passed: false` and preserves the child exit status, and publication failures after completion fail closed with a bounded error.
- Ensure no result file is created or overwritten on pre-execution failures (validation failure, invalid runner SHA, spawn/launch failure, signal/incomplete execution), preserving any existing result file so Sugarkube can detect stale results.
- Add focused unit tests exercising paired-option validation, full-SHA validation, exact key set and schema, atomic replacement behavior and restrictive permissions where supported, completed-failure semantics, preservation of existing results on pre-exec failures, temporary-file cleanup on atomic failure, and legacy invocation behavior; update `docs/ops/sugarkube-release.md` with the pinned invocation example and semantics note.

### Testing

- Ran unit/test suite focused on the runner changes: `npx vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts` — all tests passed (49 tests total).
- Ran repository checks: `npm run lint`, `npm run type-check`, and `node scripts/link-check.mjs` — these succeeded in this environment.
- Ran `git diff --check` and the repository secret scan `git diff --cached | python3 scripts/scan-secrets.py` against the committed patch — both passed.
- Notes about publishing the branch: the local branch `codex/remote-chat-result-contract` was created and a commit was made, but `git push` / PR creation failed in this environment due to missing GitHub credentials (`fatal: could not read Username for 'https://github.com'`), so a PR was not opened from here; the branch and commit are ready for push from a credentialed environment.

Commands executed (examples):
- `npx vitest run scripts/tests/remote-chat-smoke-contract.test.ts scripts/tests/run-remote-chat-smoke.test.ts` (passed)
- `npm run lint` (passed)
- `npm run type-check` (passed)
- `node scripts/link-check.mjs` (passed)
- `git diff --check` (passed)
- `git diff --cached | python3 scripts/scan-secrets.py` (passed)

Residual notes and risks:
- Feature is opt-in: invoking the runner without `--result-file`/`--runner-revision` preserves prior behavior exactly.
- Operator guidance: pin the checkout/tooling to the same full SHA supplied as `--runner-revision` when scheduling Sugarkube observability; example usage is documented in `docs/ops/sugarkube-release.md`.
- I was unable to create the PR from this environment due to missing GitHub auth; please push the branch `codex/remote-chat-result-contract` and open the PR against `main` to complete submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7621e99120832fa49e6eb18b09e8a5)