### PR TITLE
docs(outage): close July 23 postmortem action items

### DIFF
--- a/outages/2026-07-23-dspace-production-version-drift.json
+++ b/outages/2026-07-23-dspace-production-version-drift.json
@@ -6,7 +6,7 @@
     "component": "production release artifact integrity for democratized.space",
     "impact": "Production democratized.space served later 3.1-era frontend and changelog content while the footer, /healthz, and /livez still reported prod v3.0.1. The unintended 3.1-era frontend also made the non-working token.place prototype the default /chat path for fresh/default profiles; OpenAI required a manual /settings opt-in and the user's own valid API key, so it was not an automatic fallback. Exact user-impact start, affected sessions, failed chat attempts, precise token.place failure mode, and impact to already-persisted OpenAI users were not captured. Service availability remained healthy, and no evidence showed data loss, save corruption, credential exposure, privacy/security compromise, staging impact, token.place users outside DSPACE, or impact to other Sugarkube applications.",
     "rootCause": "Release-artifact mutability was the primary control failure: ordinary eligible branch image builds could publish the semantic v<package-version> tag as well as immutable branch-SHA tags. Because the package version remained 3.0.1 while later main-branch changes accumulated, later source revisions could be published under v3.0.1. Production used v3.0.1 with image.pullPolicy=Always, so the strongest evidence-supported causal mechanism is that a later source revision was resolved under the moved v3.0.1 tag when the observed production pods were created or restarted. The exact workflow run, pre-recovery digest, and semantic tag prior/final digests were not captured. A separate published OCI chart dspace:3.0.1 mismatch was discovered during recovery and complicated Helm reconciliation, but it is not treated as the primary source of the user-visible frontend drift.",
