### PR TITLE
Harden remote chat smoke navigation retries for Playwright net::ERR_ABORTED

### DIFF
--- a/frontend/e2e/remote-chat-smoke.spec.ts
+++ b/frontend/e2e/remote-chat-smoke.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 
 import { expect, test, type Page } from '@playwright/test';
 
-import { clearUserData, waitForHydration } from './test-helpers';
+import { clearUserData, navigateWithRetry, waitForHydration } from './test-helpers';
 import {
     chatUiContractFor,
     type IdentityContract,
@@ -271,11 +271,10 @@ async function installSuccessfulRelay(
 }
 
 async function openExpectedPanel(page: Page, provider = expectedProvider) {
-    const navigation = await page.goto('/chat');
-    expect(
-        new URL(navigation?.url() || page.url()).origin,
-        'routing/configuration: /chat origin drift'
-    ).toBe(requestedOrigin);
+    await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });
+    expect(new URL(page.url()).origin, 'routing/configuration: /chat origin drift').toBe(
+        requestedOrigin
+    );
     await waitForHydration(page);
     if (fault === 'hydration') throw new Error('hydration: injected bounded CI fault');
     const panels = page.locator('[data-testid="chat-panel"]');

--- a/frontend/e2e/test-helpers.ts
+++ b/frontend/e2e/test-helpers.ts
@@ -25,6 +25,7 @@ const CONNECTION_REFUSED_PATTERNS = [
 ];
 
 const PLAYWRIGHT_GOTO_TIMEOUT_PATTERN = /^page\.goto: Timeout \d+ms exceeded\.(?:\r?\n|$)/;
+const PLAYWRIGHT_GOTO_ABORTED_PATTERN = /^page\.goto: net::ERR_ABORTED at \S+(?:\r?\n|$)/;
 
 const DEFAULT_RETRY_ATTEMPTS = 6;
 const DEFAULT_RETRY_DELAY_MS = 300;
@@ -98,10 +99,14 @@ type NavigateWithRetryOptions = {
     maxLogAttempts?: number;
     maxDurationMs?: number;
     attemptTimeoutMs?: number;
+    retryAbortedNavigation?: boolean;
     now?: () => number;
 };
 
-function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeout' | null {
+function getNavigationRetryReason(
+    error: unknown,
+    retryAbortedNavigation: boolean
+): 'connection refusal' | 'timeout' | 'aborted navigation' | null {
     const message = error instanceof Error ? (error.message ?? String(error)) : String(error ?? '');
 
     if (CONNECTION_REFUSED_PATTERNS.some((pattern) => message.includes(pattern))) {
@@ -114,6 +119,10 @@ function getNavigationRetryReason(error: unknown): 'connection refusal' | 'timeo
 
     if (PLAYWRIGHT_GOTO_TIMEOUT_PATTERN.test(message)) {
         return 'timeout';
+    }
+
+    if (retryAbortedNavigation && PLAYWRIGHT_GOTO_ABORTED_PATTERN.test(message)) {
+        return 'aborted navigation';
     }
 
     return null;
@@ -137,6 +146,7 @@ export async function navigateWithRetry(
         maxLogAttempts = DEFAULT_MAX_LOG_ATTEMPTS,
         maxDurationMs = DEFAULT_MAX_DURATION_MS,
         attemptTimeoutMs = DEFAULT_NAVIGATION_ATTEMPT_TIMEOUT_MS,
+        retryAbortedNavigation = false,
         now = () => Date.now(),
     }: NavigateWithRetryOptions = {}
 ): Promise<void> {
@@ -175,7 +185,7 @@ export async function navigateWithRetry(
         } catch (error) {
             lastError = error;
 
-            const retryReason = getNavigationRetryReason(error);
+            const retryReason = getNavigationRetryReason(error, retryAbortedNavigation);
             const elapsedMs = now() - startedAt;
             const remainingAfterAttemptMs = Number.isFinite(maxDurationMs)
                 ? maxDurationMs - elapsedMs

--- a/tests/navigateWithRetry.test.ts
+++ b/tests/navigateWithRetry.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import type { Page } from '../frontend/e2e/test-helpers';
 import { navigateWithRetry } from '../frontend/e2e/test-helpers';
@@ -152,6 +154,126 @@ describe('navigateWithRetry', () => {
     expect(page.waitForTimeout).toHaveBeenCalledTimes(1);
   });
 
+  it('retries an opted-in Playwright navigation abort before succeeding', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Retrying navigation to /chat after aborted navigation (attempt 1 of 2)'
+    );
+  });
+
+  it('retries multiple opted-in navigation aborts within the configured bounds', async () => {
+    const abort = new Error(
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating'
+    );
+    const page = createMockPage([abort, abort, 'success']);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 3,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails exhausted navigation aborts with the original diagnostic context', async () => {
+    const diagnostic =
+      'page.goto: net::ERR_ABORTED at https://democratized.space/chat\nCall log:\n  - navigating to chat';
+    const page = createMockPage([new Error(diagnostic), new Error(diagnostic)]);
+
+    await expect(
+      navigateWithRetry(page, '/chat', {
+        attempts: 2,
+        delayMs: 1,
+        maxDurationMs: 20_000,
+        retryAbortedNavigation: true,
+      })
+    ).rejects.toThrow(
+      `${diagnostic} while navigating to /chat after 2 attempts`
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a Playwright navigation abort without explicit opt-in', async () => {
+    const page = createMockPage([
+      new Error(
+        'page.goto: net::ERR_ABORTED at https://democratized.space/chat'
+      ),
+      'success',
+    ]);
+
+    await expect(navigateWithRetry(page, '/chat')).rejects.toThrow(
+      'after 1 attempt'
+    );
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'page.goto: net::ERR_CERT_AUTHORITY_INVALID at https://democratized.space/chat',
+    'routing/configuration: /chat origin drift',
+    'hydration: chat panel did not hydrate',
+    'assertion: expected exactly one chat panel',
+  ])(
+    'fails closed without retrying unrelated diagnostics: %s',
+    async (message) => {
+      const page = createMockPage([new Error(message), 'success']);
+
+      await expect(
+        navigateWithRetry(page, '/chat', {
+          attempts: 2,
+          retryAbortedNavigation: true,
+        })
+      ).rejects.toThrow(message);
+
+      expect(page.goto).toHaveBeenCalledTimes(1);
+      expect(page.waitForTimeout).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    'page.goto: net::ERR_ABORTED while loading https://democratized.space/chat',
+    'page.goto: net::ERR_ABORTED_BY_CLIENT at https://democratized.space/chat',
+    'request aborted at https://democratized.space/chat',
+  ])(
+    'does not retry unrelated or near-match abort text: %s',
+    async (message) => {
+      const page = createMockPage([new Error(message), 'success']);
+
+      await expect(
+        navigateWithRetry(page, '/chat', {
+          attempts: 2,
+          retryAbortedNavigation: true,
+        })
+      ).rejects.toThrow('after 1 attempt');
+
+      expect(page.goto).toHaveBeenCalledTimes(1);
+      expect(page.waitForTimeout).not.toHaveBeenCalled();
+    }
+  );
+
   it('succeeds on the first attempt without sleeping or logging', async () => {
     const page = createMockPage(['success']);
 
@@ -293,6 +415,35 @@ describe('navigateWithRetry', () => {
     expect(consoleWarnSpy).toHaveBeenNthCalledWith(
       2,
       'Suppressing further retry logs for /; attempts 2-4 will retry silently'
+    );
+  });
+});
+
+describe('remote chat smoke navigation contract', () => {
+  it('uses bounded opted-in navigation retry before verifying the final origin and hydration', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'frontend/e2e/remote-chat-smoke.spec.ts'),
+      'utf8'
+    );
+    const openExpectedPanel = source.slice(
+      source.indexOf('async function openExpectedPanel'),
+      source.indexOf('async function selectOpenAI')
+    );
+
+    expect(openExpectedPanel).toContain(
+      "await navigateWithRetry(page, '/chat', { retryAbortedNavigation: true });"
+    );
+    expect(
+      openExpectedPanel.indexOf('new URL(page.url()).origin')
+    ).toBeGreaterThan(openExpectedPanel.indexOf('navigateWithRetry'));
+    expect(openExpectedPanel.indexOf('waitForHydration(page)')).toBeGreaterThan(
+      openExpectedPanel.indexOf('new URL(page.url()).origin')
+    );
+    expect(openExpectedPanel).toContain(
+      "'routing/configuration: /chat origin drift'"
+    );
+    expect(openExpectedPanel).toContain(
+      "'hydration: chat panel did not hydrate'"
     );
   });
 });


