### PR TITLE
e2e: opt-in retry for Playwright net::ERR_ABORTED in remote /chat smoke

### DIFF
--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 
 import { expect, test, type Page } from '@playwright/test';
 
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
 import {
     chatUiContractFor,
     type IdentityContract,
@@ -271,11 +271,10 @@ async function installSuccessfulRelay(
 }
 
 async function openExpectedPanel(page: Page, provider = expectedProvider) {
-    const navigation = await page.goto('/chat');
-    expect(
-        new URL(navigation?.url() || page.url()).origin,
-        'routing/configuration: /chat origin drift'
-    ).toBe(requestedOrigin);
+    await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });
+    expect(new URL(page.url()).origin, 'routing/configuration: /chat origin drift').toBe(
+        requestedOrigin
+    );
     await waitForHydration(page);
     if (fault === 'hydration') throw new Error('hydration: injected bounded CI fault');
     const panels = page.locator('[data-testid="chat-panel"]');

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -25,6 +25,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 ];
 
 const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\.(?:\r?\n|$)/;
+const PLAYWRIGHT_GOTO_ABORTED_PATTERN =
+    /^page\.goto: net::ERR_ABORTED at https?:\/\/[^\s]+(?:\r?\n|$)/;
 
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
@@ -98,10 +100,14 @@ type NavigateWithRetryOptions = {
     maxLogAttempts?: number;
     maxDurationMs?: number;
     attemptTimeoutMs?: number;
+    retryAbortedNavigation?: boolean;
     now?: () => number;
 };
 