-    "resolution": "The operator replaced the live Deployment image with ghcr.io/democratizedspace/dspace:main-1a31a56, the immutable branch-SHA image for canonical v3.0.1 commit 1a31a569aff2dbeb238e8c2688b9e85140d2077d. The second replacement container started at 2026-07-23T23:13:28Z; the successful rollout and subsequent verification established both replacement pods as ready with zero restarts on sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401, and user impact was declared over after that rollout. Sugarkube PR #2320 then made the production image pin durable as main-1a31a56. Helm revision 8 still stores image.tag=v3.0.1, so Helm reconciliation remains open follow-up work rather than current user impact.",
+    "resolution": "The operator ended user impact by replacing the live Deployment image with ghcr.io/democratizedspace/dspace:main-1a31a56, the immutable branch-SHA image for canonical v3.0.1 commit 1a31a569aff2dbeb238e8c2688b9e85140d2077d, at digest sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401. Sugarkube PR #2320 made that image pin durable. A later controlled reconciliation deployed the compatible, never-overwritten chart 3.0.2 and recorded final production Helm revision 9 in deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json. Git, Helm values, the Deployment, pod image IDs, runtime/frontend identities, expected OpenAI provider, public/direct responses, replica agreement, and the bounded /chat check now agree. The temporary Helm freeze is lifted without altering Helm history, and every labeled corrective-action issue is closed.",
     "verification": [
         "Manual production inspection detected later 3.1-era frontend/changelog content while footer, /healthz, and /livez reported v3.0.1 prod.",
         "Recovered pods used ghcr.io/democratizedspace/dspace:main-1a31a56 with image ID ghcr.io/democratizedspace/dspace@sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401.",
@@ -14,7 +14,11 @@
         "Post-recovery public and direct-origin root hashes matched: b8fc71b476d5d3c7000d3a2558f2824c553a886f81775f3dcd2fce3dea13c884.",
         "Post-recovery public and direct-origin changelog hashes matched: 01bd0fbe848825dd8f33ab50561df1863c7c4efcece5314af24d25f42ce01dde.",
         "Post-recovery public and direct-origin docs changelog hashes matched: 8303f63583db3b48326050d2bf1643b48753a3c70265164bb1e44bcc0bb017e3.",
-        "Post-recovery public and direct-origin /config.json hashes matched: a42d7e88885d9a6529270d15584f2c9715f9bc53def928c4bae41a03747d3ee2."
+        "Post-recovery public and direct-origin /config.json hashes matched: a42d7e88885d9a6529270d15584f2c9715f9bc53def928c4bae41a03747d3ee2.",
+        "Final production evidence records application 3.0.1, source 1a31a569aff2dbeb238e8c2688b9e85140d2077d, image main-1a31a56 at sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401, chart 3.0.2 at sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575 from chart source 63063e287adb92a4158ce2c8e7d378b73f52c1c5, and Helm revision 9.",
+        "The finalized production record reports successful image, chart, Helm-values, runtime, frontend, replica, public/direct, provider, and /chat checks.",
+        "DSPACE 3.1.1 release validation proved source 22f506e07e0b5abfd0cf756e9c5827c0458fb4b2, immutable image main-22f506e and semantic alias v3.1.1 at one digest, and chart 3.1.2 at its recorded digest; an intentional duplicate publication was rejected before mutation.",
+        "Sugarkube staging observability Helm revision 8 passed its owner-scoped alert/PagerDuty drill and clean-state verification; production observability was not deployed or live-tested and remains a separate rollout."
     ],
     "references": [
         ".github/workflows/ci-image.yml",
@@ -35,7 +39,15 @@
         "https://github.com/democratizedspace/dspace/tree/1a31a569aff2dbeb238e8c2688b9e85140d2077d/charts/dspace",
         "https://github.com/futuroptimist/sugarkube/blob/301cb8a4c5a75a75bb73dde7a198731c762b1d5c/docs/apps/dspace.prod.tag",
         "https://github.com/futuroptimist/sugarkube/blob/61303e079e425808eb25f30d3be07e93ccdf6a37/docs/apps/dspace.prod.tag",
-        "outages/2026-07-23-dspace-production-version-drift.md"
+        "outages/2026-07-23-dspace-production-version-drift.md",
+        "https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json",
+        "https://github.com/democratizedspace/dspace/releases/tag/v3.1.1",
+        "https://github.com/democratizedspace/dspace/actions/runs/31058866232",
+        "https://github.com/democratizedspace/dspace/actions/runs/31059130820",
+        "https://github.com/futuroptimist/sugarkube/pull/2478",
+        "https://github.com/futuroptimist/sugarkube/pull/2501",
+        "https://github.com/democratizedspace/dspace/pull/4806",
+        "https://github.com/futuroptimist/sugarkube/pull/2523"
     ],
     "longForm": "outages/2026-07-23-dspace-production-version-drift.md"
 }

--- a/outages/2026-07-23-dspace-production-version-drift.md
+++ b/outages/2026-07-23-dspace-production-version-drift.md
@@ -326,71 +326,112 @@ contain changing uptime and timestamp fields; those differing hashes were not tr
   results.
 - The exact impact start and exact workflow run that moved the semantic tag remain unknown.
 
-## Current residual risk
+## Final production state and residual risk
 
-Incident status is resolved. The current live Deployment and Git pin agree on `main-1a31a56`, and
-this incident is not currently causing user impact.
+The temporary Helm drift and operations freeze are closed. The finalized Sugarkube evidence record
+[`deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json`](https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json)
+records the controlled production reconciliation at Helm revision 9:
 
