### PR TITLE
Harden remote chat smoke navigation abort handling

### DIFF
--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 
 import { expect, test, type Page } from '@playwright/test';
 
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
 import {
     chatUiContractFor,
     type IdentityContract,
@@ -271,11 +271,10 @@ async function installSuccessfulRelay(
 }
 
 async function openExpectedPanel(page: Page, provider = expectedProvider) {
-    const navigation = await page.goto('/chat');
-    expect(
-        new URL(navigation?.url() || page.url()).origin,
-        'routing/configuration: /chat origin drift'
-    ).toBe(requestedOrigin);
+    await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });
+    expect(new URL(page.url()).origin, 'routing/configuration: /chat origin drift').toBe(
+        requestedOrigin
+    );
     await waitForHydration(page);
     if (fault === 'hydration') throw new Error('hydration: injected bounded CI fault');
     const panels = page.locator('[data-testid="chat-panel"]');

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -25,6 +25,8 @@ const CONNECTION_REFUSED_PATTERNS = [
 ];
 
 const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\.(?:\r?\n|$)/;
+const PLAYWRIGHT_GOTO_ABORTED_PATTERN =
+    /^page\.goto: net::ERR_ABORTED at https?:\/\/[^\s]+(?:\r?\n|$)/;
 
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
@@ -99,9 +101,13 @@ type NavigateWithRetryOptions = {
     maxDurationMs?: number;
     attemptTimeoutMs?: number;
     now?: () => number;
+    retryAbortedNavigation?: boolean;
 };
 