-function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeout' | null {
+function getNavigationRetryReason(
+    error: unknown,
+    retryAbortedNavigation: boolean
+): 'connection refusal' | 'timeout' | 'aborted navigation' | null {
     const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
 
     if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
@@ -114,6 +120,10 @@ function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeo
 
     if (PLAYWRIGHT_GOTO_TIMEOUT_PATTERN.test(message)) {
         return 'timeout';
+    }
+
+    if (retryAbortedNavigation && PLAYWRIGHT_GOTO_ABORTED_PATTERN.test(message)) {
+        return 'aborted navigation';
     }
 
     return null;
@@ -137,6 +147,7 @@ export async function navigateWithRetry(
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
         attemptTimeoutMs = DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS,
+        retryAbortedNavigation = false,
         now = () => Date.now(),
     }: NavigateWithRetryOptions = {}
 ): Promise<void> {
@@ -175,7 +186,7 @@ export async function navigateWithRetry(
         } catch (error) {
             lastError = error;
 
-            const retryReason = getNavigationRetryReason(error);
+            const retryReason = getNavigationRetryReason(error, retryAbortedNavigation);
             const elapsedMs = now() - startedAt;
             const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
                 ? maxDurationMs - elapsedMs

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
@@ -152,6 +154,105 @@ describe('navigateWithRetry', () => {
     expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
   });
 
+  it('retries an opted-in Playwright navigation abort before succeeding', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to /chat after aborted navigation (attempt 1 of 2)'
+    );
+  });
+
+  it('retries multiple opted-in navigation aborts within the configured bounds', async () => {
+    const aborted = () =>
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to "/chat"'
+      );
+    const page = createMockPage([aborted(), aborted(), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 3,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the original abort diagnostic when opted-in retries are exhausted', async () => {
+    const diagnostic =
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to "/chat"';
+    const page = createMockPage([new Error(diagnostic), new Error(diagnostic)]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow(
+      `${diagnostic} while navigating to /chat after 2 attempts`
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a navigation abort without explicit opt-in', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(navigateWithRetry(page, '/chat')).rejects.toThrow(
+      'after 1 attempt'
+    );
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'page.goto: net::ERR_ABORTED',
+    'page.goto: net::ERR_ABORTED while loading https://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED at file:///chat',
+    'locator.click: net::ERR_ABORTED at https://democratized.space/chat',
+  ])(
+    'does not retry unrelated or near-match abort text: %s',
+    async (message) => {
+      const page = createMockPage([new Error(message), 'success']);
+
+      await expect(
+        navigateWithRetry(page, '/chat', {
+          attempts: 2,
+          retryAbortedNavigation: true,
+        })
+      ).rejects.toThrow('after 1 attempt');
+
+      expect(page.goto).toHaveBeenCalledTimes(1);
+      expect(page.waitForTimeout).not.toHaveBeenCalled();
+    }
+  );
+
   it('succeeds on the first attempt without sleeping or logging', async () => {
     const page = createMockPage(['success']);
 
@@ -294,5 +395,28 @@ describe('navigateWithRetry', () => {
       2,
       'Suppressing further retry logs for /; attempts 2-4 will retry silently'
     );
+  });
+});
+
+describe('remote chat smoke navigation', () => {
+  it('uses opted-in bounded navigation before verifying the final origin and hydration', () => {
+    const source = readFileSync(
+      'frontend/e2e/remote-chat-smoke.spec.ts',
+      'utf8'
+    );
+    const openExpectedPanel = source.slice(
+      source.indexOf('async function openExpectedPanel'),
+      source.indexOf('async function selectOpenAI')
+    );
+
+    expect(openExpectedPanel).toContain(
+      "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });"
+    );
+    expect(
+      openExpectedPanel.indexOf('new URL(page.url()).origin')
+    ).toBeGreaterThan(openExpectedPanel.indexOf('await navigateWithRetry'));
+    expect(
+      openExpectedPanel.indexOf('await waitForHydration(page)')
+    ).toBeGreaterThan(openExpectedPanel.indexOf('new URL(page.url()).origin'));
   });
 });


### PR DESCRIPTION
### Motivation
- Harden the remote `/chat` smoke against an intermittent Playwright `page.goto: net::ERR_ABORTED` navigation abort observed in production without changing app behavior or release coordinates. 
- Keep retries narrow, opt-in, bounded by attempts and total duration, and restricted to the exact Playwright abort diagnostic shape.

### Description
- Added an explicit `retryAbortedNavigation` option to `navigateWithRetry` in `frontend/e2e/test-helpers.ts` and a `PLAYWRIGHT_GOTO_ABORTED_PATTERN` to recognize the stable `page.goto: net::ERR_ABORTED at https://...` message, with the option defaulting to `false` so existing callers are unchanged. 
- Updated the remote chat smoke helper `openExpectedPanel()` in `frontend/e2e/remote-chat-smoke.spec.ts` to use `navigateWithRetry(page, '/chat', { retryAbortedNavigation: true })` and to assert the final `page.url()` origin before hydration and provider checks. 
- Added focused unit tests in `tests/navigateWithRetry.test.ts` that exercise opted-in abort retries, multi-abort recovery, diagnostic preservation on exhaustion, non-opt-in behavior, and near-match rejection to ensure only the exact abort shape is retried.

### Testing
- `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` — all tests passed (28 tests). 
- `pnpm exec prettier --check frontend/e2e/remote-chat-smoke.spec.ts frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts` — passed. 
- `npm run lint` and `npm run type-check` and `npm run check` — repository checks passed via project scripts. 
- Direct `eslint` invocation without the repo flat config reported parser/config errors (expected in this environment), but the repository `npm run lint` (which sets the environment-compatible flags) succeeded. 
- The real intercepted remote smoke (`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=... npm run qa:remote-chat-smoke`) was not executed here because no system Chromium/runtime was available in this environment; this step should be run in CI or an environment with the system browser to verify the live intercepted smoke.

Commit/branch notes: changes were committed on branch `codex/retry-remote-chat-abort` (commit `0d182ba`, message: "test: retry opted-in aborted chat navigation"); a PR was not created because the environment lacked an authenticated `gh` session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6cd82128832f89bbfdafb47ae48d)