-A residual operational risk remains: Helm revision 8 still stores `image.tag=v3.0.1`, and the live
-Deployment was corrected outside Helm. Helm stored state and live Deployment state are therefore
-intentionally drifted. DSPACE production Helm operations should remain frozen until a controlled
-reconciliation is performed using a newly published, never-overwritten chart version and the
-immutable image tag. Recovery and residual-risk follow-up is tracked in
-[Sugarkube #2325](https://github.com/futuroptimist/sugarkube/issues/2325) for controlled Helm-state
-reconciliation, [Sugarkube #2326](https://github.com/futuroptimist/sugarkube/issues/2326) for
-immutable release manifests and deployment evidence, and
-[Sugarkube #2327](https://github.com/futuroptimist/sugarkube/issues/2327) for manifest-based
-rollback and verification. This record does not recommend editing Helm revision history directly.
+- application DSPACE `3.0.1`, source `1a31a569aff2dbeb238e8c2688b9e85140d2077d`;
+- image `main-1a31a56`, digest
+  `sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`;
+- chart `3.0.2`, digest
+  `sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575`,
+  from source `63063e287adb92a4158ce2c8e7d378b73f52c1c5`; and
+- expected provider OpenAI.
 
-## Corrective actions
+Image, chart, Helm values, runtime identity, frontend identity, replica agreement, public/direct
+agreement, provider, and `/chat` checks all passed. Git, Helm, the Deployment, pod image IDs,
+runtime identity, and the finalized manifest now agree, so normal guarded Helm operations may
+resume. This reconciliation created revision 9; it did not alter historical Helm revisions.
 
-| Priority | Owner area | Status | Action | Completion condition |
-| --- | --- | --- | --- | --- |
-| P0 | Production operations | Completed | Restore production to immutable image `main-1a31a56`. | Live Deployment image is `ghcr.io/democratizedspace/dspace:main-1a31a56`. |
-| P0 | Production operations | Completed | Verify both replicas use image digest `sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`. | Both pods report that resolved image ID and are ready with zero restarts. |
-| P0 | Sugarkube production config | Completed | Pin Sugarkube production to `main-1a31a56` through PR #2320. | PR #2320 is merged with production pin `main-1a31a56`. |
-| P0 | Production verification | Completed | Compare public and direct-origin content after recovery. | Root, changelog, docs changelog, and `/config.json` hashes match between public and origin responses. |
-| P0 | Image release workflow | Open | Change `.github/workflows/ci-image.yml` so semantic `vX.Y.Z` tags are published only from the matching Git tag or release event, never ordinary branch pushes; track with [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727). | Branch pushes can no longer publish semantic image tags. |
-| P0 | Image release workflow | Open | Add a guard that refuses to overwrite an already published semantic image tag; track with [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727). | CI fails before publishing if the semantic tag already exists with any digest. |
-| P0 | Production deploy tooling | Open | Reject semantic `vX.Y.Z` image tags for production deployment and rollback; require an approved branch-SHA tag with digest verification or a direct digest pin; track with [Sugarkube #2321](https://github.com/futuroptimist/sugarkube/issues/2321). | Production commands fail before Helm/Kubernetes mutation when given a semantic or otherwise mutable image tag. |
-| P0 | Chart publication | Open | Verify an existing OCI chart version before push and fail closed rather than replacing it; track with [DSPACE #4728](https://github.com/democratizedspace/dspace/issues/4728). | CI fails before publishing if the chart version already exists. |
-| P0 | Helm release workflow | Open | Publish any chart repair under a new version and decouple future chart versions from application versions where their release cadence differs; track with [DSPACE #4729](https://github.com/democratizedspace/dspace/issues/4729) and [DSPACE #4731](https://github.com/democratizedspace/dspace/issues/4731). | Any repaired chart has a new chart version, the `3.0.1` artifact is not replaced, and chart-version selection is independent from application-version selection. |
-| P1 | Release evidence | Open | Record the expected full Git SHA, OCI revision label, branch-SHA tag, resolved multi-architecture image digest, and immutable release manifest at promotion time; track with [Sugarkube #2326](https://github.com/futuroptimist/sugarkube/issues/2326). | Promotion evidence makes later tag movement detectable without requiring retrospective package-API access. |
-| P0 | Production operations | Open | Reconcile production Helm state in a controlled maintenance operation so Git, Helm stored values, live Deployment, and resolved image digest all agree on the immutable image; track with [Sugarkube #2325](https://github.com/futuroptimist/sugarkube/issues/2325). | Helm-managed state and live state converge on the immutable image coordinate without editing Helm history directly. |
-| P0 | Sugarkube environment config | Open | Introduce environment-specific Sugarkube chart pins so staging can use DSPACE chart 3.1.0 while production remains on its approved chart version; track with [Sugarkube #2322](https://github.com/futuroptimist/sugarkube/issues/2322). | Staging and production chart pins are independently represented and reviewed. |
-| P0 | Sugarkube deployment tooling | Open | Render every app release before cluster mutation and remove `--reuse-values` from standard app upgrades so the exact release is reviewed before it can change production; track with [Sugarkube #2323](https://github.com/futuroptimist/sugarkube/issues/2323) and [Sugarkube #2324](https://github.com/futuroptimist/sugarkube/issues/2324). | Standard app upgrades render the exact release before mutation and do not use `--reuse-values`. |
-| P1 | Application identity | Open | Expose and verify a bounded build-identity signal containing the Git revision, not only the semantic application version; track with [DSPACE #4732](https://github.com/democratizedspace/dspace/issues/4732). | Health or a bounded identity endpoint reports the approved source revision in a safe form. |
-| P0 | Production verification | Open | Require production verification to compare the running image revision/digest against the approved release commit through an end-to-end release-coordinate consistency gate; track with [DSPACE #4730](https://github.com/democratizedspace/dspace/issues/4730). | Release checks fail if live image revision or digest does not match the approved commit. |
-| P1 | Production verification | Open | Add a deterministic remote fresh-profile synthetic or promotion smoke test for `/chat` that verifies the default provider matches the approved release, the default chat panel is usable for that release's intended provider, and the OpenAI opt-in path remains discoverable and correctly gated by a user-supplied key; track with [DSPACE #4733](https://github.com/democratizedspace/dspace/issues/4733) and [Sugarkube #2328](https://github.com/futuroptimist/sugarkube/issues/2328). | Promotion checks fail when the served frontend silently changes the default provider or when the approved default `/chat` journey is visibly non-functional. |
-| P1 | Recovery verification | Open | Capture rollout completion time, old/new pod identities, old/new resolved image IDs, and manifest-based rollback verification during rollback or emergency redeploy; track with [Sugarkube #2327](https://github.com/futuroptimist/sugarkube/issues/2327). | Rollback or redeploy evidence records completion time plus old/new pods and image IDs and verifies the rollback against the approved manifest. |
-| P1 | Frontend verification | Open | Add a deterministic frontend content/build marker check so release-content drift is caught even when `/healthz` and `/livez` remain healthy. | Monitoring or deploy verification compares an expected frontend build marker. |
-| P1 | Monitoring | Open | Add monitoring or alerting for unexpected production build-revision drift and `/chat` failures with mobile routing; track with [Sugarkube #2329](https://github.com/futuroptimist/sugarkube/issues/2329). | Alert fires when production build identity differs from the approved release coordinate or the default `/chat` journey fails. |
-| P1 | Incident evidence | Open | Ensure incident operators can retrieve package-version metadata or have another documented method to record semantic-tag and immutable-tag digests at deployment time. | Operators can capture semantic-tag and immutable-tag digests during incidents without relying on missing package API scopes. |
+## Post-incident closeout
 
-### Tracked GitHub issues
+All 16 independent corrective actions and all nine mirrored DSPACE tracking issues carrying
+`outage_2026_07_23_1` are closed; no labeled issue remains open. The final controls are:
 
-This table is the canonical issue tracker for postmortem follow-up. Each issue appears exactly
-once. `Type` records the action's primary control function. `Status` should be updated from
-`OPEN` to `CLOSED` only when the linked GitHub issue is actually closed.
+- **Prevention:** semantic images publish only from a matching release, existing image and chart
+  coordinates fail closed, chart and application versions are independent, production accepts only
+  immutable image coordinates, environment chart pins are separate, every exact release renders
+  before mutation, and standard upgrades do not use `--reuse-values`.
+- **Mitigation and recovery:** chart `3.0.2` was published once for application `3.0.1`; guarded
+  manifests now drive deployment and rollback using immutable chart/image digests and complete
+  values, with rollout and identity verification. The production record above is durable proof.
+- **Detection:** DSPACE exposes bounded runtime and frontend source identity and a deterministic,
+  release-aware `/chat` smoke result. Promotion compares manifest, OCI, Helm, pod, runtime,
+  frontend, provider, and journey coordinates. This also satisfies the formerly unlinked frontend
+  marker and incident artifact-retrieval actions: the former is part of the build-identity and
+  promotion controls, and the latter is provided by immutable manifests and deployment evidence.
 
-| Repository | Issue | Type | Status |
+### DSPACE 3.1.1 release-control proof
+
+The genuine [v3.1.1 release](https://github.com/democratizedspace/dspace/releases/tag/v3.1.1)
+validated source `22f506e07e0b5abfd0cf756e9c5827c0458fb4b2`, immutable image
+`main-22f506e`, and semantic alias `v3.1.1` at the same digest,
+`sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b`.
+It paired chart `3.1.2` at digest
+`sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161`.
+The [semantic recovery workflow](https://github.com/democratizedspace/dspace/actions/runs/31058866232)
+succeeded. The later [duplicate-publication exercise](https://github.com/democratizedspace/dspace/actions/runs/31059130820)
+was an expected negative test: it stopped at the preflight existence guard without publishing or
+changing the digest, rather than representing an unexpected CI failure.
+
+### Canonical corrective-action accounting
+
+Each row below is one independent action. `Completed` reflects verified implementation or
+operational evidence, not issue closure alone.
+
+| Repository issue | Type | Status | Verified completion and durable evidence |
 | --- | --- | --- | --- |
-| DSPACE | [#4727: Make semantic image tags release-only and immutable](https://github.com/democratizedspace/dspace/issues/4727) | Prevent | OPEN |
-| DSPACE | [#4728: Prevent republishing existing Helm chart versions](https://github.com/democratizedspace/dspace/issues/4728) | Prevent | OPEN |
-| DSPACE | [#4729: Decouple Helm chart version from application version](https://github.com/democratizedspace/dspace/issues/4729) | Prevent | OPEN |
-| DSPACE | [#4730: Add an end-to-end release-coordinate consistency gate](https://github.com/democratizedspace/dspace/issues/4730) | Prevent | OPEN |
-| DSPACE | [#4731: Publish a v3.0.1-compatible recovery chart under a new version](https://github.com/democratizedspace/dspace/issues/4731) | Mitigate | OPEN |
-| DSPACE | [#4732: Expose a bounded full-source build identity at runtime](https://github.com/democratizedspace/dspace/issues/4732) | Detect | OPEN |
-| DSPACE | [#4733: Add a deterministic remote smoke harness for the default `/chat` journey](https://github.com/democratizedspace/dspace/issues/4733) | Detect | OPEN |
-| Sugarkube | [#2321: Reject semantic image tags for production deployments](https://github.com/futuroptimist/sugarkube/issues/2321) | Prevent | OPEN |
-| Sugarkube | [#2322: Add environment-specific chart version pins](https://github.com/futuroptimist/sugarkube/issues/2322) | Prevent | OPEN |
-| Sugarkube | [#2323: Render every app release before cluster mutation](https://github.com/futuroptimist/sugarkube/issues/2323) | Prevent | OPEN |
-| Sugarkube | [#2324: Remove `--reuse-values` from standard app upgrades](https://github.com/futuroptimist/sugarkube/issues/2324) | Prevent | OPEN |
-| Sugarkube | [#2325: Reconcile DSPACE production Helm state with immutable coordinates](https://github.com/futuroptimist/sugarkube/issues/2325) | Mitigate | OPEN |
-| Sugarkube | [#2326: Add immutable release manifests and deployment evidence](https://github.com/futuroptimist/sugarkube/issues/2326) | Prevent | OPEN |
-| Sugarkube | [#2327: Replace Helm-revision rollback with manifest-based rollback verification](https://github.com/futuroptimist/sugarkube/issues/2327) | Mitigate | OPEN |
-| Sugarkube | [#2328: Require DSPACE build identity and `/chat` smoke checks during promotion](https://github.com/futuroptimist/sugarkube/issues/2328) | Prevent | OPEN |
-| Sugarkube | [#2329: Alert on DSPACE release drift and `/chat` failures with mobile routing](https://github.com/futuroptimist/sugarkube/issues/2329) | Detect | OPEN |
+| [DSPACE #4727](https://github.com/democratizedspace/dspace/issues/4727) | Prevent | Completed | Release-only semantic publication and non-overwrite guard landed through [PR #4802](https://github.com/democratizedspace/dspace/pull/4802) and passed both v3.1.1 workflow exercises above. |
+| [DSPACE #4728](https://github.com/democratizedspace/dspace/issues/4728) | Prevent | Completed | [PR #4747](https://github.com/democratizedspace/dspace/pull/4747) made chart publication fail closed; chart 3.0.2's first publish succeeded and its intentional retry was rejected. |
+| [DSPACE #4729](https://github.com/democratizedspace/dspace/issues/4729) | Prevent | Completed | [PR #4747](https://github.com/democratizedspace/dspace/pull/4747) separated chart version, appVersion, and release triggers; published 3.0.2/3.0.1 and 3.1.2/3.1.1 coordinates prove independent cadence. |
+| [DSPACE #4730](https://github.com/democratizedspace/dspace/issues/4730) | Prevent | Completed | [PR #4802](https://github.com/democratizedspace/dspace/pull/4802) completed the fail-closed coordinate gate; the v3.1.1 release manifest validated source, image, chart, semantic alias, and digests end to end. |
+| [DSPACE #4731](https://github.com/democratizedspace/dspace/issues/4731) | Mitigate | Completed | [PR #4751](https://github.com/democratizedspace/dspace/pull/4751) published compatible chart 3.0.2 once from `63063e2`; the production evidence verifies its OCI digest. |
+| [DSPACE #4732](https://github.com/democratizedspace/dspace/issues/4732) | Detect | Completed | [PR #4759](https://github.com/democratizedspace/dspace/pull/4759) added bounded full-source runtime and frontend identity; final staging and production evidence verifies both. |
+| [DSPACE #4733](https://github.com/democratizedspace/dspace/issues/4733) | Detect | Completed | [PR #4763](https://github.com/democratizedspace/dspace/pull/4763) added the deterministic release-aware remote `/chat` harness; later compatibility work supplied bounded machine-readable results. |
+| [Sugarkube #2321](https://github.com/futuroptimist/sugarkube/issues/2321) | Prevent | Completed | [PR #2373](https://github.com/futuroptimist/sugarkube/pull/2373) rejects semantic/movable production image tags before registry, Helm, or cluster access. |
+| [Sugarkube #2322](https://github.com/futuroptimist/sugarkube/issues/2322) | Prevent | Completed | [PR #2331](https://github.com/futuroptimist/sugarkube/pull/2331) added independently reviewable environment version files; generic inline override intentionally remains highest precedence. |
+| [Sugarkube #2323](https://github.com/futuroptimist/sugarkube/issues/2323) | Prevent | Completed | [PR #2381](https://github.com/futuroptimist/sugarkube/pull/2381) requires exact chart, namespace, values, and immutable image rendering before mutation. |
+| [Sugarkube #2324](https://github.com/futuroptimist/sugarkube/issues/2324) | Prevent | Completed | [PR #2390](https://github.com/futuroptimist/sugarkube/pull/2390) removed `--reuse-values` from standard paths and made Git-controlled values authoritative. |
+| [Sugarkube #2325](https://github.com/futuroptimist/sugarkube/issues/2325) | Mitigate | Completed | [PR #2478](https://github.com/futuroptimist/sugarkube/pull/2478) preserves the finalized production revision-9 reconciliation record linked above. |
+| [Sugarkube #2326](https://github.com/futuroptimist/sugarkube/issues/2326) | Prevent | Completed | [PR #2350](https://github.com/futuroptimist/sugarkube/pull/2350) added strict, non-overwritable manifests/evidence; the final production record also supplies the previously missing artifact-retrieval path. |
+| [Sugarkube #2327](https://github.com/futuroptimist/sugarkube/issues/2327) | Mitigate | Completed | [PR #2363](https://github.com/futuroptimist/sugarkube/pull/2363) added manifest-based guarded recovery without Helm rollback or reused values; live records proved its runtime/frontend dependencies, not a destructive rollback drill. |
+| [Sugarkube #2328](https://github.com/futuroptimist/sugarkube/issues/2328) | Prevent | Completed | [PR #2426](https://github.com/futuroptimist/sugarkube/pull/2426) gates promotion on immutable coordinates, runtime/frontend identity, provider, replica/public/direct agreement, and bounded `/chat` results. |
+| [Sugarkube #2329](https://github.com/futuroptimist/sugarkube/issues/2329) | Detect | Completed (staging scope) | [PR #2501](https://github.com/futuroptimist/sugarkube/pull/2501), [DSPACE PR #4806](https://github.com/democratizedspace/dspace/pull/4806), and [PR #2523](https://github.com/futuroptimist/sugarkube/pull/2523) preserve the staging implementation and acceptance evidence described below. |
+
+### Mirrored DSPACE issue reconciliation
+
+These nine issues were closed as `not planned` on 2026-07-24 because the work is canonical in
+Sugarkube. They are accounting mirrors, not nine additional corrective actions.
+
+| Mirrored DSPACE issue | Canonical Sugarkube action | Disposition |
+| --- | --- | --- |
+| [#4734](https://github.com/democratizedspace/dspace/issues/4734) | 2321 | Closed as duplicate tracking (`not planned`) |
+| [#4735](https://github.com/democratizedspace/dspace/issues/4735) | 2322 | Closed as duplicate tracking (`not planned`) |
+| [#4736](https://github.com/democratizedspace/dspace/issues/4736) | 2323 | Closed as duplicate tracking (`not planned`) |
+| [#4737](https://github.com/democratizedspace/dspace/issues/4737) | 2324 | Closed as duplicate tracking (`not planned`) |
+| [#4738](https://github.com/democratizedspace/dspace/issues/4738) | 2325 | Closed as duplicate tracking (`not planned`) |
+| [#4739](https://github.com/democratizedspace/dspace/issues/4739) | 2326 | Closed as duplicate tracking (`not planned`) |
+| [#4740](https://github.com/democratizedspace/dspace/issues/4740) | 2327 | Closed as duplicate tracking (`not planned`) |
+| [#4741](https://github.com/democratizedspace/dspace/issues/4741) | 2328 | Closed as duplicate tracking (`not planned`) |
+| [#4742](https://github.com/democratizedspace/dspace/issues/4742) | 2329 | Closed as duplicate tracking (`not planned`) |
+
+### Final observability scope
+
+The #2329 closeout is deliberately bounded to staging. At observability Helm revision 8, all five
+installed DSPACE release-integrity alerts—`DspaceBuildRevisionMismatch`,
+`DspaceMixedBuildRevisions`, `DspaceDeploymentImagePinMismatch`, `DspaceChatSyntheticFailed`, and
+`DspaceMetricsTargetDown`—were healthy and inactive at steady state, and the pinned `/chat`
+synthetic ran every five minutes. Owner-scoped drill
+`dspace-2329-20260808T051818Z-1053` exercised three representative alerts; Prometheus and
+Alertmanager observed them, PagerDuty delivered firing notifications that were acknowledged on the
+configured mobile receiver and delivered resolution, the exact temporary rule was deleted, and
+steady state was clean afterward.
+
+Production observability was not deployed or live-tested in that drill and remains a separate
+future rollout. Closing the action records staging acceptance and completion of this postmortem
+item; it is not production observability proof.
 
 ## Evidence gaps and unknowns
 


### PR DESCRIPTION
### Motivation

- Finalize and close the July 23, 2026 DSPACE production release-artifact drift postmortem now that every issue labeled `outage_2026_07_23_1` in both DSPACE and Sugarkube is closed. 
- Replace stale operational guidance (the Helm freeze and “revision 8” residual-risk wording) with the finalized production reconciliation evidence and explicit post-incident closeout statements.
- Ensure the compact JSON catalog and long-form markdown consistently record verified coordinates, evidence links, and the precise scope of staging vs production observability.

### Description

- Updated `outages/2026-07-23-dspace-production-version-drift.md` to remove the obsolete Helm freeze language, record the finalized Sugarkube production evidence (Helm revision 9) and the verified coordinates (application, source SHA, immutable image tag and digest, chart/version/digest, expected provider), and add a concise post-incident closeout summarizing prevention, mitigation, detection, and recovery controls with links to the implementing PRs and evidence. 
- Reconciled and converted the corrective-action table into a canonical accounting table that marks each of the 16 DSPACE and 9 Sugarkube actions as verified Completed (or explicitly bounded staging completion where applicable), and added a distinct mirrored-issue reconciliation table for the nine DSPACE mirror issues. 
- Updated `outages/2026-07-23-dspace-production-version-drift.json` to refresh `resolution`, `verification`, and `references` fields so they reference the finalized production evidence and release-control proof (including DSPACE v3.1.1 release and the duplicate-publication negative-test run), while preserving original incident facts and evidence gaps. 
- Preserved all original evidence gaps and unknowns and kept the postmortem strictly documentation-only (no code, chart, workflow, or infra changes). Files changed: `outages/2026-07-23-dspace-production-version-drift.md`, `outages/2026-07-23-dspace-production-version-drift.json`.

### Testing

- Ran repository checks and focused assertions: `git diff --check` (no whitespace/errors), `jq -e . outages/2026-07-23-dspace-production-version-drift.json` (valid JSON). — passed.
- Ran the targeted tests: `npm run test:root -- tests/outagesConventions.test.ts tests/docsPromptsOutages.test.ts` — 2 files ran and all tests passed (6 tests total). — passed.
- Ran repository verification commands: `npm run lint`, `npm run type-check`, `npm run build`, and `node scripts/link-check.mjs` — all completed successfully in this environment. — passed.
- Ran the secrets/scan assertion: `git diff "$(git merge-base HEAD origin/main)" | python3 scripts/scan-secrets.py` — no secrets found. — passed.
- Executed a focused Python assertion that verifies there are no `OPEN` statuses in the postmortem tables and that each of the 25 labeled issues (16 canonical + 9 mirrored) is present exactly once — assertion passed.
- Commit created on branch `codex/close-july-23-postmortem` with message `docs(outage): close July 23 postmortem action items` and working-tree changes staged and committed; attempted `git push` in this environment required GitHub authentication and was cancelled because no credentials are available here, so a remote PR was not created by this run (local branch is ahead by one commit). Reviewer instructions: push or open the PR from the branch `codex/close-july-23-postmortem` against `main` with title `docs(outage): close July 23 postmortem action items`, reference original postmortem PR #4723 and the verified issue/PR evidence (do not use automatic closing keywords).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e04ea214832f8978a1e6d2babbee)