### PR TITLE
e2e: opt-in retry for Playwright net::ERR_ABORTED on /chat and tests

### DIFF
--- a/.github/actions/run-lychee/action.yml
+++ b/.github/actions/run-lychee/action.yml
@@ -31,7 +31,7 @@ runs:
         tmp_dir="$(mktemp -d)"
         url="https://github.com/lycheeverse/lychee/releases/download/v${LYCHEE_VERSION}/lychee-v${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
         echo "Downloading Lychee ${LYCHEE_VERSION} from ${url}" >&2
-        curl --fail --location --silent --show-error --retry 5 --retry-delay 5 "${url}" --output "${tmp_dir}/lychee.tar.gz"
+        curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 5 "${url}" --output "${tmp_dir}/lychee.tar.gz"
         tar -xzf "${tmp_dir}/lychee.tar.gz" -C "${tmp_dir}"
         install -m 0755 -D "${tmp_dir}/lychee" "$HOME/.local/bin/lychee"
         rm -rf "${tmp_dir}"

--- a/.github/actions/run-lychee/action.yml
+++ b/.github/actions/run-lychee/action.yml
@@ -31,7 +31,7 @@ runs:
         tmp_dir="$(mktemp -d)"
         url="https://github.com/lycheeverse/lychee/releases/download/v${LYCHEE_VERSION}/lychee-v${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
         echo "Downloading Lychee ${LYCHEE_VERSION} from ${url}" >&2
-        curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 5 "${url}" --output "${tmp_dir}/lychee.tar.gz"
+        curl --fail --location --silent --show-error --retry 5 --retry-delay 5 "${url}" --output "${tmp_dir}/lychee.tar.gz"
         tar -xzf "${tmp_dir}/lychee.tar.gz" -C "${tmp_dir}"
         install -m 0755 -D "${tmp_dir}/lychee" "$HOME/.local/bin/lychee"
         rm -rf "${tmp_dir}"

--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 
 import { expect, test, type Page } from '@playwright/test';
 
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
 import {
     chatUiContractFor,
     type IdentityContract,
@@ -271,11 +271,10 @@ async function installSuccessfulRelay(
 }
 
 async function openExpectedPanel(page: Page, provider = expectedProvider) {
-    const navigation = await page.goto('/chat');
-    expect(
-        new URL(navigation?.url() || page.url()).origin,
-        'routing/configuration: /chat origin drift'
-    ).toBe(requestedOrigin);
+    await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });
+    expect(new URL(page.url()).origin, 'routing/configuration: /chat origin drift').toBe(
+        requestedOrigin
+    );
     await waitForHydration(page);
     if (fault === 'hydration') throw new Error('hydration: injected bounded CI fault');
     const panels = page.locator('[data-testid="chat-panel"]');

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -25,6 +25,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 ];
 
 const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\.(?:\r?\n|$)/;
+const PLAYWRIGHT_GOTO_ABORTED_PATTERN =
+    /^page\.goto: net::ERR_ABORTED at https?:\/\/[^\s]+(?:\r?\n|$)/;
 
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
@@ -98,10 +100,14 @@ type NavigateWithRetryOptions = {
     maxLogAttempts?: number;
     maxDurationMs?: number;
     attemptTimeoutMs?: number;
+    retryAbortedNavigation?: boolean;
     now?: () => number;
 };
 