### PR DESCRIPTION
### Motivation

- Intermittent Playwright `page.goto: net::ERR_ABORTED` errors were aborting the remote `/chat` smoke before any provider activity, so the smoke needs a narrowly scoped, bounded retry for that exact failure shape. 
- The fix must be opt-in, bounded by attempts and total duration, and must not change application behavior, provider contracts, or release metadata.

### Description

- Added a targeted abort matcher `PLAYWRIGHT_GOTO_ABORTED_PATTERN` and an explicit, default-off `retryAbortedNavigation` option to the existing `navigateWithRetry` helper in `frontend/e2e/test-helpers.ts`.  
- Expanded `getNavigationRetryReason` to return a distinct `'aborted navigation'` reason only when `retryAbortedNavigation` is enabled and the error exactly matches Playwright's `page.goto: net::ERR_ABORTED at <url>` shape.  
- Updated `openExpectedPanel()` in `frontend/e2e/remote-chat-smoke.spec.ts` to use `navigateWithRetry(page, '/chat', { retryAbortedNavigation: true })`, then verify the final origin via `page.url()` before hydration and provider assertions.  
- Added focused unit tests in `tests/navigateWithRetry.test.ts` to cover opt-in success, repeated aborts then success, exhaustion preserving diagnostics, default opt-out behavior, near-match non-retry cases, and fail-closed diagnostics; no application code, dependencies, lockfiles, or charts were changed.

### Testing

- Ran the focused test suites with `pnpm exec vitest run tests/navigateWithRetry.test.ts tests/purgeClientStateRetry.test.ts` and all tests passed (31 tests total passed).  
- Formatting checks `pnpm exec prettier --check frontend/e2e/remote-chat-smoke.spec.ts frontend/e2e/test-helpers.ts tests/navigateWithRetry.test.ts` passed after applying `prettier --write`.  
- Lint and type checks using repository scripts succeeded with `npm run lint` and `npm run type-check`.  
- Repository hygiene checks `git diff --check` and `git diff | python3 scripts/scan-secrets.py` were run and reported no issues.  
- Note: a direct ad-hoc `eslint` invocation is incompatible with the repository's typed ESLint project config; the repository-supported `npm run lint` was used and passed.  
- Attempt to push and create the remote PR failed due to missing GitHub authentication in this environment (local branch `codex/harden-remote-chat-navigation` and commit `test: retry opted-in aborted chat navigation` are present locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6ce5e6a0832f8d6f8844b8e407de)