-function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeout' | null {
+function getNavigationRetryReason(
+    error: unknown,
+    retryAbortedNavigation: boolean
+): 'aborted navigation' | 'connection refusal' | 'timeout' | null {
     const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
 
     if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
@@ -114,6 +120,10 @@ function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeo
 
     if (PLAYWRIGHT_GOTO_TIMEOUT_PATTERN.test(message)) {
         return 'timeout';
+    }
+
+    if (retryAbortedNavigation && PLAYWRIGHT_GOTO_ABORTED_PATTERN.test(message)) {
+        return 'aborted navigation';
     }
 
     return null;
@@ -138,6 +148,7 @@ export async function navigateWithRetry(
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
         attemptTimeoutMs = DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS,
         now = () => Date.now(),
+        retryAbortedNavigation = false,
     }: NavigateWithRetryOptions = {}
 ): Promise<void> {
     if (!Number.isFinite(attemptTimeoutMs) || attemptTimeoutMs <= 0) {
@@ -175,7 +186,7 @@ export async function navigateWithRetry(
         } catch (error) {
             lastError = error;
 
-            const retryReason = getNavigationRetryReason(error);
+            const retryReason = getNavigationRetryReason(error, retryAbortedNavigation);
             const elapsedMs = now() - startedAt;
             const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
                 ? maxDurationMs - elapsedMs

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Page } from '../frontend/e2e/test-helpers';
@@ -31,6 +33,12 @@ function createTimeoutError(
   const error = new Error(message);
   error.name = 'TimeoutError';
   return error;
+}
+
+function createAbortedNavigationError(): Error {
+  return new Error(
+    'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to "https://democratized.space/chat"'
+  );
 }
 
 describe('navigateWithRetry', () => {
@@ -150,6 +158,98 @@ describe('navigateWithRetry', () => {
 
     expect(page.goto).toHaveBeenCalledTimes(2);
     expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an opted-in Playwright navigation abort before succeeding', async () => {
+    const page = createMockPage([createAbortedNavigationError(), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to /chat after aborted navigation (attempt 1 of 2)'
+    );
+  });
+
+  it('retries multiple opted-in navigation aborts within both bounds', async () => {
+    const page = createMockPage([
+      createAbortedNavigationError(),
+      createAbortedNavigationError(),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 3,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails abort exhaustion with the original Playwright diagnostic context', async () => {
+    const originalError = createAbortedNavigationError();
+    const page = createMockPage([
+      originalError,
+      createAbortedNavigationError(),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow(
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:'
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a navigation abort without explicit opt-in', async () => {
+    const page = createMockPage([createAbortedNavigationError(), 'success']);
+
+    await expect(navigateWithRetry(page, '/chat')).rejects.toThrow(
+      'after 1 attempt'
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'page.goto: net::ERR_ABORTED while loading https://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED at ftp://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED at https://democratized.space/chat unrelated trailing text',
+    'routing/configuration: /chat origin drift',
+    'hydration: chat panel did not hydrate',
+    'assertion: expected exactly one chat panel',
+  ])('does not retry near-match or fail-closed error: %s', async (message) => {
+    const page = createMockPage([new Error(message), 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow('after 1 attempt');
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
   });
 
   it('succeeds on the first attempt without sleeping or logging', async () => {
@@ -294,5 +394,23 @@ describe('navigateWithRetry', () => {
       2,
       'Suppressing further retry logs for /; attempts 2-4 will retry silently'
     );
+  });
+});
+
+describe('remote chat smoke navigation', () => {
+  it('opts openExpectedPanel into bounded navigation and verifies the final origin', () => {
+    const source = readFileSync(
+      'frontend/e2e/remote-chat-smoke.spec.ts',
+      'utf8'
+    );
+    const openExpectedPanel = source.match(
+      /async function openExpectedPanel[\s\S]*?\n}\n\nasync function selectOpenAI/
+    )?.[0];
+
+    expect(openExpectedPanel).toContain(
+      "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true })"
+    );
+    expect(openExpectedPanel).toContain('new URL(page.url()).origin');
+    expect(openExpectedPanel).toContain('await waitForHydration(page)');
   });
 });


### PR DESCRIPTION
### Motivation

- The remote `/chat` Playwright smoke intermittently fails with a stable `page.goto: net::ERR_ABORTED` navigation abort before provider submission begins, causing flaky QA runs; the goal is to harden the smoke test only, without changing application behavior.

### Description

- Add a precise Playwright abort pattern and an explicit opt-in `retryAbortedNavigation` flag to the existing bounded `navigateWithRetry` helper so callers can retry only the exact `page.goto: net::ERR_ABORTED at <https://...>` diagnostic shape. (`frontend/e2e/test-helpers.ts`) 
- Keep the original bounded behavior (attempt count, overall duration budget, per-attempt timeout, incremental backoff, and `waitUntil: 'domcontentloaded'`) and only add the narrow abort recognition when opted in. (`frontend/e2e/test-helpers.ts`) 
- Route the remote smoke’s unguarded `/chat` navigation through the helper with `retryAbortedNavigation: true` and preserve the strict final-origin check and all hydration/provider/identity/submission assertions in `openExpectedPanel()`. (`frontend/e2e/remote-chat-smoke.spec.ts`) 
- Add focused unit tests exercising the new opt-in behavior and failure modes (single abort then success, multiple aborts then success, exhaustion preserving original diagnostic, opt-out behavior, near-match rejection, and smoke wiring verification). (`tests/navigateWithRetry.test.ts`) 

### Testing

- `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` — all tests passed (30 tests total). 
- `pnpm exec prettier --check frontend/e2e/remote-chat-smoke.spec.ts frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts` — passed and files were formatted. 
- `npm run lint` — repository lint command ran (repository ESLint config used) and did not fail in this environment. 
- `npm run type-check` — TypeScript checks completed successfully. 

Notes and residuals: the change is intentionally scoped to QA tooling only and preserves all identity/provider/hydration assertions and `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` support; I could not run the external system Chromium smoke against production here because `/usr/bin/chromium` is not available in this environment, so the on-device reproduction on `aarch64` Chromium remains a recommended follow-up verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6ce3f30c832fa6ea881c2e860fa5)