-function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeout' | null {
+function getNavigationRetryReason(
+    error: unknown,
+    retryAbortedNavigation: boolean
+): 'connection refusal' | 'timeout' | 'aborted navigation' | null {
     const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
 
     if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
@@ -114,6 +120,10 @@ function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeo
 
     if (PLAYWRIGHT_GOTO_TIMEOUT_PATTERN.test(message)) {
         return 'timeout';
+    }
+
+    if (retryAbortedNavigation && PLAYWRIGHT_GOTO_ABORTED_PATTERN.test(message)) {
+        return 'aborted navigation';
     }
 
     return null;
@@ -137,6 +147,7 @@ export async function navigateWithRetry(
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
         attemptTimeoutMs = DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS,
+        retryAbortedNavigation = false,
         now = () => Date.now(),
     }: NavigateWithRetryOptions = {}
 ): Promise<void> {
@@ -175,7 +186,7 @@ export async function navigateWithRetry(
         } catch (error) {
             lastError = error;
 
-            const retryReason = getNavigationRetryReason(error);
+            const retryReason = getNavigationRetryReason(error, retryAbortedNavigation);
             const elapsedMs = now() - startedAt;
             const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
                 ? maxDurationMs - elapsedMs

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
@@ -152,6 +154,151 @@ describe('navigateWithRetry', () => {
     expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
   });
 
+  it('retries an opted-in stable Playwright navigation abort before succeeding', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to /chat after aborted navigation (attempt 1 of 2)'
+    );
+  });
+
+  it('retries multiple opted-in navigation aborts within the configured bounds', async () => {
+    const abort = () =>
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to "https://democratized.space/chat"'
+      );
+    const page = createMockPage([abort(), abort(), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 3,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the original abort diagnostic when opted-in attempts are exhausted', async () => {
+    const diagnostic =
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to "https://democratized.space/chat"';
+    const page = createMockPage([
+      new Error(diagnostic),
+      new Error(diagnostic),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow(
+      `${diagnostic} while navigating to /chat after 2 attempts`
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops opted-in abort retries when the total-duration budget is exhausted', async () => {
+    let nowMs = 0;
+    const diagnostic =
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat';
+    const page = createMockPage([new Error(diagnostic), 'success']);
+    page.goto.mockImplementationOnce(async () => {
+      nowMs = 950;
+      throw new Error(diagnostic);
+    });
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 3,
+        delayMs: 100,
+        maxDurationMs: 1_000,
+        retryAbortedNavigation: true,
+        now: () => nowMs,
+      })
+    ).rejects.toThrow(
+      `${diagnostic} while navigating to /chat after 950ms (limit 1000ms)`
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a navigation abort without explicit opt-in', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(navigateWithRetry(page, '/chat')).rejects.toThrow(
+      'after 1 attempt'
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'page.goto: net::ERR_ABORTED for https://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED at democratized.space/chat',
+    'locator.click: net::ERR_ABORTED at https://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED_BY_CLIENT at https://democratized.space/chat',
+  ])('does not retry near-match abort text: %s', async (message) => {
+    const page = createMockPage([new Error(message), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow('after 1 attempt');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'routing/configuration: /chat origin drift',
+    'hydration: chat panel did not hydrate',
+    'assertion: expected chat panel',
+  ])('fails closed for non-navigation smoke failure: %s', async (message) => {
+    const page = createMockPage([new Error(message), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow(message);
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
   it('succeeds on the first attempt without sleeping or logging', async () => {
     const page = createMockPage(['success']);
 
@@ -294,5 +441,32 @@ describe('navigateWithRetry', () => {
       2,
       'Suppressing further retry logs for /; attempts 2-4 will retry silently'
     );
+  });
+});
+
+describe('remote chat smoke navigation contract', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'frontend/e2e/remote-chat-smoke.spec.ts'),
+    'utf8'
+  );
+  const openExpectedPanel = source.match(
+    /async function openExpectedPanel[\s\S]*?\n}\n\nasync function selectOpenAI/
+  )?.[0];
+
+  it('uses bounded opted-in navigation and verifies final origin before hydration', () => {
+    expect(openExpectedPanel).toBeDefined();
+    expect(openExpectedPanel).toContain(
+      "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });"
+    );
+    expect(openExpectedPanel).not.toContain("page.goto('/chat')");
+
+    const originCheck = openExpectedPanel!.indexOf(
+      'new URL(page.url()).origin'
+    );
+    const hydrationCheck = openExpectedPanel!.indexOf(
+      'await waitForHydration(page)'
+    );
+    expect(originCheck).toBeGreaterThan(-1);
+    expect(hydrationCheck).toBeGreaterThan(originCheck);
   });
 });

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,6 +1,6 @@
+// @vitest-environment node
+
 import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
@@ -448,26 +448,32 @@ describe('navigateWithRetry', () => {
 describe('remote chat smoke navigation contract', () => {
   it('uses bounded opted-in navigation and verifies final origin before hydration', () => {
     const source = readFileSync(
-      resolve(
-        dirname(fileURLToPath(import.meta.url)),
-        '../frontend/e2e/remote-chat-smoke.spec.ts'
-      ),
+      new URL('../frontend/e2e/remote-chat-smoke.spec.ts', import.meta.url),
       'utf8'
     );
-    const openExpectedPanel = source.match(
-      /async function openExpectedPanel[\s\S]*?\n}\n\nasync function selectOpenAI/
-    )?.[0];
+    const openExpectedPanelStart = source.indexOf(
+      'async function openExpectedPanel'
+    );
+    const selectOpenAIBoundary = source.indexOf(
+      'async function selectOpenAI',
+      openExpectedPanelStart
+    );
 
-    expect(openExpectedPanel).toBeDefined();
+    expect(openExpectedPanelStart).toBeGreaterThanOrEqual(0);
+    expect(selectOpenAIBoundary).toBeGreaterThan(openExpectedPanelStart);
+
+    const openExpectedPanel = source.slice(
+      openExpectedPanelStart,
+      selectOpenAIBoundary
+    );
+
     expect(openExpectedPanel).toContain(
       "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });"
     );
     expect(openExpectedPanel).not.toContain("page.goto('/chat')");
 
-    const originCheck = openExpectedPanel!.indexOf(
-      'new URL(page.url()).origin'
-    );
-    const hydrationCheck = openExpectedPanel!.indexOf(
+    const originCheck = openExpectedPanel.indexOf('new URL(page.url()).origin');
+    const hydrationCheck = openExpectedPanel.indexOf(
       'await waitForHydration(page)'
     );
     expect(originCheck).toBeGreaterThan(-1);

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
@@ -445,15 +446,18 @@ describe('navigateWithRetry', () => {
 });
 
 describe('remote chat smoke navigation contract', () => {
-  const source = readFileSync(
-    resolve(process.cwd(), 'frontend/e2e/remote-chat-smoke.spec.ts'),
-    'utf8'
-  );
-  const openExpectedPanel = source.match(
-    /async function openExpectedPanel[\s\S]*?\n}\n\nasync function selectOpenAI/
-  )?.[0];
-
   it('uses bounded opted-in navigation and verifies final origin before hydration', () => {
+    const source = readFileSync(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        '../frontend/e2e/remote-chat-smoke.spec.ts'
+      ),
+      'utf8'
+    );
+    const openExpectedPanel = source.match(
+      /async function openExpectedPanel[\s\S]*?\n}\n\nasync function selectOpenAI/
+    )?.[0];
+
     expect(openExpectedPanel).toBeDefined();
     expect(openExpectedPanel).toContain(
       "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });"


### PR DESCRIPTION
### Motivation

- Harden the remote `/chat` smoke against a narrowly-observed intermittent Playwright `page.goto: net::ERR_ABORTED` navigation abort without changing app behavior or global Playwright settings. 
- Keep retries tightly bounded, opt-in, and limited to the exact observed abort diagnostic so other errors remain fail-closed.

### Description

- Add an explicit `retryAbortedNavigation` boolean option to `navigateWithRetry` and add a precise `PLAYWRIGHT_GOTO_ABORTED_PATTERN` recognizing `page.goto: net::ERR_ABORTED at https://...` so only that exact error shape can be retried. 
- Make `navigateWithRetry` respect the opt-in flag, preserve existing retry logic for connection refusal and timeouts, and continue to bound retries by attempts, per-attempt timeout, backoff, and total duration. 
- Replace the unguarded `page.goto('/chat')` in the remote-chat smoke helper `openExpectedPanel()` with `await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true })`, then verify the final page origin via `new URL(page.url()).origin` before hydration and provider assertions. 
- Add focused unit tests in `tests/navigateWithRetry.test.ts` covering opted-in abort retry success, multiple aborts then success, exhaustion behavior preserving diagnostics, opt-out behavior, near-match rejection, duration-budget stopping, and a small contract test that the smoke helper uses the bounded opt-in navigation and checks origin before hydration.

### Testing

- Ran `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` and the suite passed: 2 test files, 32 tests, all green. 
- Ran formatting checks with `pnpm exec prettier --check frontend/e2e/remote-chat-smoke.spec.ts frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts` and formatting passed; files were also written with `prettier --write` where applicable. 
- ESLint: direct per-file `eslint` invocation reported config/TS inclusion limitations in this environment, but the repository-supported lint command `npm run lint` completed successfully. 
- Additional repository checks `npm run check`, `npm run type-check`, `npm run build`, and `git diff --check` were executed and succeeded in this environment. 
- System Chromium was not available here, so the full intercepted public-network remote smoke run against a real system browser was not executed; the change preserves `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` support and the provider-intercept/no-real-credential contract so the smoke should exercise the new retry when run in the CI or an environment with system Chromium.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6ce1af88832fba5184c9de57f60f)