### PR TITLE
Backport authenticated ServiceMonitor relabelings to chart 3.0.3

### DIFF
--- a/charts/dspace/Chart.yaml
+++ b/charts/dspace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dspace
 # Keep this chart version in sync with docs/apps/dspace.version for sugarkube automation.
-version: 3.0.2
+version: 3.0.3
 description: Helm chart for deploying the DSPACE application
 type: application
 appVersion: "3.0.1"

--- a/charts/dspace/templates/servicemonitor.yaml
+++ b/charts/dspace/templates/servicemonitor.yaml
@@ -32,4 +32,23 @@ spec:
       bearerTokenSecret: # scan-secrets: ignore (Kubernetes Secret reference field, not secret material)
         name: {{ $metricsAuth.existingSecret | quote }}
         key: {{ $metricsAuth.secretKey | default "token" | quote }}
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: {{ include "dspace.name" . | quote }}
+        - action: replace
+          targetLabel: environment
+          replacement: {{ .Values.environment | default "production" | quote }}
+        - action: replace
+          targetLabel: namespace
+          replacement: {{ .Release.Namespace | quote }}
+        - action: replace
+          targetLabel: release
+          replacement: {{ .Release.Name | quote }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ $serviceMonitor.cluster | default "sugarkube" | quote }}
+        {{- with $serviceMonitor.relabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/dspace/values.yaml
+++ b/charts/dspace/values.yaml
@@ -26,6 +26,7 @@ serviceMonitor:
   scrapeTimeout: 10s
   additionalLabels:
     release: kube-prometheus-stack
+  relabelings: []
   cluster: sugarkube
 
 ingress:

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,3 +1,3 @@
 # Helm chart version consumed by sugarkube helpers (helm-oci-install/upgrade).
 # Keep this in sync with charts/dspace/Chart.yaml:version.
-3.0.2
+3.0.3

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -37,6 +37,9 @@ settings.
   (liveness) and `/healthz` (readiness) respectively.
 - `probes.liveness` / `probes.readiness`: Probe timing defaults (`initialDelaySeconds`,
   `periodSeconds`, `timeoutSeconds`, `failureThreshold`).
+- `serviceMonitor.relabelings`: Optional list of extra Prometheus relabeling rules appended after
+  the chart's five built-in `app`/`environment`/`namespace`/`release`/`cluster` relabelings.
+  Defaults to `[]`. Requires `metrics.enabled=true` and `serviceMonitor.enabled=true`.
 
 For development, `charts/dspace/values.dev.yaml` enables ingress and sets a placeholder host:
 `dspace-v3.example.dev`. Override this host for your own environment.
@@ -101,3 +104,25 @@ Issue #4731 remains open after the implementation PR. Before it can be closed, i
 the single successful publication run and capture its full source SHA, OCI reference, packaged
 archive SHA-256 digest, and OCI manifest digest. Creating or pushing the release tag and changing
 GHCR or deployment state are separate, post-merge operator actions.
+
+## v3.0.1 chart 3.0.3 observability compatibility patch
+
+Chart `3.0.3` is a chart-only compatibility patch for the same canonical DSPACE application v3.0.1
+described above; it does not promote or change the application version or the default
+`main-1a31a56` image. It adds authenticated ServiceMonitor relabeling so Prometheus can attribute
+scraped `/metrics` samples to `app`, `environment`, `namespace`, `release`, and `cluster` labels.
+When `metrics.enabled=true` and `serviceMonitor.enabled=true`, the rendered `ServiceMonitor`
+always includes five built-in `action: replace` relabelings, in this order: `app` (chart name via
+`include "dspace.name" .`), `environment` (`.Values.environment`), `namespace`
+(`.Release.Namespace`), `release` (`.Release.Name`), and `cluster` (`serviceMonitor.cluster`,
+defaulting to `sugarkube`). Operators may append additional relabelings via the new
+`serviceMonitor.relabelings` values key, which defaults to `[]`; any entries provided there are
+rendered after the five built-in rules, in the order supplied.
+
+This section is additive. The "v3.0.1 chart-only recovery release" section above documents chart
+`3.0.2` and remains unchanged, immutable history; it is not superseded, rewritten, or deleted by
+this patch.
+
+As with chart `3.0.2`, merging this PR into `release/chart-3.0.x` does not publish anything.
+Publication requires a separate, reviewed maintainer action creating the `chart-v3.0.3` tag at the
+exact merged commit on this branch. This PR does not create or push that tag.

--- a/docs/k3s-sugarkube-prod.md
+++ b/docs/k3s-sugarkube-prod.md
@@ -169,8 +169,8 @@ If rehearsal succeeds and you proceed to production, switch back to `docs/exampl
 ## DSPACE v3.0.1 recovery chart retention
 
 While DSPACE v3.0.1 is an approved production rollback candidate, retain the
-`release/chart-3.0.x` branch. Its chart `3.0.2` manages application v3.0.1 through the immutable
-`main-1a31a56` image. Publish only after the recovery PR merges, by placing `chart-v3.0.2` on the
+`release/chart-3.0.x` branch. Its chart `3.0.3` manages application v3.0.1 through the immutable
+`main-1a31a56` image. Publish only after the recovery PR merges, by placing `chart-v3.0.3` on the
 exact approved recovery-branch commit. Chart `3.0.1` is permanently tombstoned.
 
 The publication run is not complete evidence until operators capture and independently verify the

--- a/tests/helmChartRecovery.test.ts
+++ b/tests/helmChartRecovery.test.ts
@@ -22,12 +22,12 @@ const deploymentEnv = (manifest: string) =>
     .template.spec.containers[0].env;
 
 describe('v3.0.1-compatible recovery chart', () => {
-  it('reports chart 3.0.2 and application 3.0.1 with an immutable default image', () => {
+  it('reports chart 3.0.3 and application 3.0.1 with an immutable default image', () => {
     const chart = YAML.parse(readFileSync('charts/dspace/Chart.yaml', 'utf8'));
     const values = YAML.parse(
       readFileSync('charts/dspace/values.yaml', 'utf8')
     );
-    expect(chart.version).toBe('3.0.2');
+    expect(chart.version).toBe('3.0.3');
     expect(String(chart.appVersion)).toBe('3.0.1');
     expect(values.image.tag).toBe('main-1a31a56');
     expect(values.image.tag).not.toBe('v3.0.1');
@@ -87,5 +87,128 @@ describe('v3.0.1-compatible recovery chart', () => {
         secretKeyRef: { name: 'dspace-metrics-token', key: 'token' },
       },
     });
+  });
+
+  it('renders no ServiceMonitor or bearer-token reference with pure chart defaults', () => {
+    const manifest = render();
+    expect(manifest).not.toContain('kind: ServiceMonitor');
+    expect(manifest).not.toContain('bearerTokenSecret');
+  });
+});
+
+describe('chart 3.0.3 ServiceMonitor relabelings', () => {
+  const authArgs = [
+    '--set',
+    'metrics.enabled=true',
+    '--set',
+    'metrics.auth.existingSecret=dspace-metrics-token', // scan-secrets: ignore (fixture Secret name)
+    '--set',
+    'serviceMonitor.enabled=true',
+  ];
+
+  it('renders exactly one ServiceMonitor with the expected name, labels, selector, and endpoint', () => {
+    const manifest = render([
+      ...authArgs,
+      '--set',
+      'environment=prod',
+      '--set',
+      'serviceMonitor.cluster=sugarkube-prod',
+    ]);
+    const serviceMonitors = documents(manifest).filter(
+      (document) => document.kind === 'ServiceMonitor'
+    );
+    expect(serviceMonitors).toHaveLength(1);
+    const [serviceMonitor] = serviceMonitors;
+    expect(serviceMonitor.metadata.name).toBe('dspace');
+    expect(serviceMonitor.metadata.namespace).toBeUndefined();
+    expect(serviceMonitor.spec.selector.matchLabels).toMatchObject({
+      'app.kubernetes.io/name': 'dspace',
+      'app.kubernetes.io/instance': 'dspace',
+    });
+    expect(serviceMonitor.spec.namespaceSelector.matchNames).toEqual([
+      'dspace',
+    ]);
+    const endpoint = serviceMonitor.spec.endpoints[0];
+    expect(endpoint.port).toBe('http');
+    expect(endpoint.path).toBe('/metrics');
+    expect(endpoint.interval).toBe('30s');
+    expect(endpoint.scrapeTimeout).toBe('10s');
+    expect(endpoint.bearerTokenSecret).toEqual({
+      name: 'dspace-metrics-token',
+      key: 'token',
+    });
+  });
+
+  it('orders the five built-in relabelings deterministically', () => {
+    const manifest = render([
+      ...authArgs,
+      '--set',
+      'environment=prod',
+      '--set',
+      'serviceMonitor.cluster=sugarkube-prod',
+    ]);
+    const serviceMonitor = documents(manifest).find(
+      (document) => document.kind === 'ServiceMonitor'
+    );
+    expect(serviceMonitor.spec.endpoints[0].relabelings).toEqual([
+      { action: 'replace', targetLabel: 'app', replacement: 'dspace' },
+      { action: 'replace', targetLabel: 'environment', replacement: 'prod' },
+      { action: 'replace', targetLabel: 'namespace', replacement: 'dspace' },
+      { action: 'replace', targetLabel: 'release', replacement: 'dspace' },
+      {
+        action: 'replace',
+        targetLabel: 'cluster',
+        replacement: 'sugarkube-prod',
+      },
+    ]);
+  });
+
+  it('appends an operator-supplied relabeling after the five built-in rules', () => {
+    const manifest = render([
+      ...authArgs,
+      '--set-json',
+      'serviceMonitor.relabelings=[{"action":"labeldrop","regex":"pod_template_hash"}]',
+    ]);
+    const serviceMonitor = documents(manifest).find(
+      (document) => document.kind === 'ServiceMonitor'
+    );
+    const { relabelings } = serviceMonitor.spec.endpoints[0];
+    expect(relabelings).toHaveLength(6);
+    expect(
+      relabelings.slice(0, 5).map((rule: { targetLabel: string }) => rule.targetLabel)
+    ).toEqual(['app', 'environment', 'namespace', 'release', 'cluster']);
+    expect(relabelings[5]).toEqual({
+      action: 'labeldrop',
+      regex: 'pod_template_hash',
+    });
+  });
+
+  it('never renders a raw bearer token, only a Secret reference', () => {
+    const manifest = render(authArgs);
+    expect(manifest).not.toMatch(/^\s*bearerToken:/m);
+    expect(manifest).toContain('bearerTokenSecret');
+  });
+
+  it('fails closed when serviceMonitor.enabled is set without metrics.enabled', () => {
+    expect(() => render(['--set', 'serviceMonitor.enabled=true'])).toThrow(
+      /serviceMonitor\.enabled requires metrics\.enabled=true/
+    );
+  });
+
+  it('fails closed when serviceMonitor.enabled is set without metrics.auth.existingSecret', () => {
+    expect(() =>
+      render([
+        '--set',
+        'metrics.enabled=true',
+        '--set',
+        'serviceMonitor.enabled=true',
+      ])
+    ).toThrow(/serviceMonitor\.enabled requires metrics\.auth\.existingSecret/);
+  });
+
+  it('fails closed when metrics.enabled is set without metrics.auth.existingSecret even without ServiceMonitor', () => {
+    expect(() => render(['--set', 'metrics.enabled=true'])).toThrow(
+      /metrics\.enabled=true requires metrics\.auth\.existingSecret/
+    );
   });
 });

--- a/tests/helmChartReleaseVersion.test.ts
+++ b/tests/helmChartReleaseVersion.test.ts
@@ -84,16 +84,16 @@ describe('independent DSPACE application and chart coordinates', () => {
       expect(result.stdout).toContain(`chart version ${chart}`);
     }));
 
-  it('permits chart 3.0.2 with application 3.0.1', () =>
+  it('permits chart 3.0.3 with application 3.0.1', () =>
     withFixture((root) => {
       expect(currentVersions(root)).toEqual({
         application: '3.0.1',
-        chart: '3.0.2',
+        chart: '3.0.3',
       });
       const result = runGuard(root);
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain('application version 3.0.1');
-      expect(result.stdout).toContain('chart version 3.0.2');
+      expect(result.stdout).toContain('chart version 3.0.3');
     }));
 
   it.each([


### PR DESCRIPTION
## Summary

- Chart-only patch on `release/chart-3.0.x`: bumps `charts/dspace` from 3.0.2 to 3.0.3, adding the deterministic `app`/`environment`/`namespace`/`release`/`cluster` ServiceMonitor relabelings (each `action: replace`) that Sugarkube's downstream classifier requires, plus an optional `serviceMonitor.relabelings` append point (`[]` default) for operator-supplied rules.
- **This changes only the chart, not DSPACE application 3.0.1 or its image.** `appVersion` stays `"3.0.1"`, `image.repository`/`image.tag` (`main-1a31a56`)/`pullPolicy` are untouched, and metrics/ServiceMonitor remain disabled by default. This is not an application promotion.
- Chart 3.0.2 is preserved as immutable history — its section in `docs/charts.md` is unmodified; a new "chart 3.0.3 observability compatibility patch" section is appended describing this change.
- `metadata.namespace` is intentionally still omitted from the rendered `ServiceMonitor` (Helm owns namespace placement for this namespaced release); a separate Sugarkube change will validate the omitted namespace using effective Helm release-namespace semantics.
- **No tag was created and no chart was published** by this PR. After merge, a maintainer must separately create a reviewed `chart-v3.0.3` tag at the exact merged commit to publish and verify the immutable chart artifact. A separate Sugarkube task must then onboard the new chart digest, update effective-namespace and five-relabel validation, produce new deployment evidence, and perform a guarded staging-before-production rollout.

## Test plan

- [x] `helm lint charts/dspace` passes.
- [x] `helm template dspace charts/dspace --namespace dspace --set metrics.enabled=true --set metrics.auth.existingSecret=dspace-prod-metrics-token --set serviceMonitor.enabled=true --set environment=prod --set serviceMonitor.cluster=sugarkube-prod` renders exactly one `ServiceMonitor` with correct selector, endpoint, Secret reference, and the five relabelings in order, no `metadata.namespace`.
- [x] Manually verified fail-closed behavior: `serviceMonitor.enabled` without `metrics.enabled` fails; `serviceMonitor.enabled` without `metrics.auth.existingSecret` fails; `metrics.enabled` alone without a secret fails (all via existing `fail` guards, unmodified).
- [x] Manually verified an operator-supplied `serviceMonitor.relabelings` entry (via `--set-json`) is appended after the five built-in rules, and default rendering has no `ServiceMonitor`/`bearerTokenSecret`.
- [x] New/updated focused tests in `tests/helmChartRecovery.test.ts` (12 tests: chart metadata 3.0.3/3.0.1, no-ServiceMonitor default, production-like render assertions, exact ordered relabelings, custom relabeling append, no raw bearer token, three fail-closed cases) and `tests/helmChartReleaseVersion.test.ts` (chart 3.0.3 coordinate assertion) — all pass.
- [x] `bash scripts/check-dspace-chart-version.sh` passes: `DSPACE release coordinates are aligned: application version 3.0.1 (main-1a31a56); chart version 3.0.3.` — note the originally-referenced `node scripts/check-release-consistency.mjs --verify-chart-local` does not exist anywhere in this repo; this is the actual, equivalent gate.
- [x] `git diff --check` clean; no literal credential values anywhere in the diff (only Secret names/reference keys).
- [x] `tests/helmChartRecovery.test.ts`, `tests/helmChartReleaseVersion.test.ts`, `tests/configConsistency.test.ts`, `tests/ciHelmWorkflow.test.ts`, `tests/chartResourcesDefaults.test.ts` — 103/103 pass.
- [x] `npm run lint`, `npm run type-check`, `npm run build`, `npm run check` all pass.
- [ ] `SKIP_E2E=1 npm test` (full suite): 1129/1180 pass. The 51 failures are all pre-existing, unrelated frontend localStorage/IndexedDB/gameState/quest-chat tests (e.g. `frontend/__tests__/gameState/common.test.js`, `DataReset.spec.ts`, `QuestChat.spec.ts`) — this PR touches zero files under `frontend/`, so these failures are environment/baseline (likely a Node version mismatch: `.nvmrc` pins Node 20, this environment ran Node 26) and unrelated to the chart change. Flagging per instructions rather than weakening any test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)